### PR TITLE
feat(actions): PAM password policy — pwquality, faillock, chage (#68)

### DIFF
--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -206,6 +206,15 @@ pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
      "forward all logs to a remote collector via rsyslog (validated with rsyslogd -N1) — params: host*, port* (1-65535), protocol* (tcp|udp); High risk — logs leave the host"),
     ("RemoveRemoteSyslog",
      "stop remote syslog forwarding (remove the rsyslog drop-in) — no params; High risk"),
+    // PAM password policy
+    ("GetPasswordAging",
+     "show a user's password-aging fields (chage -l) — param: user*; read-only"),
+    ("SetPasswordAging",
+     "set a user's password aging (chage) — params: user*, plus at least one of max_days/min_days/warn_days (0-99999); High risk"),
+    ("SetPasswordPolicy",
+     "set password-quality rules via pwquality — params: at least one of minlen (1-128), dcredit/ucredit/lcredit/ocredit (-64..64); High risk — needs libpam-pwquality enabled in the PAM stack to take effect"),
+    ("SetAccountLockout",
+     "configure account lockout via faillock — params: at least one of deny (1-1000), unlock_time/fail_interval (seconds, 0-604800); High risk — needs pam_faillock enabled in the PAM stack to take effect"),
     // Identity / time / locale
     ("GetDateTime",
      "current date, time, timezone, and NTP status (timedatectl) — no params"),

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -422,7 +422,7 @@ GetAuthorizedKeys, ListPackageRepositories, ListContainers, GetContainerInfo,
 ListUsers, ListGroups, ListJobHistory,
 ResolvectlStatus,
 GetJournalLog, GetLvmReport, GetSysctl, GetServiceResourceLimits, GetMounts, GetSudoGrants,
-GetLogrotateStatus
+GetLogrotateStatus, GetPasswordAging
 
 ### Medium risk — cross-distro (approval required before execution)
 
@@ -449,7 +449,8 @@ ExtendLogicalVolume, CreateLogicalVolume, CreateLvSnapshot,
 SetSysctl, SetServiceResourceLimits,
 AddMount, RemoveMount, AddSwap, RemoveSwap,
 GrantSudoAccess, RevokeSudoAccess,
-ConfigureRemoteSyslog, RemoveRemoteSyslog
+ConfigureRemoteSyslog, RemoveRemoteSyslog,
+SetPasswordAging, SetPasswordPolicy, SetAccountLockout
 
 ## Risk classification rules
 
@@ -553,6 +554,12 @@ Use `"username"` as the key — NOT `"user"`.
 - `RemoveLogRotation`: `{"name":"nginx"}`.
 - `ConfigureRemoteSyslog`: `{"host":"logs.example.com","port":514,"protocol":"tcp"}`.
 - `RemoveRemoteSyslog`: `{}`.
+
+**PAM password policy** (password hardening; lockout settings take effect only when the PAM module is enabled in the auth stack):
+- `GetPasswordAging`: `{"user":"alice"}` (read-only; runs `chage -l`).
+- `SetPasswordAging`: `{"user":"alice","max_days":90,"min_days":1,"warn_days":7}` (at least one of max/min/warn; days 0..99999).
+- `SetPasswordPolicy`: `{"minlen":12,"dcredit":-1,"ucredit":-1,"lcredit":-1,"ocredit":-1}` (pwquality; at least one; a negative credit requires that many chars of the class).
+- `SetAccountLockout`: `{"deny":5,"unlock_time":900,"fail_interval":900}` (faillock; at least one; deny 1..1000, times in seconds 0..604800).
 
 **Scoped sudoers.d**:
 - `GetSudoGrants`: `{}` (read-only).

--- a/crates/sysknife-daemon/src/actions/mod.rs
+++ b/crates/sysknife-daemon/src/actions/mod.rs
@@ -23,6 +23,7 @@ pub mod multipass;
 pub mod netplan;
 pub mod network;
 pub mod package_repos;
