### PR TITLE
feat(actions): scoped sudoers.d management (#71)

### DIFF
--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -181,6 +181,13 @@ pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
      "create a swap file, enable it, and persist to /etc/fstab — params: file* (absolute path), size_mb* (integer MB); High risk"),
     ("RemoveSwap",
      "disable a swap file, remove it, and drop its /etc/fstab entry — param: file*; High risk"),
+    // Scoped sudoers.d
+    ("GetSudoGrants",
+     "list SysKnife-managed sudoers.d drop-ins — no params; read-only"),
+    ("GrantSudoAccess",
+     "grant a scoped sudo rule (validated with visudo before install) — params: name* (^[a-z0-9][a-z0-9_-]*$), user*, commands* ('ALL' or comma-separated ABSOLUTE paths), runas (default root, or 'ALL'), nopasswd (bool); High risk — this configures privilege escalation"),
+    ("RevokeSudoAccess",
+     "remove a SysKnife-managed sudoers.d drop-in — param: name*; High risk"),
     // Identity / time / locale
     ("GetDateTime",
      "current date, time, timezone, and NTP status (timedatectl) — no params"),

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -421,7 +421,7 @@ GetNetworkStatus, GetDiskUsage, GetDateTime, ListProcesses, GetMemoryInfo,
 GetAuthorizedKeys, ListPackageRepositories, ListContainers, GetContainerInfo,
 ListUsers, ListGroups, ListJobHistory,
 ResolvectlStatus,
-GetJournalLog, GetLvmReport, GetSysctl, GetServiceResourceLimits, GetMounts
+GetJournalLog, GetLvmReport, GetSysctl, GetServiceResourceLimits, GetMounts, GetSudoGrants
 
 ### Medium risk — cross-distro (approval required before execution)
 
@@ -446,7 +446,8 @@ AddUserToGroup, RemoveUserFromGroup, DeleteUser,
 AddAuthorizedKey, RemoveAuthorizedKey,
 ExtendLogicalVolume, CreateLogicalVolume, CreateLvSnapshot,
 SetSysctl, SetServiceResourceLimits,
-AddMount, RemoveMount, AddSwap, RemoveSwap
+AddMount, RemoveMount, AddSwap, RemoveSwap,
+GrantSudoAccess, RevokeSudoAccess
 
 ## Risk classification rules
 
@@ -543,6 +544,11 @@ Use `"username"` as the key — NOT `"user"`.
 - `RemoveMount`: `{"mountpoint":"/mnt/data"}`.
 - `AddSwap`: `{"file":"/swapfile","size_mb":2048}`.
 - `RemoveSwap`: `{"file":"/swapfile"}`.
+
+**Scoped sudoers.d**:
+- `GetSudoGrants`: `{}` (read-only).
+- `GrantSudoAccess`: `{"name":"deploy-restart","user":"deploy","commands":"/usr/bin/systemctl","runas":"root","nopasswd":true}` (`commands` is `"ALL"` or comma-separated absolute paths; `runas`/`nopasswd` optional).
+- `RevokeSudoAccess`: `{"name":"deploy-restart"}`.
 
 **Users and groups**:
 - `CreateUser`: `{"username":"alice"}` (optional: `"shell"`, `"home"`)

--- a/crates/sysknife-daemon/src/actions/mod.rs
+++ b/crates/sysknife-daemon/src/actions/mod.rs
@@ -29,6 +29,7 @@ pub mod resolvectl;
 pub mod services;
 pub mod snap;
 pub mod ssh;
+pub mod sudoers;
 pub mod sysctl;
 pub mod system_info;
 pub mod toolbox;

