### PR TITLE
feat(actions): sysctl kernel-parameter family (#67)

### DIFF
--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -161,6 +161,11 @@ pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
      "create a new logical volume in a volume group (lvcreate) — params: vg*, name*, size* (e.g. '20G'); High risk"),
     ("CreateLvSnapshot",
      "snapshot a logical volume before risky changes (lvcreate -s) — params: vg*, origin* (LV to snapshot), snapshot* (new name), size* (copy-on-write reserve, e.g. '5G'); High risk"),
+    // Kernel / sysctl
+    ("GetSysctl",
+     "read a kernel parameter (sysctl) — param: key (optional, dotted e.g. 'net.ipv4.ip_forward'; omit to dump all); read-only"),
+    ("SetSysctl",
+     "set AND persist a kernel parameter (runtime + /etc/sysctl.d drop-in) — params: key* (dotted, e.g. 'vm.swappiness'), value* (number or space-separated list); High risk"),
     // Identity / time / locale
     ("GetDateTime",
      "current date, time, timezone, and NTP status (timedatectl) — no params"),

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -421,7 +421,7 @@ GetNetworkStatus, GetDiskUsage, GetDateTime, ListProcesses, GetMemoryInfo,
 GetAuthorizedKeys, ListPackageRepositories, ListContainers, GetContainerInfo,
 ListUsers, ListGroups, ListJobHistory,
 ResolvectlStatus,
-GetJournalLog, GetLvmReport
+GetJournalLog, GetLvmReport, GetSysctl
 
 ### Medium risk — cross-distro (approval required before execution)
 
@@ -444,7 +444,8 @@ CreateUser
 RebootSystem,
 AddUserToGroup, RemoveUserFromGroup, DeleteUser,
 AddAuthorizedKey, RemoveAuthorizedKey,
-ExtendLogicalVolume, CreateLogicalVolume, CreateLvSnapshot
+ExtendLogicalVolume, CreateLogicalVolume, CreateLvSnapshot,
+SetSysctl
 
 ## Risk classification rules
 
@@ -528,6 +529,10 @@ Use `"username"` as the key — NOT `"user"`.
 - `ExtendLogicalVolume`: `{"vg":"ubuntu-vg","lv":"ubuntu-lv","size":"+10G"}` — grows the LV **and** its filesystem; `size` is `+N<unit>` to add or `N<unit>` absolute.
 - `CreateLogicalVolume`: `{"vg":"ubuntu-vg","name":"data","size":"20G"}`.
 - `CreateLvSnapshot`: `{"vg":"ubuntu-vg","origin":"ubuntu-lv","snapshot":"ubuntu-lv-snap","size":"5G"}` — `size` is the copy-on-write reserve.
+
+**Kernel / sysctl**:
+- `GetSysctl`: `{"key":"net.ipv4.ip_forward"}` (omit `key` to dump the whole table).
+- `SetSysctl`: `{"key":"vm.swappiness","value":"10"}` — applies immediately and persists; `value` is a number or space-separated list.
 
 **Users and groups**:
 - `CreateUser`: `{"username":"alice"}` (optional: `"shell"`, `"home"`)

--- a/crates/sysknife-daemon/src/actions/mod.rs
+++ b/crates/sysknife-daemon/src/actions/mod.rs
@@ -28,6 +28,7 @@ pub mod resolvectl;
 pub mod services;
 pub mod snap;
 pub mod ssh;
+pub mod sysctl;
 pub mod system_info;
 pub mod toolbox;
 pub mod ubuntu_pro;

