### PR TITLE
fix: implement main code-review findings (error classification, vsock logging)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,6 +4821,7 @@ dependencies = [
  "async-openai",
  "async-trait",
  "futures",
+ "http",
  "rig-core",
  "serde",
  "serde_json",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -18,6 +18,12 @@ async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.
 rig = { package = "rig-core", version = "0.40.0" }
+# Used to classify structured provider error status codes (rig's
+# `CompletionError::provider_response_status()` and async-openai's
+# `ApiErrorResponse::status_code` both return this type). Already present
+# transitively via async-openai/rig-core/reqwest; declared directly here
+# because we match on its constants in our own code.
+http = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/sysknife-brain/src/provider.rs
+++ b/crates/sysknife-brain/src/provider.rs
@@ -165,8 +165,8 @@ pub enum ProviderError {
     #[error("authentication failed: {0}")]
     Auth(String),
 
-    #[error("rate limited")]
-    RateLimit,
+    #[error("rate limited: {0}")]
+    RateLimit(String),
 
     #[error("invalid response: {0}")]
     Parse(String),

--- a/crates/sysknife-brain/src/providers/mod.rs
+++ b/crates/sysknife-brain/src/providers/mod.rs
@@ -1,6 +1,31 @@
 pub mod openai_adapter;
 pub mod rig_adapter;
 
+/// Coarse classification of a provider's HTTP status code, shared by every
+/// adapter that maps SDK errors onto [`crate::provider::ProviderError`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StatusClass {
+    /// 401 Unauthorized / 403 Forbidden — credentials are missing or invalid.
+    Auth,
+    /// 429 Too Many Requests.
+    RateLimit,
+    /// Any other 4xx/5xx status — a generic request error.
+    Other,
+}
+
+/// Classifies a structured HTTP status code from a provider response.
+///
+/// This is the preferred classification path: adapters should only fall back
+/// to substring matching against SDK error messages when no structured status
+/// is available (e.g. a transport-level failure with no HTTP response).
+pub(super) fn classify_status(status: http::StatusCode) -> StatusClass {
+    match status {
+        http::StatusCode::UNAUTHORIZED | http::StatusCode::FORBIDDEN => StatusClass::Auth,
+        http::StatusCode::TOO_MANY_REQUESTS => StatusClass::RateLimit,
+        _ => StatusClass::Other,
+    }
+}
+
 /// Redact common key-bearing query parameters from error messages to prevent
 /// API key leakage in logs. Handles both first-position (`?key=`, `?api_key=`)
 /// and subsequent-position (`&key=`, `&api_key=`) query params, and redacts

--- a/crates/sysknife-brain/src/providers/openai_adapter.rs
+++ b/crates/sysknife-brain/src/providers/openai_adapter.rs
@@ -365,13 +365,48 @@ fn map_openai_error(err: async_openai::error::OpenAIError) -> ProviderError {
     // from misconfigured proxies or HTTP-level transport failures.
     let msg = sanitize_error_msg(&err.to_string());
 
+    // Prefer the structured status async-openai attaches to `ApiError` — it is
+    // the HTTP status code the OpenAI API itself returned, so it is far more
+    // reliable than matching on the SDK's rendered error text.
+    if let async_openai::error::OpenAIError::ApiError(ref api_err) = err {
+        return match super::classify_status(api_err.status_code) {
+            super::StatusClass::Auth => {
+                // Log the sanitized message for operator diagnostics but do not
+                // propagate it to the caller — auth errors can echo key-adjacent
+                // context.
+                tracing::error!(
+                    target: "sysknife_brain::openai_adapter",
+                    "OpenAI authentication error: {}",
+                    msg
+                );
+                ProviderError::Auth("OpenAI authentication failed — check your API key".to_string())
+            }
+            super::StatusClass::RateLimit => {
+                tracing::warn!(
+                    target: "sysknife_brain::openai_adapter",
+                    "OpenAI rate limit hit: {}",
+                    msg
+                );
+                ProviderError::RateLimit(msg)
+            }
+            super::StatusClass::Other => {
+                tracing::error!(
+                    target: "sysknife_brain::openai_adapter",
+                    "OpenAI error: {}",
+                    msg
+                );
+                ProviderError::Request(msg)
+            }
+        };
+    }
+
+    // Fall back to string matching for non-`ApiError` variants (e.g.
+    // `Reqwest`, `JSONDeserialize`), which carry no structured HTTP status.
     if msg.contains("401")
         || msg.to_lowercase().contains("authentication")
         || msg.to_lowercase().contains("api key")
         || msg.to_lowercase().contains("incorrect api key")
     {
-        // Log the sanitized message for operator diagnostics but do not propagate
-        // it to the caller — auth errors can echo key-adjacent context.
         tracing::error!(
             target: "sysknife_brain::openai_adapter",
             "OpenAI authentication error: {}",
@@ -384,7 +419,7 @@ fn map_openai_error(err: async_openai::error::OpenAIError) -> ProviderError {
             "OpenAI rate limit hit: {}",
             msg
         );
-        ProviderError::RateLimit
+        ProviderError::RateLimit(msg)
     } else {
         tracing::error!(
             target: "sysknife_brain::openai_adapter",
@@ -875,6 +910,101 @@ mod tests {
                 "auth classification wrong for: {msg}"
             );
         }
+    }
+
+    #[test]
+    fn map_openai_error_classifies_401_as_auth_via_real_api_error() {
+        let err =
+            async_openai::error::OpenAIError::ApiError(async_openai::error::ApiErrorResponse {
+                status_code: http::StatusCode::UNAUTHORIZED,
+                api_error: async_openai::error::ApiError {
+                    message: "Incorrect API key provided".into(),
+                    r#type: Some("invalid_request_error".into()),
+                    param: None,
+                    code: Some("invalid_api_key".into()),
+                },
+            });
+        let mapped = map_openai_error(err);
+        assert!(
+            matches!(mapped, ProviderError::Auth(_)),
+            "expected Auth, got {mapped:?}"
+        );
+        if let ProviderError::Auth(msg) = mapped {
+            assert_eq!(
+                msg, "OpenAI authentication failed — check your API key",
+                "auth message must be the fixed key-safe string, not the raw SDK text"
+            );
+        }
+    }
+
+    #[test]
+    fn map_openai_error_classifies_403_as_auth_via_real_api_error() {
+        let err =
+            async_openai::error::OpenAIError::ApiError(async_openai::error::ApiErrorResponse {
+                status_code: http::StatusCode::FORBIDDEN,
+                api_error: async_openai::error::ApiError {
+                    message: "forbidden".into(),
+                    r#type: None,
+                    param: None,
+                    code: None,
+                },
+            });
+        let mapped = map_openai_error(err);
+        assert!(
+            matches!(mapped, ProviderError::Auth(_)),
+            "expected Auth, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_openai_error_classifies_429_as_rate_limit_via_real_api_error() {
+        let err =
+            async_openai::error::OpenAIError::ApiError(async_openai::error::ApiErrorResponse {
+                status_code: http::StatusCode::TOO_MANY_REQUESTS,
+                api_error: async_openai::error::ApiError {
+                    message: "Rate limit reached for requests".into(),
+                    r#type: Some("rate_limit_error".into()),
+                    param: None,
+                    code: None,
+                },
+            });
+        let mapped = map_openai_error(err);
+        assert!(
+            matches!(mapped, ProviderError::RateLimit(_)),
+            "expected RateLimit, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_openai_error_classifies_other_4xx_as_request_via_real_api_error() {
+        let err =
+            async_openai::error::OpenAIError::ApiError(async_openai::error::ApiErrorResponse {
+                status_code: http::StatusCode::BAD_REQUEST,
+                api_error: async_openai::error::ApiError {
+                    message: "model not found".into(),
+                    r#type: None,
+                    param: None,
+                    code: None,
+                },
+            });
+        let mapped = map_openai_error(err);
+        assert!(
+            matches!(mapped, ProviderError::Request(_)),
+            "expected Request, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_openai_error_falls_back_to_substring_for_non_api_error_variant() {
+        // `JSONDeserialize` carries no structured HTTP status, so this
+        // exercises the substring-fallback path in `map_openai_error`.
+        let json_err = serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        let err = async_openai::error::OpenAIError::JSONDeserialize(json_err, "not json".into());
+        let mapped = map_openai_error(err);
+        assert!(
+            matches!(mapped, ProviderError::Request(_)),
+            "expected Request via fallback, got {mapped:?}"
+        );
     }
 
     #[test]

--- a/crates/sysknife-brain/src/providers/rig_adapter.rs
+++ b/crates/sysknife-brain/src/providers/rig_adapter.rs
@@ -380,18 +380,30 @@ fn from_rig_response(choice: OneOrMany<AssistantContent>) -> Result<Completion, 
 
 fn map_rig_error(err: rig::completion::CompletionError) -> ProviderError {
     let msg = sanitize_error_msg(&err.to_string());
-
-    // NOTE: This classification relies on string matching against Rig's error
-    // messages, which is inherently fragile — a Rig version bump could change
-    // the wording and break our categorisation. We accept this trade-off
-    // because Rig does not expose structured error variants for HTTP status
-    // codes. If Rig adds typed error variants in the future, prefer those.
     eprintln!("[sysknife-brain] Rig completion error: {msg}");
 
+    // Prefer the structured HTTP status Rig preserves via
+    // `provider_response_status()` (see `impl_provider_response_helpers!` in
+    // rig-core's `provider_response` module). This is available whenever Rig
+    // captured a real HTTP response, success or failure.
+    if let Some(status) = err.provider_response_status() {
+        return match super::classify_status(status) {
+            super::StatusClass::Auth => ProviderError::Auth(msg),
+            super::StatusClass::RateLimit => ProviderError::RateLimit(msg),
+            super::StatusClass::Other => ProviderError::Request(msg),
+        };
+    }
+
+    // Fall back to string matching against Rig's error messages only when no
+    // structured status is available (e.g. a non-HTTP transport such as a
+    // gRPC/SDK-based provider, or a transport-level failure with no response).
+    // This fallback is inherently fragile — a Rig version bump could change
+    // the wording and break our categorisation — but there is no structured
+    // alternative in that case.
     if msg.contains("401") || msg.to_lowercase().contains("auth") {
         ProviderError::Auth(msg)
     } else if msg.contains("429") || msg.to_lowercase().contains("rate") {
-        ProviderError::RateLimit
+        ProviderError::RateLimit(msg)
     } else {
         ProviderError::Request(msg)
     }
@@ -616,5 +628,78 @@ mod tests {
             }
             other => panic!("expected Parse error, got {other:?}"),
         }
+    }
+
+    // --- map_rig_error ---------------------------------------------------
+
+    #[test]
+    fn map_rig_error_classifies_401_as_auth() {
+        let err = rig::completion::CompletionError::from_http_response(
+            http::StatusCode::UNAUTHORIZED,
+            r#"{"error":"unauthorized"}"#,
+        );
+        let mapped = map_rig_error(err);
+        assert!(
+            matches!(mapped, ProviderError::Auth(_)),
+            "expected Auth, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_rig_error_classifies_403_as_auth() {
+        let err = rig::completion::CompletionError::from_http_response(
+            http::StatusCode::FORBIDDEN,
+            "forbidden",
+        );
+        let mapped = map_rig_error(err);
+        assert!(
+            matches!(mapped, ProviderError::Auth(_)),
+            "expected Auth, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_rig_error_classifies_429_as_rate_limit() {
+        let err = rig::completion::CompletionError::from_http_response(
+            http::StatusCode::TOO_MANY_REQUESTS,
+            r#"{"error":"rate limited"}"#,
+        );
+        let mapped = map_rig_error(err);
+        assert!(
+            matches!(mapped, ProviderError::RateLimit(_)),
+            "expected RateLimit, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_rig_error_classifies_other_4xx_as_request() {
+        let err = rig::completion::CompletionError::from_http_response(
+            http::StatusCode::BAD_REQUEST,
+            "bad request",
+        );
+        let mapped = map_rig_error(err);
+        assert!(
+            matches!(mapped, ProviderError::Request(_)),
+            "expected Request, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_rig_error_falls_back_to_substring_when_no_structured_status() {
+        // `ProviderError(String)` carries no HTTP status — this is the
+        // non-HTTP-transport case (e.g. gRPC/SDK-based providers) where the
+        // substring fallback in `map_rig_error` is the only option.
+        let err =
+            rig::completion::CompletionError::ProviderError("401 unauthorized from grpc".into());
+        assert_eq!(
+            err.provider_response_status(),
+            None,
+            "sanity check: this variant must carry no structured status"
+        );
+        let mapped = map_rig_error(err);
+        assert!(
+            matches!(mapped, ProviderError::Auth(_)),
+            "expected Auth via substring fallback, got {mapped:?}"
+        );
     }
 }

--- a/crates/sysknife-daemon/src/auth.rs
+++ b/crates/sysknife-daemon/src/auth.rs
@@ -66,7 +66,13 @@ pub fn validate_token_against_file(
     }
     let stored = match std::fs::read_to_string(token_path) {
         Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "[sysknife-daemon] WARNING: vsock token file {} does not exist; rejecting vsock auth (provision the token file to allow vsock connections)",
+                token_path.display()
+            );
+            return None;
+        }
         Err(e) => {
             eprintln!(
                 "[sysknife-daemon] WARNING: cannot read token file {}: {e}; rejecting vsock auth",

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -711,7 +711,13 @@ pub async fn connection_handler_with_executor<S>(
 /// Receive the first frame, parse the auth message, and validate the token.
 ///
 /// Returns the granted `CallerRole` on success, or `None` if the frame is
-/// malformed or the token does not match the stored value.
+/// malformed or the token does not match the stored value. Every rejection
+/// path logs a distinct, operator-facing `eprintln!` naming the specific
+/// cause (timeout, framing error, malformed JSON, wrong frame type, or a bad
+/// token) so operators can diagnose vsock auth failures from server logs.
+/// The response sent back to the *client* stays a uniform generic rejection
+/// regardless of cause — these logs are server-side only and must never be
+/// used to build a client-observable auth oracle.
 async fn authenticate_vsock_token(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     token_path: &std::path::Path,
@@ -723,18 +729,43 @@ async fn authenticate_vsock_token(
         token: String,
     }
 
-    let raw = tokio::time::timeout(
+    let recv_result = tokio::time::timeout(
         std::time::Duration::from_secs(VSOCK_AUTH_FRAME_TIMEOUT_SECS),
         framed.recv(),
     )
-    .await
-    .ok()? // timeout expired
-    .ok()?; // framing error
-    let auth: AuthFrame = serde_json::from_slice(&raw).ok()?;
+    .await;
+    let Ok(frame_result) = recv_result else {
+        eprintln!(
+            "[sysknife-daemon] vsock auth: timed out waiting for auth frame after {VSOCK_AUTH_FRAME_TIMEOUT_SECS}s"
+        );
+        return None;
+    };
+    let raw = match frame_result {
+        Ok(raw) => raw,
+        Err(e) => {
+            eprintln!("[sysknife-daemon] vsock auth: framing error reading auth frame: {e}");
+            return None;
+        }
+    };
+    let auth: AuthFrame = match serde_json::from_slice(&raw) {
+        Ok(auth) => auth,
+        Err(e) => {
+            eprintln!("[sysknife-daemon] vsock auth: malformed auth frame JSON: {e}");
+            return None;
+        }
+    };
     if auth.msg_type != "auth" {
+        eprintln!(
+            "[sysknife-daemon] vsock auth: unexpected frame type {:?} (expected \"auth\")",
+            auth.msg_type
+        );
         return None;
     }
-    crate::auth::validate_token_against_file(&auth.token, token_path)
+    let role = crate::auth::validate_token_against_file(&auth.token, token_path);
+    if role.is_none() {
+        eprintln!("[sysknife-daemon] vsock auth: token did not validate against token file");
+    }
+    role
 }
 
 // ---------------------------------------------------------------------------
@@ -1794,6 +1825,22 @@ async fn handle_execute(
 
     let is_high_risk_reboot =
         spec.risk_level == sysknife_types::RiskLevel::High && spec.reboot_required;
+
+    // Defensive invariant: the slot is only ever *claimed* inside `if
+    // is_mutating { ... }` below, but `release_high_risk_slot` runs
+    // unconditionally on every exit path (see calls further down). If a
+    // future action were classified High-risk + reboot-required yet not
+    // mutating (e.g. an Observer-role action), it would skip the claim but
+    // still attempt the release — harmless today (release is a no-op unless
+    // the hash matches a claimed slot) but a sign the risk/role policy tables
+    // have drifted out of sync. Policy validation prevents this today; this
+    // assertion catches a future regression cheaply rather than relying on
+    // that invariant holding silently forever.
+    debug_assert!(
+        !is_high_risk_reboot || is_mutating,
+        "high-risk+reboot action must be mutating (action {action_name:?} is High risk \
+         + reboot_required but policy does not require Dev/Admin to run it)"
+    );
 
     // Check the gate for any mutating action; only set it for high-risk+reboot.
     if is_mutating {


### PR DESCRIPTION
Findings from a `/pr-review-toolkit` review over main (2 agents). Main's code was otherwise verified clean.

**HIGH** — provider error classification matched substrings of SDK `Display` text; the rig 0.35→0.40 / async-openai 0.36→0.41 bump is exactly what the code's own comment warned would break it. Now classifies via **structured HTTP status** (rig `provider_response_status()`, async-openai `ApiError.status_code`) through a shared `classify_status()`; substring matching kept only as a fallback. `ProviderError::RateLimit` now carries its detail message. +10 tests using real SDK error types.

**MEDIUM** — vsock auth logged one opaque line for 4 causes; now logs the specific cause server-side (timeout/framing/bad-JSON/wrong-frame/bad-token), and `validate_token_against_file` warns on a missing token file. Client-facing rejection unchanged (no auth oracle).

**Defensive** — `debug_assert!(!is_high_risk_reboot || is_mutating)` in `handle_execute`.

`cargo fmt` + `clippy -D warnings` + `nextest` (1269 tests) green.

Note: CodeQL red on main is a private-repo/GHAS gap (not a code bug) — left for an infra decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)