### PR TITLE
fix(ci): update public-claims test baseline 1,259 → 1,270

### DIFF
--- a/scripts/check_public_claims.sh
+++ b/scripts/check_public_claims.sh
@@ -29,8 +29,8 @@ reject_pattern() {
     fi
 }
 
-reject_pattern '1,2(2[7-9]|3[0-9]|4[0-9]|5[0-8])( Rust)? tests' \
-    'test count is stale; the release baseline is 1,259 Rust tests' \
+reject_pattern '1,2(2[7-9]|[3-5][0-9]|6[0-9])( Rust)? tests' \
+    'test count is stale; the release baseline is 1,270 Rust tests' \
     "${claim_files[@]}"
 reject_pattern 'until npm publish lands|publish[- ]pending' \
     'setup package is documented as unpublished' "${claim_files[@]}"
@@ -60,8 +60,8 @@ required_test_count_docs=(
     "$repo_root/docs/distro-support.md"
 )
 for path in "${required_test_count_docs[@]}"; do
-    if ! grep -Fq '1,259 Rust tests' "$path"; then
-        printf 'Verified test baseline missing from %s: expected 1,259 Rust tests\n' \
+    if ! grep -Fq '1,270 Rust tests' "$path"; then
+        printf 'Verified test baseline missing from %s: expected 1,270 Rust tests\n' \
             "$path" >&2
         exit 1
     fi

--- a/tests/release/public-claims.test.sh
+++ b/tests/release/public-claims.test.sh
@@ -47,7 +47,7 @@ assert_rejected() {
     fi
 }
 
-sed -i 's/1,259 Rust tests/1,256 Rust tests/' "$fixture/README.md"
+sed -i 's/1,270 Rust tests/1,256 Rust tests/' "$fixture/README.md"
 assert_rejected 'old test count'
 cp "$repo_root/README.md" "$fixture/README.md"
 


### PR DESCRIPTION
PR #44 bumped the Rust test count to 1,270 in README/introduction/distro-support but left `scripts/check_public_claims.sh`'s hardcoded baseline at 1,259, so the `docs-and-hygiene` gate (`public-claims.test.sh` + `release-rehearsal.test.sh`) failed on main — visible as docs-and-hygiene FAILURE on every dependabot PR opened afterward. #44's admin-merge skipped CI, so it surfaced only later.

- Required-baseline grep + messages → `1,270 Rust tests`
- Stale-count reject range widened to 1,227–1,269 (anything below the new baseline; excludes 1,270)
- Fixture-staleness `sed` retargeted to the new baseline

Verified locally: `public-claims.test.sh`, `release-rehearsal.test.sh`, and `check_public_claims.sh` all pass; no `1,259` remains anywhere. Pre-commit ran 1270 nextest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)