### PR TITLE
feat(actions): log management — logrotate + rsyslog forwarding (#70)

### DIFF
--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -195,6 +195,17 @@ pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
      "grant a scoped sudo rule (validated with visudo before install) — params: name* (^[a-z0-9][a-z0-9_-]*$), user*, commands* ('ALL' or comma-separated ABSOLUTE paths), runas (default root, or 'ALL'), nopasswd (bool); High risk — this configures privilege escalation"),
     ("RevokeSudoAccess",
      "remove a SysKnife-managed sudoers.d drop-in — param: name*; High risk"),
+    // Log management
+    ("GetLogrotateStatus",
+     "dry-run logrotate to show what would rotate (logrotate -d) — param: config (optional path); read-only"),
+    ("ConfigureLogRotation",
+     "write a logrotate drop-in (validated with logrotate -d) — params: name*, path* (log file/glob under /var/log), frequency* (daily|weekly|monthly), rotate* (count 0-1000), compress (bool); Medium risk"),
+    ("RemoveLogRotation",
+     "remove a SysKnife-managed logrotate drop-in — param: name*; Medium risk"),
+    ("ConfigureRemoteSyslog",
+     "forward all logs to a remote collector via rsyslog (validated with rsyslogd -N1) — params: host*, port* (1-65535), protocol* (tcp|udp); High risk — logs leave the host"),
+    ("RemoveRemoteSyslog",
+     "stop remote syslog forwarding (remove the rsyslog drop-in) — no params; High risk"),
     // Identity / time / locale
     ("GetDateTime",
      "current date, time, timezone, and NTP status (timedatectl) — no params"),

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -421,11 +421,12 @@ GetNetworkStatus, GetDiskUsage, GetDateTime, ListProcesses, GetMemoryInfo,
 GetAuthorizedKeys, ListPackageRepositories, ListContainers, GetContainerInfo,
 ListUsers, ListGroups, ListJobHistory,
 ResolvectlStatus,
-GetJournalLog, GetLvmReport, GetSysctl, GetServiceResourceLimits, GetMounts, GetSudoGrants
+GetJournalLog, GetLvmReport, GetSysctl, GetServiceResourceLimits, GetMounts, GetSudoGrants,
+GetLogrotateStatus
 
 ### Medium risk — cross-distro (approval required before execution)
 
-ResolvectlSetDns, VacuumJournal
+ResolvectlSetDns, VacuumJournal, ConfigureLogRotation, RemoveLogRotation
 "#;
 
 const CROSS_DISTRO_RISK_RULES: &str = r#"
@@ -447,7 +448,8 @@ AddAuthorizedKey, RemoveAuthorizedKey,
 ExtendLogicalVolume, CreateLogicalVolume, CreateLvSnapshot,
 SetSysctl, SetServiceResourceLimits,
 AddMount, RemoveMount, AddSwap, RemoveSwap,
-GrantSudoAccess, RevokeSudoAccess
+GrantSudoAccess, RevokeSudoAccess,
+ConfigureRemoteSyslog, RemoveRemoteSyslog
 
 ## Risk classification rules
 
@@ -544,6 +546,13 @@ Use `"username"` as the key — NOT `"user"`.
 - `RemoveMount`: `{"mountpoint":"/mnt/data"}`.
 - `AddSwap`: `{"file":"/swapfile","size_mb":2048}`.
 - `RemoveSwap`: `{"file":"/swapfile"}`.
+
+**Log management**:
+- `GetLogrotateStatus`: `{}` or `{"config":"/etc/logrotate.conf"}` (read-only dry-run).
+- `ConfigureLogRotation`: `{"name":"nginx","path":"/var/log/nginx/*.log","frequency":"daily","rotate":14,"compress":true}`.
+- `RemoveLogRotation`: `{"name":"nginx"}`.
+- `ConfigureRemoteSyslog`: `{"host":"logs.example.com","port":514,"protocol":"tcp"}`.
+- `RemoveRemoteSyslog`: `{}`.
 
 **Scoped sudoers.d**:
 - `GetSudoGrants`: `{}` (read-only).

