### PR TITLE
chore: add Glama ownership marker

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["vladimirrott"]
+}


### PR DESCRIPTION
## Summary
- add the root `glama.json` required to claim an organization-owned MCP server
- identify `vladimirrott` as the GitHub maintainer

## Verification
- `jq` schema/value assertion for `glama.json`
- `cargo nextest run --workspace --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`