### PR TITLE
fix(ci): repair broken intra-doc link + de-flake markdown link check

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,10 +1,11 @@
 {
   "ignorePatterns": [
     { "pattern": "^https://github\\.com" },
-    { "pattern": "^https://www\\.npmjs\\.com" }
+    { "pattern": "^https://www\\.npmjs\\.com" },
+    { "pattern": "^https://img\\.shields\\.io" }
   ],
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "5s",
-  "_comment": "npmjs.com returns 403 to the link checker's user-agent (anti-bot); the package URL works for npm clients. Skip from link-check to keep CI green."
+  "_comment": "Hosts skipped from link-check to keep CI deterministic: github.com and img.shields.io rate-limit/anti-bot the checker (intermittent 403/408/429) and shields.io badges are decorative dynamic images, not content links; npmjs.com returns 403 to the checker's user-agent though the package URL works for npm clients."
 }

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -28,9 +28,10 @@ use crate::auth::role_rank;
 /// action's `ActionSpec` (single source of truth, `crate::actions`) and maps to
 /// a role via [`role_for_risk_level`] (`Low`→Observer, `Medium`→Dev,
 /// `High`→Admin), so RBAC can never drift from the documented risk. A short,
-/// *monotonic* exception list ([`role_exception`]) may raise an action's role
+/// *monotonic* exception list (`role_exception`) may raise an action's role
 /// above its risk floor when it is more sensitive than its risk implies; an
-/// exception may never lower it. Pinned by `role_matches_risk_or_exception` in
+/// exception may never lower it. Pinned by
+/// `role_mirrors_risk_except_documented_monotonic_exceptions` in
 /// `tests/action_consistency.rs`.
 pub fn min_role_for_action(action_name: &str) -> Option<CallerRole> {
     if let Some(role) = role_exception(action_name) {


### PR DESCRIPTION
## Why
`main` went red right after #98 merged. Two independent CI failures:

1. **`rust` job (deterministic regression from #98)** — the SSOT policy rewrite gave `min_role_for_action` a doc comment that intra-doc-links the **private** `role_exception`. Under `RUSTDOCFLAGS=-D warnings`, `rustdoc::private_intra_doc_links` makes `cargo doc` fail. Public docs must not link private items.
2. **`docs-and-hygiene` job (external flake)** — an `img.shields.io` badge returned **408** (transient timeout) and failed the markdown link check. A near-identical badge URL passed in the same run, proving it transient.

## Fix
- Downgrade the intra-doc link to a plain code span (no link target). Also correct a stale test name in the same comment.
- Ignore the `img.shields.io` host in `.markdown-link-check.json`, consistent with the existing `github.com`/`npmjs.com` ignores — badges are decorative dynamic images that rate-limit CI checkers.

## Verification (local)
- `cargo doc --no-deps --workspace --exclude sysknife-shell --locked` clean under `-D warnings`
- `markdown-link-check README.md` exits 0, 0 dead links (all shields.io now skipped)
- `cargo nextest run --workspace` → 1351/1351 pass (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)