### PR TITLE
fix(setup): merge MCP configs instead of overwriting them

### DIFF
--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -40,6 +40,7 @@ const crypto   = require('crypto');
 
 const { installBinaryIfMissing } = require('./install-binary.js');
 const { installDaemonService }   = require('./install-daemon.js');
+const { mergeMcpServers }        = require('./mcp-config.js');
 
 // ---------------------------------------------------------------------------
 // Terminal helpers
@@ -633,17 +634,8 @@ async function main() {
     }
   }
 
-  // ── 7.5. Pre-flight: ask about existing .mcp.json before closing rl ────────
-
-  let skipMcpJson = false;
-  if (doClaude && fs.existsSync('.mcp.json')) {
-    warn('.mcp.json already exists.');
-    const overwriteAnswer = await ask(rl, lineQueue, 'Overwrite?', 'Y');
-    skipMcpJson = !overwriteAnswer.toLowerCase().startsWith('y');
-    if (skipMcpJson) {
-      warn('Skipping .mcp.json — edit it manually to update.');
-    }
-  }
+  // .mcp.json / .cursor/mcp.json are merged (existing servers preserved), so no
+  // destructive "Overwrite?" prompt is needed before closing the readline.
 
   rl.close();
 
@@ -685,18 +677,18 @@ async function main() {
   // ── Claude Code ──────────────────────────────────────────────────────────
 
   if (doClaude) {
-    const mcpConfig = { mcpServers };
+    // Merge into any existing .mcp.json so the user's other MCP servers survive.
+    const mcpExisted = fs.existsSync('.mcp.json');
+    const mcpConfig  = mergeMcpServers('.mcp.json', mcpServers);
 
-    if (!skipMcpJson) {
-      // .mcp.json may contain provider API keys in plain text. Restrict to owner
-      // read/write so a coworker on a shared workstation (or a stray `cat *` in a
-      // build script) cannot recover them. `chmodSync` is idempotent and also
-      // tightens permissions on a pre-existing file that was created with the
-      // process umask before this change.
-      fs.writeFileSync('.mcp.json', JSON.stringify(mcpConfig, null, 2) + '\n', { mode: 0o600 });
-      fs.chmodSync('.mcp.json', 0o600);
-      ok(`Created .mcp.json  (${targets.length} target${targets.length > 1 ? 's' : ''}: ${targetSummary})`);
-    }
+    // .mcp.json may contain provider API keys in plain text. Restrict to owner
+    // read/write so a coworker on a shared workstation (or a stray `cat *` in a
+    // build script) cannot recover them. `chmodSync` is idempotent and also
+    // tightens permissions on a pre-existing file that was created with the
+    // process umask before this change.
+    fs.writeFileSync('.mcp.json', JSON.stringify(mcpConfig, null, 2) + '\n', { mode: 0o600 });
+    fs.chmodSync('.mcp.json', 0o600);
+    ok(`${mcpExisted ? 'Updated' : 'Created'} .mcp.json  (${targets.length} target${targets.length > 1 ? 's' : ''}: ${targetSummary})`);
 
     if (!fs.existsSync('.claude')) {
       fs.mkdirSync('.claude', { recursive: true });
@@ -725,14 +717,13 @@ async function main() {
     if (!fs.existsSync('.cursor')) {
       fs.mkdirSync('.cursor', { recursive: true });
     }
-    const cursorMcp = { mcpServers };
-    fs.writeFileSync(
-      path.join('.cursor', 'mcp.json'),
-      JSON.stringify(cursorMcp, null, 2) + '\n',
-      { mode: 0o600 }
-    );
-    fs.chmodSync(path.join('.cursor', 'mcp.json'), 0o600);
-    ok(`Created .cursor/mcp.json  (${targets.length} target${targets.length > 1 ? 's' : ''}: ${targetSummary})`);
+    // Merge into any existing .cursor/mcp.json so other MCP servers survive.
+    const cursorPath    = path.join('.cursor', 'mcp.json');
+    const cursorExisted = fs.existsSync(cursorPath);
+    const cursorMcp     = mergeMcpServers(cursorPath, mcpServers);
+    fs.writeFileSync(cursorPath, JSON.stringify(cursorMcp, null, 2) + '\n', { mode: 0o600 });
+    fs.chmodSync(cursorPath, 0o600);
+    ok(`${cursorExisted ? 'Updated' : 'Created'} .cursor/mcp.json  (${targets.length} target${targets.length > 1 ? 's' : ''}: ${targetSummary})`);
 
     const rulesDir = path.join('.cursor', 'rules');
     if (!fs.existsSync(rulesDir)) {

--- a/packages/setup/mcp-config.js
+++ b/packages/setup/mcp-config.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// Merge SysKnife's MCP server entries into an existing client config instead of
+// overwriting the whole file. A plain `{ mcpServers }` write clobbered any other
+// MCP servers the user had configured (Claude Code's `.mcp.json`, Cursor's
+// `.cursor/mcp.json`); this preserves them and every other top-level key.
+
+const fs = require('fs');
+
+/**
+ * Return an MCP config object with `servers` merged under `mcpServers`,
+ * preserving any existing servers and unrelated top-level keys. A missing or
+ * unparseable file is treated as an empty config (never throws).
+ *
+ * @param {string} filePath  path to the client's MCP config JSON
+ * @param {Record<string, unknown>} servers  the sysknife server entries to upsert
+ * @returns {Record<string, unknown>} the merged config, ready to JSON.stringify
+ */
+function mergeMcpServers(filePath, servers) {
+  let existing = {};
+  try {
+    if (fs.existsSync(filePath)) {
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        existing = parsed;
+      }
+    }
+  } catch {
+    // Malformed JSON — start from an empty config rather than crashing the wizard.
+    existing = {};
+  }
+  const existingServers =
+    existing.mcpServers && typeof existing.mcpServers === 'object' ? existing.mcpServers : {};
+  return { ...existing, mcpServers: { ...existingServers, ...servers } };
+}
+
+module.exports = { mergeMcpServers };

--- a/packages/setup/tests/mcp-config.test.mjs
+++ b/packages/setup/tests/mcp-config.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { mergeMcpServers } = require('../mcp-config.js');
+
+function tmpFile(contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-mcp-'));
+  const file = path.join(dir, '.mcp.json');
+  if (contents !== undefined) fs.writeFileSync(file, contents);
+  return file;
+}
+
+const SYSKNIFE = { sysknife: { command: '/bin/sysknife', args: ['mcp-server'] } };
+
+test('merges sysknife in while preserving other servers', () => {
+  const file = tmpFile(JSON.stringify({ mcpServers: { other: { command: 'x', args: [] } } }));
+  const merged = mergeMcpServers(file, SYSKNIFE);
+  assert.deepEqual(Object.keys(merged.mcpServers).sort(), ['other', 'sysknife']);
+  assert.equal(merged.mcpServers.other.command, 'x'); // untouched
+});
+
+test('preserves unrelated top-level keys', () => {
+  const file = tmpFile(JSON.stringify({ mcpServers: {}, editorConfig: 42 }));
+  const merged = mergeMcpServers(file, SYSKNIFE);
+  assert.equal(merged.editorConfig, 42);
+});
+
+test('creates a fresh config when the file is missing', () => {
+  const file = tmpFile(); // not written
+  const merged = mergeMcpServers(file, SYSKNIFE);
+  assert.deepEqual(Object.keys(merged.mcpServers), ['sysknife']);
+});
+
+test('does not throw on a malformed file (starts fresh)', () => {
+  const file = tmpFile('{ not: valid json ');
+  const merged = mergeMcpServers(file, SYSKNIFE);
+  assert.deepEqual(Object.keys(merged.mcpServers), ['sysknife']);
+});
+
+test('upserts a stale sysknife entry', () => {
+  const file = tmpFile(JSON.stringify({ mcpServers: { sysknife: { command: 'OLD', args: [] } } }));
+  const merged = mergeMcpServers(file, { sysknife: { command: 'NEW', args: ['mcp-server'] } });
+  assert.equal(merged.mcpServers.sysknife.command, 'NEW');
+});
+
+test('handles a file with no mcpServers key', () => {
+  const file = tmpFile(JSON.stringify({ somethingElse: true }));
+  const merged = mergeMcpServers(file, SYSKNIFE);
+  assert.equal(merged.somethingElse, true);
+  assert.deepEqual(Object.keys(merged.mcpServers), ['sysknife']);
+});

--- a/packages/setup/tests/setup-contract.test.mjs
+++ b/packages/setup/tests/setup-contract.test.mjs
@@ -16,6 +16,13 @@ test('generated integration rules require terminal-issued approval receipts', ()
   assert.doesNotMatch(source, /words like \"yes\", \"do it\"/);
 });
 
+test('MCP configs are merged, not overwritten (preserves other servers)', () => {
+  assert.match(source, /mergeMcpServers\('\.mcp\.json'/);
+  assert.match(source, /mergeMcpServers\(cursorPath/);
+  assert.doesNotMatch(source, /const mcpConfig = \{ mcpServers \}/);
+  assert.doesNotMatch(source, /const cursorMcp = \{ mcpServers \}/);
+});
+
 test('default MCP target and user service use the same socket', () => {
   assert.match(source, /\.local', 'share', 'sysknife', 'daemon\.sock/);
   assert.match(daemonInstaller, /\.local', 'share', 'sysknife', 'daemon\.sock/);


### PR DESCRIPTION
## Problem
`sysknife-setup` wrote a fresh `{ mcpServers: { sysknife } }` to Claude Code's `.mcp.json` and Cursor's `.cursor/mcp.json`, **discarding any other MCP servers** the user had configured — Cursor silently, Claude only behind a destructive "Overwrite?" prompt.

## Fix
New `packages/setup/mcp-config.js` `mergeMcpServers()` merges the sysknife entry into the existing config, preserving other servers + unrelated top-level keys, and treating a missing/malformed file as empty (never throws). Wired into both write sites; the destructive overwrite prompt is removed.

## Tests
6 unit tests (preserve / upsert / missing / malformed / no-`mcpServers`-key) + a source-contract test pinning the wiring. 16→23 setup tests, all green; `--help` smoke intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)