### PR TITLE
feat(actions): Ubuntu Pro service enable/disable toggles (#73)

### DIFF
--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -420,6 +420,10 @@ pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
      "attach machine to an Ubuntu Pro subscription — param: token* (credential, never log); Ubuntu only; High risk"),
     ("ProDetach",
      "detach from Ubuntu Pro subscription — no params; Ubuntu only; High risk"),
+    ("EnableProService",
+     "enable one Ubuntu Pro service (pro enable <service>) — param: service* (one of esm-apps, esm-infra, livepatch, usg, fips, fips-updates, cis, ros, ros-updates, cc-eal, realtime-kernel, landscape, anbox-cloud); Ubuntu only; High risk; needs an attached subscription"),
+    ("DisableProService",
+     "disable one Ubuntu Pro service (pro disable <service>) — param: service* (same allowlist as EnableProService); Ubuntu only; High risk"),
     // ── Ubuntu / Tier 3 — Livepatch ──────────────────────────────────────────
     ("LivepatchStatus",
      "show Canonical Livepatch kernel-patch status — no params; Ubuntu only; read-only; requires canonical-livepatch installed and Ubuntu Pro"),

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -807,7 +807,7 @@ UfwEnable, UfwDisable, UfwAllow, UfwDeny, UfwReset, UfwDeleteRule, UfwLimit,
 NetplanApply, NetplanSet,
 AppArmorEnforce,
 Fail2banBanIp,
-ProAttach, ProDetach,
+ProAttach, ProDetach, EnableProService, DisableProService,
 UbuntuReleaseUpgrade
 "#;
 
@@ -837,6 +837,7 @@ const DEBIAN_SELECTION_RULES: &str = r#"
 - `ProStatus` shows Ubuntu Pro subscription state — LOW, read-only. Use for "is Ubuntu Pro active?", "what Pro services are enabled?".
 - `ProAttach` binds the machine to an Ubuntu Pro subscription — HIGH. Requires a token param (treated as a credential — never log or echo it). Use only when the user provides an explicit token.
 - `ProDetach` removes the active Ubuntu Pro subscription — HIGH. No params.
+- `EnableProService` / `DisableProService` toggle a single Pro service — HIGH. Param `service` must be one of the fixed allowlist (esm-apps, esm-infra, livepatch, usg, fips, …). Use for "enable ESM", "turn on livepatch". Requires an attached subscription.
 - `LivepatchStatus` shows Canonical Livepatch kernel-patch state — LOW, read-only. Requires `canonical-livepatch` installed and Ubuntu Pro; surfaces "command not found" if binary is absent.
 - `MultipassList` lists Multipass VMs — LOW, read-only. Use for "list VMs", "show multipass instances".
 - `UbuntuReleaseUpgrade` upgrades to the next Ubuntu release — HIGH. Tier 3: takes 20–45 minutes, requires reboot. Only propose when the user explicitly requests a distribution upgrade. Do NOT propose for routine `apt upgrade`.
@@ -922,6 +923,7 @@ ProStatus, ProDetach, LivepatchStatus, MultipassList, UbuntuReleaseUpgrade.
 - `ProStatus`: `{}`
 - `ProAttach`: `{"token":"<ubuntu-pro-token>"}` — token is a credential; never echo or log it
 - `ProDetach`: `{}`
+- `EnableProService` / `DisableProService`: `{"service":"esm-apps"}` (service ∈ the fixed allowlist)
 
 **Distrobox**:
 - `DistroboxList`: `{}`

--- a/crates/sysknife-core/src/action_family.rs
+++ b/crates/sysknife-core/src/action_family.rs
@@ -104,6 +104,8 @@ pub const DEBIAN_ONLY_ACTIONS: &[&str] = &[
     "ProStatus",
     "ProAttach",
     "ProDetach",
+    "EnableProService",
+    "DisableProService",
     "LivepatchStatus",
     "MultipassList",
     "UfwDeleteRule",

--- a/crates/sysknife-daemon/src/actions/ubuntu_pro.rs
+++ b/crates/sysknife-daemon/src/actions/ubuntu_pro.rs
@@ -40,7 +40,13 @@ use sysknife_types::RiskLevel;
 
 /// Return one representative `ActionSpec` per Ubuntu Pro action name.
 pub fn specs() -> Vec<ActionSpec> {
-    vec![pro_status(), pro_attach("<REDACTED>"), pro_detach()]
+    vec![
+        pro_status(),
+        pro_attach("<REDACTED>"),
+        pro_detach(),
+        enable_pro_service("esm-apps"),
+        disable_pro_service("esm-apps"),
+    ]
 }
 
 // ---------------------------------------------------------------------------
@@ -96,6 +102,35 @@ pub fn pro_detach() -> ActionSpec {
         risk_level: RiskLevel::High,
         reboot_required: false,
         rollback_available: true,
+    }
+}
+
+/// Enable a single Ubuntu Pro service (`sudo pro enable <service> --assume-yes`).
+///
+/// Risk: High / Admin. Activates a licensed service (ESM, Livepatch, FIPS, …).
+/// `service` must be one of the allowlist in `validated_pro_service`. Requires
+/// an attached subscription + network at run time.
+pub fn enable_pro_service(service: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "EnableProService",
+        mechanism: command_mechanism("sudo", ["pro", "enable", service, "--assume-yes"]),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Disable a single Ubuntu Pro service (`sudo pro disable <service> --assume-yes`).
+///
+/// Risk: High / Admin. Deactivates a licensed service. `service` must be one of
+/// the allowlist in `validated_pro_service`.
+pub fn disable_pro_service(service: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "DisableProService",
+        mechanism: command_mechanism("sudo", ["pro", "disable", service, "--assume-yes"]),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
     }
 }
 
