### PR TITLE
docs(mcp): cargo-based MCP Registry publishing + crate READMEs

### DIFF
--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Approval-gated AI system administration CLI and MCP server"
+readme = "README.md"
 keywords = ["linux", "sysadmin", "mcp", "ai-agent"]
 categories = ["command-line-utilities", "os::linux-apis"]
 

--- a/apps/sysknife-cli/README.md
+++ b/apps/sysknife-cli/README.md
@@ -1,0 +1,44 @@
+# sysknife-cli
+
+> Your sysadmin co-pilot. Plan. Approve. Audit.
+
+`sysknife-cli` installs the `sysknife` binary — an approval-gated AI system
+administration CLI and MCP server. The AI never runs a shell command: it emits
+**typed actions** with formal risk levels, a privileged daemon executes only
+what you approve, and every action is written to a tamper-evident,
+Ed25519-signed hash-chain audit trail with automatic rollback on atomic hosts.
+
+Part of [SysKnife](https://github.com/lacs-project/sysknife), the MIT reference
+implementation of the LACS (Linux Agent Control Standard) protocol.
+
+## Install
+
+```sh
+cargo install sysknife-cli
+```
+
+## Use
+
+```sh
+# Standalone CLI (plan → approve → execute):
+sysknife "show disk usage and list services that ate cpu in the last hour"
+
+# Stdio MCP server, for Claude Code / Cursor / Codex CLI:
+sysknife mcp-server
+```
+
+`npx sysknife-setup` wires the MCP server into your AI IDE and installs the
+privileged daemon for you. The server exposes `sysknife_plan`,
+`sysknife_execute`, `sysknife_history`, `sysknife_doctor`, and
+`sysknife_audit_verify` as MCP tools.
+
+## Links
+
+- Documentation: <https://lacs-project.github.io/sysknife/>
+- Repository: <https://github.com/lacs-project/sysknife>
+- License: MIT
+
+<!-- The following marker verifies crates.io ownership for the MCP Registry.
+     It must be VISIBLE text: crates.io strips HTML comments when rendering. -->
+
+mcp-name: io.github.lacs-project/sysknife

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Policy-enforced, audit-logged Linux action daemon for SysKnife"
+readme = "README.md"
 keywords = ["linux", "sysadmin", "daemon", "security"]
 categories = ["command-line-utilities", "os::linux-apis"]
 

--- a/crates/sysknife-daemon/README.md
+++ b/crates/sysknife-daemon/README.md
@@ -1,0 +1,23 @@
+# sysknife-daemon
+
+> The privileged executor for [SysKnife](https://github.com/lacs-project/sysknife).
+
+`sysknife-daemon` is the only privileged component of SysKnife. It executes
+**typed actions** — proposed by the planner and explicitly approved by you,
+never shell strings — enforces policy and one-time TTL approval receipts, writes
+a tamper-evident Ed25519-signed hash-chain audit trail (SQLite or Postgres), and
+rolls back atomic-host (rpm-ostree) changes automatically on failure.
+
+It is normally installed and managed for you by `npx sysknife-setup` as a systemd
+service. To install the crate directly:
+
+```sh
+cargo install sysknife-daemon
+```
+
+Part of SysKnife, the MIT reference implementation of the LACS (Linux Agent
+Control Standard) protocol.
+
+- Documentation: <https://lacs-project.github.io/sysknife/>
+- Repository: <https://github.com/lacs-project/sysknife>
+- License: MIT

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -1,59 +1,118 @@
 # MCP Registry listing
 
 SysKnife's MCP server is the `sysknife mcp-server` subcommand (stdio). This note
-records how it maps onto the official MCP Registry and the one open step before
-we publish a listing.
+records how it maps onto the official [MCP Registry](https://registry.modelcontextprotocol.io)
+and the exact steps to publish a listing.
 
-## The launch model
+> The official registry is in **preview** — it may reset data before general
+> availability, so treat a published entry as non-permanent for now.
 
-The registry runs an npm package's default `npx <name>` bin and treats its
-stdio as the MCP stream. `sysknife-setup`'s default bin is the interactive setup
-wizard, not a server, so it cannot itself be the registry entry.
+## Distribution: the `cargo` package type
 
-`sysknife-setup` therefore ships a second bin, `sysknife-mcp`, that locates the
-installed `sysknife` binary and execs `sysknife mcp-server` with inherited
-stdio:
+The registry supports a `cargo` package type: `registryType` is an open string
+(the schema's enumerated examples are only npm/pypi/oci/nuget/mcpb, so `cargo`
+is permitted rather than listed), and the registry validator
+(`internal/validators/registries/cargo.go`) implements it. That lets us list the
+crate directly:
 
-```sh
-npx -p sysknife-setup sysknife-mcp
+- `registryType`: `cargo`, `identifier`: `sysknife-cli` (the crate that installs
+  the `sysknife` binary), `transport`: `stdio`.
+- Because `sysknife`'s MCP server is a subcommand, the package entry passes
+  `mcp-server` as a positional `packageArguments` value. A client resolves the
+  listing to `cargo install sysknife-cli` then runs `sysknife mcp-server`.
+
+This supersedes the earlier npm-launcher plan: the npm package `sysknife-setup`
+is an installer/wizard, not a stdio server, and `npx sysknife-setup` would launch
+the wizard rather than the server. The `cargo` type avoids that entirely — no
+dedicated launcher package is needed.
+
+Namespace: `io.github.lacs-project/sysknife` (verified by GitHub identity — the
+authenticating account must belong to the `lacs-project` org; no DNS needed).
+
+## Ownership marker (already in place)
+
+crates.io ownership is proven by a visible `mcp-name:` token in the crate's
+**rendered** README. crates.io strips HTML comments when rendering, so the
+marker must be plain text — `apps/sysknife-cli/README.md` carries:
+
+```
+mcp-name: io.github.lacs-project/sysknife
 ```
 
-If the binary is not installed it exits with guidance to run `npx sysknife-setup`
-first. The server also needs the privileged daemon running (a systemd service
-the wizard installs); this launcher starts the server front-end, not the daemon.
+The verifier fetches `https://crates.io/api/v1/crates/sysknife-cli/<version>/readme`
+and searches the rendered README for that token. **The marker only takes effect
+in a *published* crate version**, so the `server.json` `version` must match a
+crate version whose README carries it (see the release step below).
 
-## Remaining step (post-launch, deferred)
+## `server.json`
 
-The registry `server.json` runs `npx <identifier>` (the package's default bin)
-and has no field to select a non-default bin. Two clean options, decide before
-submitting:
-
-1. Publish a tiny dedicated `sysknife-mcp` npm package whose default bin is the
-   launcher, so `npx sysknife-mcp` just works. Costs a second npm
-   trusted-publisher setup.
-2. Keep the launcher inside `sysknife-setup` and validate whether the registry
-   runner can be told to invoke it via `runtime_arguments`
-   (`-p sysknife-setup sysknife-mcp`) with a live `mcp-publisher` dry-run.
-
-Namespace: `io.github.lacs-project/sysknife` (GitHub OIDC via the lacs-project
-org). `packages/setup/package.json` carries the matching `mcpName` for
-verification.
-
-Draft manifest:
+Not shipped as a root file: the `version` is coupled to a published crate
+version that carries the marker, so it is finalized at release time. Template:
 
 ```json
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.lacs-project/sysknife",
-  "description": "Let AI operate your Linux box without ever handing it a shell.",
-  "version": "0.2.5",
-  "repository": { "url": "https://github.com/lacs-project/sysknife", "source": "github" },
+  "description": "Let AI operate your Linux box through typed, approval-gated, Ed25519-audited actions instead of shell strings.",
+  "repository": {
+    "url": "https://github.com/lacs-project/sysknife",
+    "source": "github"
+  },
+  "version": "0.2.6",
   "packages": [
-    { "registry_type": "npm", "identifier": "sysknife-mcp", "version": "0.2.5", "transport": { "type": "stdio" } }
+    {
+      "registryType": "cargo",
+      "registryBaseUrl": "https://crates.io",
+      "identifier": "sysknife-cli",
+      "version": "0.2.6",
+      "transport": { "type": "stdio" },
+      "packageArguments": [
+        { "type": "positional", "valueHint": "subcommand", "value": "mcp-server" }
+      ]
+    }
   ]
 }
 ```
 
-This is intentionally not shipped as a root `server.json`: it needs the package
-published and a live publisher run first, and a root manifest pointing at
-`sysknife-setup` would make clients launch the wizard instead of a server.
+## Publish steps
+
+The crate README marker (`apps/sysknife-cli/README.md`) is already in the repo,
+so the next crate release is registry-ready. To publish the listing:
+
+1. **Release a crate version that carries the marker.** The marker landed after
+   0.2.5, so cut the next version (e.g. 0.2.6) via the normal tag-driven
+   release; that publishes `sysknife-cli` with the marker in its README. Confirm
+   the README ships in the packaged crate first
+   (`cargo package -p sysknife-cli --list | grep README.md`), then set the
+   `version` fields in `server.json` to that version.
+2. **Install the publisher CLI:**
+   ```sh
+   brew install mcp-publisher   # or download from the registry's GitHub Releases
+   ```
+3. **Authenticate as the `lacs-project` org** — pick one:
+   - Local, interactive (one-time device-flow login in a browser):
+     ```sh
+     mcp-publisher login github
+     ```
+   - CI, headless (no stored secret), inside a GitHub Actions job with
+     `permissions: id-token: write` (the `./` reflects the binary downloaded
+     into the job's working directory rather than a PATH install):
+     ```sh
+     ./mcp-publisher login github-oidc
+     ```
+4. **Validate and publish** (from the repo root, with `server.json` present):
+   ```sh
+   mcp-publisher validate
+   mcp-publisher publish
+   ```
+5. **Verify:**
+   ```sh
+   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.lacs-project/sysknife"
+   ```
+
+## Downstream propagation
+
+One publish to the official registry auto-propagates to the **GitHub MCP
+Registry** and **PulseMCP** (they ingest from it). Glama, mcp.so, Smithery,
+LobeHub, and mcpservers.org still take **separate manual submissions** for
+maximum reach.


### PR DESCRIPTION
## What
- Rewrites `docs/mcp-registry.md` to publish via the **`cargo` package type**. The old note described an obsolete npm-launcher blocker; `registryType: cargo` (implemented by the registry validator) lets us list `sysknife-cli` directly and bypass it.
- Adds a crate README to **sysknife-cli** carrying the visible `mcp-name: io.github.lacs-project/sysknife` ownership marker (crates.io strips HTML comments, so the marker must be visible text).
- Adds a parity crate README to **sysknife-daemon** (both crates are `cargo install`-able but rendered empty on crates.io).
- Sets `readme = "README.md"` on both crates.

## Why now
Makes the **next** crate release registry-ready. The marker is inert until a published version carries it, so the doc instructs cutting 0.2.6 (with a `cargo package --list` check) before running `mcp-publisher publish`. One publish auto-propagates to the GitHub MCP Registry and PulseMCP.

## Verification
- `server.json` template validated against the official `2025-12-11` schema (incl. the `packageArguments` positional shape — `anyOf`, so `value`+`valueHint` together is allowed).
- `mcp-name:` marker confirmed to render as visible text; `cargo package --list` includes both READMEs; `cargo metadata` parses.
- Reviewed by comment-analyzer (doc accuracy) + code-reviewer (packaging) — all three suggestions implemented. Full test suite (1349) green in pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)