### PR TITLE
chore(deps): bump serde_with; triage remaining dependabot alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4333,11 +4342,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4352,9 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",


### PR DESCRIPTION
Takes care of the 11 open dependabot alerts.

**Fixed in code**
- `serde_with` 3.18.0 → 3.21.0 (clears the advisory; semver-compatible transitive bump via tauri-utils; workspace builds unchanged, 1283 tests pass).

**Already fixed (stale alerts, dismissed as `not_used`)**
- The 9 `vite` / `undici` alerts referenced `apps/sysknife-shell/pnpm-lock.yaml`, which no longer exists — the frontend uses npm. The live `package-lock.json` already carries **vite 8.1.5** (>8.0.15) and **undici 7.28.0** (patched); `npm audit` reports **0 vulnerabilities**, and the frontend's 72 tests + build pass.

**Won't-fix, dismissed as `tolerable_risk`**
- `glib` 0.18.5 is pinned by `gtk 0.18` in the **frozen, unshipped** Tauri GUI (`apps/sysknife-shell`); 0.20 needs a Tauri/gtk-rs major upgrade. Medium severity, no effect on the shipped CLI/daemon artifacts. Tracked for the eventual Tauri upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)