@@ -234,10 +269,36 @@ mod tests {
 
     #[test]
     fn specs_covers_all_action_names() {
-        let expected = ["ProStatus", "ProAttach", "ProDetach"];
+        let expected = [
+            "ProStatus",
+            "ProAttach",
+            "ProDetach",
+            "EnableProService",
+            "DisableProService",
+        ];
         let spec_names: Vec<&str> = specs().iter().map(|s| s.action_name).collect();
         for name in &expected {
             assert!(spec_names.contains(name), "specs() missing {name}");
         }
+    }
+
+    // ── enable/disable service ──────────────────────────────────────────────
+
+    #[test]
+    fn enable_service_argv() {
+        let spec = enable_pro_service("esm-infra");
+        let (prog, args) = extract_cmd(&spec);
+        assert_eq!(prog, "sudo");
+        assert_eq!(args, vec!["pro", "enable", "esm-infra", "--assume-yes"]);
+        assert_eq!(spec.risk_level, RiskLevel::High);
+    }
+
+    #[test]
+    fn disable_service_argv() {
+        let spec = disable_pro_service("livepatch");
+        let (prog, args) = extract_cmd(&spec);
+        assert_eq!(prog, "sudo");
+        assert_eq!(args, vec!["pro", "disable", "livepatch", "--assume-yes"]);
+        assert_eq!(spec.risk_level, RiskLevel::High);
     }
 }

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -746,9 +746,48 @@ pub fn validated_sudo_commands(s: &str, param: &'static str) -> Result<String, E
     Ok(s.to_string())
 }
 
+/// Validate an Ubuntu Pro service name against a fixed allowlist. Prevents both
+/// option injection and typos reaching `pro enable/disable`. The list matches
+/// the services `pro` recognises across supported releases.
+pub fn validated_pro_service(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    const SERVICES: &[&str] = &[
+        "esm-apps",
+        "esm-infra",
+        "livepatch",
+        "usg",
+        "fips",
+        "fips-updates",
+        "fips-preview",
+        "cis",
+        "ros",
+        "ros-updates",
+        "cc-eal",
+        "realtime-kernel",
+        "landscape",
+        "anbox-cloud",
+    ];
+    if SERVICES.contains(&s) {
+        Ok(s.to_string())
+    } else {
+        Err(ExecutorError::InvalidParam(param))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pro_service_allowlist() {
+        assert!(validated_pro_service("esm-apps", "service").is_ok());
+        assert!(validated_pro_service("livepatch", "service").is_ok());
+        assert!(validated_pro_service("realtime-kernel", "service").is_ok());
+        // rejects unknown names and injection attempts
+        assert!(validated_pro_service("bogus", "service").is_err());
+        assert!(validated_pro_service("--help", "service").is_err());
+        assert!(validated_pro_service("esm-apps; rm -rf /", "service").is_err());
+        assert!(validated_pro_service("", "service").is_err());
+    }
 
     // ── validated_username / validated_group ──────────────────────────────
 

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -10,9 +10,10 @@ use crate::actions::{
         validated_journal_time, validated_locale, validated_log_path, validated_lvm_name,
         validated_lvm_size, validated_memory_limit, validated_mount_device,
         validated_mount_options, validated_mount_point, validated_port_or_service,
-        validated_ppa_name, validated_safe_arg, validated_sudo_commands, validated_sudoers_name,
-        validated_swap_path, validated_sysctl_key, validated_sysctl_value, validated_syslog_host,
-        validated_tasks_max, validated_timezone, validated_unit_name, validated_username,
+        validated_ppa_name, validated_pro_service, validated_safe_arg, validated_sudo_commands,
+        validated_sudoers_name, validated_swap_path, validated_sysctl_key, validated_sysctl_value,
+        validated_syslog_host, validated_tasks_max, validated_timezone, validated_unit_name,
+        validated_username,
     },
     ActionMechanism, ActionSpec,
 };
@@ -1192,6 +1193,14 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
             Ok(ubuntu_pro::pro_attach(&token))
         }
         "ProDetach" => Ok(ubuntu_pro::pro_detach()),
