### PR TITLE
feat(actions): mount/fstab + swap family (#65)

### DIFF
--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -170,6 +170,17 @@ pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
      "read a kernel parameter (sysctl) — param: key (optional, dotted e.g. 'net.ipv4.ip_forward'; omit to dump all); read-only"),
     ("SetSysctl",
      "set AND persist a kernel parameter (runtime + /etc/sysctl.d drop-in) — params: key* (dotted, e.g. 'vm.swappiness'), value* (number or space-separated list); High risk"),
+    // Filesystem mounts / swap
+    ("GetMounts",
+     "list mounted filesystems as JSON (findmnt) — no params; read-only"),
+    ("AddMount",
+     "mount a device and persist it to /etc/fstab with nofail — params: device* (/dev/.., UUID=.., LABEL=.., //host/share, or host:/export), mountpoint* (absolute; not a system dir), fstype* (ext4/xfs/btrfs/vfat/nfs/cifs/…), options (csv, optional); High risk"),
+    ("RemoveMount",
+     "unmount and drop the /etc/fstab entry for a mountpoint — param: mountpoint*; High risk"),
+    ("AddSwap",
+     "create a swap file, enable it, and persist to /etc/fstab — params: file* (absolute path), size_mb* (integer MB); High risk"),
+    ("RemoveSwap",
+     "disable a swap file, remove it, and drop its /etc/fstab entry — param: file*; High risk"),
     // Identity / time / locale
     ("GetDateTime",
      "current date, time, timezone, and NTP status (timedatectl) — no params"),

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -421,7 +421,7 @@ GetNetworkStatus, GetDiskUsage, GetDateTime, ListProcesses, GetMemoryInfo,
 GetAuthorizedKeys, ListPackageRepositories, ListContainers, GetContainerInfo,
 ListUsers, ListGroups, ListJobHistory,
 ResolvectlStatus,
-GetJournalLog, GetLvmReport, GetSysctl, GetServiceResourceLimits
+GetJournalLog, GetLvmReport, GetSysctl, GetServiceResourceLimits, GetMounts
 
 ### Medium risk — cross-distro (approval required before execution)
 
@@ -445,7 +445,8 @@ RebootSystem,
 AddUserToGroup, RemoveUserFromGroup, DeleteUser,
 AddAuthorizedKey, RemoveAuthorizedKey,
 ExtendLogicalVolume, CreateLogicalVolume, CreateLvSnapshot,
-SetSysctl, SetServiceResourceLimits
+SetSysctl, SetServiceResourceLimits,
+AddMount, RemoveMount, AddSwap, RemoveSwap
 
 ## Risk classification rules
 
@@ -535,6 +536,13 @@ Use `"username"` as the key — NOT `"user"`.
 **Kernel / sysctl**:
 - `GetSysctl`: `{"key":"net.ipv4.ip_forward"}` (omit `key` to dump the whole table).
 - `SetSysctl`: `{"key":"vm.swappiness","value":"10"}` — applies immediately and persists; `value` is a number or space-separated list.
+
+**Filesystem mounts / swap** (managed fstab entries always get `nofail`):
+- `GetMounts`: `{}` (read-only).
+- `AddMount`: `{"device":"/dev/sdb1","mountpoint":"/mnt/data","fstype":"ext4","options":"noatime"}` (`options` optional; `device` also accepts `UUID=…`/`LABEL=…`/`//host/share`/`host:/export`; mountpoint must not be a system dir).
+- `RemoveMount`: `{"mountpoint":"/mnt/data"}`.
+- `AddSwap`: `{"file":"/swapfile","size_mb":2048}`.
+- `RemoveSwap`: `{"file":"/swapfile"}`.
 
 **Users and groups**:
 - `CreateUser`: `{"username":"alice"}` (optional: `"shell"`, `"home"`)

--- a/crates/sysknife-daemon/src/actions/mod.rs
+++ b/crates/sysknife-daemon/src/actions/mod.rs
@@ -16,6 +16,7 @@ pub mod layering;
 pub mod layering_ubuntu;
 pub mod livepatch;
 pub mod lvm;
+pub mod mounts;
 pub mod multipass;
 pub mod netplan;
 pub mod network;

