### PR TITLE
fix(actions): apt-pin spec example 1001 → 990 (in valid range)

### DIFF
--- a/crates/sysknife-daemon/src/actions/apt_preferences.rs
+++ b/crates/sysknife-daemon/src/actions/apt_preferences.rs
@@ -13,7 +13,7 @@ const HELPER: &str = "/usr/lib/sysknife/apt-pin-edit";
 pub fn specs() -> Vec<ActionSpec> {
     vec![
         get_apt_pins(None),
-        set_apt_pin("hold-nginx", "nginx", "version 1.24.*", 1001),
+        set_apt_pin("hold-nginx", "nginx", "version 1.24.*", 990),
         remove_apt_pin("hold-nginx"),
     ]
 }
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn set_and_remove_shapes() {
-        let (program, set) = args_of(&set_apt_pin("hold-nginx", "nginx", "version 1.24.*", 1001));
+        let (program, set) = args_of(&set_apt_pin("hold-nginx", "nginx", "version 1.24.*", 990));
         assert_eq!(program, "sudo");
         assert_eq!(
             set,
@@ -109,7 +109,7 @@ mod tests {
                 "--pin",
                 "version 1.24.*",
                 "--priority",
-                "1001"
+                "990"
             ]
         );
         assert_eq!(set_apt_pin("a", "b", "c", 1).risk_level, RiskLevel::Medium);

--- a/docs/action-reference.md
+++ b/docs/action-reference.md
@@ -304,7 +304,7 @@ Every row is derived from the live code: the command from each action's `ActionS
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
 | `GetAptPins` | `apt-cache policy` | Low | Ubuntu | – | – | show apt pin priorities (apt-cache policy) — param: package (optional); Ubuntu only; read-only |
-| `SetAptPin` | `sudo /usr/lib/sysknife/apt-pin-edit --op set --name hold-nginx --package nginx --pin version 1.24.* --priority 1001` | Medium | Ubuntu | – | – | pin a package to a version/release via /etc/apt/preferences.d — params: name\*, package\* (glob), pin\* (e.g. 'version 1.24.\*' or 'release a=noble-security'), priority\* (int -1..1000); Ubuntu only; Medium risk |
+| `SetAptPin` | `sudo /usr/lib/sysknife/apt-pin-edit --op set --name hold-nginx --package nginx --pin version 1.24.* --priority 990` | Medium | Ubuntu | – | – | pin a package to a version/release via /etc/apt/preferences.d — params: name\*, package\* (glob), pin\* (e.g. 'version 1.24.\*' or 'release a=noble-security'), priority\* (int -1..1000); Ubuntu only; Medium risk |
 | `RemoveAptPin` | `sudo /usr/lib/sysknife/apt-pin-edit --op remove --name hold-nginx` | Medium | Ubuntu | – | – | remove a SysKnife-managed apt pin — param: name\*; Ubuntu only; Medium risk |
 
 ## PPA


### PR DESCRIPTION
The `apt_preferences` `specs()` representative example used `--priority 1001`, which the helper/validator actually reject (range is `-1..1000`). Harmless at runtime (spec examples are not validated), but the new generated `action-reference.md` surfaced it as an example contradicting its own `-1..1000` description. Changed the example + its unit test to `990` (a valid strong pin) and regenerated the reference via the drift guard. nextest 1349; clippy/fmt/markdownlint clean.