### PR TITLE
chore(release): v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
-## [0.2.5] — Unreleased (first public release)
+## [0.2.6] — 2026-07-23
+
+### Security
+
+- **Per-action risk is now single-sourced on each action's `ActionSpec`.** The
+  preview/approval gate and the RBAC role table derive risk from it and are
+  consistency-tested for every action, so they can no longer silently diverge
+  from the documented risk. Consolidating the sources surfaced and fixed five
+  actions the gate had been treating as auto-approvable **Medium** despite being
+  **High**: `ConfigureFirewall`, `CreateUser`, `SetDnsServers`,
+  `AddPackageRepository`, and `MaskService` now correctly require High-risk,
+  exact-name approval.
+
+### Changed
+
+- Reclassified twelve actions against common sysadmin practice — raised
+  `AddAuthorizedKey`, `RemoveAuthorizedKey`, `AddPpa`, `VacuumJournal`, and
+  `ConfigureWifi`; lowered `RenewCertificates`, `CreateGroup`, `AddAuditRule`,
+  `CreateLvSnapshot`, `CreateLogicalVolume`, and `SetServiceResourceLimits`.
+- Documentation risk levels and action names are aligned with the code, and the
+  demo assets were corrected to match.
+- The Code of Conduct now lists the project contact address.
+
+### Added
+
+- Glama MCP registry listing support (Dockerfile and ownership marker).
+- Documented cargo-based MCP Registry publishing, with per-crate READMEs.
+
+### Fixed
+
+- Corrected the social-preview image URL.
+- Repaired a broken intra-doc link and de-flaked the CI markdown link check.
+
+## [0.2.5] — 2026-07-23 (first public release)
 
 ### Added
 
@@ -50,4 +83,5 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   (non-repudiable, third-party verifiable), with signed checkpoints guarding
   against truncation.
 
+[0.2.6]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.6
 [0.2.5]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.5

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,8 +60,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**<vladimir@entropia.ai>**. All complaints will be reviewed and investigated
-promptly and fairly.
+**<sysknife-development@protonmail.com>**. All complaints will be reviewed and
+investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "prost",
  "prost-build",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,11 +15,11 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.5" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.2.5" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.2.5" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.6" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.2.6" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.2.6" }
 chrono = "0.4"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.2.5" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.2.6" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "@vitest/coverage-v8": "^4.1.4",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.2.5" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.2.5" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.2.6" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.2.6" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -12,8 +12,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.2.5" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.5" }
+sysknife-core = { path = "../sysknife-core", version = "0.2.6" }
+sysknife-types = { path = "../sysknife-types", version = "0.2.6" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.5"
+version = "0.2.6"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.2.5" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.2.6" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -11,8 +11,8 @@ keywords = ["linux", "sysadmin", "daemon", "security"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.2.5" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.5" }
+sysknife-core = { path = "../sysknife-core", version = "0.2.6" }
+sysknife-types = { path = "../sysknife-types", version = "0.2.6" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -53,7 +53,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.2.5" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.2.6" }
 serde_json = { workspace = true }
 syslog_loose = "0.23"
 tempfile = "3"

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.2.5" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.2.6" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Zero-friction setup for SysKnife MCP server — Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {


### PR DESCRIPTION
Release prep for **v0.2.6**. Bumps all crate + package versions `0.2.5 → 0.2.6`, refreshes `Cargo.lock`, and records the changelog.

## What ships in v0.2.6 (merged after v0.2.5)
- **Security** — per-action risk single-sourced on `ActionSpec`; the approval gate + RBAC derive from it and are consistency-tested. Fixed five actions the gate had treated as auto-approvable Medium despite being High: `ConfigureFirewall`, `CreateUser`, `SetDnsServers`, `AddPackageRepository`, `MaskService` (#98).
- Reclassified twelve actions against sysadmin norms (#98).
- Glama MCP registry listing (#96, #97); cargo-based MCP Registry publishing docs (#94).
- Doc/demo risk alignment (#95); social-preview URL fix (#92); CI doc-link + link-check repair (#99).
- Code of Conduct now lists the project contact address.

## Verification
- `check_release_versions.sh v0.2.6` → all versions match
- `cargo nextest run --workspace --locked` → 1351/1351 pass

After merge, tag `v0.2.6` on the merge commit to trigger the release workflow (npm + crates.io + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)