### PR TITLE
ci: gate Pages-deploy + scorecard on public visibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,11 @@ concurrency:
 
 jobs:
   build:
+    # GitHub Pages is only enabled while the repo is public; the deploy step
+    # 404s otherwise. Gate the whole workflow on visibility (same pattern as
+    # codeql.yml / ci.yml) so it stays green — not red — while the repo is
+    # private, and resumes automatically on the public flip.
+    if: github.event.repository.visibility == 'public'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
@@ -47,6 +52,7 @@ jobs:
           path: book
 
   deploy:
+    if: github.event.repository.visibility == 'public'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,6 +18,11 @@ permissions:
 
 jobs:
   analysis:
+    # Scorecard publishes results and uploads SARIF to code scanning, both of
+    # which require the repo to be public (GHAS). Gate on visibility (same
+    # pattern as codeql.yml) so the run stays green while private and resumes
+    # automatically on the public flip.
+    if: github.event.repository.visibility == 'public'
     runs-on: ubuntu-latest
     permissions:
       security-events: write  # upload SARIF to code scanning


### PR DESCRIPTION
While private, Pages deploy 404s and Scorecard can't publish/upload SARIF (needs GHAS), so both show red on every push to main. Gate both on `github.event.repository.visibility == 'public'` — the same pattern codeql.yml/ci.yml already use. Skips (green) while private; resumes on the public flip. No effect on required checks.