### PR TITLE
docs: re-sync code-vs-docs drift (189 actions, 1,348 tests, author link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ milestone.
 | Component | State |
 |---|---|
 | `sysknife-brain` — LLM planner, tool loop, safety fence | ✅ |
-| `sysknife-daemon` — 140+ typed actions, auth, preview, transactions | ✅ |
+| `sysknife-daemon` — 189 typed actions, auth, preview, transactions | ✅ |
 | Live IPC + streaming + atomic-host rollback (rpm-ostree) | ✅ |
 | Terminal approval gate — one-time, TTL-bounded receipts | ✅ |
 | MCP server (Claude Code / Cursor / any MCP client) | ✅ |
@@ -215,7 +215,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,292 Rust tests and 72 frontend tests** form the current deterministic
+**1,348 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM
@@ -328,7 +328,7 @@ The [LACS specification](https://github.com/lacs-project/specification) is
 ---
 
 <p align="center">
-  Built by <a href="https://github.com/vladimirrotariu">Vladimir Rotariu</a>.
+  Built by <a href="https://github.com/vladimirrott">Vladimir Rotariu</a>.
   ·
   Issues, ideas, war stories — <a href="https://github.com/lacs-project/sysknife/discussions">come say hi</a>.
 </p>

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -4,7 +4,14 @@ The Fedora / rpm-ostree (atomic-host) action family — each action's underlying
 command, whether it is destructive, and what it does. Ubuntu-family actions
 (apt, snap, ufw, netplan, distrobox, …) are documented in the
 [Ubuntu action reference](ubuntu-action-reference.md). Across all families
-SysKnife defines 140+ typed actions.
+SysKnife defines **189 typed actions**.
+
+> This page tables the deployment/systemd/core families only. Cross-distro
+> families added later — storage (LVM), journald, sysctl, per-service resource
+> limits, mounts/swap, sudoers.d, log rotation + remote syslog, PAM password
+> policy, auditd, and certbot — are not tabled here yet. The complete,
+> authoritative catalogue is the in-code `KNOWN_ACTION_NAMES` list, summarised
+> in [Typed Actions](typed-actions.md).
 
 > **Destructive** — mutates persistent system state (package installs,
 > deployment changes, user/group writes, firewall rules, reboots).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ component uses the same resolution order.
 
 Privileged. The only component that touches the system. Provides:
 
-- 140+ typed actions (rpm-ostree, systemd, firewall, users, containers,
+- 189 typed actions (rpm-ostree, systemd, firewall, users, containers,
   flatpak, toolbox, SSH, kernel args, …)
 - Role-based authorization (`Observer` → `Dev` → `Admin`)
 - Policy enforcement: stale-approval detection, request hash validation

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -218,7 +218,7 @@ crates/
   sysknife-brain/     LLM planner, provider adapters, safety fence
   sysknife-types/     Shared domain types (CallerRole, RiskLevel, JobState, …)
   sysknife-core/      Config loading, shared constants
-  sysknife-daemon/    Privileged executor, 140+ actions, IPC, rollback, SQLite
+  sysknife-daemon/    Privileged executor, 189 actions, IPC, rollback, SQLite
   sysknife-proto/     Protobuf definitions (future use)
 apps/
   sysknife-shell/     Tauri + React GUI

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -26,7 +26,7 @@ release.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** until variant-specific VM evidence exists |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,292 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,348 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -117,7 +117,7 @@ SysKnife auto-detects it. See [Quick Start](quickstart.md).
 
 ## Status
 
-140+ typed actions · 1,292 Rust tests + 72 frontend tests · MIT
+189 typed actions · 1,348 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/ubuntu-action-reference.md
+++ b/docs/ubuntu-action-reference.md
@@ -1,8 +1,15 @@
 # Ubuntu action reference
 
-Canonical CLI invocations for the Ubuntu action families in SysKnife,
-verified against Ubuntu 24.04 LTS (Noble Numbat) authoritative sources
-on 2026-04-25.
+Canonical CLI invocations for the **core** Ubuntu action families in SysKnife
+(apt, snap, ufw, netplan, distrobox), verified against Ubuntu 24.04 LTS
+(Noble Numbat) authoritative sources on 2026-04-25.
+
+> This page covers the source-verified core families only. SysKnife's Ubuntu
+> support has since grown further families — e.g. apt preferences/pinning,
+> Ubuntu Pro service toggles, and fail2ban jail configuration. The complete,
+> authoritative catalogue is the in-code `KNOWN_ACTION_NAMES` list, summarised
+> in [Typed Actions](typed-actions.md); entries here are added as each family's
+> invocations are source-verified.
 
 Sources consulted:
 

--- a/scripts/check_public_claims.sh
+++ b/scripts/check_public_claims.sh
@@ -29,8 +29,8 @@ reject_pattern() {
     fi
 }
 
-reject_pattern '1,2(2[7-9]|[3-8][0-9]|9[0-1])( Rust)? tests' \
-    'test count is stale; the release baseline is 1,292 Rust tests' \
+reject_pattern '1,(2[2-9][0-9]|3[0-3][0-9]|34[0-7])( Rust)? tests' \
+    'test count is stale; the release baseline is 1,348 Rust tests' \
     "${claim_files[@]}"
 reject_pattern 'until npm publish lands|publish[- ]pending' \
     'setup package is documented as unpublished' "${claim_files[@]}"
@@ -60,8 +60,8 @@ required_test_count_docs=(
     "$repo_root/docs/distro-support.md"
 )
 for path in "${required_test_count_docs[@]}"; do
-    if ! grep -Fq '1,292 Rust tests' "$path"; then
-        printf 'Verified test baseline missing from %s: expected 1,292 Rust tests\n' \
+    if ! grep -Fq '1,348 Rust tests' "$path"; then
+        printf 'Verified test baseline missing from %s: expected 1,348 Rust tests\n' \
             "$path" >&2
         exit 1
     fi

--- a/tests/release/public-claims.test.sh
+++ b/tests/release/public-claims.test.sh
@@ -47,7 +47,7 @@ assert_rejected() {
     fi
 }
 
-sed -i 's/1,292 Rust tests/1,256 Rust tests/' "$fixture/README.md"
+sed -i 's/1,348 Rust tests/1,256 Rust tests/' "$fixture/README.md"
 assert_rejected 'old test count'
 cp "$repo_root/README.md" "$fixture/README.md"
 


### PR DESCRIPTION
Re-syncs public claims that lagged behind the gap-family wave (150→189 actions, 1,259→1,348 tests). Verified against ground truth: `KNOWN_ACTION_NAMES`=189, `cargo nextest`=1,348, MCP=5 tools, 8 providers.

- **Action count** `140+` → **189**: README status table, architecture, developer-guide, introduction, actions.md.
- **Test baseline** `1,292` → **1,348**: README, introduction, distro-support — *coupled* with the public-claims gate (required-literal + stale-reject regex + message) and its contract test fixture, which pin the baseline.
- **Broken author link** `vladimirrotariu` (404) → **vladimirrott** (README footer).
- **Reference tables** (`actions.md` Fedora/core, unpublished; `ubuntu-action-reference.md` core Ubuntu, published) had fallen behind. Rather than hand-fabricate ~40 rows, added an honest source-of-truth note to each pointing at `typed-actions.md` + in-code `KNOWN_ACTION_NAMES`. Full deterministic regeneration is a follow-up.

Verified accurate, no change: MCP tool list (5), providers (8), `LacsConfig` refs, 65/65 story claim, LACS spec link (now resolves). `check_public_claims.sh` + its contract test pass locally.