### PR TITLE
feat(actions): auditd rules, certbot/ACME, fail2ban jail config (#74)

### DIFF
--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -400,6 +400,22 @@ pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
      "ban an IP address in a fail2ban jail — params: jail* (string), ip* (IPv4 or IPv6); Ubuntu only; High risk"),
     ("Fail2banUnbanIp",
      "unban an IP address from a fail2ban jail — params: jail*, ip*; Ubuntu only; Medium risk"),
+    ("ConfigureFail2banJail",
+     "write a fail2ban jail override (/etc/fail2ban/jail.d/) — params: name*, plus at least one of enabled (bool), maxretry (1-100), bantime/findtime (seconds 0-2592000); Ubuntu only; High risk; needs fail2ban installed"),
+    // ── auditd file-watch rules (cross-distro) ───────────────────────────────
+    ("GetAuditRules",
+     "list loaded audit rules (auditctl -l) — no params; read-only; needs auditd installed"),
+    ("AddAuditRule",
+     "add a persistent audit file-watch rule — params: path* (absolute file/dir), perms* (subset of r/w/x/a), key* (label); High risk; needs auditd installed"),
+    ("RemoveAuditRule",
+     "remove a SysKnife-managed audit rule by key — param: key*; High risk"),
+    // ── certbot / ACME (cross-distro) ────────────────────────────────────────
+    ("GetCertificates",
+     "list certbot-managed certificates — no params; read-only; needs certbot installed"),
+    ("ObtainCertificate",
+     "obtain a TLS certificate non-interactively (certbot certonly) — params: domains* (array) or domain* (string), email*, challenge (standalone|nginx|apache, default standalone); High risk; needs certbot + network"),
+    ("RenewCertificates",
+     "renew due certbot certificates (certbot renew) — no params; High risk; needs certbot + network"),
     // ── Ubuntu / Tier 3 — netplan extensions ─────────────────────────────────
     ("NetplanSet",
      "set a single netplan key to a value — params: key* (e.g. 'ethernets.eth0.dhcp4'), value*; Ubuntu only; High risk; run NetplanApply to activate"),