+pub mod pam;
 pub mod ppa;
 pub mod processes;
 pub mod reboot;

--- a/crates/sysknife-daemon/src/actions/pam.rs
+++ b/crates/sysknife-daemon/src/actions/pam.rs
@@ -1,0 +1,139 @@
+//! PAM password-policy + account-aging actions.
+//!
+//! `GetPasswordAging` (`chage -l`) is read-only. `SetPasswordAging` runs
+//! `chage` directly (fully live-verifiable — `chage` is on every base image).
+//! `SetPasswordPolicy` (pwquality) and `SetAccountLockout` (faillock) delegate
+//! to the root-owned helper `/usr/lib/sysknife/pam-edit`, which re-validates and
+//! writes managed config.
+//!
+//! Enforcement caveat: pwquality needs `libpam-pwquality` installed and both
+//! modules wired into `/etc/pam.d` — SysKnife manages the *config* only, never
+//! the auth stack (a bad stack edit locks out every account). See the helper.
+
+use super::{command_mechanism, ActionSpec};
+use sysknife_types::RiskLevel;
+
+const HELPER: &str = "/usr/lib/sysknife/pam-edit";
+
+pub fn specs() -> Vec<ActionSpec> {
+    vec![
+        get_password_aging("alice"),
+        set_password_aging("alice", &["-M".to_string(), "90".to_string()]),
+        set_password_policy(&["--minlen".to_string(), "12".to_string()]),
+        set_account_lockout(&["--deny".to_string(), "5".to_string()]),
+    ]
+}
+
+/// Show a user's password-aging fields (`chage -l <user>`). Read-only.
+///
+/// Run directly (no `sudo`): reading `/etc/shadow` aging needs root and the
+/// daemon already runs as root, matching the `GetSudoGrants` pattern.
+pub fn get_password_aging(user: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "GetPasswordAging",
+        mechanism: command_mechanism("chage", ["-l", user]),
+        risk_level: RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Set a user's password aging via `chage`. `flags` is a pre-validated list of
+/// `chage` options (`-M`/`-m`/`-W` + values); the username is appended last.
+pub fn set_password_aging(user: &str, flags: &[String]) -> ActionSpec {
+    let mut args = vec!["chage".to_string()];
+    args.extend(flags.iter().cloned());
+    args.push(user.to_string());
+    ActionSpec {
+        action_name: "SetPasswordAging",
+        mechanism: command_mechanism("sudo", args),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Write a pwquality drop-in via the helper. `extra` is a pre-validated list of
+/// `--minlen`/`--dcredit`/… flag pairs.
+pub fn set_password_policy(extra: &[String]) -> ActionSpec {
+    let mut args = vec![
+        HELPER.to_string(),
+        "--op".to_string(),
+        "pwquality".to_string(),
+    ];
+    args.extend(extra.iter().cloned());
+    ActionSpec {
+        action_name: "SetPasswordPolicy",
+        mechanism: command_mechanism("sudo", args),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Configure account lockout (faillock) via the helper. `extra` is a
+/// pre-validated list of `--deny`/`--unlock-time`/`--fail-interval` flag pairs.
+pub fn set_account_lockout(extra: &[String]) -> ActionSpec {
+    let mut args = vec![
+        HELPER.to_string(),
+        "--op".to_string(),
+        "faillock".to_string(),
+    ];
+    args.extend(extra.iter().cloned());
+    ActionSpec {
+        action_name: "SetAccountLockout",
+        mechanism: command_mechanism("sudo", args),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::ActionMechanism;
+
+    fn args_of(spec: &ActionSpec) -> (&'static str, Vec<String>) {
+        match &spec.mechanism {
+            ActionMechanism::Command { program, args } => (program, args.clone()),
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_aging_is_read_only_direct_chage() {
+        let (program, args) = args_of(&get_password_aging("bob"));
+        assert_eq!(program, "chage");
+        assert_eq!(args, vec!["-l", "bob"]);
+        assert_eq!(get_password_aging("bob").risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn set_aging_appends_user_after_flags() {
+        let (program, args) = args_of(&set_password_aging(
+            "bob",
+            &["-M".to_string(), "90".to_string()],
+        ));
+        assert_eq!(program, "sudo");
+        assert_eq!(args, vec!["chage", "-M", "90", "bob"]);
+        assert_eq!(set_password_aging("b", &[]).risk_level, RiskLevel::High);
+    }
+
+    #[test]
+    fn policy_and_lockout_route_through_helper() {
+        let (program, args) = args_of(&set_password_policy(&[
+            "--minlen".to_string(),
+            "12".to_string(),
+        ]));
+        assert_eq!(program, "sudo");
+        assert_eq!(args, vec![HELPER, "--op", "pwquality", "--minlen", "12"]);
+
+        let (_, lock) = args_of(&set_account_lockout(&[
+            "--deny".to_string(),
+            "5".to_string(),
+        ]));
+        assert_eq!(lock, vec![HELPER, "--op", "faillock", "--deny", "5"]);
+        assert_eq!(set_account_lockout(&[]).risk_level, RiskLevel::High);
+    }
+}

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -1,7 +1,7 @@
 use crate::actions::{
     apparmor, apt, apt_preferences, cloudinit, containers, deployment, distrobox, fail2ban,
     filesystem, flatpak, grub, identity, journald, layering, livepatch, logging, lvm, mounts,
-    multipass, netplan, network, package_repos, ppa, processes, reboot, release_upgrade,
+    multipass, netplan, network, package_repos, pam, ppa, processes, reboot, release_upgrade,
     resolvectl, services, snap, ssh, sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
     validate::{
         validated_apparmor_profile, validated_apt_package, validated_apt_pin_expr,
@@ -770,6 +770,87 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
             ))
         }
         "RemoveRemoteSyslog" => Ok(logging::remove_remote_syslog()),
+
+        // ── PAM password policy ───────────────────────────────────────────
+        "GetPasswordAging" => {
+            let user = validated_username(require_str(params, "user")?, "user")?;
+            Ok(pam::get_password_aging(&user))
+        }
+        "SetPasswordAging" => {
+            let user = validated_username(require_str(params, "user")?, "user")?;
+            // chage days: 0..=99999 (chage's own ceiling). At least one required.
+            let mut flags = Vec::new();
+            for (key, opt) in [("max_days", "-M"), ("min_days", "-m"), ("warn_days", "-W")] {
+                if let Some(n) = params.get(key).and_then(|v| v.as_u64()) {
+                    if n > 99999 {
+                        return Err(ExecutorError::InvalidParam(key));
+                    }
+                    flags.push(opt.to_string());
+                    flags.push(n.to_string());
+                }
+            }
+            if flags.is_empty() {
+                return Err(ExecutorError::MissingParam("max_days"));
+            }
+            Ok(pam::set_password_aging(&user, &flags))
+        }
+        "SetPasswordPolicy" => {
+            // minlen 1..=128; *credit knobs -64..=64 (negative = require that
+            // many chars of the class). At least one required.
+            let mut extra = Vec::new();
+            if let Some(n) = params.get("minlen").and_then(|v| v.as_u64()) {
+                if !(1..=128).contains(&n) {
+                    return Err(ExecutorError::InvalidParam("minlen"));
+                }
+                extra.push("--minlen".to_string());
+                extra.push(n.to_string());
+            }
+            for (key, flag) in [
+                ("dcredit", "--dcredit"),
+                ("ucredit", "--ucredit"),
+                ("lcredit", "--lcredit"),
+                ("ocredit", "--ocredit"),
+            ] {
+                if let Some(n) = params.get(key).and_then(|v| v.as_i64()) {
+                    if !(-64..=64).contains(&n) {
+                        return Err(ExecutorError::InvalidParam(key));
+                    }
+                    extra.push(flag.to_string());
+                    extra.push(n.to_string());
+                }
+            }
+            if extra.is_empty() {
+                return Err(ExecutorError::MissingParam("minlen"));
+            }
+            Ok(pam::set_password_policy(&extra))
+        }
+        "SetAccountLockout" => {
+            // deny 1..=1000; unlock_time/fail_interval seconds 0..=604800 (7d).
+            let mut extra = Vec::new();
+            if let Some(n) = params.get("deny").and_then(|v| v.as_u64()) {
+                if !(1..=1000).contains(&n) {
+                    return Err(ExecutorError::InvalidParam("deny"));
+                }
+                extra.push("--deny".to_string());
+                extra.push(n.to_string());
+            }
+            for (key, flag) in [
+                ("unlock_time", "--unlock-time"),
+                ("fail_interval", "--fail-interval"),
+            ] {
+                if let Some(n) = params.get(key).and_then(|v| v.as_u64()) {
+                    if n > 604800 {
+                        return Err(ExecutorError::InvalidParam(key));
+                    }
+                    extra.push(flag.to_string());
+                    extra.push(n.to_string());
+                }
+            }
+            if extra.is_empty() {
+                return Err(ExecutorError::MissingParam("deny"));
+            }
+            Ok(pam::set_account_lockout(&extra))
+        }
 
         // ── System info ──────────────────────────────────────────────────
         "GetMemoryInfo" => Ok(system_info::get_memory_info_spec()),

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -69,6 +69,8 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "GetSudoGrants"
         // ── Log management read-only ──────────────────────────────────────
         | "GetLogrotateStatus"
+        // ── PAM read-only ─────────────────────────────────────────────────
+        | "GetPasswordAging"
         | "GetAuthorizedKeys"
         | "ListUsers"
         | "ListGroups"
@@ -282,6 +284,10 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         // data-exfiltration vector — so it is Admin/High.
         | "ConfigureRemoteSyslog"
         | "RemoveRemoteSyslog"
+        // ── PAM password policy (auth-hardening; lockout can deny logins) ─
+        | "SetPasswordAging"
+        | "SetPasswordPolicy"
+        | "SetAccountLockout"
         | "DeleteUser"
         | "AddAuthorizedKey"
         | "RemoveAuthorizedKey"

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -95,6 +95,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "GetMounts"
         | "GetSudoGrants"
         | "GetLogrotateStatus"
+        | "GetPasswordAging"
         | "GetAuthorizedKeys"
         | "GetDateTime"
         | "ListJobHistory"
@@ -411,6 +412,30 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             rollback_available: false,
             warnings: vec![
                 "forwarding sends log data off-host (exfiltration surface)".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── PAM password policy ───────────────────────────────────────────
+        "SetPasswordAging" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "the target account's password-aging limits will change".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec!["exact approval required".to_string()],
+        },
+        "SetPasswordPolicy" | "SetAccountLockout" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "a system-wide PAM policy file will be written".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "affects password/lockout rules for all accounts".to_string(),
+                "takes effect only if the PAM module is enabled in the auth stack".to_string(),
                 "exact approval required".to_string(),
             ],
         },

--- a/crates/sysknife-daemon/tests/action_consistency.rs
+++ b/crates/sysknife-daemon/tests/action_consistency.rs
@@ -14,7 +14,7 @@ use sysknife_brain::planning_tools::propose_plan::KNOWN_ACTIONS;
 use sysknife_daemon::actions::{
     apparmor, apt, apt_preferences, cloudinit, containers, deployment, distrobox, fail2ban,
     filesystem, flatpak, grub, identity, journald, layering, livepatch, logging, lvm, mounts,
-    multipass, netplan, network, package_repos, ppa, processes, reboot, release_upgrade,
+    multipass, netplan, network, package_repos, pam, ppa, processes, reboot, release_upgrade,
     resolvectl, services, snap, ssh, sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
 };
 use sysknife_daemon::executor::build_action_spec;
@@ -77,6 +77,9 @@ fn all_spec_action_names() -> BTreeSet<&'static str> {
         names.insert(spec.action_name);
     }
     for spec in logging::specs() {
+        names.insert(spec.action_name);
+    }
+    for spec in pam::specs() {
         names.insert(spec.action_name);
     }
     for spec in identity::specs() {

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -148,6 +148,11 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     "RemoveLogRotation",
     "ConfigureRemoteSyslog",
     "RemoveRemoteSyslog",
+    // PAM password policy (cross-distro)
+    "GetPasswordAging",
+    "SetPasswordAging",
+    "SetPasswordPolicy",
+    "SetAccountLockout",
     "GetDateTime",
     "SetHostname",
     "SetTimezone",

--- a/docs/typed-actions.md
+++ b/docs/typed-actions.md
@@ -53,7 +53,7 @@ codebase. On the daemon side (`sysknife-daemon`), each action is backed by an
 | `reboot_required` | Whether the daemon should warn the caller before proceeding |
 | `rollback_available` | Whether a failure triggers automatic rollback |
 
-As of this writing the catalogue defines **176 actions** across families such
+As of this writing the catalogue defines **180 actions** across families such
 as Deployment, Services, Package Layering, Flatpak, Containers, Toolbox,
 Network, Identity, SSH Keys, Package Repositories, apt/snap/ufw/netplan/grub
 (Debian-family), and rpm-ostree/AppArmor/cloud-init/Pro (Fedora-family). Each

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -26,7 +26,7 @@ system.
    `state.planner.plan_intent(intent)`.
 
 4. **LLM planning loop** (`crates/sysknife-brain/src/planner.rs:318`)
-   Turn 0: LLM receives system prompt (176-action catalogue, risk rules) +
+   Turn 0: LLM receives system prompt (180-action catalogue, risk rules) +
    user message. LLM calls `get_system_state`.
 
 5. **State injection** (`crates/sysknife-brain/src/planner.rs:366`)

--- a/packaging/sysknife-pam-edit
+++ b/packaging/sysknife-pam-edit
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# sysknife-pam-edit — manage PAM password-quality and account-lockout policy.
+#
+# Install to: /usr/lib/sysknife/pam-edit
+# Mode:       0755
+# Owner:      root:root
+#
+# Invoked exclusively by the sysknife-daemon via one of:
+#   sudo /usr/lib/sysknife/pam-edit --op pwquality \
+#        [--minlen N] [--dcredit N] [--ucredit N] [--lcredit N] [--ocredit N]
+#   sudo /usr/lib/sysknife/pam-edit --op faillock \
+#        [--deny N] [--unlock-time N] [--fail-interval N]
+#
+# Inputs are re-validated here (defense-in-depth). `pwquality` writes a managed
+# drop-in at /etc/security/pwquality.conf.d/60-sysknife.conf. `faillock` edits
+# /etc/security/faillock.conf in place, replacing only a marker-delimited
+# `# >>> sysknife managed >>>` block so the distro's documented defaults survive.
+#
+# NOTE (network-gated): pam_pwquality.so ships in `libpam-pwquality`, which is
+# NOT on the minimal cloud image and cannot be installed offline; pam_faillock.so
+# ships in libpam-modules (present) but is not wired into the PAM auth stack by
+# default. This helper only manages the *config*; enabling the modules in
+# /etc/pam.d (e.g. via `pam-auth-update`) is a deliberate, separate admin step
+# SysKnife does not perform (a wrong auth-stack edit can lock out every account).
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+
+PWQUALITY_D = "/etc/security/pwquality.conf.d"
+PWQUALITY_FILE = os.path.join(PWQUALITY_D, "60-sysknife.conf")
+FAILLOCK_FILE = "/etc/security/faillock.conf"
+
+BEGIN = "# >>> sysknife managed (set_account_lockout) >>>"
+END = "# <<< sysknife managed <<<"
+
+# pwquality knobs: minlen is an absolute minimum length; the *credit knobs are
+# the classic pam_pwquality form where a negative value means "require at least
+# |N| chars of this class" and a positive value grants length credit.
+PWQUALITY_CREDITS = ("dcredit", "ucredit", "lcredit", "ocredit")
+
+
+def die(msg: str) -> None:
+    print(f"sysknife-pam-edit: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def atomic_write(path: str, content: str, mode: int = 0o644) -> None:
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".sysknife-pam-")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(content)
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        die(f"cannot write {path}: {exc}")
+
+
+def require_range(name: str, value, lo: int, hi: int) -> None:
+    if value is None:
+        return
+    if value < lo or value > hi:
+        die(f"{name} out of range [{lo}, {hi}]")
+
+
+def op_pwquality(args) -> None:
+    # minlen: a sane floor of 1 (pwquality itself enforces >= 6 at runtime, but
+    # we allow explicit lower values for testing) up to 128.
+    require_range("minlen", args.minlen, 1, 128)
+    for c in PWQUALITY_CREDITS:
+        require_range(c, getattr(args, c), -64, 64)
+
+    lines = ["# Managed by SysKnife (set_password_policy). Do not edit by hand."]
+    if args.minlen is not None:
+        lines.append(f"minlen = {args.minlen}")
+    for c in PWQUALITY_CREDITS:
+        v = getattr(args, c)
+        if v is not None:
+            lines.append(f"{c} = {v}")
+    if len(lines) == 1:
+        die("pwquality requires at least one of --minlen/--dcredit/--ucredit/--lcredit/--ocredit")
+    atomic_write(PWQUALITY_FILE, "\n".join(lines) + "\n")
+
+
+def op_faillock(args) -> None:
+    # deny: consecutive failures before lockout. unlock_time/fail_interval in
+    # seconds (0 = never auto-unlock / a single interval); cap at 7 days.
+    require_range("deny", args.deny, 1, 1000)
+    require_range("unlock-time", args.unlock_time, 0, 604800)
+    require_range("fail-interval", args.fail_interval, 0, 604800)
+
+    body = [BEGIN, "# Managed by SysKnife (set_account_lockout). Do not edit by hand."]
+    if args.deny is not None:
+        body.append(f"deny = {args.deny}")
+    if args.unlock_time is not None:
+        body.append(f"unlock_time = {args.unlock_time}")
+    if args.fail_interval is not None:
+        body.append(f"fail_interval = {args.fail_interval}")
+    if len(body) == 2:
+        die("faillock requires at least one of --deny/--unlock-time/--fail-interval")
+    body.append(END)
+
+    prev = ""
+    if os.path.exists(FAILLOCK_FILE):
+        with open(FAILLOCK_FILE) as fh:
+            prev = fh.read()
+    # Strip any prior sysknife block, then append the fresh one.
+    stripped = re.sub(
+        re.escape(BEGIN) + r".*?" + re.escape(END) + r"\n?",
+        "",
+        prev,
+        flags=re.DOTALL,
+    )
+    if stripped and not stripped.endswith("\n"):
+        stripped += "\n"
+    atomic_write(FAILLOCK_FILE, stripped + "\n".join(body) + "\n")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Manage PAM pwquality + faillock policy.")
+    p.add_argument("--op", required=True, choices=["pwquality", "faillock"])
+    p.add_argument("--minlen", type=int)
+    p.add_argument("--dcredit", type=int)
+    p.add_argument("--ucredit", type=int)
+    p.add_argument("--lcredit", type=int)
+    p.add_argument("--ocredit", type=int)
+    p.add_argument("--deny", type=int)
+    p.add_argument("--unlock-time", type=int, dest="unlock_time")
+    p.add_argument("--fail-interval", type=int, dest="fail_interval")
+    args = p.parse_args()
+
+    if args.op == "pwquality":
+        op_pwquality(args)
+    else:
+        op_faillock(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/sysknife-sudoers
+++ b/packaging/sysknife-sudoers
@@ -152,6 +152,15 @@ sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/apt-pin-edit *
 # runs bare `logrotate -d` (dry-run) and needs no grant.
 sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/log-edit *
 
+# PAM password policy. SetPasswordAging runs `chage` directly (fully scoped by
+# argv). SetPasswordPolicy/SetAccountLockout delegate to the root-owned pam-edit
+# helper, which re-validates ranges and writes a pwquality drop-in or a
+# marker-delimited block in /etc/security/faillock.conf. GetPasswordAging runs
+# bare `chage -l` (read-only) and needs no grant. (pam_pwquality enforcement
+# additionally needs libpam-pwquality installed + enabled in the auth stack.)
+sysknife ALL=(root) NOPASSWD: /usr/bin/chage
+sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/pam-edit *
+
 # Snap write operations (install / remove / refresh / hold / revert).
 sysknife ALL=(root) NOPASSWD: /usr/bin/snap
 

--- a/tests/e2e/ubuntu-provision.sh
+++ b/tests/e2e/ubuntu-provision.sh
@@ -261,6 +261,9 @@ install -Dm 755 packaging/sysknife-apt-pin-edit /usr/lib/sysknife/apt-pin-edit \
 # log-edit: invoked by ConfigureLogRotation/RemoveLogRotation + ConfigureRemoteSyslog/RemoveRemoteSyslog.
 install -Dm 755 packaging/sysknife-log-edit /usr/lib/sysknife/log-edit \
     || fail "Install sysknife-log-edit"
+# pam-edit: invoked by SetPasswordPolicy (pwquality) + SetAccountLockout (faillock).
+install -Dm 755 packaging/sysknife-pam-edit /usr/lib/sysknife/pam-edit \
+    || fail "Install sysknife-pam-edit"
 
 # ---------------------------------------------------------------------------
 # Step 6: Add VM user to sysknife groups


### PR DESCRIPTION
Batch 9. Adds **4 cross-distro actions** (176 → 180).

| Action | Role/Risk | Mechanism |
|---|---|---|
| `GetPasswordAging` | Observer/Low | `chage -l <user>` (read-only) |
| `SetPasswordAging` | Admin/High | `sudo chage -M/-m/-W <user>` |
| `SetPasswordPolicy` | Admin/High | `sudo pam-edit --op pwquality …` → pwquality drop-in |
| `SetAccountLockout` | Admin/High | `sudo pam-edit --op faillock …` → faillock.conf block |

New root helper `sysknife-pam-edit` re-validates ranges and writes a managed pwquality drop-in or a **marker-delimited block** in `/etc/security/faillock.conf` (stripped + rewritten each apply → distro defaults survive, re-runs never duplicate). SysKnife manages the *config* only — never `/etc/pam.d` — because a bad auth-stack edit locks out every account.

### Live-validated in QEMU — all three versions (22.04 / 24.04 / 26.04)
- `chage` get + set applied (Max/Min/Warn observed)
- pwquality drop-in written with correct `minlen`/credits
- faillock block written; **re-run replaces** (block count stays 1)
- range/empty rejections fire (`minlen` 0/999, `deny` 99999, no-args)
- resolute drives `sudo chage` + `sudo pam-edit *` under **sudo-rs**

### ⚠️ Honest caveat — NOT live-validated (no VM network)
pwquality **enforcement** needs `libpam-pwquality` installed + both modules enabled in the PAM auth stack. That package is not on the base cloud image and the QEMU sandbox has no outbound DNS, so only the config-write + validation paths were live-proven; runtime password rejection was not. Documented in the helper header + `propose_plan`/`prompt` descriptions.

`cargo nextest`: **1336 passed**; clippy + fmt clean.

Closes #68.