### PR TITLE
docs(sudoers): verify sudo-rs (26.04) compat + fix stale comment (#75)

### DIFF
--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -21,7 +21,7 @@ release.
 |---|---|---|---|
 | **Ubuntu 24.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | 65/65 stories on a live VM with `gpt-4.1` | **Validated** |
 | **Ubuntu 22.04 LTS** | Ubuntu/apt family | VM bootstrap and smoke tests | **Smoke-tested** |
-| **Ubuntu 26.04 LTS** | Ubuntu/apt family | VM bootstrap and smoke tests | **Smoke-tested** |
+| **Ubuntu 26.04 LTS** | Ubuntu/apt family | VM bootstrap, smoke tests, and sudo-rs sudoers verification (26.04 ships sudo-rs 0.2.x; `visudo -cf` parses the SysKnife sudoers and every grant — including the trailing-`*` wildcard grants — is honoured) | **Smoke-tested** |
 | **Fedora Silverblue 44** | rpm-ostree, Flatpak, toolbox, firewalld, systemd, containers | Harness and fixture coverage; current live-VM run must be recorded before release | **Current validation required** |
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** until variant-specific VM evidence exists |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |

--- a/packaging/sysknife-sudoers
+++ b/packaging/sysknife-sudoers
@@ -15,9 +15,17 @@
 #
 # IMPORTANT: test with `visudo -cf /etc/sudoers.d/sysknife` before deploying.
 #
-# Note: `Defaults:sysknife !requiretty` was removed. The requiretty token was
-# dropped from sudo in 1.9.13 (Ubuntu 26.04 ships 1.9.15+). The sysknife daemon
-# runs as a non-interactive service so no tty is involved anyway.
+# Note: `Defaults:sysknife !requiretty` was removed. Ubuntu 26.04 ships sudo-rs
+# (0.2.x — the memory-safe Rust reimplementation, now the default; verified on a
+# live 26.04 VM), which has no requiretty concept at all; on traditional sudo
+# the token was dropped in 1.9.13. Either way the sysknife daemon runs as a
+# non-interactive service, so no tty is involved.
+#
+# sudo-rs compatibility (verified 2026-07-22 on 26.04, sudo-rs 0.2.13):
+# `visudo -cf` parses this file OK and every grant is honoured, including the
+# trailing-`*` wildcard grants. sudo-rs permits `*` ONLY as the final argument
+# (non-final wildcards like `find * -exec *` are rejected as a privesc vector) —
+# which is the only wildcard form this file uses, so no grant needs reworking.
 
 # User management — create and delete system/human accounts.
 # useradd: called by CreateUser  (sudo useradd --create-home ...)


### PR DESCRIPTION
Resolves #75. Ubuntu 26.04 ships **sudo-rs 0.2.x**, not sudo 1.9.15+ — the sudoers comment was wrong.

**Verified live on a 26.04 QEMU VM (sudo-rs 0.2.13):**
- `visudo -cf` parses the full `sysknife-sudoers` OK.
- `sudo -l -U sysknife` lists every grant incl. `env … apt-get *` and all `/usr/lib/sysknife/*-edit *` helpers.
- **End-to-end**: the `sysknife` user ran a trailing-`*` helper grant via `sudo -n` (NOPASSWD) — honoured, no password.

sudo-rs permits `*` **only as the final argument** (non-final wildcards are rejected as a privesc vector); every SysKnife grant already uses only that form, so **no rework needed**. Fixes the comment + records the check in docs/distro-support.md (26.04 stays Smoke-tested — full story suite hasn't run there; public-claims guard still green).

Closes #75.