### PR TITLE
feat(actions): per-service resource limits (#69)

### DIFF
--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -125,6 +125,10 @@ pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
      "fetch recent journald log lines for a service — param: unit*"),
     ("GetServiceStatus",
      "show detailed status of a service — param: unit*"),
+    ("GetServiceResourceLimits",
+     "show a service's cgroup limits (MemoryMax/CPUQuota/TasksMax) via systemctl show — param: unit*; read-only"),
+    ("SetServiceResourceLimits",
+     "cap a service's resources via systemctl set-property (applies live + persists) — params: unit*, plus at least one of memory_max (e.g. '500M' or 'infinity'), memory_high, cpu_quota (e.g. '50%'), tasks_max (integer or 'infinity'); High risk; undo with systemctl revert"),
     // Network
     ("GetFirewallState",
      "show current firewalld zones, open services, and port rules — no params"),

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -421,7 +421,7 @@ GetNetworkStatus, GetDiskUsage, GetDateTime, ListProcesses, GetMemoryInfo,
 GetAuthorizedKeys, ListPackageRepositories, ListContainers, GetContainerInfo,
 ListUsers, ListGroups, ListJobHistory,
 ResolvectlStatus,
-GetJournalLog, GetLvmReport, GetSysctl
+GetJournalLog, GetLvmReport, GetSysctl, GetServiceResourceLimits
 
 ### Medium risk — cross-distro (approval required before execution)
 
@@ -445,7 +445,7 @@ RebootSystem,
 AddUserToGroup, RemoveUserFromGroup, DeleteUser,
 AddAuthorizedKey, RemoveAuthorizedKey,
 ExtendLogicalVolume, CreateLogicalVolume, CreateLvSnapshot,
-SetSysctl
+SetSysctl, SetServiceResourceLimits
 
 ## Risk classification rules
 
@@ -519,6 +519,8 @@ Use `"username"` as the key — NOT `"user"`.
 **Services** — require `"unit"` (systemd unit name, e.g. `"sshd.service"`):
 - `StartService` / `StopService` / `RestartService` / `ReloadService` / `MaskService` / `UnmaskService` / `GetServiceLogs` / `GetServiceStatus`: `{"unit":"sshd.service"}`
 - `SetServiceEnabled`: `{"unit":"sshd.service","enabled":true}`
+- `GetServiceResourceLimits`: `{"unit":"nginx.service"}`
+- `SetServiceResourceLimits`: `{"unit":"nginx.service","memory_max":"500M","cpu_quota":"50%","tasks_max":"4096"}` (at least one limit; `memory_max`/`tasks_max` also accept `"infinity"`)
 
 **Journald** (read-only query + maintenance):
 - `GetJournalLog`: all params optional — `{"unit":"ssh.service","priority":"err","boot":true,"lines":100,"since":"-1h","grep":"timeout"}`; kernel ring buffer only: `{"kernel":true}`. `priority` is `0`–`7`, a name (`err`), or a range (`0..3`).

--- a/crates/sysknife-daemon/src/actions/services.rs
+++ b/crates/sysknife-daemon/src/actions/services.rs
@@ -16,7 +16,58 @@ pub fn specs() -> Vec<ActionSpec> {
         list_timers(),
         reload_daemon(),
         create_scheduled_job("sysknife-example", "/usr/bin/true", "*-*-* 02:00:00"),
+        get_service_resource_limits("nginx.service"),
+        set_service_resource_limits(
+            "nginx.service",
+            &["MemoryMax=500M".to_string(), "CPUQuota=50%".to_string()],
+        ),
     ]