--- a/crates/sysknife-daemon/src/actions/sudoers.rs
+++ b/crates/sysknife-daemon/src/actions/sudoers.rs
@@ -1,0 +1,149 @@
+//! Scoped sudoers.d management.
+//!
+//! `GetSudoGrants` lists the SysKnife-managed drop-ins (read-only). `GrantSudoAccess`
+//! and `RevokeSudoAccess` create/remove a drop-in under `/etc/sudoers.d/` via the
+//! root-owned helper `/usr/lib/sysknife/sudoers-edit`, which validates the rule
+//! with `visudo -cf` on a temp file BEFORE installing it — so a malformed rule can
+//! never land in `/etc/sudoers.d/` and break sudo. This is the highest-privilege
+//! action family (it configures privilege escalation itself), hence Admin/High with
+//! exact-approval previews.
+
+use super::{command_mechanism, ActionSpec};
+use sysknife_types::RiskLevel;
+
+const HELPER: &str = "/usr/lib/sysknife/sudoers-edit";
+
+pub fn specs() -> Vec<ActionSpec> {
+    vec![
+        get_sudo_grants(),
+        grant_sudo_access("deploy-restart", "deploy", "/usr/bin/systemctl", None, true),
+        revoke_sudo_access("deploy-restart"),
+    ]
+}
+
+/// List SysKnife-managed sudoers drop-ins (`sudoers-edit --op list`). Read-only.
+///
+/// Run directly (no `sudo`): reading `/etc/sudoers.d/` needs root and the daemon
+/// already runs as root, matching the `GetLvmReport` pattern.
+pub fn get_sudo_grants() -> ActionSpec {
+    ActionSpec {
+        action_name: "GetSudoGrants",
+        mechanism: command_mechanism(HELPER, ["--op", "list"]),
+        risk_level: RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Grant a scoped sudo rule via the visudo-validated helper.
+///
+/// `commands` is either `"ALL"` or a comma-separated list of absolute command
+/// paths. `runas` defaults to `root` when `None`.
+pub fn grant_sudo_access(
+    name: &str,
+    user: &str,
+    commands: &str,
+    runas: Option<&str>,
+    nopasswd: bool,
+) -> ActionSpec {
+    let mut args = vec![
+        HELPER.to_string(),
+        "--op".to_string(),
+        "grant".to_string(),
+        "--name".to_string(),
+        name.to_string(),
+        "--user".to_string(),
+        user.to_string(),
+        "--commands".to_string(),
+        commands.to_string(),
+    ];
+    if let Some(r) = runas {
+        args.push("--runas".to_string());
+        args.push(r.to_string());
+    }
+    if nopasswd {
+        args.push("--nopasswd".to_string());
+    }
+    ActionSpec {
+        action_name: "GrantSudoAccess",
+        mechanism: command_mechanism("sudo", args),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Remove a SysKnife-managed sudoers drop-in (`sudoers-edit --op revoke`).
+pub fn revoke_sudo_access(name: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "RevokeSudoAccess",
+        mechanism: command_mechanism("sudo", [HELPER, "--op", "revoke", "--name", name]),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::ActionMechanism;
+
+    fn args_of(spec: &ActionSpec) -> (&'static str, Vec<String>) {
+        match &spec.mechanism {
+            ActionMechanism::Command { program, args } => (program, args.clone()),
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_is_read_only_bare_helper() {
+        let (program, args) = args_of(&get_sudo_grants());
+        assert_eq!(program, HELPER);
+        assert_eq!(args, vec!["--op", "list"]);
+        assert_eq!(get_sudo_grants().risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn grant_builds_flags_including_optional_runas_and_nopasswd() {
+        let (program, args) = args_of(&grant_sudo_access(
+            "ci",
+            "ci",
+            "/usr/bin/systemctl",
+            Some("root"),
+            true,
+        ));
+        assert_eq!(program, "sudo");
+        assert_eq!(
+            args,
+            vec![
+                HELPER,
+                "--op",
+                "grant",
+                "--name",
+                "ci",
+                "--user",
+                "ci",
+                "--commands",
+                "/usr/bin/systemctl",
+                "--runas",
+                "root",
+                "--nopasswd"
+            ]
+        );
+        // no runas, no nopasswd
+        let (_, minimal) = args_of(&grant_sudo_access("ci", "ci", "ALL", None, false));
+        assert!(!minimal.iter().any(|a| a == "--runas" || a == "--nopasswd"));
+        assert_eq!(
+            grant_sudo_access("a", "b", "ALL", None, false).risk_level,
+            RiskLevel::High
+        );
+    }
+
+    #[test]
+    fn revoke_shape() {
+        let (program, args) = args_of(&revoke_sudo_access("ci"));
+        assert_eq!(program, "sudo");
+        assert_eq!(args, vec![HELPER, "--op", "revoke", "--name", "ci"]);
+    }
+}

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -629,6 +629,57 @@ pub fn validated_swap_path(s: &str, param: &'static str) -> Result<String, Execu
     Ok(s.to_string())
 }
 
+/// Validate a SysKnife sudoers drop-in name: `^[a-z0-9][a-z0-9_-]{0,63}$`.
+///
+/// No dots or tildes: sudo SILENTLY ignores drop-in files whose names contain
+/// them, which would make a "grant" quietly not apply. Mirrors `NAME_RE` in
+/// `packaging/sysknife-sudoers-edit`. The file lands at
+/// `/etc/sudoers.d/sysknife-grant-<name>`.
+pub fn validated_sudoers_name(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s.is_empty() || s.len() > 64 {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    let first = s.chars().next().unwrap();
+    if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '_' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
+/// Validate a sudoers command spec: the literal `ALL`, or a comma-separated
+/// list of ABSOLUTE command paths with no wildcards, no `..`, and no shell
+/// metacharacters. Mirrors `build_rule`/`CMD_RE` in the helper.
+pub fn validated_sudo_commands(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s == "ALL" {
+        return Ok(s.to_string());
+    }
+    if s.is_empty() || s.len() > 1024 {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    let cmds: Vec<&str> = s.split(',').filter(|c| !c.is_empty()).collect();
+    if cmds.is_empty() {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    for c in cmds {
+        if !c.starts_with('/')
+            || c.contains("..")
+            || c.contains('*')
+            || !c
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-'))
+        {
+            return Err(ExecutorError::InvalidParam(param));
+        }
+    }
+    Ok(s.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1316,5 +1367,28 @@ mod tests {
         assert!(validated_swap_path("/var/swap/sk.swap", "p").is_ok());
         assert!(validated_swap_path("swapfile", "p").is_err()); // not absolute
         assert!(validated_swap_path("/../etc/x", "p").is_err()); // traversal
+    }
+
+    // ── sudoers validators ────────────────────────────────────────────────
+
+    #[test]
+    fn sudoers_name_no_dots_or_tildes() {
+        assert!(validated_sudoers_name("deploy-restart", "n").is_ok());
+        assert!(validated_sudoers_name("ci_01", "n").is_ok());
+        assert!(validated_sudoers_name("bad.name", "n").is_err()); // dot → sudo ignores file
+        assert!(validated_sudoers_name("bad~", "n").is_err()); // tilde
+        assert!(validated_sudoers_name("-lead", "n").is_err());
+        assert!(validated_sudoers_name("", "n").is_err());
+    }
+
+    #[test]
+    fn sudo_commands_all_or_abs_paths() {
+        assert!(validated_sudo_commands("ALL", "c").is_ok());
+        assert!(validated_sudo_commands("/usr/bin/systemctl", "c").is_ok());
+        assert!(validated_sudo_commands("/usr/bin/systemctl,/usr/sbin/service", "c").is_ok());
+        assert!(validated_sudo_commands("systemctl", "c").is_err()); // not absolute
+        assert!(validated_sudo_commands("/usr/bin/*", "c").is_err()); // wildcard
+        assert!(validated_sudo_commands("/usr/bin/../bin/sh", "c").is_err()); // traversal
+        assert!(validated_sudo_commands("/bin/sh; rm -rf /", "c").is_err()); // metachars
     }
 }

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -2,15 +2,16 @@ use crate::actions::{
     apparmor, apt, cloudinit, containers, deployment, distrobox, fail2ban, filesystem, flatpak,
     grub, identity, journald, layering, livepatch, lvm, mounts, multipass, netplan, network,
     package_repos, ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh,
-    sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
+    sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
     validate::{
         validated_apparmor_profile, validated_cpu_quota, validated_fstype, validated_group,
         validated_hostname, validated_journal_grep, validated_journal_priority,
         validated_journal_time, validated_locale, validated_lvm_name, validated_lvm_size,
         validated_memory_limit, validated_mount_device, validated_mount_options,
         validated_mount_point, validated_port_or_service, validated_ppa_name, validated_safe_arg,
-        validated_swap_path, validated_sysctl_key, validated_sysctl_value, validated_tasks_max,
-        validated_timezone, validated_unit_name, validated_username,
+        validated_sudo_commands, validated_sudoers_name, validated_swap_path, validated_sysctl_key,
+        validated_sysctl_value, validated_tasks_max, validated_timezone, validated_unit_name,
+        validated_username,
     },
     ActionMechanism, ActionSpec,
 };
@@ -663,6 +664,39 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
         "RemoveSwap" => {
             let file = validated_swap_path(require_str(params, "file")?, "file")?;
             Ok(mounts::remove_swap(&file))
+        }
+
+        // ── Scoped sudoers.d ────────────────────────────────────────────────
+        "GetSudoGrants" => Ok(sudoers::get_sudo_grants()),
+        "GrantSudoAccess" => {
+            let name = validated_sudoers_name(require_str(params, "name")?, "name")?;
+            let user = validated_username(require_str(params, "user")?, "user")?;
+            let commands = validated_sudo_commands(require_str(params, "commands")?, "commands")?;
+            // runas defaults to root; if given it must be "ALL" or a username.
+            let runas = match params
+                .get("runas")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                Some("ALL") => Some("ALL".to_string()),
+                Some(u) => Some(validated_username(u, "runas")?),
+                None => None,
+            };
+            let nopasswd = params
+                .get("nopasswd")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            Ok(sudoers::grant_sudo_access(
+                &name,
+                &user,
+                &commands,
+                runas.as_deref(),
+                nopasswd,
+            ))
+        }
+        "RevokeSudoAccess" => {
+            let name = validated_sudoers_name(require_str(params, "name")?, "name")?;
+            Ok(sudoers::revoke_sudo_access(&name))
         }
 
         // ── System info ──────────────────────────────────────────────────

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -65,6 +65,8 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "GetSysctl"
         // ── Filesystem mounts read-only ───────────────────────────────────
         | "GetMounts"
+        // ── Scoped sudoers.d read-only ────────────────────────────────────
+        | "GetSudoGrants"
         | "GetAuthorizedKeys"
         | "ListUsers"
         | "ListGroups"
@@ -256,6 +258,14 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "RemoveMount"
         | "AddSwap"
         | "RemoveSwap"
+        // ── Scoped sudoers.d mutations ────────────────────────────────────
+        //
+        // Grant/RevokeSudoAccess configure privilege escalation itself — the
+        // highest-consequence mutating family. Admin/High (the helper's
+        // visudo -cf gate prevents a syntactically broken drop-in, but the
+        // grant is still a real privilege change).
+        | "GrantSudoAccess"
+        | "RevokeSudoAccess"
         | "DeleteUser"
         | "AddAuthorizedKey"
         | "RemoveAuthorizedKey"

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -93,6 +93,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "GetLvmReport"
         | "GetSysctl"
         | "GetMounts"
+        | "GetSudoGrants"
         | "GetAuthorizedKeys"
         | "GetDateTime"
         | "ListJobHistory"
@@ -384,6 +385,21 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             rollback_available: false,
             warnings: vec![
                 "too tight a MemoryMax can OOM-kill the service".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── Scoped sudoers.d ──────────────────────────────────────────────
+        "GrantSudoAccess" | "RevokeSudoAccess" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "a sudoers.d drop-in will be created/removed".to_string(),
+                "the target user's sudo privileges will change".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "this configures privilege escalation — review the rule carefully".to_string(),
                 "exact approval required".to_string(),
             ],
         },

--- a/crates/sysknife-daemon/tests/action_consistency.rs
+++ b/crates/sysknife-daemon/tests/action_consistency.rs
@@ -15,7 +15,7 @@ use sysknife_daemon::actions::{
     apparmor, apt, cloudinit, containers, deployment, distrobox, fail2ban, filesystem, flatpak,
     grub, identity, journald, layering, livepatch, lvm, mounts, multipass, netplan, network,
     package_repos, ppa, processes, reboot, release_upgrade, resolvectl, services, snap, ssh,
-    sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
+    sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
 };
 use sysknife_daemon::executor::build_action_spec;
 use sysknife_daemon::policy::min_role_for_action;
@@ -71,6 +71,9 @@ fn all_spec_action_names() -> BTreeSet<&'static str> {
         names.insert(spec.action_name);
     }
     for spec in mounts::specs() {
+        names.insert(spec.action_name);
+    }
+    for spec in sudoers::specs() {
         names.insert(spec.action_name);
     }
     for spec in identity::specs() {

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -138,6 +138,10 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     "RemoveMount",
     "AddSwap",
     "RemoveSwap",
+    // Scoped sudoers.d (cross-distro)
+    "GetSudoGrants",
+    "GrantSudoAccess",
+    "RevokeSudoAccess",
     "GetDateTime",
     "SetHostname",
     "SetTimezone",

--- a/docs/typed-actions.md
+++ b/docs/typed-actions.md
@@ -53,7 +53,7 @@ codebase. On the daemon side (`sysknife-daemon`), each action is backed by an
 | `reboot_required` | Whether the daemon should warn the caller before proceeding |
 | `rollback_available` | Whether a failure triggers automatic rollback |
 
-As of this writing the catalogue defines **165 actions** across families such
+As of this writing the catalogue defines **168 actions** across families such
 as Deployment, Services, Package Layering, Flatpak, Containers, Toolbox,
 Network, Identity, SSH Keys, Package Repositories, apt/snap/ufw/netplan/grub
 (Debian-family), and rpm-ostree/AppArmor/cloud-init/Pro (Fedora-family). Each

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -26,7 +26,7 @@ system.
    `state.planner.plan_intent(intent)`.
 
 4. **LLM planning loop** (`crates/sysknife-brain/src/planner.rs:318`)
-   Turn 0: LLM receives system prompt (165-action catalogue, risk rules) +
+   Turn 0: LLM receives system prompt (168-action catalogue, risk rules) +
    user message. LLM calls `get_system_state`.
 
 5. **State injection** (`crates/sysknife-brain/src/planner.rs:366`)

--- a/packaging/sysknife-sudoers
+++ b/packaging/sysknife-sudoers
@@ -209,3 +209,12 @@ sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/sysctl-edit *
 # `findmnt` and needs no grant. Bare mount/swapon grants are NOT given: they
 # would let the daemon mount arbitrary sources over arbitrary paths.
 sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/mount-edit *
+
+# sudoers edit — GrantSudoAccess/RevokeSudoAccess delegate to this root-owned
+# helper, which builds a scoped rule and validates it with `visudo -cf` on a
+# temp file BEFORE atomically installing it to /etc/sudoers.d/sysknife-grant-*
+# (0440). The drop-in name is charset-restricted (no dots/tildes, which sudo
+# would silently ignore) and command paths must be absolute with no wildcards.
+# GetSudoGrants reads via the bare helper (`--op list`; the daemon is root) and
+# needs no grant. A bare `visudo`/editor grant is NOT given.
+sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/sudoers-edit *

--- a/packaging/sysknife-sudoers-edit
+++ b/packaging/sysknife-sudoers-edit
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# sysknife-sudoers-edit — create/remove a scoped sudoers drop-in, or list the
+# SysKnife-managed ones.
+#
+# Install to: /usr/lib/sysknife/sudoers-edit
+# Mode:       0755
+# Owner:      root:root
+#
+# Invoked exclusively by the sysknife-daemon via one of:
+#   sudo /usr/lib/sysknife/sudoers-edit --op grant --name <name> --user <user> \
+#        --commands <ALL|/abs/cmd1,/abs/cmd2> [--runas <user|ALL>] [--nopasswd]
+#   sudo /usr/lib/sysknife/sudoers-edit --op revoke --name <name>
+#        /usr/lib/sysknife/sudoers-edit --op list        (read-only; daemon is root)
+#
+# This helper writes to /etc/sudoers.d/ — a mistake here can lock out sudo or
+# grant unintended root. Guards:
+#   - name: ^[a-z0-9][a-z0-9_-]{0,63}$  (no dots/tildes — sudo SILENTLY ignores
+#     drop-in files containing them, which would make a "grant" not apply).
+#     Files are namespaced `sysknife-grant-<name>` so revoke/list only ever
+#     touch SysKnife's own drop-ins.
+#   - commands: literal `ALL`, or a comma list of ABSOLUTE paths with no shell
+#     metacharacters and no wildcards.
+#   - user / runas: validated identifiers (runas may be `ALL`).
+#   - The rule is written to a temp file and validated with `visudo -cf` BEFORE
+#     being atomically moved into place (0440). If visudo rejects it, nothing
+#     is installed. This is the core safety property.
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+SUDOERS_D = "/etc/sudoers.d"
+VISUDO = "/usr/sbin/visudo"
+PREFIX = "sysknife-grant-"
+
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+IDENT_RE = re.compile(r"^[a-z_][a-z0-9_-]*\$?$")  # unix user/group name
+CMD_RE = re.compile(r"^/[A-Za-z0-9/._-]+$")
+
+
+def die(msg: str) -> None:
+    print(f"sysknife-sudoers-edit: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def validated_ident(value: str, what: str) -> str:
+    if value == "ALL":
+        return value
+    if len(value) > 32 or not IDENT_RE.match(value):
+        die(f"invalid {what} {value!r}")
+    return value
+
+
+def build_rule(user: str, runas: str, nopasswd: bool, commands: str) -> str:
+    if commands == "ALL":
+        cmd_spec = "ALL"
+    else:
+        cmds = [c for c in commands.split(",") if c]
+        if not cmds:
+            die("no commands given")
+        for c in cmds:
+            if not CMD_RE.match(c) or ".." in c or "*" in c:
+                die(f"invalid command path {c!r} (absolute, no wildcards, no ..)")
+        cmd_spec = ", ".join(cmds)
+    tag = "NOPASSWD: " if nopasswd else ""
+    return f"{user} ALL=({runas}) {tag}{cmd_spec}\n"
+
+
+def op_grant(args) -> None:
+    if not NAME_RE.match(args.name):
+        die(f"invalid name {args.name!r}")
+    user = validated_ident(args.user, "user")
+    if user == "ALL":
+        die("refusing to grant to ALL users")
+    runas = validated_ident(args.runas or "root", "runas")
+    rule = build_rule(user, runas, args.nopasswd, args.commands)
+
+    header = f"# Managed by SysKnife (grant_sudo_access: {args.name}). Do not edit by hand.\n"
+    content = header + rule
+    dest = os.path.join(SUDOERS_D, PREFIX + args.name)
+
+    fd, tmp = tempfile.mkstemp(dir=SUDOERS_D, prefix=".sysknife-sudoers-")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(content)
+        os.chmod(tmp, 0o440)
+        # Validate BEFORE installing — the core safety gate.
+        check = subprocess.run([VISUDO, "-cf", tmp], check=False, stderr=subprocess.PIPE)
+        if check.returncode != 0:
+            die(f"visudo rejected the rule: {check.stderr.decode(errors='replace').strip()}")
+        os.replace(tmp, dest)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        die(f"cannot install drop-in: {exc}")
+
+
+def op_revoke(args) -> None:
+    if not NAME_RE.match(args.name):
+        die(f"invalid name {args.name!r}")
+    dest = os.path.join(SUDOERS_D, PREFIX + args.name)
+    if os.path.exists(dest):
+        try:
+            os.unlink(dest)
+        except OSError as exc:
+            die(f"cannot remove drop-in: {exc}")
+
+
+def op_list(_args) -> None:
+    try:
+        names = sorted(n for n in os.listdir(SUDOERS_D) if n.startswith(PREFIX))
+    except OSError as exc:
+        die(f"cannot read {SUDOERS_D}: {exc}")
+    for n in names:
+        path = os.path.join(SUDOERS_D, n)
+        try:
+            with open(path, "r") as fh:
+                body = "".join(
+                    ln for ln in fh if ln.strip() and not ln.lstrip().startswith("#")
+                ).strip()
+        except OSError:
+            body = "(unreadable)"
+        print(f"{n[len(PREFIX):]}\t{body}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage scoped sudoers.d drop-ins.")
+    parser.add_argument("--op", required=True, choices=["grant", "revoke", "list"])
+    parser.add_argument("--name")
+    parser.add_argument("--user")
+    parser.add_argument("--commands")
+    parser.add_argument("--runas")
+    parser.add_argument("--nopasswd", action="store_true")
+    args = parser.parse_args()
+
+    if args.op == "grant":
+        if not (args.name and args.user and args.commands):
+            die("grant requires --name, --user, --commands")
+        op_grant(args)
+    elif args.op == "revoke":
+        if not args.name:
+            die("revoke requires --name")
+        op_revoke(args)
+    else:
+        op_list(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/ubuntu-provision.sh
+++ b/tests/e2e/ubuntu-provision.sh
@@ -252,6 +252,9 @@ install -Dm 755 packaging/sysknife-sysctl-edit /usr/lib/sysknife/sysctl-edit \
 # mount-edit: invoked by AddMount/RemoveMount/AddSwap/RemoveSwap.
 install -Dm 755 packaging/sysknife-mount-edit /usr/lib/sysknife/mount-edit \
     || fail "Install sysknife-mount-edit"
+# sudoers-edit: invoked by GrantSudoAccess/RevokeSudoAccess/GetSudoGrants.
+install -Dm 755 packaging/sysknife-sudoers-edit /usr/lib/sysknife/sudoers-edit \
+    || fail "Install sysknife-sudoers-edit"
 
 # ---------------------------------------------------------------------------
 # Step 6: Add VM user to sysknife groups


### PR DESCRIPTION
Batch 6. Adds **3 cross-distro actions** (165 → 168), verified end-to-end in the noble QEMU VM.

## Actions
- `GetSudoGrants` (Observer/Low) — list SysKnife-managed drop-ins.
- `GrantSudoAccess`/`RevokeSudoAccess` (Admin/High) — create/remove a scoped rule under `/etc/sudoers.d/sysknife-grant-<name>`.

## Safety (helper)
Core gate: build the rule in a temp file, run **`visudo -cf`**, and only atomically install (0440) if it validates — a malformed rule can never land in `/etc/sudoers.d/` and wedge sudo. Plus: name `^[a-z0-9][a-z0-9_-]{0,63}$` (no dots/tildes — sudo silently ignores such files); commands are `ALL` or absolute paths only (no wildcards/`..`/metachars); refuses granting to ALL users.

## Verification (Ubuntu 24.04)
Grant for a test user parsed via visudo, showed in `sudo -l -U`, and the user **actually ran the NOPASSWD command end-to-end** (`systemctl is-system-running` → degraded); revoke removed it cleanly; dot-names, non-absolute commands, and wildcards all rejected. `cargo nextest`: **1326 passed**; clippy+fmt clean; action_consistency green.

Closes #71.