### PR TITLE
fix: implement 2-part main review findings (wizard + daemon + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,269 Rust tests and 72 frontend tests** form the current deterministic
+**1,270 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -1526,7 +1526,19 @@ async fn handle_preview(
         request_hash: sysknife_types::RequestHash::new(request_hash.to_string()),
     };
 
-    let preview = preview_action(&envelope, current_state, proposed_change);
+    // If state collection failed above, current_state is Null (collect_state
+    // never yields null on success). Surface that in the client-visible
+    // warnings — not just daemon stderr — so a human approving a high-risk
+    // action knows the "current state" backing this preview is missing.
+    let state_unavailable = current_state.is_null();
+    let mut preview = preview_action(&envelope, current_state, proposed_change);
+    if state_unavailable {
+        preview.warnings.push(
+            "System state could not be collected; this preview was generated without it. \
+             Review the action carefully before approving."
+                .to_string(),
+        );
+    }
 
     // Persist a pending transaction so execute can verify a prior preview.
     let new_tx = NewTransaction {

--- a/crates/sysknife-daemon/src/main.rs
+++ b/crates/sysknife-daemon/src/main.rs
@@ -11,6 +11,11 @@ use sysknife_daemon::transport::listen::{bind_unix_listener, ListenTarget};
 use tokio::net::UnixListener;
 use tokio::sync::Semaphore;
 
+/// How often the daemon sweeps `Queued` transactions that outlived the approval
+/// TTL and cancels them. A third of the 15-minute TTL, so an abandoned preview
+/// clears within ~5 min of expiry without hammering the store.
+const STALE_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
+
 /// Maximum number of concurrent IPC connections the daemon accepts.
 ///
 /// Each shell instance opens one connection per plan step. 16 slots allow
@@ -94,6 +99,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
 
     eprintln!("[sysknife-daemon] listening on {listen_uri}");
+
+    // Periodically cancel Queued transactions that outlived the approval TTL, so
+    // an abandoned preview does not linger forever as a phantom "queued" row in
+    // `sysknife history`. cleanup_stale_queued only touches expired Queued rows
+    // (never Running/Approved) — see the transactions.rs regression tests.
+    {
+        let sweep = state.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(STALE_SWEEP_INTERVAL);
+            loop {
+                ticker.tick().await;
+                match sweep.audit.cleanup_stale_queued().await {
+                    Ok(n) if n > 0 => {
+                        eprintln!(
+                            "[sysknife-daemon] swept {n} stale queued transaction(s) past TTL"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => eprintln!("[sysknife-daemon] stale-queued sweep failed: {e}"),
+                }
+            }
+        });
+    }
 
     match listen_target {
         ListenTarget::Unix(path) => {

--- a/crates/sysknife-daemon/src/state_collector.rs
+++ b/crates/sysknife-daemon/src/state_collector.rs
@@ -51,6 +51,29 @@ impl CommandRunner for RealCommandRunner {
     }
 }
 
+/// Run a best-effort state probe, returning the parsed value or its default.
+///
+/// A missing binary (`NotFound`) is expected on distros that don't ship the
+/// tool (e.g. `rpm-ostree`/`toolbox` on Ubuntu), so it stays quiet. Any other
+/// error means the tool exists but the probe broke — log it (instead of
+/// silently swallowing) so an operator can tell "genuinely empty" from
+/// "collection failed".
+fn probe_or_warn<T: Default>(
+    label: &str,
+    result: Result<String, io::Error>,
+    parse: impl FnOnce(&str) -> T,
+) -> T {
+    match result {
+        Ok(s) => parse(&s),
+        Err(e) => {
+            if e.kind() != io::ErrorKind::NotFound {
+                eprintln!("[sysknife-daemon] state: {label} probe failed ({e}); reporting empty");
+            }
+            T::default()
+        }
+    }
+}
+
 /// Collect a system state snapshot using the provided runner.
 ///
 /// Only `host_name` is required. All other fields (`deployment`, `services`,
@@ -67,16 +90,18 @@ pub fn collect_state(runner: &dyn CommandRunner) -> Result<CollectedState, Colle
         })?;
 
     // Call rpm-ostree once and reuse for both deployment and layered_packages.
-    let rpm_ostree_output = runner
-        .run("rpm-ostree", &["status", "--booted", "--json"])
-        .map(|s| s.trim().to_string())
-        .unwrap_or_default();
+    let rpm_ostree_output = probe_or_warn(
+        "rpm-ostree",
+        runner.run("rpm-ostree", &["status", "--booted", "--json"]),
+        |s| s.trim().to_string(),
+    );
 
     let deployment = parse_deployment_summary(&rpm_ostree_output);
     let layered_packages = parse_layered_packages(&rpm_ostree_output);
 
-    let services = runner
-        .run(
+    let services = probe_or_warn(
+        "systemctl",
+        runner.run(
             "systemctl",
             &[
                 "list-units",
@@ -86,29 +111,33 @@ pub fn collect_state(runner: &dyn CommandRunner) -> Result<CollectedState, Colle
                 "--no-pager",
                 "--plain",
             ],
-        )
-        .map(|s| parse_service_lines(&s))
-        .unwrap_or_default();
+        ),
+        parse_service_lines,
+    );
 
-    let flatpaks = runner
-        .run("flatpak", &["list", "--columns=application"])
-        .map(|s| parse_lines(&s))
-        .unwrap_or_default();
+    let flatpaks = probe_or_warn(
+        "flatpak",
+        runner.run("flatpak", &["list", "--columns=application"]),
+        parse_lines,
+    );
 
-    let toolboxes = runner
-        .run("toolbox", &["list", "--containers"])
-        .map(|s| parse_lines(&s))
-        .unwrap_or_default();
+    let toolboxes = probe_or_warn(
+        "toolbox",
+        runner.run("toolbox", &["list", "--containers"]),
+        parse_lines,
+    );
 
-    let containers = runner
-        .run("podman", &["ps", "--format", "{{.Names}}"])
-        .map(|s| parse_lines(&s))
-        .unwrap_or_default();
+    let containers = probe_or_warn(
+        "podman",
+        runner.run("podman", &["ps", "--format", "{{.Names}}"]),
+        parse_lines,
+    );
 
-    let users = runner
-        .run("getent", &["passwd", "--service", "files"])
-        .map(|s| parse_local_users(&s))
-        .unwrap_or_default();
+    let users = probe_or_warn(
+        "getent",
+        runner.run("getent", &["passwd", "--service", "files"]),
+        parse_local_users,
+    );
 
     Ok(CollectedState {
         host_name,

--- a/crates/sysknife-daemon/tests/preview_state_warning.rs
+++ b/crates/sysknife-daemon/tests/preview_state_warning.rs
@@ -1,0 +1,75 @@
+//! Regression test for the silent-failure review finding: when daemon state
+//! collection fails, the preview must carry a **client-visible** warning (not
+//! just a daemon-stderr log), so a human approving a high-risk action knows the
+//! "current state" backing the preview is missing rather than genuinely empty.
+
+use std::io;
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+use sysknife_daemon::dispatcher::connection_handler_with_executor;
+use sysknife_daemon::executor::{ActionExecutor, RealActionExecutor};
+use sysknife_daemon::state::{DaemonConfig, DaemonState};
+use sysknife_daemon::state_collector::CommandRunner;
+use sysknife_daemon::transport::{framing::FramedStream, listen::ListenTarget};
+use sysknife_types::CallerRole;
+use tempfile::tempdir;
+use tokio::net::UnixStream;
+
+/// `hostname` fails, which makes `collect_state` return an error, so the preview
+/// is generated with an empty (Null) `current_state`. Every other probe succeeds
+/// so only the state-collection failure is under test.
+struct FailingHostnameRunner;
+
+impl CommandRunner for FailingHostnameRunner {
+    fn run(&self, program: &str, _args: &[&str]) -> Result<String, io::Error> {
+        match program {
+            "hostname" => Err(io::Error::other("hostname unavailable in test")),
+            "rpm-ostree" => Ok("{}".to_string()),
+            _ => Ok(String::new()),
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn preview_warns_when_state_collection_fails() {
+    let dir = tempdir().unwrap();
+    let config = DaemonConfig::new(
+        ListenTarget::Unix(dir.path().join("preview-warn.sock")),
+        dir.path().join("preview-warn.db"),
+    );
+    let state = DaemonState::open(config).unwrap();
+
+    let (client, server) = UnixStream::pair().unwrap();
+    let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(FailingHostnameRunner);
+    let executor: Arc<dyn ActionExecutor> = Arc::new(RealActionExecutor);
+    tokio::spawn(async move {
+        connection_handler_with_executor(server, state, runner, executor, CallerRole::Admin).await;
+    });
+    let mut framed = FramedStream::new(client);
+
+    let req = json!({
+        "type": "preview",
+        "request_id": "preview-warn-1",
+        "action_name": "GetSystemState",
+        "params": {},
+    });
+    framed
+        .send(&serde_json::to_vec(&req).unwrap())
+        .await
+        .unwrap();
+
+    let resp: Value = serde_json::from_slice(&framed.recv().await.unwrap()).unwrap();
+    assert_eq!(resp["type"], "preview_response", "got: {resp}");
+
+    let warnings = resp["preview"]["warnings"]
+        .as_array()
+        .expect("preview.warnings should be an array");
+    assert!(
+        warnings.iter().any(|w| w
+            .as_str()
+            .unwrap_or("")
+            .contains("System state could not be collected")),
+        "expected a state-unavailable warning in the preview, got: {warnings:?}"
+    );
+}

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,7 +1,10 @@
 # SysKnife Action Reference
 
-All 78 daemon actions, their underlying commands, whether they are
-destructive, and what they do.
+The Fedora / rpm-ostree (atomic-host) action family — each action's underlying
+command, whether it is destructive, and what it does. Ubuntu-family actions
+(apt, snap, ufw, netplan, distrobox, …) are documented in the
+[Ubuntu action reference](ubuntu-action-reference.md). Across all families
+SysKnife defines 140+ typed actions.
 
 > **Destructive** — mutates persistent system state (package installs,
 > deployment changes, user/group writes, firewall rules, reboots).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -270,6 +270,10 @@ to override.
 | `ANTHROPIC_API_KEY` | Use the Anthropic provider (default model: `claude-sonnet-4-6`) |
 | `OPENAI_API_KEY` | Use the OpenAI provider (default model: `gpt-4.1`) |
 | `GEMINI_API_KEY` | Use the Gemini provider (default model: `gemini-2.0-flash`) |
+| `GROQ_API_KEY` | Use the Groq provider (default model: `llama-3.3-70b-versatile`) |
+| `DEEPSEEK_API_KEY` | Use the DeepSeek provider (default model: `deepseek-chat`) |
+| `MISTRAL_API_KEY` | Use the Mistral provider (default model: `mistral-large-latest`) |
+| `XAI_API_KEY` | Use the xAI provider (default model: `grok-3`) |
 | `SYSKNIFE_ANTHROPIC_URL` | Override the Anthropic base URL (default: `https://api.anthropic.com`) |
 | `SYSKNIFE_OLLAMA_URL` | Override the Ollama base URL (default: `http://localhost:11434`) |
 | `SYSKNIFE_BRAIN_MAX_TURNS` | Planning loop turn limit — integer ≥ 1 (default: `10`) |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -162,25 +162,29 @@ socket   = "/run/sysknife/daemon.sock"    # raw path, not URI
 database = "/var/lib/sysknife/daemon.sqlite"
 
 [llm]
-provider   = "ollama"                 # "ollama" | "anthropic"
+provider   = "ollama"                 # ollama | anthropic | openai | gemini | groq | deepseek | mistral | xai
 model      = "llama3.2:3b"
 ollama_url = "http://localhost:11434"
-max_turns  = 5
+max_turns  = 10
 ```
 
 Config file values act as defaults. Environment variables always win.
 
 | Variable | Default | Description |
 |---|---|---|
-| `SYSKNIFE_LISTEN_URI` | `unix:///tmp/sysknife-daemon.sock` | Daemon socket path |
-| `SYSKNIFE_DATABASE_PATH` | `/tmp/sysknife-daemon.sqlite` | SQLite database path |
-| `SYSKNIFE_LLM_PROVIDER` | auto-detect | `anthropic`, `openai`, `gemini`, or `ollama` |
+| `SYSKNIFE_LISTEN_URI` | `$XDG_RUNTIME_DIR/sysknife/daemon.sock` (prod: `/run/sysknife/daemon.sock`) | Daemon socket URI |
+| `SYSKNIFE_DATABASE_PATH` | `$XDG_STATE_HOME/sysknife/daemon.sqlite` (fallback `~/.local/state/sysknife/daemon.sqlite`) | SQLite database path |
+| `SYSKNIFE_LLM_PROVIDER` | auto-detect | `anthropic`, `openai`, `gemini`, `ollama`, `groq`, `deepseek`, `mistral`, or `xai` |
 | `ANTHROPIC_API_KEY` | — | Required for the Anthropic provider |
 | `OPENAI_API_KEY` | — | Required for the OpenAI provider |
 | `GEMINI_API_KEY` | — | Required for the Gemini provider |
+| `GROQ_API_KEY` | — | Required for the Groq provider |
+| `DEEPSEEK_API_KEY` | — | Required for the DeepSeek provider |
+| `MISTRAL_API_KEY` | — | Required for the Mistral provider |
+| `XAI_API_KEY` | — | Required for the xAI provider |
 | `SYSKNIFE_OLLAMA_URL` | `http://localhost:11434` | Ollama base URL |
 | `SYSKNIFE_LLM_MODEL` | provider default | Override the model name |
-| `SYSKNIFE_BRAIN_MAX_TURNS` | `5` | Planning loop turn limit |
+| `SYSKNIFE_BRAIN_MAX_TURNS` | `10` | Planning loop turn limit |
 
 ## User Preferences
 

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -26,7 +26,7 @@ release.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** until variant-specific VM evidence exists |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,269 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,270 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -117,7 +117,7 @@ SysKnife auto-detects it. See [Quick Start](quickstart.md).
 
 ## Status
 
-140+ typed actions · 1,269 Rust tests + 72 frontend tests · MIT
+140+ typed actions · 1,270 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -21,7 +21,9 @@
     "index.js",
     "install-binary.js",
     "install-daemon.js",
-    "mcp-launcher.js"
+    "mcp-config.js",
+    "mcp-launcher.js",
+    "providers.js"
   ],
   "keywords": [
     "sysknife",

--- a/packages/setup/providers.js
+++ b/packages/setup/providers.js
@@ -35,7 +35,7 @@ const PROVIDERS = [
 const MODEL_DEFAULTS = {
   openai:   'gpt-4.1',
   anthropic:'claude-sonnet-4-6',
-  gemini:   'gemini-2.5-pro',
+  gemini:   'gemini-2.0-flash',
   ollama:   'qwen3:8b',
   groq:     'llama-3.3-70b-versatile',
   deepseek: 'deepseek-chat',

--- a/packages/setup/tests/package-files.test.mjs
+++ b/packages/setup/tests/package-files.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const setupDir = path.resolve(here, '..');
+const pkg = require('../package.json');
+
+// A published npm tarball ships only the paths in `files`. If an entrypoint
+// require()s a local module that isn't listed, `npx sysknife-setup` crashes on
+// first run with "Cannot find module" — and CI never catches it because CI runs
+// from the git checkout where every file is present. Guard the whole require
+// graph of the bin entrypoints, not just individual known modules.
+
+/** Local `require('./x.js')` specifiers in a source file. */
+function localRequires(file) {
+  const src = fs.readFileSync(path.join(setupDir, file), 'utf8');
+  const out = [];
+  const re = /require\(\s*'(\.\/[^']+)'\s*\)/g;
+  let m;
+  while ((m = re.exec(src)) !== null) out.push(m[1].replace(/^\.\//, ''));
+  return out;
+}
+
+test('every local module required by a bin entrypoint is in package.json files', () => {
+  const files = new Set(pkg.files);
+  const entrypoints = Object.values(pkg.bin); // index.js, mcp-launcher.js
+  for (const entry of entrypoints) {
+    assert.ok(files.has(entry), `bin entrypoint "${entry}" missing from files`);
+    for (const dep of localRequires(entry)) {
+      assert.ok(
+        files.has(dep),
+        `"${entry}" requires "./${dep}" but it is not in package.json files — the published package would crash`,
+      );
+    }
+  }
+});
+
+test('the extracted modules are packaged', () => {
+  // Explicit belt-and-suspenders for the two modules whose omission crashed the
+  // published wizard (mcp-config.js from the merge fix, providers.js from the
+  // 8-provider extraction).
+  assert.ok(pkg.files.includes('mcp-config.js'));
+  assert.ok(pkg.files.includes('providers.js'));
+});

--- a/packages/setup/tests/providers.test.mjs
+++ b/packages/setup/tests/providers.test.mjs
@@ -42,8 +42,14 @@ test('maps each new provider to its engine API-key env var', () => {
   assert.equal(API_KEY_VARS.ollama, null);
 });
 
-test('new provider model defaults match the engine defaults', () => {
-  // Must equal DEFAULT_*_MODEL in crates/sysknife-brain/src/config.rs.
+test('all eight model defaults match the engine defaults', () => {
+  // Must equal the DEFAULT_*_MODEL constants in
+  // crates/sysknife-brain/src/config.rs (all 8, not just the new 4 — a stale
+  // pre-existing default is drift too).
+  assert.equal(MODEL_DEFAULTS.openai, 'gpt-4.1');
+  assert.equal(MODEL_DEFAULTS.anthropic, 'claude-sonnet-4-6');
+  assert.equal(MODEL_DEFAULTS.gemini, 'gemini-2.0-flash');
+  assert.equal(MODEL_DEFAULTS.ollama, 'qwen3:8b');
   assert.equal(MODEL_DEFAULTS.groq, 'llama-3.3-70b-versatile');
   assert.equal(MODEL_DEFAULTS.deepseek, 'deepseek-chat');
   assert.equal(MODEL_DEFAULTS.mistral, 'mistral-large-latest');


### PR DESCRIPTION
Two-part sonnet review over `main` (Part A Rust engine/daemon, Part B wizard/build/docs). **No critical security issues** — auth, approval-receipt TTL/replay, and the audit chain were all verified fail-closed.

## Implemented

**Wizard (2 critical)**
- `package.json` `files` omitted `providers.js` **and** `mcp-config.js` → the *published* npm package crashed on first run (`Cannot find module`); CI never caught it because it tests from the checkout. Added both + a require-graph parity test.
- `providers.js` gemini default `gemini-2.5-pro` → `gemini-2.0-flash` to match the engine; the test now pins all 8 model defaults.

**Daemon (2 medium + 1 dead-code)**
- `state_collector`: log when a *present* tool's probe fails (was silently swallowed); stay quiet for legitimately-absent tools (`NotFound`) so Ubuntu isn't spammed for rpm-ostree/toolbox.
- `handle_preview`: surface a **client-visible** warning when state collection fails (was daemon-stderr only) — matters for high-risk approvals. Regression test **verified to fail without the fix**.
- `main.rs`: wire the periodic `cleanup_stale_queued` sweep (implemented + tested but never called) so abandoned previews don't linger as phantom "queued" rows.

**Docs (drift #43 missed)**
- `developer-guide.md`: 4→8 providers + key vars, `max_turns` 5→10, XDG socket/db defaults.
- `cli.md`: +4 API-key rows. `actions.md`: "All 78" → Fedora-family scope + cross-link + 140+ total.
- Rust test count 1,269 → **1,270** (this PR adds one test).

## Deferred (documented)
- A `sysknife cancel` CLI/MCP verb — the sweep now auto-resolves the stale-queued UX gap; exposing the existing IPC verb is a clean follow-up.
- 3 LOW polish items: watermark message wording, JobProgress send-log consistency, an unreachable rig-adapter message drop.

Local: fmt + clippy `-D warnings` + 1270 nextest + 30 setup tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)