### PR TITLE
feat(setup): offer all 8 engine providers in the wizard + fix doc/code drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SysKnife Makefile — build, install, and uninstall the daemon and shell.
+# SysKnife Makefile — build, install, and uninstall the daemon and CLI.
 #
 # Typical usage (as root or via sudo):
 #   make build
@@ -28,19 +28,28 @@ HELPERS     ?= /usr/lib/sysknife
 
 CARGO_BUILD_FLAGS ?= --release --locked
 
-.PHONY: build install uninstall daemon-install daemon-uninstall check
+.PHONY: build install uninstall daemon-install cli-install daemon-uninstall cli-uninstall check
 
 ## ── Build ────────────────────────────────────────────────────────────────────
 
+# Builds both binaries: the privileged daemon (sysknife-daemon) and the user CLI
+# (sysknife), which provides `mcp-server` and `approve`. Docs run `sysknife` right
+# after `make install`, so `install` must place both — see cli-install below.
 build:
-	cargo build $(CARGO_BUILD_FLAGS) -p sysknife-daemon
-	@echo "Build complete. Binary: target/release/sysknife-daemon"
+	cargo build $(CARGO_BUILD_FLAGS) -p sysknife-daemon -p sysknife-cli
+	@echo "Build complete. Binaries: target/release/sysknife-daemon, target/release/sysknife"
 
 ## ── Install ──────────────────────────────────────────────────────────────────
 
-install: daemon-install
+install: daemon-install cli-install
 	@echo ""
-	@echo "SysKnife daemon installed. Run 'sudo systemctl enable --now sysknife-daemon' to start."
+	@echo "SysKnife daemon + CLI installed. Run 'sudo systemctl enable --now sysknife-daemon' to start."
+
+# The `sysknife` CLI is what the setup wizard (`--no-binary`) and the MCP server
+# invoke, so a from-source install must place it on PATH alongside the daemon.
+cli-install: build
+	install -Dm 755 target/release/sysknife $(BINDIR)/sysknife
+	@echo "CLI installed: $(BINDIR)/sysknife"
 
 daemon-install: build
 	install -Dm 755 target/release/sysknife-daemon $(BINDIR)/sysknife-daemon
@@ -69,7 +78,11 @@ daemon-install: build
 
 ## ── Uninstall ────────────────────────────────────────────────────────────────
 
-uninstall: daemon-uninstall
+uninstall: daemon-uninstall cli-uninstall
+
+cli-uninstall:
+	rm -f $(BINDIR)/sysknife
+	@echo "CLI uninstalled: $(BINDIR)/sysknife"
 
 daemon-uninstall:
 	-systemctl disable --now sysknife-daemon 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -89,15 +89,19 @@ What this does:
    each against the release checksum file — a mismatch aborts the install — and
    places them in `~/.local/bin` (no sudo). Pass `--no-binary` to skip the
    download and build from source instead.
-2. **Installs and starts the daemon as a service** — a systemd *user* service by
-   default (no sudo; kept alive across logout via linger). Pick the system-level
-   service for a production, multi-user host.
-3. Asks for your LLM provider + key (OpenAI / Anthropic / Gemini / Ollama).
-4. Asks which AI integration to wire up, or lets you pick `--claude`,
-   `--cursor`, `--codex`, or `--all` directly.
-5. Writes the integration-specific MCP config so the next chat session sees the
-   `sysknife_*` tools — `sysknife_plan`, `sysknife_execute`, `sysknife_history`,
-   `sysknife_doctor`, `sysknife_audit_verify` — as first-class tools.
+2. Asks for your **LLM provider, key, and model** — OpenAI / Anthropic / Gemini
+   / Ollama / Groq / DeepSeek / Mistral / xAI (Ollama needs no key). The key
+   prompt is skipped when the matching env var is already set.
+3. Asks **which AI integration** to wire up (or pick `--claude` / `--cursor` /
+   `--codex` / `--all`) and your **daemon target(s)** — socket, plus an optional
+   vsock token for a remote VM.
+4. **Writes the integration-specific MCP config** (merging into any existing
+   file, never clobbering) so the next chat session sees the `sysknife_*` tools —
+   `sysknife_plan`, `sysknife_execute`, `sysknife_history`, `sysknife_doctor`,
+   `sysknife_audit_verify` — as first-class tools.
+5. **Installs and starts the daemon as a service** (last step) — a systemd
+   *user* service by default (no sudo; kept alive across logout via linger).
+   Pick the system-level service for a production, multi-user host.
 
 | Client          | Files written                                        |
 |-----------------|------------------------------------------------------|
