### PR TITLE
docs(readme): drop stale pre-launch banner (v0.2.5 released)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,6 @@ npx sysknife-setup
 
 [![npm version](https://img.shields.io/npm/v/sysknife-setup?style=flat-square&logo=npm)](https://www.npmjs.com/package/sysknife-setup)
 
-> **Pre-launch:** the binary auto-download resolves against a published GitHub
-> Release, which isn't tagged yet — until the first release lands, run
-> `npx sysknife-setup --no-binary` and build the binaries with the **Manual
-> install** steps below.
-
 What this does:
 
 1. **Downloads the prebuilt `sysknife` + `sysknife-daemon` binaries** for your


### PR DESCRIPTION
The **Pre-launch** blockquote in the Install section claimed the GitHub Release "isn't tagged yet" and told users to run `npx sysknife-setup --no-binary`. That is now stale and misleading:

- GitHub Release `v0.2.5` exists with SHA-256-verified prebuilt binaries (`sysknife` + `sysknife-daemon`, x86_64 + aarch64) and SPDX SBOMs.
- `sysknife-cli` and `sysknife-daemon` 0.2.5 are published on crates.io.

So the default `npx sysknife-setup` auto-download path works. This removes the banner only; the legitimate from-source `--no-binary` guidance inside the manual-install `<details>` is unchanged.

Verified: `scripts/check_public_claims.sh` passes; no dangling references to the banner remain in README or published docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)