+        "EnableProService" => {
+            let service = validated_pro_service(require_str(params, "service")?, "service")?;
+            Ok(ubuntu_pro::enable_pro_service(&service))
+        }
+        "DisableProService" => {
+            let service = validated_pro_service(require_str(params, "service")?, "service")?;
+            Ok(ubuntu_pro::disable_pro_service(&service))
+        }
 
         // ── Livepatch ─────────────────────────────────────────────────────
         "LivepatchStatus" => Ok(livepatch::livepatch_status()),

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -362,6 +362,8 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         // Valid Accounts — contract modification). ProDetach removes it.
         | "ProAttach"
         | "ProDetach"
+        | "EnableProService"
+        | "DisableProService"
         // ── Ubuntu release upgrade Tier 3 high-risk ───────────────────────
         //
         // UbuntuReleaseUpgrade upgrades the entire OS to the next release.

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -282,6 +282,20 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
         },
 
+        // ── Ubuntu Pro service toggles ──────────────────────────────────
+        "EnableProService" | "DisableProService" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "a single Ubuntu Pro service will be enabled/disabled".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "exact approval required".to_string(),
+                "requires an attached Pro subscription + network to take effect".to_string(),
+            ],
+        },
+
         // ── Ubuntu release upgrade Tier 3 ────────────────────────────────
         "UbuntuReleaseUpgrade" => PreviewProfile {
             risk_level: RiskLevel::High,

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -260,6 +260,8 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     "ProStatus",
     "ProAttach",
     "ProDetach",
+    "EnableProService",
+    "DisableProService",
     // Ubuntu / Livepatch (Tier 3)
     "LivepatchStatus",
     // Ubuntu / Multipass (Tier 3)

--- a/docs/typed-actions.md
+++ b/docs/typed-actions.md
@@ -53,7 +53,7 @@ codebase. On the daemon side (`sysknife-daemon`), each action is backed by an
 | `reboot_required` | Whether the daemon should warn the caller before proceeding |
 | `rollback_available` | Whether a failure triggers automatic rollback |
 
-As of this writing the catalogue defines **180 actions** across families such
+As of this writing the catalogue defines **182 actions** across families such
 as Deployment, Services, Package Layering, Flatpak, Containers, Toolbox,
 Network, Identity, SSH Keys, Package Repositories, apt/snap/ufw/netplan/grub
 (Debian-family), and rpm-ostree/AppArmor/cloud-init/Pro (Fedora-family). Each

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -26,7 +26,7 @@ system.
    `state.planner.plan_intent(intent)`.
 
 4. **LLM planning loop** (`crates/sysknife-brain/src/planner.rs:318`)
-   Turn 0: LLM receives system prompt (180-action catalogue, risk rules) +
+   Turn 0: LLM receives system prompt (182-action catalogue, risk rules) +
    user message. LLM calls `get_system_state`.
 
 5. **State injection** (`crates/sysknife-brain/src/planner.rs:366`)


### PR DESCRIPTION
Batch 10. Adds **2 DEBIAN_ONLY actions** (180 → 182): `EnableProService` / `DisableProService` (both Admin/High).

`sudo pro enable|disable <service> --assume-yes`, where `service` is checked against a fixed allowlist (`validated_pro_service`: esm-apps, esm-infra, livepatch, usg, fips, fips-updates, fips-preview, cis, ros, ros-updates, cc-eal, realtime-kernel, landscape, anbox-cloud) — blocking option injection + typos before `pro` runs. `/usr/bin/pro` is already granted in sudoers.

### Live-validated in QEMU — all three versions (22.04 / 24.04 / 26.04)
- `pro` present; `pro status` reports unattached
- `sudo pro enable esm-apps --assume-yes` runs and **fails gracefully** ("Cannot enable services when unattached … need an Ubuntu Pro subscription")
- resolute drives it under **sudo-rs**

### ⚠️ Honest caveat — NOT live-validated (no VM network / no subscription)
The enable/disable **success** path needs an attached Pro subscription + network to `contracts.canonical.com`. The QEMU sandbox has neither, so only the argv wiring + graceful-unattached path were proven — actual service activation was not.

`cargo nextest`: **1339 passed**; clippy + fmt clean.

Closes #73.