### PR TITLE
build: add Glama MCP Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*
+!Cargo.toml
+!Cargo.lock
+!crates/
+!crates/**
+!apps/
+!apps/sysknife-cli/
+!apps/sysknife-cli/**
+!apps/sysknife-shell/
+!apps/sysknife-shell/src-tauri/
+!apps/sysknife-shell/src-tauri/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+#
+# Glama starts this image to inspect the MCP server over stdio. The privileged
+# sysknife-daemon remains external to the container: this image only publishes
+# the CLI's MCP transport and never grants it host administration access.
+FROM docker.io/library/rust:1-bookworm AS builder
+
+WORKDIR /src
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+COPY apps/sysknife-cli ./apps/sysknife-cli
+# Cargo resolves every workspace member before selecting sysknife-cli.
+COPY apps/sysknife-shell/src-tauri ./apps/sysknife-shell/src-tauri
+RUN cargo build --locked --release --package sysknife-cli
+
+FROM docker.io/library/debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends --yes ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 10001 --shell /usr/sbin/nologin sysknife
+
+COPY --from=builder /src/target/release/sysknife /usr/local/bin/sysknife
+
+USER sysknife
+ENTRYPOINT ["sysknife", "mcp-server"]


### PR DESCRIPTION
## Summary
- add a multi-stage OCI image that runs `sysknife mcp-server` over stdio
- keep the privileged daemon outside the registry container and run the image as an unprivileged user
- exclude local build outputs and potential secret files from the container context

## Verification
- `cargo nextest run --workspace --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `podman build --tag sysknife-mcp:glama-test .`
- MCP `initialize` and `tools/list` smoke test against the built image