### PR TITLE
fix(release): crates.io keyword too long (system-administration → sysadmin)

### DIFF
--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Approval-gated AI system administration CLI and MCP server"
-keywords = ["linux", "system-administration", "mcp", "ai-agent"]
+keywords = ["linux", "sysadmin", "mcp", "ai-agent"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [[bin]]

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "LLM planning core for SysKnife — typed action proposals with formal risk levels"
-keywords = ["llm", "ai-agent", "linux", "system-administration", "planning"]
+keywords = ["llm", "ai-agent", "linux", "sysadmin", "planning"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Configuration and domain primitives for SysKnife"
-keywords = ["linux", "system-administration", "configuration"]
+keywords = ["linux", "sysadmin", "configuration"]
 categories = ["command-line-utilities", "config"]
 
 [dependencies]

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Policy-enforced, audit-logged Linux action daemon for SysKnife"
-keywords = ["linux", "system-administration", "daemon", "security"]
+keywords = ["linux", "sysadmin", "daemon", "security"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Protocol buffer definitions for the SysKnife daemon IPC contract"
-keywords = ["linux", "system-administration", "protobuf", "ipc"]
+keywords = ["linux", "sysadmin", "protobuf", "ipc"]
 categories = ["os::linux-apis", "encoding"]
 
 [dependencies]


### PR DESCRIPTION
v0.2.5 crates.io publish failed on the first crate (`sysknife-proto`, 400 Bad Request): `"system-administration"` is 21 chars and crates.io caps keywords at <20. Nothing reached crates.io (clean re-publish). `cargo package` does not validate keyword length — only server-side publish does. Replaced with `sysadmin` in all 5 affected crates. npm 0.2.5 already published (its job is idempotent). Re-tagging v0.2.5 to this commit re-runs the release.