+}
+
+/// Read a service's cgroup resource limits (`systemctl show --property=…`).
+///
+/// Read-only. `CPUQuota` is reported by systemd as `CPUQuotaPerSecUSec`, so
+/// that is the property name queried here.
+pub fn get_service_resource_limits(unit: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "GetServiceResourceLimits",
+        mechanism: command_mechanism(
+            "systemctl",
+            [
+                "show",
+                unit,
+                "--property=MemoryMax,MemoryHigh,CPUQuotaPerSecUSec,TasksMax",
+            ],
+        ),
+        risk_level: RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Set a service's cgroup resource limits (`sudo systemctl set-property …`).
+///
+/// Risk: High. `set-property` both applies the limit live and writes a
+/// persistent drop-in under `/etc/systemd/system.control/<unit>.d/`; the change
+/// is undone with `systemctl revert <unit>`. Using systemd's own verb (rather
+/// than a hand-written drop-in helper) means systemd validates and manages the
+/// unit files. `assignments` are pre-validated `PROPERTY=VALUE` pairs
+/// (`MemoryMax=`, `CPUQuota=`, `TasksMax=`); the executor guarantees at least
+/// one is present.
+pub fn set_service_resource_limits(unit: &str, assignments: &[String]) -> ActionSpec {
+    let mut args = vec![
+        "systemctl".to_string(),
+        "set-property".to_string(),
+        unit.to_string(),
+    ];
+    args.extend(assignments.iter().cloned());
+    ActionSpec {
+        action_name: "SetServiceResourceLimits",
+        mechanism: command_mechanism("sudo", args),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
 }
 
 /// Installed path of the privileged scheduled-job helper script.
@@ -199,5 +250,50 @@ pub fn get_service_logs(unit: &str) -> ActionSpec {
         risk_level: RiskLevel::Low,
         reboot_required: false,
         rollback_available: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::ActionMechanism;
+
+    fn args_of(spec: &ActionSpec) -> (&'static str, Vec<String>) {
+        match &spec.mechanism {
+            ActionMechanism::Command { program, args } => (program, args.clone()),
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_resource_limits_is_read_only_show() {
+        let spec = get_service_resource_limits("nginx.service");
+        let (program, args) = args_of(&spec);
+        assert_eq!(program, "systemctl");
+        assert_eq!(args[0], "show");
+        assert_eq!(args[1], "nginx.service");
+        assert!(args[2].contains("MemoryMax") && args[2].contains("CPUQuotaPerSecUSec"));
+        assert_eq!(spec.risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn set_resource_limits_builds_set_property() {
+        let spec = set_service_resource_limits(
+            "nginx.service",
+            &["MemoryMax=500M".to_string(), "CPUQuota=50%".to_string()],
+        );
+        let (program, args) = args_of(&spec);
+        assert_eq!(program, "sudo");
+        assert_eq!(
+            args,
+            vec![
+                "systemctl",
+                "set-property",
+                "nginx.service",
+                "MemoryMax=500M",
+                "CPUQuota=50%"
+            ]
+        );
+        assert_eq!(spec.risk_level, RiskLevel::High);
     }
 }

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -463,6 +463,48 @@ pub fn validated_sysctl_value(s: &str, param: &'static str) -> Result<String, Ex
     Ok(s.to_string())
 }
 
+/// Validate a systemd memory limit (`MemoryMax` / `MemoryHigh`): a byte count
+/// with an optional `K`/`M`/`G`/`T` suffix, or the literal `infinity`.
+pub fn validated_memory_limit(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s == "infinity" {
+        return Ok(s.to_string());
+    }
+    if s.len() > 24 {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    let digits = match s.chars().last() {
+        Some('K' | 'M' | 'G' | 'T') => &s[..s.len() - 1],
+        _ => s,
+    };
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
+/// Validate a systemd `CPUQuota`: `<n>%` where `n` is a positive integer (values
+/// above 100% are legal — they mean more than one core's worth).
+pub fn validated_cpu_quota(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    let digits = s
+        .strip_suffix('%')
+        .ok_or(ExecutorError::InvalidParam(param))?;
+    if digits.is_empty() || digits.len() > 7 || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
+/// Validate a systemd `TasksMax`: a positive integer or the literal `infinity`.
+pub fn validated_tasks_max(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s == "infinity" {
+        return Ok(s.to_string());
+    }
+    if s.is_empty() || s.len() > 12 || !s.chars().all(|c| c.is_ascii_digit()) {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1073,5 +1115,37 @@ mod tests {
         assert!(validated_sysctl_value("bad\nvalue", "value").is_err());
         assert!(validated_sysctl_value("v$(id)", "value").is_err()); // shell metachar
         assert!(validated_sysctl_value("", "value").is_err());
+    }
+
+    // ── systemd resource-limit validators ─────────────────────────────────
+
+    #[test]
+    fn memory_limit_accepts_bytes_suffix_infinity() {
+        assert!(validated_memory_limit("infinity", "m").is_ok());
+        assert!(validated_memory_limit("500M", "m").is_ok());
+        assert!(validated_memory_limit("2G", "m").is_ok());
+        assert!(validated_memory_limit("1048576", "m").is_ok()); // bare bytes
+        assert!(validated_memory_limit("500m", "m").is_err()); // lowercase suffix
+        assert!(validated_memory_limit("500MB", "m").is_err()); // two-char suffix
+        assert!(validated_memory_limit("-5M", "m").is_err());
+        assert!(validated_memory_limit("", "m").is_err());
+    }
+
+    #[test]
+    fn cpu_quota_requires_percent() {
+        assert!(validated_cpu_quota("50%", "q").is_ok());
+        assert!(validated_cpu_quota("200%", "q").is_ok()); // >100% = multi-core
+        assert!(validated_cpu_quota("50", "q").is_err()); // no percent
+        assert!(validated_cpu_quota("%", "q").is_err());
+        assert!(validated_cpu_quota("5.5%", "q").is_err());
+    }
+
+    #[test]
+    fn tasks_max_positive_int_or_infinity() {
+        assert!(validated_tasks_max("4096", "t").is_ok());
+        assert!(validated_tasks_max("infinity", "t").is_ok());
+        assert!(validated_tasks_max("40.5", "t").is_err());
+        assert!(validated_tasks_max("-1", "t").is_err());
+        assert!(validated_tasks_max("", "t").is_err());
     }
 }

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -4,10 +4,11 @@ use crate::actions::{
     ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh, sysctl, system_info,
     toolbox, ubuntu_pro, ufw, users,
     validate::{
-        validated_apparmor_profile, validated_group, validated_hostname, validated_journal_grep,
-        validated_journal_priority, validated_journal_time, validated_locale, validated_lvm_name,
-        validated_lvm_size, validated_port_or_service, validated_ppa_name, validated_safe_arg,
-        validated_sysctl_key, validated_sysctl_value, validated_timezone, validated_unit_name,
+        validated_apparmor_profile, validated_cpu_quota, validated_group, validated_hostname,
+        validated_journal_grep, validated_journal_priority, validated_journal_time,
+        validated_locale, validated_lvm_name, validated_lvm_size, validated_memory_limit,
+        validated_port_or_service, validated_ppa_name, validated_safe_arg, validated_sysctl_key,
+        validated_sysctl_value, validated_tasks_max, validated_timezone, validated_unit_name,
         validated_username,
     },
     ActionMechanism, ActionSpec,
@@ -440,6 +441,32 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
                 return Err(ExecutorError::InvalidParam("schedule"));
             }
             Ok(services::create_scheduled_job(name, command, schedule))
+        }
+        "GetServiceResourceLimits" => {
+            let unit = validated_unit_name(require_str(params, "unit")?, "unit")?;
+            Ok(services::get_service_resource_limits(&unit))
+        }
+        "SetServiceResourceLimits" => {
+            let unit = validated_unit_name(require_str(params, "unit")?, "unit")?;
+            // Build validated PROPERTY=VALUE assignments from whichever limits
+            // were supplied; at least one is required.
+            let mut assignments = Vec::new();
+            if let Some(v) = optional_validated(params, "memory_max", validated_memory_limit)? {
+                assignments.push(format!("MemoryMax={v}"));
+            }
+            if let Some(v) = optional_validated(params, "memory_high", validated_memory_limit)? {
+                assignments.push(format!("MemoryHigh={v}"));
+            }
+            if let Some(v) = optional_validated(params, "cpu_quota", validated_cpu_quota)? {
+                assignments.push(format!("CPUQuota={v}"));
+            }
+            if let Some(v) = optional_validated(params, "tasks_max", validated_tasks_max)? {
+                assignments.push(format!("TasksMax={v}"));
+            }
+            if assignments.is_empty() {
+                return Err(ExecutorError::MissingParam("memory_max"));
+            }
+            Ok(services::set_service_resource_limits(&unit, &assignments))
         }
 
         // ── Toolbox ───────────────────────────────────────────────────────

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -47,6 +47,7 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "ListServices"
         | "GetServiceLogs"
         | "GetServiceStatus"
+        | "GetServiceResourceLimits"
         | "ListTimers"
         | "ListToolboxes"
         | "GetFirewallState"
@@ -239,6 +240,10 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         // net.* / vm.* / kernel.* value can degrade networking, memory
         // behaviour, or security posture, so it is Admin/High.
         | "SetSysctl"
+        // SetServiceResourceLimits caps a service's memory/CPU/tasks via
+        // set-property; too tight a MemoryMax can OOM-kill the service, so it
+        // is Admin/High.
+        | "SetServiceResourceLimits"
         | "DeleteUser"
         | "AddAuthorizedKey"
         | "RemoveAuthorizedKey"

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -75,6 +75,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "ListServices"
         | "GetServiceLogs"
         | "GetServiceStatus"
+        | "GetServiceResourceLimits"
         | "ListTimers"
         | "GetFirewallState"
         | "ListUsers"
@@ -367,6 +368,21 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             rollback_available: false,
             warnings: vec![
                 "consumes VG capacity; snapshots fill as the origin changes".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── systemd resource limits ───────────────────────────────────────
+        "SetServiceResourceLimits" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "the service's memory/CPU/task limits will change immediately".to_string(),
+                "a persistent drop-in will be written (undo: systemctl revert)".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "too tight a MemoryMax can OOM-kill the service".to_string(),
                 "exact approval required".to_string(),
             ],
         },

--- a/crates/sysknife-daemon/tests/actions_batch2.rs
+++ b/crates/sysknife-daemon/tests/actions_batch2.rs
@@ -28,6 +28,8 @@ fn services_family_covers_list_control_and_logs() {
             "ListTimers",
             "ReloadDaemon",
             "CreateScheduledJob",
+            "GetServiceResourceLimits",
+            "SetServiceResourceLimits",
         ]
     );
 }

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -109,6 +109,8 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     "UnmaskService",
     "GetServiceLogs",
     "GetServiceStatus",
+    "GetServiceResourceLimits",
+    "SetServiceResourceLimits",
     "GetFirewallState",
     "GetNetworkStatus",
     "GetListeningPorts",

--- a/docs/typed-actions.md
+++ b/docs/typed-actions.md
@@ -53,7 +53,7 @@ codebase. On the daemon side (`sysknife-daemon`), each action is backed by an
 | `reboot_required` | Whether the daemon should warn the caller before proceeding |
 | `rollback_available` | Whether a failure triggers automatic rollback |
 
-As of this writing the catalogue defines **158 actions** across families such
+As of this writing the catalogue defines **160 actions** across families such
 as Deployment, Services, Package Layering, Flatpak, Containers, Toolbox,
 Network, Identity, SSH Keys, Package Repositories, apt/snap/ufw/netplan/grub
 (Debian-family), and rpm-ostree/AppArmor/cloud-init/Pro (Fedora-family). Each

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -26,7 +26,7 @@ system.
    `state.planner.plan_intent(intent)`.
 
 4. **LLM planning loop** (`crates/sysknife-brain/src/planner.rs:318`)
-   Turn 0: LLM receives system prompt (158-action catalogue, risk rules) +
+   Turn 0: LLM receives system prompt (160-action catalogue, risk rules) +
    user message. LLM calls `get_system_state`.
 
 5. **State injection** (`crates/sysknife-brain/src/planner.rs:366`)


### PR DESCRIPTION
Batch 3 of the second gap-family wave. Adds **2 cross-distro actions** (158 → 160), verified end-to-end in the noble QEMU VM.

## Actions
- `GetServiceResourceLimits` (Observer/Low) — `systemctl show <unit> --property=MemoryMax,MemoryHigh,CPUQuotaPerSecUSec,TasksMax`.
- `SetServiceResourceLimits` (Admin/High) — `sudo systemctl set-property <unit> <ASSIGN>…`.

## Why `set-property` (no helper)
systemd's own `set-property` verb **both** applies the limit live **and** writes a persistent drop-in under `/etc/systemd/system.control/<unit>.d/`, undone with `systemctl revert <unit>`. So — unlike sysctl — no hand-written drop-in helper and **no new sudoers grant** are needed (systemctl is already granted). Letting systemd own the unit files is strictly safer.

Params: `unit*` + at least one of `memory_max`/`memory_high` (`500M`/`infinity`), `cpu_quota` (`50%`), `tasks_max` (int/`infinity`), each strictly validated (`validated_memory_limit`/`_cpu_quota`/`_tasks_max`) before formatting into a `PROPERTY=VALUE` assignment.

## Verification (Ubuntu 24.04)
- read reports current limits; `set-property` moves MemoryMax→500M (524288000 B), CPUQuota→50% (500ms/s), TasksMax→4096 **live**; `systemctl revert` removes all three drop-ins cleanly.
- Local `cargo nextest run --workspace`: **1314 passed, 0 failed**; clippy + fmt clean; `action_consistency` + the `actions_batch2` family-membership test updated & green.

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)