@@ -118,15 +122,15 @@ the prompt, enforces the receipt boundary.
 <summary><strong>Manual install — Ubuntu LTS · Fedora Atomic</strong></summary>
 
 ```sh
-# Build + install the daemon the wizard configures
 git clone https://github.com/lacs-project/sysknife
 cd sysknife
-make build
-sudo make install
+make build                            # builds sysknife (CLI) + sysknife-daemon
+sudo make install                     # installs both; daemon runs as a system service
 sudo systemctl enable --now sysknife-daemon
 
-# Then run the published setup wizard
-npx sysknife-setup
+# Then wire your IDE — --no-binary skips the download since you just built them
+# (choose "skip" at the daemon-service prompt; make install already set it up)
+npx sysknife-setup --no-binary
 ```
 
 Ubuntu 24.04 is validated with 65/65 stories on a live VM. Ubuntu 22.04 and
@@ -211,7 +215,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,259 Rust tests and 72 frontend tests** form the current deterministic
+**1,269 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ produced. Provides:
 
 - `LlmPlanner` — the planning loop entry point
 - `BrainConfig` — provider and model selection
-- Provider adapters: Anthropic, OpenAI, Gemini, Ollama
+- Provider adapters: Anthropic, OpenAI, Gemini, Ollama, Groq, DeepSeek, Mistral, xAI
 - Planning tools: `get_system_state`, `query_*`, `propose_plan`, `remember`, `forget`
 - Safety fence: validates every action name and risk level before a plan
   leaves the brain

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -26,7 +26,7 @@ release.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** until variant-specific VM evidence exists |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,259 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,269 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -117,7 +117,7 @@ SysKnife auto-detects it. See [Quick Start](quickstart.md).
 
 ## Status
 