--- a/crates/sysknife-daemon/src/actions/mounts.rs
+++ b/crates/sysknife-daemon/src/actions/mounts.rs
@@ -1,0 +1,183 @@
+//! Filesystem mount + swap actions.
+//!
+//! `GetMounts` is a read-only inventory (`findmnt --json`). The four mutating
+//! actions (`AddMount`, `RemoveMount`, `AddSwap`, `RemoveSwap`) all delegate to
+//! the root-owned helper `/usr/lib/sysknife/mount-edit`, which keeps `/etc/fstab`
+//! in sync and — crucially — writes every managed entry with `nofail`, so a bad
+//! or absent device can never wedge the boot. See `packaging/sysknife-mount-edit`.
+
+use super::{command_mechanism, ActionSpec};
+use sysknife_types::RiskLevel;
+
+const HELPER: &str = "/usr/lib/sysknife/mount-edit";
+
+pub fn specs() -> Vec<ActionSpec> {
+    vec![
+        get_mounts(),
+        add_mount("/dev/sdb1", "/mnt/data", "ext4", Some("defaults")),
+        remove_mount("/mnt/data"),
+        add_swap("/swapfile", 2048),
+        remove_swap("/swapfile"),
+    ]
+}
+
+/// List mounted filesystems as JSON (`findmnt --json`). Read-only.
+pub fn get_mounts() -> ActionSpec {
+    ActionSpec {
+        action_name: "GetMounts",
+        mechanism: command_mechanism("findmnt", ["--json"]),
+        risk_level: RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Mount a device and persist it to `/etc/fstab` (with `nofail`).
+pub fn add_mount(
+    device: &str,
+    mountpoint: &str,
+    fstype: &str,
+    options: Option<&str>,
+) -> ActionSpec {
+    let mut args = vec![
+        HELPER.to_string(),
+        "--op".to_string(),
+        "mount".to_string(),
+        "--device".to_string(),
+        device.to_string(),
+        "--mountpoint".to_string(),
+        mountpoint.to_string(),
+        "--fstype".to_string(),
+        fstype.to_string(),
+    ];
+    if let Some(opts) = options {
+        args.push("--options".to_string());
+        args.push(opts.to_string());
+    }
+    ActionSpec {
+        action_name: "AddMount",
+        mechanism: command_mechanism("sudo", args),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Unmount and remove the `/etc/fstab` entry for a mountpoint.
+pub fn remove_mount(mountpoint: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "RemoveMount",
+        mechanism: command_mechanism(
+            "sudo",
+            [HELPER, "--op", "unmount", "--mountpoint", mountpoint],
+        ),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Create a swap file, enable it, and persist it to `/etc/fstab`.
+pub fn add_swap(file: &str, size_mb: u32) -> ActionSpec {
+    let size = size_mb.to_string();
+    ActionSpec {
+        action_name: "AddSwap",
+        mechanism: command_mechanism(
+            "sudo",
+            [
+                HELPER,
+                "--op",
+                "addswap",
+                "--file",
+                file,
+                "--size-mb",
+                &size,
+            ],
+        ),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Disable a swap file, remove it, and drop its `/etc/fstab` entry.
+pub fn remove_swap(file: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "RemoveSwap",
+        mechanism: command_mechanism("sudo", [HELPER, "--op", "rmswap", "--file", file]),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::ActionMechanism;
+
+    fn args_of(spec: &ActionSpec) -> (&'static str, Vec<String>) {
+        match &spec.mechanism {
+            ActionMechanism::Command { program, args } => (program, args.clone()),
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_mounts_is_read_only_json() {
+        let (program, args) = args_of(&get_mounts());
+        assert_eq!(program, "findmnt");
+        assert_eq!(args, vec!["--json"]);
+        assert_eq!(get_mounts().risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn add_mount_passes_op_and_optional_options() {
+        let (program, args) = args_of(&add_mount(
+            "/dev/sdb1",
+            "/mnt/data",
+            "ext4",
+            Some("noatime"),
+        ));
+        assert_eq!(program, "sudo");
+        assert_eq!(
+            args,
+            vec![
+                HELPER,
+                "--op",
+                "mount",
+                "--device",
+                "/dev/sdb1",
+                "--mountpoint",
+                "/mnt/data",
+                "--fstype",
+                "ext4",
+                "--options",
+                "noatime"
+            ]
+        );
+        // options omitted → no --options flag
+        let (_, no_opts) = args_of(&add_mount("/dev/sdb1", "/mnt/data", "ext4", None));
+        assert!(!no_opts.iter().any(|a| a == "--options"));
+    }
+
+    #[test]
+    fn swap_ops_shapes() {
+        let (_, add) = args_of(&add_swap("/swapfile", 2048));
+        assert_eq!(
+            add,
+            vec![
+                HELPER,
+                "--op",
+                "addswap",
+                "--file",
+                "/swapfile",
+                "--size-mb",
+                "2048"
+            ]
+        );
+        let (_, rm) = args_of(&remove_swap("/swapfile"));
+        assert_eq!(rm, vec![HELPER, "--op", "rmswap", "--file", "/swapfile"]);
+        assert_eq!(add_swap("/s", 1).risk_level, RiskLevel::High);
+    }
+}

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -505,6 +505,130 @@ pub fn validated_tasks_max(s: &str, param: &'static str) -> Result<String, Execu
     Ok(s.to_string())
 }
 
+/// Filesystem types SysKnife will mount. Mirrors `FSTYPE_ALLOW` in
+/// `packaging/sysknife-mount-edit`.
+const FSTYPE_ALLOW: &[&str] = &[
+    "ext4", "ext3", "ext2", "xfs", "btrfs", "vfat", "exfat", "ntfs3", "nfs", "nfs4", "cifs",
+];
+
+/// Mountpoints SysKnife must never touch (remounting them can break the box).
+/// Mirrors `CRITICAL_MOUNTPOINTS` in the helper.
+const CRITICAL_MOUNTPOINTS: &[&str] = &[
+    "/",
+    "/boot",
+    "/boot/efi",
+    "/etc",
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/var",
+    "/home",
+    "/root",
+    "/proc",
+    "/sys",
+    "/dev",
+    "/run",
+];
+
+/// Validate a mount source: a `/dev/…` node, `UUID=…`, `LABEL=…`, a cifs
+/// `//host/share`, or an nfs `host:/export`. No leading dash / shell metachars.
+pub fn validated_mount_device(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s.is_empty() || s.len() > 256 || s.starts_with('-') || s.contains("..") {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    let dev_like = s.starts_with("/dev/")
+        && s[5..]
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '.' | '-'));
+    let uuid = s
+        .strip_prefix("UUID=")
+        .is_some_and(|u| u.len() >= 8 && u.chars().all(|c| c.is_ascii_hexdigit() || c == '-'));
+    let label = s.strip_prefix("LABEL=").is_some_and(|l| {
+        !l.is_empty()
+            && l.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | ':' | '-'))
+    });
+    let cifs = s.starts_with("//")
+        && s.matches('/').count() >= 3
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-'));
+    let nfs = {
+        match s.split_once(":/") {
+            Some((host, _)) => {
+                !host.is_empty()
+                    && !host.starts_with('/')
+                    && s.chars().all(|c| {
+                        c.is_ascii_alphanumeric() || matches!(c, ':' | '/' | '.' | '_' | '-')
+                    })
+            }
+            None => false,
+        }
+    };
+    if dev_like || uuid || label || cifs || nfs {
+        Ok(s.to_string())
+    } else {
+        Err(ExecutorError::InvalidParam(param))
+    }
+}
+
+/// Validate a mountpoint: absolute, no `..`, safe charset, and not a critical
+/// system mountpoint. Mirrors `valid_mountpoint` in the helper.
+pub fn validated_mount_point(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if !s.starts_with('/') || s.len() > 256 || s.contains("..") {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '.' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if CRITICAL_MOUNTPOINTS.contains(&s) {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
+/// Validate a filesystem type against the mount allowlist.
+pub fn validated_fstype(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if FSTYPE_ALLOW.contains(&s) {
+        Ok(s.to_string())
+    } else {
+        Err(ExecutorError::InvalidParam(param))
+    }
+}
+
+/// Validate a comma-separated mount options string (charset only; the helper
+/// forces `nofail` in). Empty is allowed (helper defaults to `defaults`).
+pub fn validated_mount_options(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s.len() > 256 {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s.chars().all(|c| {
+        c.is_ascii_alphanumeric()
+            || matches!(c, '=' | ',' | '.' | '_' | ':' | '@' | '/' | '+' | '-')
+    }) {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
+/// Validate an absolute file path for a swap file (no `..`, safe charset).
+pub fn validated_swap_path(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if !s.starts_with('/') || s.len() > 256 || s.contains("..") {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '.' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1147,5 +1271,50 @@ mod tests {
         assert!(validated_tasks_max("40.5", "t").is_err());
         assert!(validated_tasks_max("-1", "t").is_err());
         assert!(validated_tasks_max("", "t").is_err());
+    }
+
+    // ── mount / swap validators ───────────────────────────────────────────
+
+    #[test]
+    fn mount_device_accepts_forms_and_rejects_junk() {
+        assert!(validated_mount_device("/dev/sdb1", "d").is_ok());
+        assert!(validated_mount_device("UUID=1234abcd-5678", "d").is_ok());
+        assert!(validated_mount_device("LABEL=data", "d").is_ok());
+        assert!(validated_mount_device("//nas/share", "d").is_ok());
+        assert!(validated_mount_device("nas.local:/export", "d").is_ok());
+        assert!(validated_mount_device("-rf", "d").is_err()); // option injection
+        assert!(validated_mount_device("/dev/../etc", "d").is_err()); // traversal
+        assert!(validated_mount_device("$(id)", "d").is_err());
+    }
+
+    #[test]
+    fn mount_point_rejects_critical_and_traversal() {
+        assert!(validated_mount_point("/mnt/data", "m").is_ok());
+        assert!(validated_mount_point("/srv/backups", "m").is_ok());
+        assert!(validated_mount_point("/", "m").is_err()); // critical
+        assert!(validated_mount_point("/boot", "m").is_err()); // critical
+        assert!(validated_mount_point("/etc", "m").is_err()); // critical
+        assert!(validated_mount_point("/mnt/../etc", "m").is_err()); // traversal
+        assert!(validated_mount_point("relative", "m").is_err()); // not absolute
+    }
+
+    #[test]
+    fn fstype_allowlist() {
+        assert!(validated_fstype("ext4", "f").is_ok());
+        assert!(validated_fstype("xfs", "f").is_ok());
+        assert!(validated_fstype("nfs", "f").is_ok());
+        assert!(validated_fstype("proc", "f").is_err());
+        assert!(validated_fstype("", "f").is_err());
+    }
+
+    #[test]
+    fn mount_options_and_swap_path() {
+        assert!(validated_mount_options("noatime,ro", "o").is_ok());
+        assert!(validated_mount_options("", "o").is_ok()); // helper defaults it
+        assert!(validated_mount_options("bad opt", "o").is_err()); // space
+        assert!(validated_swap_path("/swapfile", "p").is_ok());
+        assert!(validated_swap_path("/var/swap/sk.swap", "p").is_ok());
+        assert!(validated_swap_path("swapfile", "p").is_err()); // not absolute
+        assert!(validated_swap_path("/../etc/x", "p").is_err()); // traversal
     }
 }

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -1,15 +1,16 @@
 use crate::actions::{
     apparmor, apt, cloudinit, containers, deployment, distrobox, fail2ban, filesystem, flatpak,
-    grub, identity, journald, layering, livepatch, lvm, multipass, netplan, network, package_repos,
-    ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh, sysctl, system_info,
-    toolbox, ubuntu_pro, ufw, users,
+    grub, identity, journald, layering, livepatch, lvm, mounts, multipass, netplan, network,
+    package_repos, ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh,
+    sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
     validate::{
-        validated_apparmor_profile, validated_cpu_quota, validated_group, validated_hostname,
-        validated_journal_grep, validated_journal_priority, validated_journal_time,
-        validated_locale, validated_lvm_name, validated_lvm_size, validated_memory_limit,
-        validated_port_or_service, validated_ppa_name, validated_safe_arg, validated_sysctl_key,
-        validated_sysctl_value, validated_tasks_max, validated_timezone, validated_unit_name,
-        validated_username,
+        validated_apparmor_profile, validated_cpu_quota, validated_fstype, validated_group,
+        validated_hostname, validated_journal_grep, validated_journal_priority,
+        validated_journal_time, validated_locale, validated_lvm_name, validated_lvm_size,
+        validated_memory_limit, validated_mount_device, validated_mount_options,
+        validated_mount_point, validated_port_or_service, validated_ppa_name, validated_safe_arg,
+        validated_swap_path, validated_sysctl_key, validated_sysctl_value, validated_tasks_max,
+        validated_timezone, validated_unit_name, validated_username,
     },
     ActionMechanism, ActionSpec,
 };
@@ -628,6 +629,40 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
             let key = validated_sysctl_key(require_str(params, "key")?, "key")?;
             let value = validated_sysctl_value(require_str(params, "value")?, "value")?;
             Ok(sysctl::set_sysctl(&key, &value))
+        }
+
+        // ── Filesystem mounts / swap ────────────────────────────────────────
+        "GetMounts" => Ok(mounts::get_mounts()),
+        "AddMount" => {
+            let device = validated_mount_device(require_str(params, "device")?, "device")?;
+            let mountpoint =
+                validated_mount_point(require_str(params, "mountpoint")?, "mountpoint")?;
+            let fstype = validated_fstype(require_str(params, "fstype")?, "fstype")?;
+            let options = optional_validated(params, "options", validated_mount_options)?;
+            Ok(mounts::add_mount(
+                &device,
+                &mountpoint,
+                &fstype,
+                options.as_deref(),
+            ))
+        }
+        "RemoveMount" => {
+            let mountpoint =
+                validated_mount_point(require_str(params, "mountpoint")?, "mountpoint")?;
+            Ok(mounts::remove_mount(&mountpoint))
+        }
+        "AddSwap" => {
+            let file = validated_swap_path(require_str(params, "file")?, "file")?;
+            let size_mb = require_u32(params, "size_mb")?;
+            // 1 MiB .. 1 TiB — reject 0 (empty) and absurdly large requests.
+            if !(1..=1_048_576).contains(&size_mb) {
+                return Err(ExecutorError::InvalidParam("size_mb"));
+            }
+            Ok(mounts::add_swap(&file, size_mb))
+        }
+        "RemoveSwap" => {
+            let file = validated_swap_path(require_str(params, "file")?, "file")?;
+            Ok(mounts::remove_swap(&file))
         }
 
         // ── System info ──────────────────────────────────────────────────

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -63,6 +63,8 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "GetLvmReport"
         // ── Kernel / sysctl read-only ─────────────────────────────────────
         | "GetSysctl"
+        // ── Filesystem mounts read-only ───────────────────────────────────
+        | "GetMounts"
         | "GetAuthorizedKeys"
         | "ListUsers"
         | "ListGroups"
@@ -244,6 +246,16 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         // set-property; too tight a MemoryMax can OOM-kill the service, so it
         // is Admin/High.
         | "SetServiceResourceLimits"
+        // ── Filesystem mounts / swap mutations ────────────────────────────
+        //
+        // Mount/unmount and swap ops rewrite /etc/fstab and change what is
+        // mounted; a wrong device or mountpoint risks data/availability. All
+        // Admin/High (the helper forces `nofail` so a bad entry can't wedge
+        // boot, but the operation itself is still privileged).
+        | "AddMount"
+        | "RemoveMount"
+        | "AddSwap"
+        | "RemoveSwap"
         | "DeleteUser"
         | "AddAuthorizedKey"
         | "RemoveAuthorizedKey"

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -92,6 +92,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "GetJournalLog"
         | "GetLvmReport"
         | "GetSysctl"
+        | "GetMounts"
         | "GetAuthorizedKeys"
         | "GetDateTime"
         | "ListJobHistory"
@@ -385,6 +386,31 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "too tight a MemoryMax can OOM-kill the service".to_string(),
                 "exact approval required".to_string(),
             ],
+        },
+
+        // ── Filesystem mounts / swap ──────────────────────────────────────
+        "AddMount" | "RemoveMount" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "a filesystem will be (un)mounted".to_string(),
+                "/etc/fstab will be updated (managed entries carry nofail)".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "a wrong device or mountpoint risks data or availability".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+        "AddSwap" | "RemoveSwap" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "swap will be enabled/disabled".to_string(),
+                "a swap file will be created/removed and /etc/fstab updated".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec!["exact approval required".to_string()],
         },
 
         // ── Kernel / sysctl mutation ──────────────────────────────────────

--- a/crates/sysknife-daemon/tests/action_consistency.rs
+++ b/crates/sysknife-daemon/tests/action_consistency.rs
@@ -13,9 +13,9 @@ use serde_json::json;
 use sysknife_brain::planning_tools::propose_plan::KNOWN_ACTIONS;
 use sysknife_daemon::actions::{
     apparmor, apt, cloudinit, containers, deployment, distrobox, fail2ban, filesystem, flatpak,
-    grub, identity, journald, layering, livepatch, lvm, multipass, netplan, network, package_repos,
-    ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh, sysctl, system_info,
-    toolbox, ubuntu_pro, ufw, users,
+    grub, identity, journald, layering, livepatch, lvm, mounts, multipass, netplan, network,
+    package_repos, ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh,
+    sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
 };
 use sysknife_daemon::executor::build_action_spec;
 use sysknife_daemon::policy::min_role_for_action;
@@ -68,6 +68,9 @@ fn all_spec_action_names() -> BTreeSet<&'static str> {
         names.insert(spec.action_name);
     }
     for spec in sysctl::specs() {
+        names.insert(spec.action_name);
+    }
+    for spec in mounts::specs() {
         names.insert(spec.action_name);
     }
     for spec in identity::specs() {

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -132,6 +132,12 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     // Kernel / sysctl (cross-distro)
     "GetSysctl",
     "SetSysctl",
+    // Filesystem mounts / swap (cross-distro)
+    "GetMounts",
+    "AddMount",
+    "RemoveMount",
+    "AddSwap",
+    "RemoveSwap",
     "GetDateTime",
     "SetHostname",
     "SetTimezone",

--- a/docs/typed-actions.md
+++ b/docs/typed-actions.md
@@ -53,7 +53,7 @@ codebase. On the daemon side (`sysknife-daemon`), each action is backed by an
 | `reboot_required` | Whether the daemon should warn the caller before proceeding |
 | `rollback_available` | Whether a failure triggers automatic rollback |
 
-As of this writing the catalogue defines **160 actions** across families such
+As of this writing the catalogue defines **165 actions** across families such
 as Deployment, Services, Package Layering, Flatpak, Containers, Toolbox,
 Network, Identity, SSH Keys, Package Repositories, apt/snap/ufw/netplan/grub
 (Debian-family), and rpm-ostree/AppArmor/cloud-init/Pro (Fedora-family). Each

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -26,7 +26,7 @@ system.
    `state.planner.plan_intent(intent)`.
 
 4. **LLM planning loop** (`crates/sysknife-brain/src/planner.rs:318`)
-   Turn 0: LLM receives system prompt (160-action catalogue, risk rules) +
+   Turn 0: LLM receives system prompt (165-action catalogue, risk rules) +
    user message. LLM calls `get_system_state`.
 
 5. **State injection** (`crates/sysknife-brain/src/planner.rs:366`)

--- a/packaging/sysknife-mount-edit
+++ b/packaging/sysknife-mount-edit
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# sysknife-mount-edit — mount/unmount a filesystem or enable/disable swap, and
+# keep /etc/fstab in sync.
+#
+# Install to: /usr/lib/sysknife/mount-edit
+# Mode:       0755
+# Owner:      root:root
+#
+# Invoked exclusively by the sysknife-daemon via one of:
+#   sudo /usr/lib/sysknife/mount-edit --op mount \
+#        --device <dev|UUID=..|LABEL=..|//host/share|host:/export> \
+#        --mountpoint <abs-path> --fstype <fs> [--options <csv>]
+#   sudo /usr/lib/sysknife/mount-edit --op unmount   --mountpoint <abs-path>
+#   sudo /usr/lib/sysknife/mount-edit --op addswap   --file <abs-path> --size-mb <n>
+#   sudo /usr/lib/sysknife/mount-edit --op rmswap    --file <abs-path>
+#
+# Safety model (all inputs re-validated here — defense-in-depth):
+#   - Every fstab entry SysKnife writes carries `nofail`, so a device that is
+#     absent or wrong at boot can never wedge the boot (systemd skips it) —
+#     this is the key guard against the classic "bad fstab bricks the box".
+#   - mount: the fstab entry is appended FIRST, then `mount <mountpoint>` is run
+#     (which reads fstab). If the mount fails the just-added line is rolled back
+#     and the op fails — so a broken entry never persists.
+#   - Critical system mountpoints (/, /boot, /etc, /usr, /var, /home, …) are
+#     refused; SysKnife will not remount or shadow them.
+#   - fstype is an allowlist; device/mountpoint/options are charset-validated;
+#     fstab is rewritten atomically (temp file + os.replace).
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+FSTAB = "/etc/fstab"
+MOUNT = "/usr/bin/mount"
+UMOUNT = "/usr/bin/umount"
+MKSWAP = "/usr/sbin/mkswap"
+SWAPON = "/usr/sbin/swapon"
+SWAPOFF = "/usr/sbin/swapoff"
+DD = "/usr/bin/dd"
+
+FSTYPE_ALLOW = {
+    "ext4", "ext3", "ext2", "xfs", "btrfs", "vfat", "exfat",
+    "ntfs3", "nfs", "nfs4", "cifs",
+}
+# Mountpoints SysKnife must never touch (remounting these can break the system).
+CRITICAL_MOUNTPOINTS = {
+    "/", "/boot", "/boot/efi", "/etc", "/usr", "/bin", "/sbin", "/lib",
+    "/lib64", "/var", "/home", "/root", "/proc", "/sys", "/dev", "/run",
+}
+
+DEVICE_RE = re.compile(
+    r"^(/dev/[A-Za-z0-9/_.-]+"
+    r"|UUID=[0-9A-Fa-f-]{8,}"
+    r"|LABEL=[A-Za-z0-9_.:-]+"
+    r"|//[A-Za-z0-9._-]+/[A-Za-z0-9._/$-]+"          # cifs //host/share
+    r"|[A-Za-z0-9._-]+:/[A-Za-z0-9._/-]*)$"           # nfs host:/export
+)
+MOUNTPOINT_RE = re.compile(r"^/[A-Za-z0-9/_.-]*$")
+OPTIONS_RE = re.compile(r"^[A-Za-z0-9=,._:@/+-]*$")
+
+
+def die(msg: str) -> None:
+    print(f"sysknife-mount-edit: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def valid_mountpoint(mp: str) -> bool:
+    return (
+        bool(MOUNTPOINT_RE.match(mp))
+        and ".." not in mp
+        and mp not in CRITICAL_MOUNTPOINTS
+        and mp != ""
+    )
+
+
+def read_fstab() -> list:
+    if not os.path.exists(FSTAB):
+        return []
+    with open(FSTAB, "r") as fh:
+        return fh.readlines()
+
+
+def write_fstab(lines: list) -> None:
+    directory = os.path.dirname(FSTAB)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".sysknife-fstab-")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.writelines(lines)
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, FSTAB)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        die(f"cannot write {FSTAB}: {exc}")
+
+
+def ensure_nofail(options: str) -> str:
+    opts = [o for o in options.split(",") if o]
+    if not opts:
+        opts = ["defaults"]
+    if "nofail" not in opts:
+        opts.append("nofail")
+    return ",".join(opts)
+
+
+def fstab_field2(line: str) -> str:
+    """Return the mountpoint (field 2) of an fstab line, or '' for comments."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return ""
+    parts = stripped.split()
+    return parts[1] if len(parts) >= 2 else ""
+
+
+def fstab_field1(line: str) -> str:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return ""
+    parts = stripped.split()
+    return parts[0] if len(parts) >= 1 else ""
+
+
+def op_mount(args) -> None:
+    if not DEVICE_RE.match(args.device):
+        die(f"invalid device {args.device!r}")
+    if not valid_mountpoint(args.mountpoint):
+        die(f"invalid or forbidden mountpoint {args.mountpoint!r}")
+    if args.fstype not in FSTYPE_ALLOW:
+        die(f"fstype {args.fstype!r} not in allowlist")
+    options = args.options or "defaults"
+    if not OPTIONS_RE.match(options):
+        die(f"invalid options {options!r}")
+    options = ensure_nofail(options)
+
+    try:
+        os.makedirs(args.mountpoint, exist_ok=True)
+    except OSError as exc:
+        die(f"cannot create mountpoint: {exc}")
+
+    lines = read_fstab()
+    # Refuse if this mountpoint already has an fstab entry.
+    if any(fstab_field2(ln) == args.mountpoint for ln in lines):
+        die(f"{args.mountpoint} already has an /etc/fstab entry")
+
+    entry = f"{args.device}\t{args.mountpoint}\t{args.fstype}\t{options}\t0\t0\n"
+    new_lines = lines + ([] if (not lines or lines[-1].endswith("\n")) else ["\n"]) + [entry]
+    write_fstab(new_lines)
+
+    # Validate the entry actually mounts; roll back the fstab line if not.
+    result = subprocess.run(
+        [MOUNT, args.mountpoint], check=False, stderr=subprocess.PIPE
+    )
+    if result.returncode != 0:
+        write_fstab(lines)  # rollback
+        die(f"mount failed, fstab reverted: {result.stderr.decode(errors='replace').strip()}")
+
+
+def op_unmount(args) -> None:
+    if not valid_mountpoint(args.mountpoint):
+        die(f"invalid or forbidden mountpoint {args.mountpoint!r}")
+    # Unmount if currently mounted (ignore "not mounted").
+    subprocess.run([UMOUNT, args.mountpoint], check=False, stderr=subprocess.DEVNULL)
+    lines = read_fstab()
+    kept = [ln for ln in lines if fstab_field2(ln) != args.mountpoint]
+    if len(kept) != len(lines):
+        write_fstab(kept)
+
+
+def op_addswap(args) -> None:
+    path = args.file
+    if not path.startswith("/") or ".." in path or not MOUNTPOINT_RE.match(path):
+        die(f"invalid swap file path {path!r}")
+    if args.size_mb < 1 or args.size_mb > 1_048_576:  # cap at 1 TiB
+        die("size-mb out of range")
+    if os.path.exists(path):
+        die(f"{path} already exists")
+    # Allocate with real zeros via dd — a swap file must NOT be sparse
+    # (`swapon` refuses files "with holes"), which rules out truncate/fallocate.
+    alloc = subprocess.run(
+        [DD, "if=/dev/zero", f"of={path}", "bs=1M", f"count={args.size_mb}"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    if alloc.returncode != 0:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        die(f"dd failed: {alloc.stderr.decode(errors='replace').strip()}")
+    try:
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        die(f"cannot chmod swap file: {exc}")
+    for cmd in ([MKSWAP, path], [SWAPON, path]):
+        r = subprocess.run(cmd, check=False, stderr=subprocess.PIPE)
+        if r.returncode != 0:
+            subprocess.run([SWAPOFF, path], check=False, stderr=subprocess.DEVNULL)
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            die(f"{os.path.basename(cmd[0])} failed: {r.stderr.decode(errors='replace').strip()}")
+    lines = read_fstab()
+    if not any(fstab_field1(ln) == path for ln in lines):
+        entry = f"{path}\tnone\tswap\tsw,nofail\t0\t0\n"
+        lines = lines + ([] if (not lines or lines[-1].endswith("\n")) else ["\n"]) + [entry]
+        write_fstab(lines)
+
+
+def op_rmswap(args) -> None:
+    path = args.file
+    if not path.startswith("/") or ".." in path or not MOUNTPOINT_RE.match(path):
+        die(f"invalid swap file path {path!r}")
+    subprocess.run([SWAPOFF, path], check=False, stderr=subprocess.DEVNULL)
+    lines = read_fstab()
+    kept = [ln for ln in lines if fstab_field1(ln) != path]
+    if len(kept) != len(lines):
+        write_fstab(kept)
+    if os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError as exc:
+            die(f"cannot remove swap file: {exc}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage mounts/swap + /etc/fstab.")
+    parser.add_argument("--op", required=True, choices=["mount", "unmount", "addswap", "rmswap"])
+    parser.add_argument("--device")
+    parser.add_argument("--mountpoint")
+    parser.add_argument("--fstype")
+    parser.add_argument("--options")
+    parser.add_argument("--file")
+    parser.add_argument("--size-mb", type=int, dest="size_mb")
+    args = parser.parse_args()
+
+    if args.op == "mount":
+        if not (args.device and args.mountpoint and args.fstype):
+            die("mount requires --device, --mountpoint, --fstype")
+        op_mount(args)
+    elif args.op == "unmount":
+        if not args.mountpoint:
+            die("unmount requires --mountpoint")
+        op_unmount(args)
+    elif args.op == "addswap":
+        if not (args.file and args.size_mb):
+            die("addswap requires --file and --size-mb")
+        op_addswap(args)
+    elif args.op == "rmswap":
+        if not args.file:
+            die("rmswap requires --file")
+        op_rmswap(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/sysknife-sudoers
+++ b/packaging/sysknife-sudoers
@@ -200,3 +200,12 @@ sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/scheduled-job-edit *
 # file, so only this narrow helper path is allowed. GetSysctl reads via bare
 # `sysctl` (the daemon is root) and needs no grant.
 sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/sysctl-edit *
+
+# mount edit — AddMount/RemoveMount/AddSwap/RemoveSwap delegate to this
+# root-owned helper, which validates the device/mountpoint/fstype/options
+# (allowlisted fstypes, forbidden critical mountpoints), (un)mounts, manages
+# swap files, and keeps /etc/fstab in sync — writing every managed entry with
+# `nofail` so a bad device can never wedge the boot. GetMounts reads via bare
+# `findmnt` and needs no grant. Bare mount/swapon grants are NOT given: they
+# would let the daemon mount arbitrary sources over arbitrary paths.
+sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/mount-edit *

--- a/tests/e2e/ubuntu-provision.sh
+++ b/tests/e2e/ubuntu-provision.sh
@@ -249,6 +249,9 @@ install -Dm 755 packaging/sysknife-scheduled-job-edit /usr/lib/sysknife/schedule
 # sysctl-edit: invoked by SetSysctl.
 install -Dm 755 packaging/sysknife-sysctl-edit /usr/lib/sysknife/sysctl-edit \
     || fail "Install sysknife-sysctl-edit"
+# mount-edit: invoked by AddMount/RemoveMount/AddSwap/RemoveSwap.
+install -Dm 755 packaging/sysknife-mount-edit /usr/lib/sysknife/mount-edit \
+    || fail "Install sysknife-mount-edit"
 
 # ---------------------------------------------------------------------------
 # Step 6: Add VM user to sysknife groups


### PR DESCRIPTION
Batch 5 — completes the storage story (LVM landed in #64). Adds **5 cross-distro actions** (160 → 165), verified end-to-end in the noble QEMU VM.

## Actions
- `GetMounts` (Observer/Low) — `findmnt --json`.
- `AddMount`/`RemoveMount`, `AddSwap`/`RemoveSwap` (Admin/High) — via the root-owned helper `/usr/lib/sysknife/mount-edit`.

## Safety (helper)
- **Every managed fstab entry carries `nofail`** → a missing/wrong device can't wedge boot.
- **mount** appends the fstab line, runs `mount <mp>`, and **rolls the line back if it fails** — a broken entry never persists.
- Refuses critical mountpoints (`/`,`/boot`,`/etc`,`/usr`,`/var`,`/home`,…); allowlisted fstypes; validated device/mountpoint/options.
- Swap files allocated with `dd` (real zeros) — `swapon` rejects the sparse files `truncate`/`fallocate` produce (**caught live in QEMU**).

## Verification (Ubuntu 24.04)
loopback ext4 mounted at /mnt/sktest with `noatime,nofail`, cleanly unmounted; dd-allocated /var/sk.swap enabled (swapon shows it, `sw,nofail`) and removed with no residue; mounting onto /etc refused. `cargo nextest`: **1321 passed**; clippy+fmt clean; action_consistency green.

Closes #65.