--- a/crates/sysknife-daemon/src/actions/logging.rs
+++ b/crates/sysknife-daemon/src/actions/logging.rs
@@ -1,0 +1,198 @@
+//! Log-management actions: logrotate drop-ins + rsyslog remote forwarding.
+//!
+//! `GetLogrotateStatus` is a read-only dry-run (`logrotate -d`). The mutating
+//! actions delegate to the root-owned helper `/usr/lib/sysknife/log-edit`, which
+//! validates each config before keeping it (`logrotate -d` for rotation,
+//! `rsyslogd -N1` for forwarding) and rolls back on rejection.
+
+use super::{command_mechanism, ActionSpec};
+use sysknife_types::RiskLevel;
+
+const HELPER: &str = "/usr/lib/sysknife/log-edit";
+
+pub fn specs() -> Vec<ActionSpec> {
+    vec![
+        get_logrotate_status(None),
+        configure_log_rotation("nginx", "/var/log/nginx/*.log", "daily", 14, true),
+        remove_log_rotation("nginx"),
+        configure_remote_syslog("logs.example.com", 514, "tcp"),
+        remove_remote_syslog(),
+    ]
+}
+
+/// Dry-run logrotate to show what would rotate (`logrotate -d <conf>`).
+/// Read-only — `-d` (debug) never actually rotates. Defaults to the main config.
+pub fn get_logrotate_status(config: Option<&str>) -> ActionSpec {
+    let conf = config.unwrap_or("/etc/logrotate.conf");
+    ActionSpec {
+        action_name: "GetLogrotateStatus",
+        mechanism: command_mechanism("logrotate", ["-d", conf]),
+        risk_level: RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Write a logrotate drop-in (`log-edit --op logrotate …`).
+pub fn configure_log_rotation(
+    name: &str,
+    path: &str,
+    frequency: &str,
+    rotate: u32,
+    compress: bool,
+) -> ActionSpec {
+    let rot = rotate.to_string();
+    let mut args = vec![
+        HELPER.to_string(),
+        "--op".to_string(),
+        "logrotate".to_string(),
+        "--name".to_string(),
+        name.to_string(),
+        "--path".to_string(),
+        path.to_string(),
+        "--frequency".to_string(),
+        frequency.to_string(),
+        "--rotate".to_string(),
+        rot,
+    ];
+    if compress {
+        args.push("--compress".to_string());
+    }
+    ActionSpec {
+        action_name: "ConfigureLogRotation",
+        mechanism: command_mechanism("sudo", args),
+        risk_level: RiskLevel::Medium,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Remove a SysKnife-managed logrotate drop-in.
+pub fn remove_log_rotation(name: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "RemoveLogRotation",
+        mechanism: command_mechanism("sudo", [HELPER, "--op", "rm-logrotate", "--name", name]),
+        risk_level: RiskLevel::Medium,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Configure rsyslog to forward all logs to a remote collector.
+pub fn configure_remote_syslog(host: &str, port: u16, protocol: &str) -> ActionSpec {
+    let p = port.to_string();
+    ActionSpec {
+        action_name: "ConfigureRemoteSyslog",
+        mechanism: command_mechanism(
+            "sudo",
+            [
+                HELPER,
+                "--op",
+                "rsyslog-forward",
+                "--host",
+                host,
+                "--port",
+                &p,
+                "--protocol",
+                protocol,
+            ],
+        ),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Remove the rsyslog remote-forwarding drop-in.
+pub fn remove_remote_syslog() -> ActionSpec {
+    ActionSpec {
+        action_name: "RemoveRemoteSyslog",
+        mechanism: command_mechanism("sudo", [HELPER, "--op", "rm-forward"]),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::ActionMechanism;
+
+    fn args_of(spec: &ActionSpec) -> (&'static str, Vec<String>) {
+        match &spec.mechanism {
+            ActionMechanism::Command { program, args } => (program, args.clone()),
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn logrotate_status_dry_run() {
+        let (program, args) = args_of(&get_logrotate_status(None));
+        assert_eq!(program, "logrotate");
+        assert_eq!(args, vec!["-d", "/etc/logrotate.conf"]);
+        assert_eq!(get_logrotate_status(None).risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn configure_rotation_with_compress() {
+        let (program, args) = args_of(&configure_log_rotation(
+            "nginx",
+            "/var/log/nginx/*.log",
+            "daily",
+            14,
+            true,
+        ));
+        assert_eq!(program, "sudo");
+        assert_eq!(
+            args,
+            vec![
+                HELPER,
+                "--op",
+                "logrotate",
+                "--name",
+                "nginx",
+                "--path",
+                "/var/log/nginx/*.log",
+                "--frequency",
+                "daily",
+                "--rotate",
+                "14",
+                "--compress"
+            ]
+        );
+        let (_, no_comp) = args_of(&configure_log_rotation(
+            "n",
+            "/var/log/x",
+            "weekly",
+            4,
+            false,
+        ));
+        assert!(!no_comp.iter().any(|a| a == "--compress"));
+    }
+
+    #[test]
+    fn syslog_forward_tcp_and_removes() {
+        let (_, fwd) = args_of(&configure_remote_syslog("logs.example.com", 514, "tcp"));
+        assert_eq!(
+            fwd,
+            vec![
+                HELPER,
+                "--op",
+                "rsyslog-forward",
+                "--host",
+                "logs.example.com",
+                "--port",
+                "514",
+                "--protocol",
+                "tcp"
+            ]
+        );
+        assert_eq!(
+            configure_remote_syslog("h", 1, "udp").risk_level,
+            RiskLevel::High
+        );
+        let (_, rm) = args_of(&remove_remote_syslog());
+        assert_eq!(rm, vec![HELPER, "--op", "rm-forward"]);
+    }
+}

--- a/crates/sysknife-daemon/src/actions/mod.rs
+++ b/crates/sysknife-daemon/src/actions/mod.rs
@@ -16,6 +16,7 @@ pub mod journald;
 pub mod layering;
 pub mod layering_ubuntu;
 pub mod livepatch;
+pub mod logging;
 pub mod lvm;
 pub mod mounts;
 pub mod multipass;

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -659,6 +659,36 @@ pub fn validated_apt_pin_name(s: &str, param: &'static str) -> Result<String, Ex
     validated_sudoers_name(s, param)
 }
 
+/// Validate a log path/glob for logrotate: absolute, no `..`, charset
+/// `[A-Za-z0-9/._*-]`, 1..=255. Mirrors `PATH_RE` in `packaging/sysknife-log-edit`.
+pub fn validated_log_path(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if !s.starts_with('/') || s.len() > 255 || s.contains("..") {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '*' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
+/// Validate a syslog collector host: a hostname or IPv4/IPv6 literal
+/// (`[A-Za-z0-9.:_-]`, no `..`, 1..=255). Mirrors `HOST_RE` in the helper.
+pub fn validated_syslog_host(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s.is_empty() || s.len() > 255 || s.contains("..") || s.starts_with('-') {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | ':' | '_' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
 /// Validate an apt package-name glob (`[A-Za-z0-9.+*?_:-]`, 1..=128).
 pub fn validated_apt_package(s: &str, param: &'static str) -> Result<String, ExecutorError> {
     if s.is_empty()
@@ -1441,5 +1471,20 @@ mod tests {
         assert!(validated_apt_pin_expr("version 1.24.*", "e").is_ok());
         assert!(validated_apt_pin_expr("origin\nrepo", "e").is_err()); // newline
         assert!(validated_apt_pin_expr("", "e").is_err());
+    }
+
+    // ── logging validators ────────────────────────────────────────────────
+
+    #[test]
+    fn log_path_and_syslog_host() {
+        assert!(validated_log_path("/var/log/nginx/*.log", "p").is_ok());
+        assert!(validated_log_path("/var/log/app.log", "p").is_ok());
+        assert!(validated_log_path("relative.log", "p").is_err());
+        assert!(validated_log_path("/var/log/../etc/x", "p").is_err());
+        assert!(validated_syslog_host("logs.example.com", "h").is_ok());
+        assert!(validated_syslog_host("10.0.0.5", "h").is_ok());
+        assert!(validated_syslog_host("fe80::1", "h").is_ok());
+        assert!(validated_syslog_host("-bad", "h").is_err());
+        assert!(validated_syslog_host("bad host", "h").is_err());
     }
 }

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -1,18 +1,18 @@
 use crate::actions::{
     apparmor, apt, apt_preferences, cloudinit, containers, deployment, distrobox, fail2ban,
-    filesystem, flatpak, grub, identity, journald, layering, livepatch, lvm, mounts, multipass,
-    netplan, network, package_repos, ppa, processes, reboot, release_upgrade, resolvectl, services,
-    snap, ssh, sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
+    filesystem, flatpak, grub, identity, journald, layering, livepatch, logging, lvm, mounts,
+    multipass, netplan, network, package_repos, ppa, processes, reboot, release_upgrade,
+    resolvectl, services, snap, ssh, sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
     validate::{
         validated_apparmor_profile, validated_apt_package, validated_apt_pin_expr,
         validated_apt_pin_name, validated_cpu_quota, validated_fstype, validated_group,
         validated_hostname, validated_journal_grep, validated_journal_priority,
-        validated_journal_time, validated_locale, validated_lvm_name, validated_lvm_size,
-        validated_memory_limit, validated_mount_device, validated_mount_options,
-        validated_mount_point, validated_port_or_service, validated_ppa_name, validated_safe_arg,
-        validated_sudo_commands, validated_sudoers_name, validated_swap_path, validated_sysctl_key,
-        validated_sysctl_value, validated_tasks_max, validated_timezone, validated_unit_name,
-        validated_username,
+        validated_journal_time, validated_locale, validated_log_path, validated_lvm_name,
+        validated_lvm_size, validated_memory_limit, validated_mount_device,
+        validated_mount_options, validated_mount_point, validated_port_or_service,
+        validated_ppa_name, validated_safe_arg, validated_sudo_commands, validated_sudoers_name,
+        validated_swap_path, validated_sysctl_key, validated_sysctl_value, validated_syslog_host,
+        validated_tasks_max, validated_timezone, validated_unit_name, validated_username,
     },
     ActionMechanism, ActionSpec,
 };
@@ -724,6 +724,52 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
             let name = validated_apt_pin_name(require_str(params, "name")?, "name")?;
             Ok(apt_preferences::remove_apt_pin(&name))
         }
+
+        // ── Log management (logrotate + rsyslog) ────────────────────────────
+        "GetLogrotateStatus" => {
+            let config = optional_validated(params, "config", validated_log_path)?;
+            Ok(logging::get_logrotate_status(config.as_deref()))
+        }
+        "ConfigureLogRotation" => {
+            let name = validated_sudoers_name(require_str(params, "name")?, "name")?;
+            let path = validated_log_path(require_str(params, "path")?, "path")?;
+            let frequency = require_str(params, "frequency")?;
+            if !matches!(frequency, "daily" | "weekly" | "monthly") {
+                return Err(ExecutorError::InvalidParam("frequency"));
+            }
+            let rotate = require_u32(params, "rotate")?;
+            if rotate > 1000 {
+                return Err(ExecutorError::InvalidParam("rotate"));
+            }
+            let compress = params
+                .get("compress")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            Ok(logging::configure_log_rotation(
+                &name, &path, frequency, rotate, compress,
+            ))
+        }
+        "RemoveLogRotation" => {
+            let name = validated_sudoers_name(require_str(params, "name")?, "name")?;
+            Ok(logging::remove_log_rotation(&name))
+        }
+        "ConfigureRemoteSyslog" => {
+            let host = validated_syslog_host(require_str(params, "host")?, "host")?;
+            let port = require_u32(params, "port")?;
+            if !(1..=65535).contains(&port) {
+                return Err(ExecutorError::InvalidParam("port"));
+            }
+            let protocol = require_str(params, "protocol")?;
+            if !matches!(protocol, "tcp" | "udp") {
+                return Err(ExecutorError::InvalidParam("protocol"));
+            }
+            Ok(logging::configure_remote_syslog(
+                &host,
+                port as u16,
+                protocol,
+            ))
+        }
+        "RemoveRemoteSyslog" => Ok(logging::remove_remote_syslog()),
 
         // ── System info ──────────────────────────────────────────────────
         "GetMemoryInfo" => Ok(system_info::get_memory_info_spec()),

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -67,6 +67,8 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "GetMounts"
         // ── Scoped sudoers.d read-only ────────────────────────────────────
         | "GetSudoGrants"
+        // ── Log management read-only ──────────────────────────────────────
+        | "GetLogrotateStatus"
         | "GetAuthorizedKeys"
         | "ListUsers"
         | "ListGroups"
@@ -177,6 +179,9 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         // ── Ubuntu / apt pinning (reversible; steers version resolution) ──
         | "SetAptPin"
         | "RemoveAptPin"
+        // ── Log management (logrotate; reversible config) ─────────────────
+        | "ConfigureLogRotation"
+        | "RemoveLogRotation"
         // ── Ubuntu / Flatpak medium-risk ───────────────────────────────────
         | "UbuntuInstallFlatpak"
         | "UbuntuRemoveFlatpak"
@@ -271,6 +276,12 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         // grant is still a real privilege change).
         | "GrantSudoAccess"
         | "RevokeSudoAccess"
+        // ── Remote syslog forwarding (log-exfil surface) ──────────────────
+        //
+        // ConfigureRemoteSyslog sends all logs to an external collector — a
+        // data-exfiltration vector — so it is Admin/High.
+        | "ConfigureRemoteSyslog"
+        | "RemoveRemoteSyslog"
         | "DeleteUser"
         | "AddAuthorizedKey"
         | "RemoveAuthorizedKey"

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -94,6 +94,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "GetSysctl"
         | "GetMounts"
         | "GetSudoGrants"
+        | "GetLogrotateStatus"
         | "GetAuthorizedKeys"
         | "GetDateTime"
         | "ListJobHistory"
@@ -386,6 +387,30 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             rollback_available: false,
             warnings: vec![
                 "too tight a MemoryMax can OOM-kill the service".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── Log management ────────────────────────────────────────────────
+        "ConfigureLogRotation" | "RemoveLogRotation" => PreviewProfile {
+            risk_level: RiskLevel::Medium,
+            expected_side_effects: vec![
+                "a logrotate drop-in will be written/removed".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec!["approval required".to_string()],
+        },
+        "ConfigureRemoteSyslog" | "RemoveRemoteSyslog" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "rsyslog will start/stop forwarding all logs to a remote host".to_string(),
+                "rsyslog will be restarted".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "forwarding sends log data off-host (exfiltration surface)".to_string(),
                 "exact approval required".to_string(),
             ],
         },

--- a/crates/sysknife-daemon/tests/action_consistency.rs
+++ b/crates/sysknife-daemon/tests/action_consistency.rs
@@ -13,9 +13,9 @@ use serde_json::json;
 use sysknife_brain::planning_tools::propose_plan::KNOWN_ACTIONS;
 use sysknife_daemon::actions::{
     apparmor, apt, apt_preferences, cloudinit, containers, deployment, distrobox, fail2ban,
-    filesystem, flatpak, grub, identity, journald, layering, livepatch, lvm, mounts, multipass,
-    netplan, network, package_repos, ppa, processes, reboot, release_upgrade, resolvectl, services,
-    snap, ssh, sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
+    filesystem, flatpak, grub, identity, journald, layering, livepatch, logging, lvm, mounts,
+    multipass, netplan, network, package_repos, ppa, processes, reboot, release_upgrade,
+    resolvectl, services, snap, ssh, sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
 };
 use sysknife_daemon::executor::build_action_spec;
 use sysknife_daemon::policy::min_role_for_action;
@@ -74,6 +74,9 @@ fn all_spec_action_names() -> BTreeSet<&'static str> {
         names.insert(spec.action_name);
     }
     for spec in sudoers::specs() {
+        names.insert(spec.action_name);
+    }
+    for spec in logging::specs() {
         names.insert(spec.action_name);
     }
     for spec in identity::specs() {

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -142,6 +142,12 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     "GetSudoGrants",
     "GrantSudoAccess",
     "RevokeSudoAccess",
+    // Log management (cross-distro)
+    "GetLogrotateStatus",
+    "ConfigureLogRotation",
+    "RemoveLogRotation",
+    "ConfigureRemoteSyslog",
+    "RemoveRemoteSyslog",
     "GetDateTime",
     "SetHostname",
     "SetTimezone",

--- a/docs/typed-actions.md
+++ b/docs/typed-actions.md
@@ -53,7 +53,7 @@ codebase. On the daemon side (`sysknife-daemon`), each action is backed by an
 | `reboot_required` | Whether the daemon should warn the caller before proceeding |
 | `rollback_available` | Whether a failure triggers automatic rollback |
 
-As of this writing the catalogue defines **171 actions** across families such
+As of this writing the catalogue defines **176 actions** across families such
 as Deployment, Services, Package Layering, Flatpak, Containers, Toolbox,
 Network, Identity, SSH Keys, Package Repositories, apt/snap/ufw/netplan/grub
 (Debian-family), and rpm-ostree/AppArmor/cloud-init/Pro (Fedora-family). Each

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -26,7 +26,7 @@ system.
    `state.planner.plan_intent(intent)`.
 
 4. **LLM planning loop** (`crates/sysknife-brain/src/planner.rs:318`)
-   Turn 0: LLM receives system prompt (171-action catalogue, risk rules) +
+   Turn 0: LLM receives system prompt (176-action catalogue, risk rules) +
    user message. LLM calls `get_system_state`.
 
 5. **State injection** (`crates/sysknife-brain/src/planner.rs:366`)

--- a/packaging/sysknife-log-edit
+++ b/packaging/sysknife-log-edit
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# sysknife-log-edit — manage logrotate drop-ins and rsyslog remote forwarding.
+#
+# Install to: /usr/lib/sysknife/log-edit
+# Mode:       0755
+# Owner:      root:root
+#
+# Invoked exclusively by the sysknife-daemon via one of:
+#   sudo /usr/lib/sysknife/log-edit --op logrotate --name <name> --path <logglob> \
+#        --frequency <daily|weekly|monthly> --rotate <count> [--compress]
+#   sudo /usr/lib/sysknife/log-edit --op rm-logrotate --name <name>
+#   sudo /usr/lib/sysknife/log-edit --op rsyslog-forward --host <h> --port <p> --protocol <tcp|udp>
+#   sudo /usr/lib/sysknife/log-edit --op rm-forward
+#
+# Inputs are re-validated here (defense-in-depth). logrotate configs are written
+# to /etc/logrotate.d/sysknife-<name> and validated with `logrotate -d` (debug/
+# dry-run) before being kept; a config that logrotate rejects is rolled back.
+# rsyslog forwarding writes /etc/rsyslog.d/60-sysknife-forward.conf, validates
+# with `rsyslogd -N1`, and restarts rsyslog (rolling back on failure).
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+LOGROTATE_D = "/etc/logrotate.d"
+RSYSLOG_D = "/etc/rsyslog.d"
+LOGROTATE = "/usr/sbin/logrotate"
+RSYSLOGD = "/usr/sbin/rsyslogd"
+SYSTEMCTL = "/usr/bin/systemctl"
+FWD_FILE = os.path.join(RSYSLOG_D, "60-sysknife-forward.conf")
+PREFIX = "sysknife-"
+
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+PATH_RE = re.compile(r"^/[A-Za-z0-9/._*-]{1,255}$")
+HOST_RE = re.compile(r"^[A-Za-z0-9.:_-]{1,255}$")  # hostname or IPv4/IPv6-ish
+FREQ = {"daily", "weekly", "monthly"}
+
+
+def die(msg: str) -> None:
+    print(f"sysknife-log-edit: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def atomic_write(path: str, content: str, mode: int = 0o644) -> None:
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".sysknife-log-")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(content)
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        die(f"cannot write {path}: {exc}")
+
+
+def op_logrotate(args) -> None:
+    if not NAME_RE.match(args.name):
+        die(f"invalid name {args.name!r}")
+    if not PATH_RE.match(args.path) or ".." in args.path:
+        die(f"invalid log path {args.path!r}")
+    if args.frequency not in FREQ:
+        die(f"frequency must be one of {sorted(FREQ)}")
+    if args.rotate < 0 or args.rotate > 1000:
+        die("rotate count out of range [0, 1000]")
+
+    body = (
+        f"# Managed by SysKnife (configure_log_rotation: {args.name}).\n"
+        f"{args.path} {{\n"
+        f"    {args.frequency}\n"
+        f"    rotate {args.rotate}\n"
+        f"    missingok\n"
+        f"    notifempty\n"
+        + ("    compress\n" if args.compress else "")
+        + "}\n"
+    )
+    dest = os.path.join(LOGROTATE_D, PREFIX + args.name)
+    prev = None
+    if os.path.exists(dest):
+        with open(dest) as fh:
+            prev = fh.read()
+    atomic_write(dest, body)
+    # Validate: logrotate -d is a dry-run that parses every config in the dir.
+    check = subprocess.run(
+        [LOGROTATE, "-d", dest], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+    )
+    if check.returncode != 0:
+        if prev is not None:
+            atomic_write(dest, prev)
+        else:
+            os.unlink(dest)
+        die(f"logrotate rejected the config: {check.stderr.decode(errors='replace').strip()}")
+
+
+def op_rm_logrotate(args) -> None:
+    if not NAME_RE.match(args.name):
+        die(f"invalid name {args.name!r}")
+    dest = os.path.join(LOGROTATE_D, PREFIX + args.name)
+    if os.path.exists(dest):
+        os.unlink(dest)
+
+
+def op_rsyslog_forward(args) -> None:
+    if not HOST_RE.match(args.host) or ".." in args.host:
+        die(f"invalid host {args.host!r}")
+    if args.port < 1 or args.port > 65535:
+        die("port out of range")
+    if args.protocol not in ("tcp", "udp"):
+        die("protocol must be tcp or udp")
+    # rsyslog: `@@` = TCP, `@` = UDP.
+    at = "@@" if args.protocol == "tcp" else "@"
+    body = (
+        "# Managed by SysKnife (configure_remote_syslog).\n"
+        f"*.* {at}{args.host}:{args.port}\n"
+    )
+    prev = None
+    if os.path.exists(FWD_FILE):
+        with open(FWD_FILE) as fh:
+            prev = fh.read()
+    atomic_write(FWD_FILE, body)
+    check = subprocess.run(
+        [RSYSLOGD, "-N1"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+    )
+    if check.returncode != 0:
+        if prev is not None:
+            atomic_write(FWD_FILE, prev)
+        else:
+            os.unlink(FWD_FILE)
+        die(f"rsyslog rejected the config: {check.stderr.decode(errors='replace').strip()}")
+    subprocess.run([SYSTEMCTL, "restart", "rsyslog"], check=False, stderr=subprocess.DEVNULL)
+
+
+def op_rm_forward(_args) -> None:
+    if os.path.exists(FWD_FILE):
+        os.unlink(FWD_FILE)
+        subprocess.run([SYSTEMCTL, "restart", "rsyslog"], check=False, stderr=subprocess.DEVNULL)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Manage logrotate + rsyslog forwarding.")
+    p.add_argument("--op", required=True,
+                   choices=["logrotate", "rm-logrotate", "rsyslog-forward", "rm-forward"])
+    p.add_argument("--name")
+    p.add_argument("--path")
+    p.add_argument("--frequency")
+    p.add_argument("--rotate", type=int)
+    p.add_argument("--compress", action="store_true")
+    p.add_argument("--host")
+    p.add_argument("--port", type=int)
+    p.add_argument("--protocol")
+    args = p.parse_args()
+
+    if args.op == "logrotate":
+        if not (args.name and args.path and args.frequency and args.rotate is not None):
+            die("logrotate requires --name --path --frequency --rotate")
+        op_logrotate(args)
+    elif args.op == "rm-logrotate":
+        if not args.name:
+            die("rm-logrotate requires --name")
+        op_rm_logrotate(args)
+    elif args.op == "rsyslog-forward":
+        if not (args.host and args.port and args.protocol):
+            die("rsyslog-forward requires --host --port --protocol")
+        op_rsyslog_forward(args)
+    else:
+        op_rm_forward(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/sysknife-sudoers
+++ b/packaging/sysknife-sudoers
@@ -144,6 +144,14 @@ sysknife ALL=(root) NOPASSWD: /usr/bin/add-apt-repository
 # grant. A bare editor/apt grant is NOT given.
 sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/apt-pin-edit *
 
+# log edit — ConfigureLogRotation/RemoveLogRotation and ConfigureRemoteSyslog/
+# RemoveRemoteSyslog delegate to this root-owned helper, which validates inputs,
+# writes /etc/logrotate.d/sysknife-<name> (checked with `logrotate -d`) or
+# /etc/rsyslog.d/60-sysknife-forward.conf (checked with `rsyslogd -N1`), rolling
+# back on rejection, and restarts rsyslog for forwarding. GetLogrotateStatus
+# runs bare `logrotate -d` (dry-run) and needs no grant.
+sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/log-edit *
+
 # Snap write operations (install / remove / refresh / hold / revert).
 sysknife ALL=(root) NOPASSWD: /usr/bin/snap
 

--- a/tests/e2e/ubuntu-provision.sh
+++ b/tests/e2e/ubuntu-provision.sh
@@ -258,6 +258,9 @@ install -Dm 755 packaging/sysknife-sudoers-edit /usr/lib/sysknife/sudoers-edit \
 # apt-pin-edit: invoked by SetAptPin/RemoveAptPin.
 install -Dm 755 packaging/sysknife-apt-pin-edit /usr/lib/sysknife/apt-pin-edit \
     || fail "Install sysknife-apt-pin-edit"
+# log-edit: invoked by ConfigureLogRotation/RemoveLogRotation + ConfigureRemoteSyslog/RemoveRemoteSyslog.
+install -Dm 755 packaging/sysknife-log-edit /usr/lib/sysknife/log-edit \
+    || fail "Install sysknife-log-edit"
 
 # ---------------------------------------------------------------------------
 # Step 6: Add VM user to sysknife groups


### PR DESCRIPTION
Batch 8. Adds **5 cross-distro actions** (171 → 176), verified end-to-end in the noble QEMU VM.

- `GetLogrotateStatus` (Observer/Low) — `logrotate -d` dry-run.
- `ConfigureLogRotation`/`RemoveLogRotation` (Dev/Medium) — `/etc/logrotate.d` drop-in.
- `ConfigureRemoteSyslog`/`RemoveRemoteSyslog` (Admin/High) — `/etc/rsyslog.d` forward.

Helper `/usr/lib/sysknife/log-edit` **validates before keeping** and rolls back on rejection: `logrotate -d` for rotation, `rsyslogd -N1` for the forward (then restarts rsyslog). Remote forwarding is High (logs leave the host — exfil surface).

**Verified (Ubuntu 24.04)**: logrotate drop-in passed `logrotate -d`; rsyslog forward `*.* @@logs.example.com:514` passed `rsyslogd -N1`, rsyslog restarted active, both removed cleanly; non-absolute paths + bad frequencies rejected. `cargo nextest`: **1333 passed**; clippy+fmt clean.

Closes #70.