--- a/crates/sysknife-daemon/src/actions/sysctl.rs
+++ b/crates/sysknife-daemon/src/actions/sysctl.rs
@@ -1,0 +1,103 @@
+//! sysctl kernel-parameter actions.
+//!
+//! `GetSysctl` is a read-only query of one key (or the full table); `SetSysctl`
+//! changes a kernel parameter at runtime **and** persists it for the next boot.
+//!
+//! The read runs `sysctl` directly (the daemon is root). The write goes through
+//! the root-owned helper `/usr/lib/sysknife/sysctl-edit`, which applies the
+//! value with `sysctl -w` and rewrites the `/etc/sysctl.d/60-sysknife.conf`
+//! drop-in idempotently — a narrow sudoers grant, not a bare `sysctl` grant, so
+//! the daemon cannot use `sysctl -p <arbitrary-file>` to load an attacker file.
+
+use super::{command_mechanism, ActionSpec};
+use sysknife_types::RiskLevel;
+
+pub fn specs() -> Vec<ActionSpec> {
+    vec![
+        get_sysctl(Some("net.ipv4.ip_forward")),
+        set_sysctl("net.ipv4.ip_forward", "1"),
+    ]
+}
+
+/// Read one kernel parameter (`sysctl -- <key>`) or, when `key` is `None`, the
+/// entire table (`sysctl -a`). Read-only.
+///
+/// The `--` guard means a key can never be reparsed as an option even though
+/// the validator already forbids a leading dash.
+pub fn get_sysctl(key: Option<&str>) -> ActionSpec {
+    let args = match key {
+        Some(k) => vec!["--".to_string(), k.to_string()],
+        None => vec!["-a".to_string()],
+    };
+    ActionSpec {
+        action_name: "GetSysctl",
+        mechanism: command_mechanism("sysctl", args),
+        risk_level: RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Set and persist a kernel parameter via the scoped helper.
+pub fn set_sysctl(key: &str, value: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "SetSysctl",
+        mechanism: command_mechanism(
+            "sudo",
+            [
+                "/usr/lib/sysknife/sysctl-edit",
+                "--key",
+                key,
+                "--value",
+                value,
+            ],
+        ),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::ActionMechanism;
+
+    fn args_of(spec: &ActionSpec) -> (&'static str, Vec<String>) {
+        match &spec.mechanism {
+            ActionMechanism::Command { program, args } => (program, args.clone()),
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_one_key_uses_dash_dash_guard() {
+        let (program, args) = args_of(&get_sysctl(Some("net.ipv4.ip_forward")));
+        assert_eq!(program, "sysctl");
+        assert_eq!(args, vec!["--", "net.ipv4.ip_forward"]);
+    }
+
+    #[test]
+    fn get_all_uses_minus_a() {
+        let (_, args) = args_of(&get_sysctl(None));
+        assert_eq!(args, vec!["-a"]);
+    }
+
+    #[test]
+    fn set_delegates_to_scoped_helper() {
+        let spec = set_sysctl("vm.swappiness", "10");
+        let (program, args) = args_of(&spec);
+        assert_eq!(program, "sudo");
+        assert_eq!(
+            args,
+            vec![
+                "/usr/lib/sysknife/sysctl-edit",
+                "--key",
+                "vm.swappiness",
+                "--value",
+                "10"
+            ]
+        );
+        assert_eq!(spec.risk_level, RiskLevel::High);
+    }
+}

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -423,6 +423,46 @@ pub fn validated_journal_grep(s: &str, param: &'static str) -> Result<String, Ex
     Ok(s.to_string())
 }
 
+/// Validate a sysctl key in dotted form (`net.ipv4.ip_forward`, `vm.swappiness`).
+///
+/// First character must be alphanumeric (blocks the leading-dash
+/// option-injection vector); the rest is `[a-z0-9._-]`. Slashes are rejected —
+/// SysKnife always uses the dotted form, never `net/ipv4/...`. Length ≤ 128.
+/// Mirrors `KEY_RE` in `packaging/sysknife-sysctl-edit`.
+pub fn validated_sysctl_key(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s.is_empty() || s.len() > 128 {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    let first = s.chars().next().unwrap();
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
+/// Validate a sysctl value: printable, no control characters, from a
+/// numeric/token/list allowlist (sysctl values are numbers or space-separated
+/// lists such as `4096 87380 6291456`). Length 1..=200. Mirrors `VALUE_RE` in
+/// `packaging/sysknife-sysctl-edit`.
+pub fn validated_sysctl_value(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s.is_empty() || s.len() > 200 {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, ' ' | '.' | '_' | '/' | ':' | ',' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1010,5 +1050,28 @@ mod tests {
         assert!(validated_journal_grep("err.*fatal", "grep").is_ok());
         assert!(validated_journal_grep("bad\nline", "grep").is_err());
         assert!(validated_journal_grep("", "grep").is_err());
+    }
+
+    // ── sysctl validators ─────────────────────────────────────────────────
+
+    #[test]
+    fn sysctl_key_accepts_dotted_and_rejects_injection() {
+        assert!(validated_sysctl_key("net.ipv4.ip_forward", "key").is_ok());
+        assert!(validated_sysctl_key("vm.swappiness", "key").is_ok());
+        assert!(validated_sysctl_key("kernel.kptr_restrict", "key").is_ok());
+        assert!(validated_sysctl_key("-net.ipv4.ip_forward", "key").is_err()); // injection
+        assert!(validated_sysctl_key("net/ipv4/ip_forward", "key").is_err()); // slash form
+        assert!(validated_sysctl_key("Net.Ipv4", "key").is_err()); // uppercase
+        assert!(validated_sysctl_key("", "key").is_err());
+    }
+
+    #[test]
+    fn sysctl_value_accepts_numbers_and_lists() {
+        assert!(validated_sysctl_value("1", "value").is_ok());
+        assert!(validated_sysctl_value("4096 87380 6291456", "value").is_ok()); // multi-value
+        assert!(validated_sysctl_value("kernel.core", "value").is_ok());
+        assert!(validated_sysctl_value("bad\nvalue", "value").is_err());
+        assert!(validated_sysctl_value("v$(id)", "value").is_err()); // shell metachar
+        assert!(validated_sysctl_value("", "value").is_err());
     }
 }

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -1,13 +1,14 @@
 use crate::actions::{
     apparmor, apt, cloudinit, containers, deployment, distrobox, fail2ban, filesystem, flatpak,
     grub, identity, journald, layering, livepatch, lvm, multipass, netplan, network, package_repos,
-    ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh, system_info, toolbox,
-    ubuntu_pro, ufw, users,
+    ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh, sysctl, system_info,
+    toolbox, ubuntu_pro, ufw, users,
     validate::{
         validated_apparmor_profile, validated_group, validated_hostname, validated_journal_grep,
         validated_journal_priority, validated_journal_time, validated_locale, validated_lvm_name,
         validated_lvm_size, validated_port_or_service, validated_ppa_name, validated_safe_arg,
-        validated_timezone, validated_unit_name, validated_username,
+        validated_sysctl_key, validated_sysctl_value, validated_timezone, validated_unit_name,
+        validated_username,
     },
     ActionMechanism, ActionSpec,
 };
@@ -588,6 +589,18 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
             let snapshot = validated_lvm_name(require_str(params, "snapshot")?, "snapshot")?;
             let size = validated_lvm_size(require_str(params, "size")?, "size")?;
             Ok(lvm::create_lv_snapshot(&vg, &origin, &snapshot, &size))
+        }
+
+        // ── Kernel / sysctl ─────────────────────────────────────────────────
+        "GetSysctl" => {
+            // `key` is optional — absent means dump the whole table (sysctl -a).
+            let key = optional_validated(params, "key", validated_sysctl_key)?;
+            Ok(sysctl::get_sysctl(key.as_deref()))
+        }
+        "SetSysctl" => {
+            let key = validated_sysctl_key(require_str(params, "key")?, "key")?;
+            let value = validated_sysctl_value(require_str(params, "value")?, "value")?;
+            Ok(sysctl::set_sysctl(&key, &value))
         }
 
         // ── System info ──────────────────────────────────────────────────

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -60,6 +60,8 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "GetJournalLog"
         // ── Storage / LVM read-only ───────────────────────────────────────
         | "GetLvmReport"
+        // ── Kernel / sysctl read-only ─────────────────────────────────────
+        | "GetSysctl"
         | "GetAuthorizedKeys"
         | "ListUsers"
         | "ListGroups"
@@ -231,6 +233,12 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "ExtendLogicalVolume"
         | "CreateLogicalVolume"
         | "CreateLvSnapshot"
+        // ── Kernel / sysctl mutation ──────────────────────────────────────
+        //
+        // SetSysctl changes a live kernel parameter and persists it. A wrong
+        // net.* / vm.* / kernel.* value can degrade networking, memory
+        // behaviour, or security posture, so it is Admin/High.
+        | "SetSysctl"
         | "DeleteUser"
         | "AddAuthorizedKey"
         | "RemoveAuthorizedKey"

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -90,6 +90,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "GetListeningPorts"
         | "GetJournalLog"
         | "GetLvmReport"
+        | "GetSysctl"
         | "GetAuthorizedKeys"
         | "GetDateTime"
         | "ListJobHistory"
@@ -366,6 +367,21 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             rollback_available: false,
             warnings: vec![
                 "consumes VG capacity; snapshots fill as the origin changes".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── Kernel / sysctl mutation ──────────────────────────────────────
+        "SetSysctl" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "a kernel parameter will change immediately".to_string(),
+                "the value will persist across reboots (/etc/sysctl.d)".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "a wrong net.*/vm.*/kernel.* value can degrade or lock the host".to_string(),
                 "exact approval required".to_string(),
             ],
         },

--- a/crates/sysknife-daemon/tests/action_consistency.rs
+++ b/crates/sysknife-daemon/tests/action_consistency.rs
@@ -14,8 +14,8 @@ use sysknife_brain::planning_tools::propose_plan::KNOWN_ACTIONS;
 use sysknife_daemon::actions::{
     apparmor, apt, cloudinit, containers, deployment, distrobox, fail2ban, filesystem, flatpak,
     grub, identity, journald, layering, livepatch, lvm, multipass, netplan, network, package_repos,
-    ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh, system_info, toolbox,
-    ubuntu_pro, ufw, users,
+    ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh, sysctl, system_info,
+    toolbox, ubuntu_pro, ufw, users,
 };
 use sysknife_daemon::executor::build_action_spec;
 use sysknife_daemon::policy::min_role_for_action;
@@ -65,6 +65,9 @@ fn all_spec_action_names() -> BTreeSet<&'static str> {
         names.insert(spec.action_name);
     }
     for spec in lvm::specs() {
+        names.insert(spec.action_name);
+    }
+    for spec in sysctl::specs() {
         names.insert(spec.action_name);
     }
     for spec in identity::specs() {

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -127,6 +127,9 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     "ExtendLogicalVolume",
     "CreateLogicalVolume",
     "CreateLvSnapshot",
+    // Kernel / sysctl (cross-distro)
+    "GetSysctl",
+    "SetSysctl",
     "GetDateTime",
     "SetHostname",
     "SetTimezone",

--- a/docs/typed-actions.md
+++ b/docs/typed-actions.md
@@ -53,7 +53,7 @@ codebase. On the daemon side (`sysknife-daemon`), each action is backed by an
 | `reboot_required` | Whether the daemon should warn the caller before proceeding |
 | `rollback_available` | Whether a failure triggers automatic rollback |
 
-As of this writing the catalogue defines **156 actions** across families such
+As of this writing the catalogue defines **158 actions** across families such
 as Deployment, Services, Package Layering, Flatpak, Containers, Toolbox,
 Network, Identity, SSH Keys, Package Repositories, apt/snap/ufw/netplan/grub
 (Debian-family), and rpm-ostree/AppArmor/cloud-init/Pro (Fedora-family). Each

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -26,7 +26,7 @@ system.
    `state.planner.plan_intent(intent)`.
 
 4. **LLM planning loop** (`crates/sysknife-brain/src/planner.rs:318`)
-   Turn 0: LLM receives system prompt (156-action catalogue, risk rules) +
+   Turn 0: LLM receives system prompt (158-action catalogue, risk rules) +
    user message. LLM calls `get_system_state`.
 
 5. **State injection** (`crates/sysknife-brain/src/planner.rs:366`)

--- a/packaging/sysknife-sudoers
+++ b/packaging/sysknife-sudoers
@@ -183,3 +183,12 @@ sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/sshd-option-edit *
 # validating the OnCalendar expression with systemd-analyze), writes a
 # service+timer unit pair, daemon-reloads, and enables+starts the timer.
 sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/scheduled-job-edit *
+
+# sysctl edit — SetSysctl delegates to this root-owned helper, which validates
+# the key (dotted form, no injection) and value (numeric/token allowlist),
+# applies it with `sysctl -w`, and persists a `key = value` line to
+# /etc/sysctl.d/60-sysknife.conf. A bare `sysctl` grant is deliberately NOT
+# given: `sysctl -p <file>` would let the daemon load an arbitrary attacker
+# file, so only this narrow helper path is allowed. GetSysctl reads via bare
+# `sysctl` (the daemon is root) and needs no grant.
+sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/sysctl-edit *

--- a/packaging/sysknife-sysctl-edit
+++ b/packaging/sysknife-sysctl-edit
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# sysknife-sysctl-edit — set a kernel parameter at runtime and persist it.
+#
+# Install to: /usr/lib/sysknife/sysctl-edit
+# Mode:       0755
+# Owner:      root:root
+#
+# Invoked exclusively by the sysknife-daemon via:
+#   sudo /usr/lib/sysknife/sysctl-edit --key <key> --value <value>
+#
+# The sudoers entry grants NOPASSWD only on this exact helper path. Both inputs
+# are re-validated here (defense-in-depth — the daemon validates them too):
+#   - key:   ^[a-z0-9][a-z0-9._-]*$  (dotted form, e.g. net.ipv4.ip_forward;
+#            no leading dash → no option injection, no slashes/spaces).
+#   - value: printable, no control characters, from a numeric/token/list
+#            allowlist (sysctl values are numbers or space-separated lists).
+#
+# Order of operations: apply at runtime FIRST (`sysctl -w key=value`) so an
+# invalid key or rejected value fails before anything is persisted; only then
+# rewrite the drop-in so a reboot re-applies the same value. The drop-in is
+# updated idempotently (an existing line for the same key is replaced, never
+# duplicated) and written atomically via a temp file + os.replace.
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+DROPIN = "/etc/sysctl.d/60-sysknife.conf"
+SYSCTL = "/usr/sbin/sysctl"
+
+KEY_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+VALUE_RE = re.compile(r"^[A-Za-z0-9 ._/:,-]{1,200}$")
+
+
+def die(msg: str) -> None:
+    print(f"sysknife-sysctl-edit: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Set and persist a sysctl key.")
+    parser.add_argument("--key", required=True)
+    parser.add_argument("--value", required=True)
+    args = parser.parse_args()
+
+    if not KEY_RE.match(args.key):
+        die(f"invalid sysctl key {args.key!r}")
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in args.value):
+        die("value contains control characters")
+    if not VALUE_RE.match(args.value):
+        die(f"invalid sysctl value {args.value!r}")
+
+    # Apply at runtime first — this validates the key exists and the value is
+    # acceptable to the kernel before we persist anything.
+    applied = subprocess.run(
+        [SYSCTL, "-w", "--", f"{args.key}={args.value}"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    if applied.returncode != 0:
+        die(f"failed to apply {args.key}: {applied.stderr.decode(errors='replace').strip()}")
+
+    # Persist: replace any existing line for this key, keep everything else.
+    existing = []
+    if os.path.exists(DROPIN):
+        try:
+            with open(DROPIN, "r") as fh:
+                existing = fh.readlines()
+        except OSError as exc:
+            die(f"cannot read {DROPIN}: {exc}")
+
+    def line_sets_key(line: str) -> bool:
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("#", ";")):
+            return False
+        name = stripped.split("=", 1)[0].strip()
+        return name == args.key
+
+    kept = [ln for ln in existing if not line_sets_key(ln)]
+    if kept and not kept[-1].endswith("\n"):
+        kept[-1] += "\n"
+    kept.append(f"{args.key} = {args.value}\n")
+
+    header = "# Managed by SysKnife (set_sysctl). Do not edit by hand.\n"
+    if not kept or kept[0] != header:
+        kept.insert(0, header)
+
+    try:
+        directory = os.path.dirname(DROPIN)
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=directory, prefix=".sysknife-sysctl-")
+        with os.fdopen(fd, "w") as fh:
+            fh.writelines(kept)
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, DROPIN)
+    except OSError as exc:
+        die(f"cannot persist to {DROPIN}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/ubuntu-provision.sh
+++ b/tests/e2e/ubuntu-provision.sh
@@ -246,6 +246,9 @@ install -Dm 755 packaging/sysknife-sshd-option-edit /usr/lib/sysknife/sshd-optio
 # scheduled-job-edit: invoked by CreateScheduledJob.
 install -Dm 755 packaging/sysknife-scheduled-job-edit /usr/lib/sysknife/scheduled-job-edit \
     || fail "Install sysknife-scheduled-job-edit"
+# sysctl-edit: invoked by SetSysctl.
+install -Dm 755 packaging/sysknife-sysctl-edit /usr/lib/sysknife/sysctl-edit \
+    || fail "Install sysknife-sysctl-edit"
 
 # ---------------------------------------------------------------------------
 # Step 6: Add VM user to sysknife groups


### PR DESCRIPTION
Batch 2 of the second gap-family wave. Adds **2 cross-distro actions** (156 → 158), verified end-to-end in the noble QEMU VM.

## Actions
- `GetSysctl` (Observer/Low) — read one key (`sysctl -- <key>`) or the whole table (`sysctl -a`). The `--` guard means a key can never be reparsed as an option.
- `SetSysctl` (Admin/High) — apply at runtime **and** persist, via the new root-owned helper `/usr/lib/sysknife/sysctl-edit`.

## Helper safety (`sysknife-sysctl-edit`)
- **Apply-before-persist**: runs `sysctl -w` first, so an invalid key or rejected value fails *before* anything is written to the drop-in (a bad line would otherwise fail every subsequent boot's `systemd-sysctl.service`).
- **Idempotent drop-in**: rewrites `/etc/sysctl.d/60-sysknife.conf`, replacing any existing line for the same key — never duplicating.
- **No bare `sysctl` grant**: `sysctl -p <file>` would let the daemon load an arbitrary file, so only the narrow helper path is in sudoers. New validators `validated_sysctl_key`/`_value` mirror the helper's regexes (defense-in-depth).

## Verification (Ubuntu 24.04, helper deployed into the VM)
- `GetSysctl`: reads a key + dumps 1008 keys.
- `SetSysctl`: `vm.swappiness` 60→55 at runtime + persisted with a managed header; a second set → **1** line, not 2.
- Rejections: injection key (`vm.swappiness; rm -rf /`), shell-metachar value (`x$(id)`), and nonexistent key are all refused; nothing persisted on failure.
- Local `cargo nextest run --workspace`: **1309 passed, 0 failed**; clippy + fmt clean; `action_consistency` green.
- context7: procps coverage is README-level only, so sysctl syntax authority is the live VM execution (noted).

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)