--- a/crates/sysknife-core/src/action_family.rs
+++ b/crates/sysknife-core/src/action_family.rs
@@ -99,6 +99,7 @@ pub const DEBIAN_ONLY_ACTIONS: &[&str] = &[
     "Fail2banStatus",
     "Fail2banBanIp",
     "Fail2banUnbanIp",
+    "ConfigureFail2banJail",
     // Tier 3
     "UbuntuReleaseUpgrade",
     "ProStatus",

--- a/crates/sysknife-daemon/src/actions/auditd.rs
+++ b/crates/sysknife-daemon/src/actions/auditd.rs
@@ -1,0 +1,111 @@
+//! auditd file-watch rule actions.
+//!
+//! `GetAuditRules` (`auditctl -l`) is read-only. `AddAuditRule`/`RemoveAuditRule`
+//! delegate to the root-owned helper `/usr/lib/sysknife/audit-edit`, which writes
+//! a persistent rule under `/etc/audit/rules.d/` and loads it with `augenrules`.
+//!
+//! Scope: file-WATCH rules only (`-w <path> -p <perms> -k <key>`). Syscall rules
+//! are intentionally out of scope (large injection surface).
+//!
+//! Network-gated: the `auditd` package is not on the base cloud image, so the
+//! `auditctl`/`augenrules` behaviour could not be live-validated in the sandbox
+//! — only the helper's rule-file write was. See the helper header.
+
+use super::{command_mechanism, ActionSpec};
+use sysknife_types::RiskLevel;
+
+const HELPER: &str = "/usr/lib/sysknife/audit-edit";
+
+pub fn specs() -> Vec<ActionSpec> {
+    vec![
+        get_audit_rules(),
+        add_audit_rule("/etc/passwd", "wa", "passwd-watch"),
+        remove_audit_rule("passwd-watch"),
+    ]
+}
+
+/// List the loaded audit rules (`auditctl -l`). Read-only.
+pub fn get_audit_rules() -> ActionSpec {
+    ActionSpec {
+        action_name: "GetAuditRules",
+        mechanism: command_mechanism("auditctl", ["-l"]),
+        risk_level: RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Add a persistent file-watch rule via the helper.
+pub fn add_audit_rule(path: &str, perms: &str, key: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "AddAuditRule",
+        mechanism: command_mechanism(
+            "sudo",
+            [
+                HELPER, "--op", "add", "--path", path, "--perms", perms, "--key", key,
+            ],
+        ),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Remove a SysKnife-managed audit rule by key.
+pub fn remove_audit_rule(key: &str) -> ActionSpec {
+    ActionSpec {
+        action_name: "RemoveAuditRule",
+        mechanism: command_mechanism("sudo", [HELPER, "--op", "remove", "--key", key]),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::ActionMechanism;
+
+    fn args_of(spec: &ActionSpec) -> (&'static str, Vec<String>) {
+        match &spec.mechanism {
+            ActionMechanism::Command { program, args } => (program, args.clone()),
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_rules_is_read_only() {
+        let (program, args) = args_of(&get_audit_rules());
+        assert_eq!(program, "auditctl");
+        assert_eq!(args, vec!["-l"]);
+        assert_eq!(get_audit_rules().risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn add_rule_shape() {
+        let (program, args) = args_of(&add_audit_rule("/etc/passwd", "wa", "pw"));
+        assert_eq!(program, "sudo");
+        assert_eq!(
+            args,
+            vec![
+                HELPER,
+                "--op",
+                "add",
+                "--path",
+                "/etc/passwd",
+                "--perms",
+                "wa",
+                "--key",
+                "pw"
+            ]
+        );
+        assert_eq!(add_audit_rule("/x", "r", "k").risk_level, RiskLevel::High);
+    }
+
+    #[test]
+    fn remove_rule_shape() {
+        let (_, args) = args_of(&remove_audit_rule("pw"));
+        assert_eq!(args, vec![HELPER, "--op", "remove", "--key", "pw"]);
+    }
+}

--- a/crates/sysknife-daemon/src/actions/certbot.rs
+++ b/crates/sysknife-daemon/src/actions/certbot.rs
@@ -1,0 +1,129 @@
+//! certbot / ACME certificate actions.
+//!
+//! `GetCertificates` (`certbot certificates`) is read-only. `ObtainCertificate`
+//! and `RenewCertificates` run `certbot` directly (scoped argv). Every input is
+//! validated before it reaches `certbot`.
+//!
+//! Network-gated: `certbot` is not on the base cloud image and ACME issuance
+//! needs outbound network + a DNS/HTTP challenge, so these could not be
+//! live-validated in the sandbox — only the argv construction (unit tests).
+
+use super::{command_mechanism, ActionSpec};
+use sysknife_types::RiskLevel;
+
+pub fn specs() -> Vec<ActionSpec> {
+    vec![
+        get_certificates(),
+        obtain_certificate(
+            &["example.com".to_string()],
+            "admin@example.com",
+            "standalone",
+        ),
+        renew_certificates(),
+    ]
+}
+
+/// List managed certificates (`certbot certificates`). Read-only.
+pub fn get_certificates() -> ActionSpec {
+    ActionSpec {
+        action_name: "GetCertificates",
+        mechanism: command_mechanism("certbot", ["certificates"]),
+        risk_level: RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Obtain a certificate non-interactively. `domains` is a pre-validated list;
+/// `challenge` is one of `standalone`/`nginx`/`apache` (validated upstream).
+pub fn obtain_certificate(domains: &[String], email: &str, challenge: &str) -> ActionSpec {
+    let mut args = vec![
+        "certbot".to_string(),
+        "certonly".to_string(),
+        "--non-interactive".to_string(),
+        "--agree-tos".to_string(),
+        format!("--{challenge}"),
+        "-m".to_string(),
+        email.to_string(),
+    ];
+    for d in domains {
+        args.push("-d".to_string());
+        args.push(d.clone());
+    }
+    ActionSpec {
+        action_name: "ObtainCertificate",
+        mechanism: command_mechanism("sudo", args),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+/// Renew all due certificates (`certbot renew`).
+pub fn renew_certificates() -> ActionSpec {
+    ActionSpec {
+        action_name: "RenewCertificates",
+        mechanism: command_mechanism("sudo", ["certbot", "renew"]),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::ActionMechanism;
+
+    fn args_of(spec: &ActionSpec) -> (&'static str, Vec<String>) {
+        match &spec.mechanism {
+            ActionMechanism::Command { program, args } => (program, args.clone()),
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_certs_read_only() {
+        let (program, args) = args_of(&get_certificates());
+        assert_eq!(program, "certbot");
+        assert_eq!(args, vec!["certificates"]);
+        assert_eq!(get_certificates().risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn obtain_builds_multi_domain_argv() {
+        let (program, args) = args_of(&obtain_certificate(
+            &["a.example.com".to_string(), "b.example.com".to_string()],
+            "ops@example.com",
+            "standalone",
+        ));
+        assert_eq!(program, "sudo");
+        assert_eq!(
+            args,
+            vec![
+                "certbot",
+                "certonly",
+                "--non-interactive",
+                "--agree-tos",
+                "--standalone",
+                "-m",
+                "ops@example.com",
+                "-d",
+                "a.example.com",
+                "-d",
+                "b.example.com",
+            ]
+        );
+        assert_eq!(
+            obtain_certificate(&["x.io".to_string()], "e@x.io", "nginx").risk_level,
+            RiskLevel::High
+        );
+    }
+
+    #[test]
+    fn renew_shape() {
+        let (program, args) = args_of(&renew_certificates());
+        assert_eq!(program, "sudo");
+        assert_eq!(args, vec!["certbot", "renew"]);
+    }
+}

--- a/crates/sysknife-daemon/src/actions/fail2ban.rs
+++ b/crates/sysknife-daemon/src/actions/fail2ban.rs
@@ -72,12 +72,16 @@ fn jail_is_valid(jail: &str) -> bool {
 // specs() — for action_consistency tests
 // ---------------------------------------------------------------------------
 
+/// Root-owned helper that writes a jail override to `/etc/fail2ban/jail.d/`.
+const JAIL_HELPER: &str = "/usr/lib/sysknife/fail2ban-jail-edit";
+
 /// Return one representative `ActionSpec` per fail2ban action name.
 pub fn specs() -> Vec<ActionSpec> {
     vec![
         fail2ban_status(None),
         fail2ban_ban_ip("sshd", "192.0.2.1").expect("valid IP in specs()"),
         fail2ban_unban_ip("sshd", "192.0.2.1").expect("valid IP in specs()"),
+        configure_fail2ban_jail("sshd", &["--maxretry".to_string(), "3".to_string()]),
     ]
 }
 
@@ -147,6 +151,30 @@ pub fn fail2ban_unban_ip(jail: &str, ip: &str) -> Result<ActionSpec, Fail2banErr
         reboot_required: false,
         rollback_available: false,
     })
+}
+
+/// Write a fail2ban jail override via the helper (`configure_fail2ban_jail`).
+///
+/// `extra` is a pre-validated list of `--maxretry`/`--bantime`/`--findtime`/
+/// `--enabled` flag pairs. The helper writes `/etc/fail2ban/jail.d/sysknife-<name>.local`,
+/// tests it with `fail2ban-client -t`, and reloads (rolling back on rejection).
+///
+/// Risk: High — tuning a jail changes who gets banned (too strict → locks out
+/// legitimate users; too loose → weakens brute-force protection).
+pub fn configure_fail2ban_jail(name: &str, extra: &[String]) -> ActionSpec {
+    let mut args = vec![
+        JAIL_HELPER.to_string(),
+        "--name".to_string(),
+        name.to_string(),
+    ];
+    args.extend(extra.iter().cloned());
+    ActionSpec {
+        action_name: "ConfigureFail2banJail",
+        mechanism: command_mechanism("sudo", args),
+        risk_level: RiskLevel::High,
+        reboot_required: false,
+        rollback_available: false,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -306,11 +334,25 @@ mod tests {
         assert!(matches!(err, Fail2banError::InvalidJail(_)));
     }
 
+    #[test]
+    fn configure_jail_routes_through_helper() {
+        let spec = configure_fail2ban_jail("sshd", &["--maxretry".to_string(), "3".to_string()]);
+        let (program, args) = extract_args(&spec);
+        assert_eq!(program, "sudo");
+        assert_eq!(args, vec![JAIL_HELPER, "--name", "sshd", "--maxretry", "3"]);
+        assert_eq!(spec.risk_level, RiskLevel::High);
+    }
+
     // ── specs() completeness ─────────────────────────────────────────────────
 
     #[test]
     fn specs_covers_all_action_names() {
-        let expected = ["Fail2banStatus", "Fail2banBanIp", "Fail2banUnbanIp"];
+        let expected = [
+            "Fail2banStatus",
+            "Fail2banBanIp",
+            "Fail2banUnbanIp",
+            "ConfigureFail2banJail",
+        ];
         let spec_names: Vec<&str> = specs().iter().map(|s| s.action_name).collect();
         for name in &expected {
             assert!(spec_names.contains(name), "specs() missing {name}");

--- a/crates/sysknife-daemon/src/actions/mod.rs
+++ b/crates/sysknife-daemon/src/actions/mod.rs
@@ -3,6 +3,8 @@ use sysknife_types::RiskLevel;
 pub mod apparmor;
 pub mod apt;
 pub mod apt_preferences;
+pub mod auditd;
+pub mod certbot;
 pub mod cloudinit;
 pub mod containers;
 pub mod deployment;

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -773,9 +773,115 @@ pub fn validated_pro_service(s: &str, param: &'static str) -> Result<String, Exe
     }
 }
 
+/// Validate an auditd watch path: absolute, no `..`, charset `[A-Za-z0-9/._-]`
+/// (no `*` — audit watches a concrete file/dir), 1..=255. Mirrors `PATH_RE` in
+/// `packaging/sysknife-audit-edit`.
+pub fn validated_audit_path(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if !s.starts_with('/') || s.len() > 255 || s.contains("..") {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
+/// Validate auditd watch permissions: a subset of `r`/`w`/`x`/`a`, 1..=4 chars,
+/// no repeats. Mirrors `PERMS_RE` + the repeat check in the helper.
+pub fn validated_audit_perms(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s.is_empty() || s.len() > 4 || !s.chars().all(|c| matches!(c, 'r' | 'w' | 'x' | 'a')) {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    // no repeated flags
+    let mut seen = [false; 4];
+    for c in s.chars() {
+        let i = match c {
+            'r' => 0,
+            'w' => 1,
+            'x' => 2,
+            _ => 3,
+        };
+        if seen[i] {
+            return Err(ExecutorError::InvalidParam(param));
+        }
+        seen[i] = true;
+    }
+    Ok(s.to_string())
+}
+
+/// Validate a DNS domain for certbot: labels of `[A-Za-z0-9-]` joined by `.`,
+/// no leading `-`/`.`, no `..`, total 1..=253. Blocks option/argument injection.
+pub fn validated_domain(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s.is_empty()
+        || s.len() > 253
+        || s.contains("..")
+        || s.starts_with('-')
+        || s.starts_with('.')
+        || s.ends_with('.')
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
+/// Validate an email address for certbot registration: exactly one `@`,
+/// non-empty local + domain parts, conservative charset, 3..=254. Not a full
+/// RFC 5322 parser — just enough to block injection and obvious garbage.
+pub fn validated_email(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    if s.len() < 3 || s.len() > 254 {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    let parts: Vec<&str> = s.split('@').collect();
+    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() || !parts[1].contains('.') {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '@' | '.' | '_' | '+' | '-'))
+    {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn audit_path_and_perms() {
+        assert!(validated_audit_path("/etc/passwd", "p").is_ok());
+        assert!(validated_audit_path("relative", "p").is_err());
+        assert!(validated_audit_path("/etc/../shadow", "p").is_err());
+        assert!(validated_audit_path("/var/log/*.log", "p").is_err()); // no glob
+        assert!(validated_audit_perms("wa", "p").is_ok());
+        assert!(validated_audit_perms("rwxa", "p").is_ok());
+        assert!(validated_audit_perms("ww", "p").is_err()); // repeat
+        assert!(validated_audit_perms("z", "p").is_err());
+        assert!(validated_audit_perms("", "p").is_err());
+    }
+
+    #[test]
+    fn domain_and_email() {
+        assert!(validated_domain("example.com", "d").is_ok());
+        assert!(validated_domain("a.b.example.co.uk", "d").is_ok());
+        assert!(validated_domain("-bad.com", "d").is_err());
+        assert!(validated_domain("a..b.com", "d").is_err());
+        assert!(validated_domain("ex ample.com", "d").is_err());
+        assert!(validated_email("ops@example.com", "e").is_ok());
+        assert!(validated_email("no-at-sign", "e").is_err());
+        assert!(validated_email("a@b", "e").is_err()); // domain needs a dot
+        assert!(validated_email("a@b@c.com", "e").is_err());
+    }
 
     #[test]
     fn pro_service_allowlist() {

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -1,19 +1,20 @@
 use crate::actions::{
-    apparmor, apt, apt_preferences, cloudinit, containers, deployment, distrobox, fail2ban,
-    filesystem, flatpak, grub, identity, journald, layering, livepatch, logging, lvm, mounts,
-    multipass, netplan, network, package_repos, pam, ppa, processes, reboot, release_upgrade,
-    resolvectl, services, snap, ssh, sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
+    apparmor, apt, apt_preferences, auditd, certbot, cloudinit, containers, deployment, distrobox,
+    fail2ban, filesystem, flatpak, grub, identity, journald, layering, livepatch, logging, lvm,
+    mounts, multipass, netplan, network, package_repos, pam, ppa, processes, reboot,
+    release_upgrade, resolvectl, services, snap, ssh, sudoers, sysctl, system_info, toolbox,
+    ubuntu_pro, ufw, users,
     validate::{
         validated_apparmor_profile, validated_apt_package, validated_apt_pin_expr,
-        validated_apt_pin_name, validated_cpu_quota, validated_fstype, validated_group,
-        validated_hostname, validated_journal_grep, validated_journal_priority,
-        validated_journal_time, validated_locale, validated_log_path, validated_lvm_name,
-        validated_lvm_size, validated_memory_limit, validated_mount_device,
-        validated_mount_options, validated_mount_point, validated_port_or_service,
-        validated_ppa_name, validated_pro_service, validated_safe_arg, validated_sudo_commands,
-        validated_sudoers_name, validated_swap_path, validated_sysctl_key, validated_sysctl_value,
-        validated_syslog_host, validated_tasks_max, validated_timezone, validated_unit_name,
-        validated_username,
+        validated_apt_pin_name, validated_audit_path, validated_audit_perms, validated_cpu_quota,
+        validated_domain, validated_email, validated_fstype, validated_group, validated_hostname,
+        validated_journal_grep, validated_journal_priority, validated_journal_time,
+        validated_locale, validated_log_path, validated_lvm_name, validated_lvm_size,
+        validated_memory_limit, validated_mount_device, validated_mount_options,
+        validated_mount_point, validated_port_or_service, validated_ppa_name,
+        validated_pro_service, validated_safe_arg, validated_sudo_commands, validated_sudoers_name,
+        validated_swap_path, validated_sysctl_key, validated_sysctl_value, validated_syslog_host,
+        validated_tasks_max, validated_timezone, validated_unit_name, validated_username,
     },
     ActionMechanism, ActionSpec,
 };
@@ -1317,6 +1318,75 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
                 fail2ban::Fail2banError::InvalidJail(_) => ExecutorError::InvalidParam("jail"),
             })
         }
+        "ConfigureFail2banJail" => {
+            let name = validated_sudoers_name(require_str(params, "name")?, "name")?;
+            let mut extra = Vec::new();
+            if let Some(n) = params.get("enabled").and_then(|v| v.as_bool()) {
+                extra.push("--enabled".to_string());
+                extra.push(if n { "true" } else { "false" }.to_string());
+            }
+            if let Some(n) = params.get("maxretry").and_then(|v| v.as_u64()) {
+                if !(1..=100).contains(&n) {
+                    return Err(ExecutorError::InvalidParam("maxretry"));
+                }
+                extra.push("--maxretry".to_string());
+                extra.push(n.to_string());
+            }
+            for (key, flag) in [("bantime", "--bantime"), ("findtime", "--findtime")] {
+                if let Some(n) = params.get(key).and_then(|v| v.as_u64()) {
+                    if n > 2_592_000 {
+                        return Err(ExecutorError::InvalidParam(key));
+                    }
+                    extra.push(flag.to_string());
+                    extra.push(n.to_string());
+                }
+            }
+            if extra.is_empty() {
+                return Err(ExecutorError::MissingParam("maxretry"));
+            }
+            Ok(fail2ban::configure_fail2ban_jail(&name, &extra))
+        }
+
+        // ── auditd file-watch rules ───────────────────────────────────────
+        "GetAuditRules" => Ok(auditd::get_audit_rules()),
+        "AddAuditRule" => {
+            let path = validated_audit_path(require_str(params, "path")?, "path")?;
+            let perms = validated_audit_perms(require_str(params, "perms")?, "perms")?;
+            let key = validated_sudoers_name(require_str(params, "key")?, "key")?;
+            Ok(auditd::add_audit_rule(&path, &perms, &key))
+        }
+        "RemoveAuditRule" => {
+            let key = validated_sudoers_name(require_str(params, "key")?, "key")?;
+            Ok(auditd::remove_audit_rule(&key))
+        }
+
+        // ── certbot / ACME ────────────────────────────────────────────────
+        "GetCertificates" => Ok(certbot::get_certificates()),
+        "ObtainCertificate" => {
+            // Accept a "domains" array or a single "domain" string; ≥1 required.
+            let mut domains = Vec::new();
+            if let Some(arr) = params.get("domains").and_then(|v| v.as_array()) {
+                for d in arr {
+                    let s = d.as_str().ok_or(ExecutorError::InvalidParam("domains"))?;
+                    domains.push(validated_domain(s, "domains")?);
+                }
+            } else if let Some(d) = params.get("domain").and_then(|v| v.as_str()) {
+                domains.push(validated_domain(d, "domain")?);
+            }
+            if domains.is_empty() {
+                return Err(ExecutorError::MissingParam("domains"));
+            }
+            let email = validated_email(require_str(params, "email")?, "email")?;
+            let challenge = params
+                .get("challenge")
+                .and_then(|v| v.as_str())
+                .unwrap_or("standalone");
+            if !matches!(challenge, "standalone" | "nginx" | "apache") {
+                return Err(ExecutorError::InvalidParam("challenge"));
+            }
+            Ok(certbot::obtain_certificate(&domains, &email, challenge))
+        }
+        "RenewCertificates" => Ok(certbot::renew_certificates()),
 
         _ => Err(ExecutorError::UnknownAction(action_name.to_string())),
     }

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -71,6 +71,9 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "GetLogrotateStatus"
         // ── PAM read-only ─────────────────────────────────────────────────
         | "GetPasswordAging"
+        // ── auditd / certbot read-only ────────────────────────────────────
+        | "GetAuditRules"
+        | "GetCertificates"
         | "GetAuthorizedKeys"
         | "ListUsers"
         | "ListGroups"
@@ -288,6 +291,12 @@ pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
         | "SetPasswordAging"
         | "SetPasswordPolicy"
         | "SetAccountLockout"
+        // ── auditd rules / certbot / fail2ban jail config ─────────────────
+        | "AddAuditRule"
+        | "RemoveAuditRule"
+        | "ObtainCertificate"
+        | "RenewCertificates"
+        | "ConfigureFail2banJail"
         | "DeleteUser"
         | "AddAuthorizedKey"
         | "RemoveAuthorizedKey"

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -96,6 +96,8 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "GetSudoGrants"
         | "GetLogrotateStatus"
         | "GetPasswordAging"
+        | "GetAuditRules"
+        | "GetCertificates"
         | "GetAuthorizedKeys"
         | "GetDateTime"
         | "ListJobHistory"
@@ -279,6 +281,61 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             warnings: vec![
                 "exact approval required".to_string(),
                 "after detach, this machine no longer receives Pro security patches".to_string(),
+            ],
+        },
+
+        // ── auditd file-watch rules ─────────────────────────────────────
+        "AddAuditRule" | "RemoveAuditRule" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "a persistent audit rule will be written/removed and reloaded".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "requires the auditd package installed to take effect".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── certbot / ACME ──────────────────────────────────────────────
+        "ObtainCertificate" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "certbot will obtain a TLS certificate (ACME challenge)".to_string(),
+                "TLS material will be written under /etc/letsencrypt".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "contacts a public ACME CA over the network".to_string(),
+                "requires certbot installed + a reachable DNS/HTTP challenge".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+        "RenewCertificates" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec!["certbot will renew due certificates".to_string()],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "contacts a public ACME CA over the network".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── fail2ban jail config ────────────────────────────────────────
+        "ConfigureFail2banJail" => PreviewProfile {
+            risk_level: RiskLevel::High,
+            expected_side_effects: vec![
+                "a fail2ban jail override will be written and the daemon reloaded".to_string(),
+            ],
+            reboot_required: false,
+            rollback_available: false,
+            warnings: vec![
+                "changes who gets banned (too strict can lock out real users)".to_string(),
+                "requires the fail2ban package installed to take effect".to_string(),
+                "exact approval required".to_string(),
             ],
         },
 

--- a/crates/sysknife-daemon/tests/action_consistency.rs
+++ b/crates/sysknife-daemon/tests/action_consistency.rs
@@ -12,10 +12,11 @@ use std::collections::BTreeSet;
 use serde_json::json;
 use sysknife_brain::planning_tools::propose_plan::KNOWN_ACTIONS;
 use sysknife_daemon::actions::{
-    apparmor, apt, apt_preferences, cloudinit, containers, deployment, distrobox, fail2ban,
-    filesystem, flatpak, grub, identity, journald, layering, livepatch, logging, lvm, mounts,
-    multipass, netplan, network, package_repos, pam, ppa, processes, reboot, release_upgrade,
-    resolvectl, services, snap, ssh, sudoers, sysctl, system_info, toolbox, ubuntu_pro, ufw, users,
+    apparmor, apt, apt_preferences, auditd, certbot, cloudinit, containers, deployment, distrobox,
+    fail2ban, filesystem, flatpak, grub, identity, journald, layering, livepatch, logging, lvm,
+    mounts, multipass, netplan, network, package_repos, pam, ppa, processes, reboot,
+    release_upgrade, resolvectl, services, snap, ssh, sudoers, sysctl, system_info, toolbox,
+    ubuntu_pro, ufw, users,
 };
 use sysknife_daemon::executor::build_action_spec;
 use sysknife_daemon::policy::min_role_for_action;
@@ -80,6 +81,12 @@ fn all_spec_action_names() -> BTreeSet<&'static str> {
         names.insert(spec.action_name);
     }
     for spec in pam::specs() {
+        names.insert(spec.action_name);
+    }
+    for spec in auditd::specs() {
+        names.insert(spec.action_name);
+    }
+    for spec in certbot::specs() {
         names.insert(spec.action_name);
     }
     for spec in identity::specs() {

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -153,6 +153,14 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     "SetPasswordAging",
     "SetPasswordPolicy",
     "SetAccountLockout",
+    // auditd file-watch rules (cross-distro)
+    "GetAuditRules",
+    "AddAuditRule",
+    "RemoveAuditRule",
+    // certbot / ACME (cross-distro)
+    "GetCertificates",
+    "ObtainCertificate",
+    "RenewCertificates",
     "GetDateTime",
     "SetHostname",
     "SetTimezone",
@@ -254,6 +262,7 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     "Fail2banStatus",
     "Fail2banBanIp",
     "Fail2banUnbanIp",
+    "ConfigureFail2banJail",
     // Ubuntu / release upgrade (Tier 3)
     "UbuntuReleaseUpgrade",
     // Ubuntu / Ubuntu Pro (Tier 3)

--- a/docs/typed-actions.md
+++ b/docs/typed-actions.md
@@ -53,7 +53,7 @@ codebase. On the daemon side (`sysknife-daemon`), each action is backed by an
 | `reboot_required` | Whether the daemon should warn the caller before proceeding |
 | `rollback_available` | Whether a failure triggers automatic rollback |
 
-As of this writing the catalogue defines **182 actions** across families such
+As of this writing the catalogue defines **189 actions** across families such
 as Deployment, Services, Package Layering, Flatpak, Containers, Toolbox,
 Network, Identity, SSH Keys, Package Repositories, apt/snap/ufw/netplan/grub
 (Debian-family), and rpm-ostree/AppArmor/cloud-init/Pro (Fedora-family). Each

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -26,7 +26,7 @@ system.
    `state.planner.plan_intent(intent)`.
 
 4. **LLM planning loop** (`crates/sysknife-brain/src/planner.rs:318`)
-   Turn 0: LLM receives system prompt (182-action catalogue, risk rules) +
+   Turn 0: LLM receives system prompt (189-action catalogue, risk rules) +
    user message. LLM calls `get_system_state`.
 
 5. **State injection** (`crates/sysknife-brain/src/planner.rs:366`)

--- a/packaging/sysknife-audit-edit
+++ b/packaging/sysknife-audit-edit
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# sysknife-audit-edit — manage persistent auditd file-watch rules.
+#
+# Install to: /usr/lib/sysknife/audit-edit
+# Mode:       0755
+# Owner:      root:root
+#
+# Invoked exclusively by the sysknife-daemon via one of:
+#   sudo /usr/lib/sysknife/audit-edit --op add --path <abs> --perms <rwxa> --key <key>
+#   sudo /usr/lib/sysknife/audit-edit --op remove --key <key>
+#
+# Scope: file-WATCH rules only (`-w <path> -p <perms> -k <key>`), the common
+# "audit access to this sensitive file/dir" case. Syscall rules are deliberately
+# out of scope (their grammar is a large injection surface). Each rule is written
+# to its own file /etc/audit/rules.d/sysknife-<key>.rules and loaded with
+# `augenrules --load`, so it survives reboot. Inputs are re-validated here.
+#
+# NOTE (network-gated): the `auditd`/`audit` package is NOT on the base cloud
+# image and cannot be installed offline, so the load step (augenrules/auditctl)
+# could not be live-validated in the sandbox — only the rule-file WRITE was. If
+# augenrules is absent this helper still writes the persistent rule file and
+# reports that the load was skipped (rc still 0 so the rule is in place for the
+# next boot once auditd is installed).
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+RULES_D = "/etc/audit/rules.d"
+AUGENRULES = "/sbin/augenrules"
+PREFIX = "sysknife-"
+
+KEY_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+PATH_RE = re.compile(r"^/[A-Za-z0-9/._-]{1,255}$")
+PERMS_RE = re.compile(r"^[rwxa]{1,4}$")
+
+
+def die(msg: str) -> None:
+    print(f"sysknife-audit-edit: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def atomic_write(path: str, content: str, mode: int = 0o640) -> None:
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".sysknife-audit-")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(content)
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        die(f"cannot write {path}: {exc}")
+
+
+def reload_rules() -> None:
+    # augenrules compiles every rules.d/*.rules into the running policy. If the
+    # audit package is not installed, skip cleanly — the file is still in place.
+    if not os.path.exists(AUGENRULES):
+        print("sysknife-audit-edit: augenrules not found; rule written but not loaded",
+              file=sys.stderr)
+        return
+    subprocess.run([AUGENRULES, "--load"], check=False, stderr=subprocess.DEVNULL)
+
+
+def op_add(args) -> None:
+    if not KEY_RE.match(args.key):
+        die(f"invalid key {args.key!r}")
+    if not PATH_RE.match(args.path) or ".." in args.path:
+        die(f"invalid path {args.path!r}")
+    if not PERMS_RE.match(args.perms) or len(set(args.perms)) != len(args.perms):
+        die(f"invalid perms {args.perms!r} (subset of r/w/x/a, no repeats)")
+    body = (
+        f"# Managed by SysKnife (add_audit_rule: {args.key}).\n"
+        f"-w {args.path} -p {args.perms} -k {args.key}\n"
+    )
+    atomic_write(os.path.join(RULES_D, PREFIX + args.key + ".rules"), body)
+    reload_rules()
+
+
+def op_remove(args) -> None:
+    if not KEY_RE.match(args.key):
+        die(f"invalid key {args.key!r}")
+    dest = os.path.join(RULES_D, PREFIX + args.key + ".rules")
+    if os.path.exists(dest):
+        os.unlink(dest)
+        reload_rules()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Manage auditd file-watch rules.")
+    p.add_argument("--op", required=True, choices=["add", "remove"])
+    p.add_argument("--path")
+    p.add_argument("--perms")
+    p.add_argument("--key", required=True)
+    args = p.parse_args()
+
+    if args.op == "add":
+        if not (args.path and args.perms):
+            die("add requires --path and --perms")
+        op_add(args)
+    else:
+        op_remove(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/sysknife-fail2ban-jail-edit
+++ b/packaging/sysknife-fail2ban-jail-edit
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# sysknife-fail2ban-jail-edit — write a fail2ban jail override.
+#
+# Install to: /usr/lib/sysknife/fail2ban-jail-edit
+# Mode:       0755
+# Owner:      root:root
+#
+# Invoked exclusively by the sysknife-daemon via:
+#   sudo /usr/lib/sysknife/fail2ban-jail-edit --name <jail> \
+#        [--maxretry N] [--bantime N] [--findtime N] [--enabled true|false]
+#
+# Writes a jail override to /etc/fail2ban/jail.d/sysknife-<name>.local. Inputs
+# are re-validated here. If `fail2ban-client` is present the config is checked
+# with `fail2ban-client -t` (test) before the daemon is reloaded, rolling back
+# on rejection. If fail2ban is not installed the override is still written and
+# the test/reload is skipped cleanly.
+#
+# NOTE (network-gated): the `fail2ban` package is NOT on the base cloud image
+# and cannot be installed offline, so the -t/reload path could not be
+# live-validated in the sandbox — only the override WRITE + validation were.
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+JAIL_D = "/etc/fail2ban/jail.d"
+FAIL2BAN_CLIENT = "/usr/bin/fail2ban-client"
+PREFIX = "sysknife-"
+
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def die(msg: str) -> None:
+    print(f"sysknife-fail2ban-jail-edit: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def atomic_write(path: str, content: str, mode: int = 0o644) -> None:
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".sysknife-f2b-")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(content)
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        die(f"cannot write {path}: {exc}")
+
+
+def require_range(name: str, value, lo: int, hi: int) -> None:
+    if value is None:
+        return
+    if value < lo or value > hi:
+        die(f"{name} out of range [{lo}, {hi}]")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Write a fail2ban jail override.")
+    p.add_argument("--name", required=True)
+    p.add_argument("--maxretry", type=int)
+    p.add_argument("--bantime", type=int)
+    p.add_argument("--findtime", type=int)
+    p.add_argument("--enabled", choices=["true", "false"])
+    args = p.parse_args()
+
+    if not NAME_RE.match(args.name):
+        die(f"invalid jail name {args.name!r}")
+    require_range("maxretry", args.maxretry, 1, 100)
+    # bantime/findtime seconds; cap at 30 days (bantime -1 = permanent is not
+    # offered here to keep the value a simple non-negative integer).
+    require_range("bantime", args.bantime, 0, 2592000)
+    require_range("findtime", args.findtime, 1, 2592000)
+
+    lines = [f"# Managed by SysKnife (configure_fail2ban_jail: {args.name}).", f"[{args.name}]"]
+    if args.enabled is not None:
+        lines.append(f"enabled = {args.enabled}")
+    if args.maxretry is not None:
+        lines.append(f"maxretry = {args.maxretry}")
+    if args.bantime is not None:
+        lines.append(f"bantime = {args.bantime}")
+    if args.findtime is not None:
+        lines.append(f"findtime = {args.findtime}")
+    if len(lines) == 2:
+        die("at least one of --enabled/--maxretry/--bantime/--findtime is required")
+
+    dest = os.path.join(JAIL_D, PREFIX + args.name + ".local")
+    prev = None
+    if os.path.exists(dest):
+        with open(dest) as fh:
+            prev = fh.read()
+    atomic_write(dest, "\n".join(lines) + "\n")
+
+    if not os.path.exists(FAIL2BAN_CLIENT):
+        print("sysknife-fail2ban-jail-edit: fail2ban-client not found; "
+              "override written but not tested/reloaded", file=sys.stderr)
+        return
+    check = subprocess.run(
+        [FAIL2BAN_CLIENT, "-t"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+    )
+    if check.returncode != 0:
+        if prev is not None:
+            atomic_write(dest, prev)
+        else:
+            os.unlink(dest)
+        die(f"fail2ban rejected the config: {check.stderr.decode(errors='replace').strip()}")
+    subprocess.run([FAIL2BAN_CLIENT, "reload"], check=False, stderr=subprocess.DEVNULL)
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/sysknife-sudoers
+++ b/packaging/sysknife-sudoers
@@ -181,6 +181,22 @@ sysknife ALL=(root) NOPASSWD: /usr/sbin/aa-complain
 # fail2ban-client — Fail2banStatus (read-only) / BanIp / UnbanIp.
 sysknife ALL=(root) NOPASSWD: /usr/bin/fail2ban-client
 
+# fail2ban jail config — ConfigureFail2banJail delegates to this root-owned
+# helper, which writes /etc/fail2ban/jail.d/sysknife-<name>.local, tests it with
+# `fail2ban-client -t`, and reloads (rolling back on rejection). Requires the
+# fail2ban package installed to test/reload; writes the override either way.
+sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/fail2ban-jail-edit *
+
+# auditd file-watch rules — AddAuditRule/RemoveAuditRule delegate to this helper,
+# which writes /etc/audit/rules.d/sysknife-<key>.rules and loads via augenrules.
+# GetAuditRules runs bare `auditctl -l` (read-only) and needs no grant.
+sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/audit-edit *
+
+# certbot / ACME — ObtainCertificate / RenewCertificates (mutating; write TLS
+# material). GetCertificates runs bare `certbot certificates` (read-only). Path
+# is the apt install location; a snap install lives at /snap/bin/certbot.
+sysknife ALL=(root) NOPASSWD: /usr/bin/certbot
+
 # Ubuntu Pro CLI — ProAttach / ProDetach (mutating). ProStatus is read-only and
 # does not require root, but `pro` itself is allowed for symmetry.
 sysknife ALL=(root) NOPASSWD: /usr/bin/pro

--- a/tests/e2e/ubuntu-provision.sh
+++ b/tests/e2e/ubuntu-provision.sh
@@ -264,6 +264,12 @@ install -Dm 755 packaging/sysknife-log-edit /usr/lib/sysknife/log-edit \
 # pam-edit: invoked by SetPasswordPolicy (pwquality) + SetAccountLockout (faillock).
 install -Dm 755 packaging/sysknife-pam-edit /usr/lib/sysknife/pam-edit \
     || fail "Install sysknife-pam-edit"
+# audit-edit: invoked by AddAuditRule/RemoveAuditRule (needs auditd to load).
+install -Dm 755 packaging/sysknife-audit-edit /usr/lib/sysknife/audit-edit \
+    || fail "Install sysknife-audit-edit"
+# fail2ban-jail-edit: invoked by ConfigureFail2banJail (needs fail2ban to test/reload).
+install -Dm 755 packaging/sysknife-fail2ban-jail-edit /usr/lib/sysknife/fail2ban-jail-edit \
+    || fail "Install sysknife-fail2ban-jail-edit"
 
 # ---------------------------------------------------------------------------
 # Step 6: Add VM user to sysknife groups


### PR DESCRIPTION
Batch 11 (final gap-family issue). Adds **7 actions** (182 → 189) across three package-gated families.

| Family | Actions |
|---|---|
| **auditd** (cross-distro) | `GetAuditRules` (Low), `AddAuditRule`/`RemoveAuditRule` (High) — file-watch rules via `audit-edit` helper |
| **certbot/ACME** (cross-distro) | `GetCertificates` (Low), `ObtainCertificate`/`RenewCertificates` (High) |
| **fail2ban jail** (Ubuntu) | `ConfigureFail2banJail` (High) — `jail.d` override via `fail2ban-jail-edit` helper |

Two new root helpers re-validate + write scoped config (`/etc/audit/rules.d/`, `/etc/fail2ban/jail.d/`) and **skip the load/test step cleanly** when the tool package is absent, so the config still lands. New validators: `validated_audit_path` (no glob), `validated_audit_perms` (subset of rwxa, no repeats), `validated_domain`, `validated_email`. auditd is scoped to **file-watch rules only** (syscall grammar is an injection surface). `cargo nextest`: **1348 passed**; clippy+fmt clean.

### Live-validated in QEMU — all three versions (22.04/24.04/26.04), REACHABLE paths
- `audit-edit` writes `-w <path> -p <perms> -k <key>` (0640 root); remove deletes
- `fail2ban-jail-edit` writes `[jail] enabled/maxretry/bantime/findtime`
- both skip augenrules/fail2ban-client **cleanly** when absent (file still written)
- rejections fire: bad/repeat perms, path traversal, `maxretry`>100, bad jail name

### ⚠️ Honest caveat — NOT live-validated (no VM network)
`auditctl` / `certbot` / `fail2ban-client` are **not on the base cloud image** (all confirmed MISS) and the sandbox has no outbound DNS to apt-install them (certbot/ACME also needs Lets Encrypt). So the actual tool-execution paths — rule **load**, cert **issuance**, jail **test/reload** — were **not** live-proven; only argv + the helpers config-write + validation paths were. Needs a networked env to prove end-to-end. Documented in each module, both helpers, and the commit.

Closes #74.