### PR TITLE
docs: launch assets — README pitch, full CoC, MCP registry manifest draft

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,33 +1,132 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
-This project expects contributors to be respectful, direct, and technically honest.
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-- Be constructive.
-- Be precise.
-- Disagree with ideas, not people.
-- Assume good faith unless evidence says otherwise.
-- Keep discussions focused on the work.
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-## Unacceptable Behavior
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
-- harassment
-- discrimination
-- personal attacks
-- trolling
-- malicious obstruction
-- repeated disrespectful conduct
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
-Project maintainers may:
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**<vladimir@entropia.ai>**. All complaints will be reviewed and investigated
+promptly and fairly.
 
-- warn contributors
-- remove or lock conversations
-- reject or revert contributions
-- limit participation in the project
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
-## Security and Privacy
+## Enforcement Guidelines
 
-Security reports and other sensitive disclosures should be handled privately.
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ privileged daemon executes only what you approve, writes a tamper-evident
 Ed25519-signed audit chain, and rolls back atomic-host (rpm-ostree) changes
 automatically on failure.
 
+**Why typed actions and not a guarded shell?** Red-team research (GuardFall)
+found that **10 of 11 AI agents bypass raw-string shell guards** — an allowlist
+or regex is filtering a language rich enough to hide intent. SysKnife removes
+the shell string entirely: the model emits
+[typed actions](docs/typed-actions.md), and a
+[public-key-verifiable audit chain](docs/the-audit-chain.md) records every one.
+
 ---
 
 ## Install
@@ -164,11 +171,14 @@ mechanical: no shell strings cross the wire.
 | **Claude Computer Use** | Uncontrolled desktop automation, not system administration. |
 | **Ansible** | YAML written in advance. Not conversational. No risk classification. |
 | **shell-gpt / Copilot** | Suggests raw shell commands. You still run raw shell. |
+| **AIShell-Gate** | Closest peer, but proprietary and closed; audit is symmetric HMAC (the verifier holds the signing secret, so a proof convinces no one else). No rollback. |
 | **Manual** | No audit trail. No rollback. One typo = lost work. |
 
 SysKnife is different by construction: typed actions, an Ed25519-signed audit
 chain, explicit approval gate, automatic rollback for atomic-host (rpm-ostree)
-changes, polkit-mediated privilege boundary. The AI never holds a shell.
+changes, polkit-mediated privilege boundary. The AI never holds a shell. See the
+full [SysKnife vs. alternatives](docs/comparison.md) breakdown (AIShell-Gate,
+gate-oc-audit, MCP gateways, generic mcp-shell).
 
 ## Status
 
@@ -265,6 +275,10 @@ are scoped with clear acceptance criteria.
 
 ## Documentation
 
+- [Typed actions — why never a shell string](docs/typed-actions.md)
+- [The audit chain — Ed25519, public-key verifiable](docs/the-audit-chain.md)
+- [Automatic rollback](docs/automatic-rollback.md)
+- [SysKnife vs. alternatives](docs/comparison.md)
 - [Architecture overview](docs/architecture.md)
 - [Distro support matrix](docs/distro-support.md)
 - [Configuration](docs/configuration.md)

--- a/server.json
+++ b/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.lacs-project/sysknife",
+  "description": "Let AI operate your Linux box without ever handing it a shell: typed actions, a hard approval gate, automatic rollback, and an Ed25519 public-key-verifiable audit chain.",
+  "version": "0.2.5",
+  "repository": {
+    "url": "https://github.com/lacs-project/sysknife",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registry_type": "npm",
+      "identifier": "sysknife-setup",
+      "version": "0.2.5",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Launch assets, doable on the private repo. No Rust logic changes.

- **README**: GuardFall hook (10/11 agents bypass raw-string shell guards); links the new How-It-Works pages; AIShell-Gate row in the "Why not X?" table + link to full `docs/comparison.md`.
- **CODE_OF_CONDUCT.md**: full Contributor Covenant 2.1 (was a stub).
- **server.json**: DRAFT MCP Registry manifest (`io.github.lacs-project/sysknife`). Launch story needs one decision (sysknife-setup configures rather than launches a server; daemon must run first) before `mcp-publisher publish`.

Verified locally: full release rehearsal passed (6 crates cargo-package + verify, npm pack, release binaries build); public-claims, completeness, markdownlint green; 1259/1259 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhkxxE7uGkmMCkTyyJU33