-140+ typed actions · 1,259 Rust tests + 72 frontend tests · MIT
+140+ typed actions · 1,269 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -217,21 +217,11 @@ function serverToToml(key, server) {
 // Configuration
 // ---------------------------------------------------------------------------
 
-const PROVIDERS = ['openai', 'anthropic', 'gemini', 'ollama'];
-
-const MODEL_DEFAULTS = {
-  openai:    'gpt-4.1',
-  anthropic: 'claude-sonnet-4-6',
-  gemini:    'gemini-2.5-pro',
-  ollama:    'qwen3:8b',
-};
-
-const API_KEY_VARS = {
-  openai:    'OPENAI_API_KEY',
-  anthropic: 'ANTHROPIC_API_KEY',
-  gemini:    'GEMINI_API_KEY',
-  ollama:    null,
-};
+// Provider list, model defaults, and API-key env vars live in providers.js so
+// the "wizard offers what the engine supports" invariant is unit-testable. All
+// eight sysknife-brain providers are offered; the flow below is data-driven off
+// these maps, so no per-provider branching is needed.
+const { PROVIDERS, MODEL_DEFAULTS, API_KEY_VARS } = require('./providers.js');
 
 const ARG_SET = new Set(process.argv.slice(2));
 const WANT_CLAUDE     = ARG_SET.has('--claude');
@@ -931,9 +921,11 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   Run from the root of your project directory.
 
 \x1b[1mENVIRONMENT\x1b[0m
-  OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY
-      If set in your shell environment the wizard detects them and avoids
-      writing them to config files in plain text.
+  OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY /
+  GROQ_API_KEY / DEEPSEEK_API_KEY / MISTRAL_API_KEY / XAI_API_KEY
+      The provider's key var (Ollama needs none). If set in your shell
+      environment the wizard detects it and avoids writing it to config
+      files in plain text.
 
 \x1b[1mEXAMPLES\x1b[0m
   \x1b[2m# Pick one integration interactively\x1b[0m

--- a/packages/setup/providers.js
+++ b/packages/setup/providers.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * providers.js — the single source of truth for the LLM providers the setup
+ * wizard offers.
+ *
+ * These three maps must stay in lock-step with the engine (sysknife-brain):
+ *   - the provider list          → crates/sysknife-brain/src/config.rs (from_env match)
+ *   - the API-key env var names   → crates/sysknife-brain/src/config.rs (require_api_key)
+ *   - the default model per provider → crates/sysknife-brain/src/config.rs (DEFAULT_*_MODEL)
+ *
+ * Extracted from index.js so the invariants above are unit-testable without
+ * executing the wizard (mirrors mcp-config.js). If the engine gains a provider,
+ * add it here and the wizard's provider prompt, key prompt, and model prompt all
+ * pick it up automatically.
+ */
+
+/** Providers the wizard prompts for. Index 0 (`openai`) is the default. */
+const PROVIDERS = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'ollama',
+  'groq',
+  'deepseek',
+  'mistral',
+  'xai',
+];
+
+/**
+ * Default model per provider. Must match the DEFAULT_*_MODEL constants in
+ * crates/sysknife-brain/src/config.rs so the wizard's suggestion equals what the
+ * engine would pick on its own.
+ */
+const MODEL_DEFAULTS = {
+  openai:   'gpt-4.1',
+  anthropic:'claude-sonnet-4-6',
+  gemini:   'gemini-2.5-pro',
+  ollama:   'qwen3:8b',
+  groq:     'llama-3.3-70b-versatile',
+  deepseek: 'deepseek-chat',
+  mistral:  'mistral-large-latest',
+  xai:      'grok-3',
+};
+
+/**
+ * API-key environment variable per provider (null when the provider needs no
+ * key). Names must match `require_api_key(...)` in the engine's config.rs.
+ */
+const API_KEY_VARS = {
+  openai:   'OPENAI_API_KEY',
+  anthropic:'ANTHROPIC_API_KEY',
+  gemini:   'GEMINI_API_KEY',
+  ollama:   null,
+  groq:     'GROQ_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
+  mistral:  'MISTRAL_API_KEY',
+  xai:      'XAI_API_KEY',
+};
+
+module.exports = { PROVIDERS, MODEL_DEFAULTS, API_KEY_VARS };

--- a/packages/setup/tests/providers.test.mjs
+++ b/packages/setup/tests/providers.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { PROVIDERS, MODEL_DEFAULTS, API_KEY_VARS } = require('../providers.js');
+
+// The wizard must offer every provider the engine (sysknife-brain) supports, so
+// a user never has to hand-edit config.toml just to pick groq/deepseek/mistral/xai.
+// Source of truth: crates/sysknife-brain/src/config.rs (from_env) + planner.rs.
+const ENGINE_PROVIDERS = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'ollama',
+  'groq',
+  'deepseek',
+  'mistral',
+  'xai',
+];
+
+test('offers every provider the engine supports', () => {
+  for (const p of ENGINE_PROVIDERS) {
+    assert.ok(PROVIDERS.includes(p), `PROVIDERS is missing "${p}"`);
+  }
+  assert.equal(PROVIDERS.length, ENGINE_PROVIDERS.length, 'PROVIDERS has unexpected extras');
+});
+
+test('openai stays the first/default provider', () => {
+  assert.equal(PROVIDERS[0], 'openai');
+});
+
+test('maps each new provider to its engine API-key env var', () => {
+  assert.equal(API_KEY_VARS.groq, 'GROQ_API_KEY');
+  assert.equal(API_KEY_VARS.deepseek, 'DEEPSEEK_API_KEY');
+  assert.equal(API_KEY_VARS.mistral, 'MISTRAL_API_KEY');
+  assert.equal(API_KEY_VARS.xai, 'XAI_API_KEY');
+  // Existing providers unchanged; ollama needs no key.
+  assert.equal(API_KEY_VARS.openai, 'OPENAI_API_KEY');
+  assert.equal(API_KEY_VARS.anthropic, 'ANTHROPIC_API_KEY');
+  assert.equal(API_KEY_VARS.gemini, 'GEMINI_API_KEY');
+  assert.equal(API_KEY_VARS.ollama, null);
+});
+
+test('new provider model defaults match the engine defaults', () => {
+  // Must equal DEFAULT_*_MODEL in crates/sysknife-brain/src/config.rs.
+  assert.equal(MODEL_DEFAULTS.groq, 'llama-3.3-70b-versatile');
+  assert.equal(MODEL_DEFAULTS.deepseek, 'deepseek-chat');
+  assert.equal(MODEL_DEFAULTS.mistral, 'mistral-large-latest');
+  assert.equal(MODEL_DEFAULTS.xai, 'grok-3');
+});
+
+test('every offered provider has a model default and an api-key entry', () => {
+  for (const p of PROVIDERS) {
+    assert.ok(MODEL_DEFAULTS[p], `MODEL_DEFAULTS is missing "${p}"`);
+    assert.ok(p in API_KEY_VARS, `API_KEY_VARS is missing "${p}"`);
+  }
+});


### PR DESCRIPTION
## Wizard: all 8 providers
The wizard prompted for only 4 (`openai/anthropic/gemini/ollama`) while the engine supports **8** — `groq/deepseek/mistral/xai` were reachable only by hand-editing `config.toml`. Extracted the provider config into a testable `providers.js` (mirrors `mcp-config.js`) with all 8, keyed by the engine's env-var names and `DEFAULT_*_MODEL` defaults. The prompt/key/model flow is data-driven, so no per-provider branching was needed.

**Verified end-to-end** (ran the wizard in an isolated dir): the menu shows all 8, selecting `groq` prompts for `GROQ_API_KEY`, defaults the model to `llama-3.3-70b-versatile`, and writes a correct `.mcp.json`. New unit test `providers.test.mjs` pins the wizard↔engine invariant (8 providers, env vars, model defaults).

## Doc/code drift fixes (from an e2e verification sweep)
- **Makefile**: `build`/`install` now handle **both** binaries. `make build` built only `sysknife-daemon`, yet `README`/`introduction.md`/`quickstart.md` run `sysknife` right after `make install` — the CLI was never installed. Fixed at the source (`cli-install`/`cli-uninstall`), which corrects all those docs at once.
- **README**: fix the "What this does" step order (daemon service runs **last**, not 2nd; add the model prompt), list all 8 providers, simplify the manual block.
- Test count **1,259 → 1,269** (README, introduction.md, distro-support.md).
- **architecture.md**: list all 8 provider adapters.

Pre-commit ran fmt + 1269 Rust tests; 28 setup tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)