### PR TITLE
feat(preview,cli): derive reboot/rollback + CLI approval risk from the ActionSpec

### DIFF
--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -181,6 +181,27 @@ pub fn highest_risk(plan: &sysknife_brain::planner::Plan) -> Option<&PlanRiskLev
         .map(|s| s.risk_level())
 }
 
+// ---------------------------------------------------------------------------
+// authoritative_plan_risk
+// ---------------------------------------------------------------------------
+
+/// The authoritative risk for a plan step's action: the daemon's
+/// `ActionSpec`-derived gate risk ([`sysknife_daemon::preview::gate_risk`]),
+/// mapped into the planner's risk enum.
+///
+/// The CLI substitutes this for the LLM's *proposed* per-step risk (see
+/// [`run_intent`]) so the plan the operator sees and the `--yes` / `--max-risk`
+/// auto-approval decision derive from the single source of truth rather than a
+/// model guess. Unknown actions map to `High` — `gate_risk`'s conservative
+/// fallback — so a missing spec can never downgrade the CLI's approval friction.
+fn authoritative_plan_risk(action_name: &str) -> PlanRiskLevel {
+    match sysknife_daemon::preview::gate_risk(action_name) {
+        RiskLevel::Low => PlanRiskLevel::Low,
+        RiskLevel::Medium => PlanRiskLevel::Medium,
+        RiskLevel::High => PlanRiskLevel::High,
+    }
+}
+
 pub async fn run_approve(
     transaction_id: &str,
     socket: SocketTarget,
@@ -941,6 +962,14 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
 
     let plan = plan_result.map_err(|e| CliError::PlanningFailed(e.to_string()))?;
 
+    // Substitute the daemon's ActionSpec-derived risk (the single source of
+    // truth) for the LLM's proposed per-step risk, so the plan the operator sees
+    // below and the auto-approval gate both reflect authoritative risk. Without
+    // this, an LLM that under-rates an action could let `--yes --max-risk medium`
+    // auto-approve a step that is actually High risk. The per-step daemon preview
+    // fetched during execution derives from the same source, so they agree.
+    let plan = plan.with_authoritative_risks(authoritative_plan_risk);
+
     // ---- print plan --------------------------------------------------------
 
     if opts.json {
@@ -1438,6 +1467,63 @@ mod tests {
     fn highest_risk_low_medium_picks_medium() {
         let plan = make_plan(&[PlanRiskLevel::Low, PlanRiskLevel::Medium]);
         assert_eq!(highest_risk(&plan), Some(&PlanRiskLevel::Medium));
+    }
+
+    // -----------------------------------------------------------------------
+    // authoritative_plan_risk — CLI approval gates on the daemon's spec risk
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn authoritative_plan_risk_maps_spec_gate_risk() {
+        // Values come from each action's ActionSpec via preview::gate_risk.
+        assert_eq!(authoritative_plan_risk("GetDiskUsage"), PlanRiskLevel::Low);
+        assert_eq!(
+            authoritative_plan_risk("RestartService"),
+            PlanRiskLevel::Medium
+        );
+        assert_eq!(authoritative_plan_risk("RebootSystem"), PlanRiskLevel::High);
+        // No spec → conservative High (a missing spec never downgrades friction).
+        assert_eq!(
+            authoritative_plan_risk("DefinitelyNotARealAction"),
+            PlanRiskLevel::High
+        );
+    }
+
+    #[test]
+    fn authoritative_risks_close_the_llm_under_rating_gate() {
+        let mk = |name: &str, risk| {
+            PlanStep::new(
+                ActionName::parse(name).unwrap(),
+                "s".into(),
+                risk,
+                serde_json::json!({}),
+            )
+            .unwrap()
+        };
+        // An LLM that under-rates a truly High-risk action (RebootSystem) as Low
+        // would let `--yes --max-risk medium` auto-approve it...
+        let under_rated = Plan::new(
+            "i".into(),
+            "s".into(),
+            "e".into(),
+            vec![mk("RebootSystem", PlanRiskLevel::Low)],
+        )
+        .unwrap();
+        let policy = ApprovalPolicy::new(true, Some(MaxRisk::Medium), false, false);
+        assert_eq!(
+            policy.decide_plan(&under_rated),
+            ApprovalDecision::AutoApproved,
+            "sanity: the LLM's Low rating alone would have auto-approved"
+        );
+
+        // ...but substituting the spec-derived risk restores the gate: RebootSystem
+        // is High, which exceeds the Medium auto-approval ceiling.
+        let corrected = under_rated.with_authoritative_risks(authoritative_plan_risk);
+        assert_eq!(
+            policy.decide_plan(&corrected),
+            ApprovalDecision::ExceedsCeiling,
+            "spec-derived High must not auto-approve under --max-risk medium"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -182,8 +182,25 @@ pub fn highest_risk(plan: &sysknife_brain::planner::Plan) -> Option<&PlanRiskLev
 }
 
 // ---------------------------------------------------------------------------
-// authoritative_plan_risk
+// authoritative_plan_risk + risk-consistency helpers
 // ---------------------------------------------------------------------------
+
+/// Map the daemon's `RiskLevel` into the planner's risk enum.
+fn plan_risk_of(risk: RiskLevel) -> PlanRiskLevel {
+    match risk {
+        RiskLevel::Low => PlanRiskLevel::Low,
+        RiskLevel::Medium => PlanRiskLevel::Medium,
+        RiskLevel::High => PlanRiskLevel::High,
+    }
+}
+
+fn plan_risk_rank(risk: &PlanRiskLevel) -> u8 {
+    match risk {
+        PlanRiskLevel::Low => 0,
+        PlanRiskLevel::Medium => 1,
+        PlanRiskLevel::High => 2,
+    }
+}
 
 /// The authoritative risk for a plan step's action: the daemon's
 /// `ActionSpec`-derived gate risk ([`sysknife_daemon::preview::gate_risk`]),
@@ -194,12 +211,28 @@ pub fn highest_risk(plan: &sysknife_brain::planner::Plan) -> Option<&PlanRiskLev
 /// auto-approval decision derive from the single source of truth rather than a
 /// model guess. Unknown actions map to `High` — `gate_risk`'s conservative
 /// fallback — so a missing spec can never downgrade the CLI's approval friction.
+///
+/// Note: this reads the CLI binary's *own* linked `sysknife-daemon` catalogue,
+/// which equals the running daemon's only when both are the same build. The
+/// execution loop re-validates against the live daemon preview via
+/// [`daemon_risk_within_approved`] so a version skew can never execute a step at
+/// higher risk than was approved.
 fn authoritative_plan_risk(action_name: &str) -> PlanRiskLevel {
-    match sysknife_daemon::preview::gate_risk(action_name) {
-        RiskLevel::Low => PlanRiskLevel::Low,
-        RiskLevel::Medium => PlanRiskLevel::Medium,
-        RiskLevel::High => PlanRiskLevel::High,
-    }
+    plan_risk_of(sysknife_daemon::preview::gate_risk(action_name))
+}
+
+/// Fail-closed check run at execution time: is the live daemon's risk for a step
+/// no higher than the risk the CLI approved it at?
+///
+/// The plan-level/step-level approval decisions use the CLI's locally linked
+/// [`authoritative_plan_risk`]. If the connected daemon is a *different* build
+/// that reclassified an action upward (e.g. Medium → High, the same shape as a
+/// past security fix), the CLI could have auto-approved at the stale lower tier.
+/// Before minting a receipt we compare against the daemon's live preview risk and
+/// refuse to proceed when it is higher — the CLI must never execute a step at a
+/// higher risk than the operator approved.
+fn daemon_risk_within_approved(approved: &PlanRiskLevel, daemon: &PlanRiskLevel) -> bool {
+    plan_risk_rank(daemon) <= plan_risk_rank(approved)
 }
 
 pub async fn run_approve(
@@ -962,12 +995,31 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
 
     let plan = plan_result.map_err(|e| CliError::PlanningFailed(e.to_string()))?;
 
+    // Surface any step where the planner's proposed risk disagreed with the
+    // authoritative ActionSpec risk. A mismatch is a useful signal in its own
+    // right — the model may be confused about this action (and could have gotten
+    // its params wrong too), which the operator is well-placed to notice before
+    // approving. Emitted to stderr so it never pollutes `--json` stdout.
+    for step in plan.steps() {
+        let authoritative = authoritative_plan_risk(step.action_name());
+        if *step.risk_level() != authoritative {
+            log.print_stderr(&format!(
+                "sysknife: {} — planner rated {} risk; using {} (ActionSpec-derived)",
+                step.action_name(),
+                step.risk_level().as_str(),
+                authoritative.as_str(),
+            ));
+        }
+    }
+
     // Substitute the daemon's ActionSpec-derived risk (the single source of
-    // truth) for the LLM's proposed per-step risk, so the plan the operator sees
-    // below and the auto-approval gate both reflect authoritative risk. Without
-    // this, an LLM that under-rates an action could let `--yes --max-risk medium`
-    // auto-approve a step that is actually High risk. The per-step daemon preview
-    // fetched during execution derives from the same source, so they agree.
+    // truth) for the planner's proposed per-step risk, so the plan the operator
+    // sees below and the auto-approval gate both reflect authoritative risk.
+    // Without this, a planner that under-rates an action could let
+    // `--yes --max-risk medium` auto-approve a step that is actually High risk.
+    // This uses the CLI's *own* linked catalogue; the execution loop below
+    // re-validates each step against the live daemon preview so a CLI/daemon
+    // version skew can never execute above the approved risk.
     let plan = plan.with_authoritative_risks(authoritative_plan_risk);
 
     // ---- print plan --------------------------------------------------------
@@ -1095,6 +1147,22 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
             .preview(step.action_name(), step.params())
             .await?;
         let preview = &prepared.preview;
+
+        // Fail closed on CLI/daemon risk skew: the approval decision above used
+        // the CLI's own linked catalogue. If the live daemon rates this step
+        // higher than we approved it at, refuse to mint a receipt rather than
+        // execute above the approved risk (see `daemon_risk_within_approved`).
+        let daemon_risk = plan_risk_of(preview.risk_level);
+        if !daemon_risk_within_approved(step.risk_level(), &daemon_risk) {
+            return Err(CliError::ConfigOrDaemon(format!(
+                "{}: the running daemon rates this {} risk, above the {} the CLI approved — \
+                 the CLI and daemon builds may differ. Aborting without executing; upgrade the \
+                 CLI (or re-run with a matching --max-risk) so risk gating agrees.",
+                step.action_name(),
+                daemon_risk.as_str(),
+                step.risk_level().as_str(),
+            )));
+        }
 
         if opts.json {
             log.println(&serde_json::to_string(preview).expect("PreviewEnvelope is Serialize"));
@@ -1524,6 +1592,123 @@ mod tests {
             ApprovalDecision::ExceedsCeiling,
             "spec-derived High must not auto-approve under --max-risk medium"
         );
+    }
+
+    #[test]
+    fn authoritative_risks_close_the_under_rating_gate_for_bare_yes() {
+        // The most common invocation: `--yes` with no `--max-risk` (auto-ceiling
+        // defaults to Low). A planner under-rating a Medium action as Low would
+        // otherwise auto-execute it with zero confirmation.
+        let mk = |name: &str, risk| {
+            PlanStep::new(
+                ActionName::parse(name).unwrap(),
+                "s".into(),
+                risk,
+                serde_json::json!({}),
+            )
+            .unwrap()
+        };
+        let plan = Plan::new(
+            "i".into(),
+            "s".into(),
+            "e".into(),
+            vec![mk("RestartService", PlanRiskLevel::Low)],
+        )
+        .unwrap();
+        let policy = ApprovalPolicy::new(true, None, false, false);
+        assert_eq!(
+            policy.decide_plan(&plan),
+            ApprovalDecision::AutoApproved,
+            "sanity: bare --yes would auto-approve the Low the planner claimed"
+        );
+        let corrected = plan.with_authoritative_risks(authoritative_plan_risk);
+        assert_eq!(
+            policy.decide_plan(&corrected),
+            ApprovalDecision::RequiresPrompt,
+            "spec-derived Medium must prompt under bare --yes"
+        );
+    }
+
+    #[test]
+    fn authoritative_risks_force_interaction_for_under_rated_action_non_interactive() {
+        // Scripted/non-interactive runs have no human watching: an under-rated
+        // action must hard-fail (RequiresInteraction), never auto-run.
+        let mk = |name: &str, risk| {
+            PlanStep::new(
+                ActionName::parse(name).unwrap(),
+                "s".into(),
+                risk,
+                serde_json::json!({}),
+            )
+            .unwrap()
+        };
+        let plan = Plan::new(
+            "i".into(),
+            "s".into(),
+            "e".into(),
+            vec![mk("RestartService", PlanRiskLevel::Low)],
+        )
+        .unwrap();
+        let policy = ApprovalPolicy::new(true, None, true, false);
+        assert_eq!(
+            policy.decide_plan(&plan),
+            ApprovalDecision::AutoApproved,
+            "sanity: the planner's Low would have auto-run unattended"
+        );
+        let corrected = plan.with_authoritative_risks(authoritative_plan_risk);
+        assert_eq!(
+            policy.decide_plan(&corrected),
+            ApprovalDecision::RequiresInteraction,
+            "under-rated Medium must abort a non-interactive run"
+        );
+    }
+
+    #[test]
+    fn authoritative_risks_open_the_over_rating_gate() {
+        // Over-rating direction: a truly-Low action the planner flagged High must
+        // NOT be needlessly blocked after substitution — proves the substitution
+        // is a pure override, not max(planner, spec).
+        let mk = |name: &str, risk| {
+            PlanStep::new(
+                ActionName::parse(name).unwrap(),
+                "s".into(),
+                risk,
+                serde_json::json!({}),
+            )
+            .unwrap()
+        };
+        let plan = Plan::new(
+            "i".into(),
+            "s".into(),
+            "e".into(),
+            vec![mk("GetDiskUsage", PlanRiskLevel::High)],
+        )
+        .unwrap();
+        let policy = ApprovalPolicy::new(true, Some(MaxRisk::Low), false, false);
+        assert_eq!(
+            policy.decide_plan(&plan),
+            ApprovalDecision::ExceedsCeiling,
+            "sanity: the planner's inflated High would block a safe read-only action"
+        );
+        let corrected = plan.with_authoritative_risks(authoritative_plan_risk);
+        assert_eq!(
+            policy.decide_plan(&corrected),
+            ApprovalDecision::AutoApproved,
+            "spec-derived Low must auto-approve under --max-risk low"
+        );
+    }
+
+    #[test]
+    fn daemon_risk_within_approved_fails_closed_on_upward_skew() {
+        use PlanRiskLevel::{High, Low, Medium};
+        // Daemon risk == or < approved → allowed.
+        assert!(daemon_risk_within_approved(&Medium, &Medium));
+        assert!(daemon_risk_within_approved(&High, &Low));
+        assert!(daemon_risk_within_approved(&Medium, &Low));
+        // Daemon rates HIGHER than approved → must fail closed.
+        assert!(!daemon_risk_within_approved(&Medium, &High));
+        assert!(!daemon_risk_within_approved(&Low, &Medium));
+        assert!(!daemon_risk_within_approved(&Low, &High));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/sysknife-brain/src/planner.rs
+++ b/crates/sysknife-brain/src/planner.rs
@@ -324,6 +324,21 @@ impl Plan {
     pub fn steps(&self) -> &[PlanStep] {
         &self.steps
     }
+
+    /// Replace every step's risk level using `risk_for`, keyed by action name.
+    ///
+    /// The CLI uses this to substitute the daemon's `ActionSpec`-derived risk
+    /// (the single source of truth) for the LLM's *proposed* risk, so both the
+    /// plan the operator sees and the auto-approval gate reflect authoritative
+    /// risk rather than a model guess. Brain stays agnostic to the daemon's
+    /// action catalogue: the caller supplies the mapping.
+    #[must_use]
+    pub fn with_authoritative_risks(mut self, risk_for: impl Fn(&str) -> PlanRiskLevel) -> Self {
+        for step in &mut self.steps {
+            step.risk_level = risk_for(step.action_name.as_str());
+        }
+        self
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1071,6 +1086,38 @@ mod tests {
     // serialised to avoid cross-test interference on a multi-threaded
     // test runner.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn with_authoritative_risks_replaces_every_step_risk() {
+        let step = |name: &str, risk| {
+            PlanStep::new(
+                ActionName::parse(name).unwrap(),
+                "s".into(),
+                risk,
+                serde_json::json!({}),
+            )
+            .unwrap()
+        };
+        let plan = Plan::new(
+            "i".into(),
+            "s".into(),
+            "e".into(),
+            vec![
+                step("GetDiskUsage", PlanRiskLevel::High), // model over-rated
+                step("RebootSystem", PlanRiskLevel::Low),  // model under-rated
+            ],
+        )
+        .unwrap();
+
+        // The caller-supplied mapping is authoritative; the LLM value is ignored.
+        let plan = plan.with_authoritative_risks(|name| match name {
+            "GetDiskUsage" => PlanRiskLevel::Low,
+            _ => PlanRiskLevel::High,
+        });
+
+        assert_eq!(*plan.steps()[0].risk_level(), PlanRiskLevel::Low);
+        assert_eq!(*plan.steps()[1].risk_level(), PlanRiskLevel::High);
+    }
 
     #[test]
     fn resolve_think_auto_detects_qwen3() {

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -3,16 +3,16 @@
 //! The dispatcher calls [`preview_action`] *before* execution to produce a
 //! [`PreviewEnvelope`] the shell shows the operator.
 //!
-//! ## Risk is a single source of truth
+//! ## Risk, reboot, and rollback are a single source of truth
 //!
-//! `risk_level` is **not** declared here — it is owned by each action's
-//! `ActionSpec` (`crate::actions`) and derived via [`crate::actions::spec_meta`],
-//! so the approval gate can never disagree with the documented risk in
-//! `docs/action-reference.md`. This module supplies the preview-specific fields:
-//! expected side effects, warnings, and the reboot/rollback display flags.
-//! (`reboot_required` / `rollback_available` are still declared here pending a
-//! separate consolidation onto the spec — see the follow-up note in
-//! `tests/action_consistency.rs`.)
+//! Risk, `reboot_required`, and `rollback_available` are **not** declared here —
+//! they are owned by each action's `ActionSpec` (`crate::actions`) and derived
+//! via [`crate::actions::spec_meta`] / [`gate_risk`], so the approval gate and
+//! the displayed reboot/rollback flags can never disagree with the catalogue in
+//! `docs/action-reference.md`. This module supplies only the preview-specific
+//! presentation: expected side effects and warnings. Every catalogued action
+//! must have a profile arm below; `tests/action_consistency.rs` fails the build
+//! if one falls through to the `_` "unclassified" default.
 //!
 //! ## Invariant: spec ↔ preview ↔ policy consistency
 //!
@@ -31,8 +31,6 @@ use sysknife_types::{PreviewEnvelope, RequestEnvelope, RiskLevel};
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct PreviewProfile {
     expected_side_effects: Vec<String>,
-    reboot_required: bool,
-    rollback_available: bool,
     warnings: Vec<String>,
 }
 
@@ -42,13 +40,16 @@ pub fn preview_action(
     proposed_change: Value,
 ) -> PreviewEnvelope {
     let profile = preview_profile(&request.action_name);
-    // `risk_level` is OWNED by the action's `ActionSpec` (single source of truth,
-    // `crate::actions`); derive it here so the approval gate can never disagree
-    // with the documented risk. Only the dispatcher-internal `ListJobHistory`
-    // reaches preview without a spec (see `fallback_risk`).
-    let risk_level = crate::actions::spec_meta(&request.action_name)
-        .map(|m| m.risk_level)
-        .unwrap_or_else(|| fallback_risk(&request.action_name));
+    // Risk, reboot, and rollback are OWNED by the action's `ActionSpec` (the
+    // single source of truth, `crate::actions`) and derived here so the approval
+    // gate and the displayed reboot/rollback flags can never disagree with the
+    // catalogue. Only presentation text (side effects, warnings) comes from the
+    // per-action profile. Actions with no spec (only the dispatcher-internal
+    // `ListJobHistory`) fall back to a conservative risk and no reboot/rollback.
+    let risk_level = gate_risk(&request.action_name);
+    let (reboot_required, rollback_available) = crate::actions::spec_meta(&request.action_name)
+        .map(|m| (m.reboot_required, m.rollback_available))
+        .unwrap_or((false, false));
 
     PreviewEnvelope {
         summary: preview_summary(&request.action_name, &risk_level),
@@ -56,8 +57,8 @@ pub fn preview_action(
         current_state,
         proposed_change,
         expected_side_effects: profile.expected_side_effects,
-        reboot_required: profile.reboot_required,
-        rollback_available: profile.rollback_available,
+        reboot_required,
+        rollback_available,
         warnings: profile.warnings,
         request_hash: request.request_hash.clone(),
     }
@@ -72,6 +73,18 @@ fn fallback_risk(action_name: &str) -> RiskLevel {
         "ListJobHistory" => RiskLevel::Low,
         _ => RiskLevel::High,
     }
+}
+
+/// The approval-gate risk for `action_name`: the risk declared on its
+/// `ActionSpec` (the single source of truth), or a conservative fallback for the
+/// rare action with no spec. This is the one function every risk-gated decision
+/// derives from — the preview envelope above and the CLI's auto-approval gate
+/// (`sysknife-cli`) both call it, so neither can size its friction off a stale
+/// or model-guessed risk.
+pub fn gate_risk(action_name: &str) -> RiskLevel {
+    crate::actions::spec_meta(action_name)
+        .map(|m| m.risk_level)
+        .unwrap_or_else(|| fallback_risk(action_name))
 }
 
 fn preview_profile(action_name: &str) -> PreviewProfile {
@@ -133,10 +146,18 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         // Ubuntu Pro / Livepatch / Multipass read-only (Tier 3)
         | "ProStatus"
         | "LivepatchStatus"
-        | "MultipassList" => PreviewProfile {
+        | "MultipassList"
+        // Cross-distro + Ubuntu read-only queries
+        | "AptListUpgradable"
+        | "AptHistoryList"
+        | "GrubGetKargs"
+        | "CheckPendingReboot"
+        | "ResolvectlStatus"
+        | "AppArmorStatus"
+        | "CloudInitStatus"
+        | "UbuntuListFlatpaks"
+        | "Fail2banStatus" => PreviewProfile {
             expected_side_effects: Vec::new(),
-            reboot_required: false,
-            rollback_available: false,
             warnings: Vec::new(),
         },
         // ── Ubuntu apt: package-state changes ─────────────────────────────
@@ -149,8 +170,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "package state will change".to_string(),
                 "services may be restarted by needrestart".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["approval required".to_string()],
         },
 
@@ -158,8 +177,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         "SnapInstall" | "SnapRemove" | "SnapRefresh" | "SnapHold" | "SnapUnhold" => {
             PreviewProfile {
                 expected_side_effects: vec!["snap state will change".to_string()],
-                reboot_required: false,
-                rollback_available: false,
                 warnings: vec![
                     "approval required".to_string(),
                     "snap auto-refresh: install is paired with --hold by default".to_string(),
@@ -170,8 +187,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         // ── Ubuntu distrobox medium-risk ──────────────────────────────────
         "DistroboxCreate" | "DistroboxRemove" => PreviewProfile {
             expected_side_effects: vec!["container lifecycle will change".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["approval required".to_string()],
         },
 
@@ -185,8 +200,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "packages may be removed to resolve dependency conflicts".to_string(),
                 "services may be restarted by needrestart".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "dist-upgrade may remove packages".to_string(),
                 "exact approval required".to_string(),
@@ -199,8 +212,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "firewall rules will change".to_string(),
                 "network access may be immediately affected".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "misconfigured rules can lock out SSH access".to_string(),
                 "exact approval required".to_string(),
@@ -213,8 +224,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "network interfaces will be reconfigured immediately".to_string(),
                 "SSH session may be disconnected".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "can disconnect the current SSH session if config is wrong".to_string(),
                 "exact approval required".to_string(),
@@ -226,8 +235,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "backend network config files will be regenerated".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["approval required".to_string()],
         },
 
@@ -237,8 +244,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "netplan configuration will be modified".to_string(),
                 "network may be affected when NetplanApply is run".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: true,
             warnings: vec![
                 "run NetplanApply to activate the change".to_string(),
                 "exact approval required".to_string(),
@@ -251,8 +256,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "firewall rules will change".to_string(),
                 "network access may be immediately affected".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "misconfigured rules can lock out SSH access".to_string(),
                 "exact approval required".to_string(),
@@ -265,8 +268,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "Ubuntu Pro subscription will be attached".to_string(),
                 "Pro services (ESM, Livepatch, FIPS) may be enabled".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: true,
             warnings: vec![
                 "exact approval required".to_string(),
                 "token is redacted from the preview, audit log, and diagnostic output".to_string(),
@@ -279,8 +280,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "Ubuntu Pro subscription will be released".to_string(),
                 "ESM, Livepatch, and FIPS services will be disabled".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: true,
             warnings: vec![
                 "exact approval required".to_string(),
                 "after detach, this machine no longer receives Pro security patches".to_string(),
@@ -292,8 +291,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "a persistent audit rule will be written/removed and reloaded".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "requires the auditd package installed to take effect".to_string(),
                 "exact approval required".to_string(),
@@ -306,8 +303,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "certbot will obtain a TLS certificate (ACME challenge)".to_string(),
                 "TLS material will be written under /etc/letsencrypt".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "contacts a public ACME CA over the network".to_string(),
                 "requires certbot installed + a reachable DNS/HTTP challenge".to_string(),
@@ -316,8 +311,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         },
         "RenewCertificates" => PreviewProfile {
             expected_side_effects: vec!["certbot will renew due certificates".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "contacts a public ACME CA over the network".to_string(),
                 "exact approval required".to_string(),
@@ -329,8 +322,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "a fail2ban jail override will be written and the daemon reloaded".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "changes who gets banned (too strict can lock out real users)".to_string(),
                 "requires the fail2ban package installed to take effect".to_string(),
@@ -343,8 +334,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "a single Ubuntu Pro service will be enabled/disabled".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "exact approval required".to_string(),
                 "requires an attached Pro subscription + network to take effect".to_string(),
@@ -358,8 +347,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "takes 20–45 minutes; system will be rebooted to complete".to_string(),
                 "third-party PPAs may be disabled or break during upgrade".to_string(),
             ],
-            reboot_required: true,
-            rollback_available: false,
             warnings: vec![
                 "reboot required to complete the upgrade".to_string(),
                 "long-running operation — configure timeout >= 3600 seconds".to_string(),
@@ -369,8 +356,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
 
         "ReloadService" => PreviewProfile {
             expected_side_effects: vec!["service config will be reloaded".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "approval required".to_string(),
                 "requires ExecReload= to be defined in the unit file; \
@@ -401,8 +386,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "SetNtp"
         | "CreateUser" => PreviewProfile {
             expected_side_effects: vec!["service interruption".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["approval required".to_string()],
         },
         // ── Observability / journald maintenance ─────────────────────────
@@ -411,8 +394,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "old journal entries will be permanently deleted".to_string(),
                 "disk space will be reclaimed".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["deleted log history cannot be recovered".to_string()],
         },
 
@@ -421,8 +402,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "the logical volume and its filesystem will be grown".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "resizes a live filesystem; a wrong volume target risks data".to_string(),
                 "exact approval required".to_string(),
@@ -432,8 +411,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "volume-group free space will be consumed".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "consumes VG capacity; snapshots fill as the origin changes".to_string(),
                 "exact approval required".to_string(),
@@ -446,8 +423,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "the service's memory/CPU/task limits will change immediately".to_string(),
                 "a persistent drop-in will be written (undo: systemctl revert)".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "too tight a MemoryMax can OOM-kill the service".to_string(),
                 "exact approval required".to_string(),
@@ -459,8 +434,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "a logrotate drop-in will be written/removed".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["approval required".to_string()],
         },
         "ConfigureRemoteSyslog" | "RemoveRemoteSyslog" => PreviewProfile {
@@ -468,8 +441,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "rsyslog will start/stop forwarding all logs to a remote host".to_string(),
                 "rsyslog will be restarted".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "forwarding sends log data off-host (exfiltration surface)".to_string(),
                 "exact approval required".to_string(),
@@ -481,16 +452,12 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "the target account's password-aging limits will change".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["exact approval required".to_string()],
         },
         "SetPasswordPolicy" | "SetAccountLockout" => PreviewProfile {
             expected_side_effects: vec![
                 "a system-wide PAM policy file will be written".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "affects password/lockout rules for all accounts".to_string(),
                 "takes effect only if the PAM module is enabled in the auth stack".to_string(),
@@ -504,8 +471,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "apt version/origin preferences will change".to_string(),
                 "a /etc/apt/preferences.d drop-in will be written/removed".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["approval required".to_string()],
         },
 
@@ -515,8 +480,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "a sudoers.d drop-in will be created/removed".to_string(),
                 "the target user's sudo privileges will change".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "this configures privilege escalation — review the rule carefully".to_string(),
                 "exact approval required".to_string(),
@@ -529,8 +492,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "a filesystem will be (un)mounted".to_string(),
                 "/etc/fstab will be updated (managed entries carry nofail)".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "a wrong device or mountpoint risks data or availability".to_string(),
                 "exact approval required".to_string(),
@@ -541,8 +502,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "swap will be enabled/disabled".to_string(),
                 "a swap file will be created/removed and /etc/fstab updated".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["exact approval required".to_string()],
         },
 
@@ -552,8 +511,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "a kernel parameter will change immediately".to_string(),
                 "the value will persist across reboots (/etc/sysctl.d)".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "a wrong net.*/vm.*/kernel.* value can degrade or lock the host".to_string(),
                 "exact approval required".to_string(),
@@ -562,8 +519,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
 
         "SignalProcess" => PreviewProfile {
             expected_side_effects: vec!["the target process will be terminated".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "the process and its in-flight work will stop".to_string(),
                 "exact approval required".to_string(),
@@ -573,16 +528,12 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "the automatic security-update policy will change".to_string()
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["approval required".to_string()],
         },
         "CreateScheduledJob" => PreviewProfile {
             expected_side_effects: vec![
                 "a systemd timer will run the command on a recurring schedule".to_string(),
             ],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "persistent root-scheduled execution".to_string(),
                 "exact approval required".to_string(),
@@ -601,8 +552,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             // High risk: access-control changes — group membership, account
             // deletion, and SSH key modifications require Admin authorization.
             expected_side_effects: vec!["access control will change".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec![
                 "privilege change".to_string(),
                 "exact approval required".to_string(),
@@ -613,15 +562,11 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "EnablePackageRepository"
         | "DisablePackageRepository" => PreviewProfile {
             expected_side_effects: vec!["package repository configuration will change".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["approval required".to_string()],
         },
         "CreateContainer" | "StartContainer" | "StopContainer" | "RemoveContainer" => {
             PreviewProfile {
                 expected_side_effects: vec!["container lifecycle will change".to_string()],
-                reboot_required: false,
-                rollback_available: false,
                 warnings: vec!["approval required".to_string()],
             }
         }
@@ -639,8 +584,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "system deployment will change".to_string(),
                 "reboot may be required".to_string(),
             ],
-            reboot_required: true,
-            rollback_available: true,
             warnings: vec![
                 "reboot required".to_string(),
                 "exact approval required".to_string(),
@@ -648,8 +591,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         },
         "SetKernelArguments" => PreviewProfile {
             expected_side_effects: vec!["boot arguments will change".to_string()],
-            reboot_required: true,
-            rollback_available: true,
             warnings: vec![
                 "reboot required".to_string(),
                 "exact approval required".to_string(),
@@ -657,8 +598,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         },
         "RebootSystem" => PreviewProfile {
             expected_side_effects: vec!["system reboot will interrupt running work".to_string()],
-            reboot_required: true,
-            rollback_available: false,
             warnings: vec![
                 "reboot required".to_string(),
                 "exact approval required".to_string(),
@@ -666,20 +605,122 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         },
         "CleanupDeployments" => PreviewProfile {
             expected_side_effects: vec!["old deployments may be removed".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["exact approval required".to_string()],
         },
         "PinDeployment" | "UnpinDeployment" => PreviewProfile {
             expected_side_effects: vec!["deployment pin state will change".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["exact approval required".to_string()],
         },
+        // ── Ubuntu apt: index refresh + autoremove ───────────────────────
+        "AptUpdate" => PreviewProfile {
+            expected_side_effects: vec!["the apt package index will be refreshed".to_string()],
+            warnings: Vec::new(),
+        },
+        "AptAutoremove" => PreviewProfile {
+            expected_side_effects: vec![
+                "automatically-installed packages no longer needed will be removed".to_string(),
+            ],
+            warnings: vec!["approval required".to_string()],
+        },
+
+        // ── Launchpad PPAs ────────────────────────────────────────────────
+        "AddPpa" => PreviewProfile {
+            expected_side_effects: vec![
+                "a Launchpad PPA and its signing key will be added".to_string(),
+                "the trusted software supply chain will expand".to_string(),
+            ],
+            warnings: vec![
+                "a PPA is a third-party package source outside the distro archive".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+        "RemovePpa" => PreviewProfile {
+            expected_side_effects: vec!["a Launchpad PPA will be removed".to_string()],
+            warnings: vec!["approval required".to_string()],
+        },
+
+        // ── snap revert / classic install ─────────────────────────────────
+        "SnapRevert" => PreviewProfile {
+            expected_side_effects: vec![
+                "the snap will be reverted to its previous revision".to_string(),
+            ],
+            warnings: vec!["approval required".to_string()],
+        },
+        "SnapClassicInstall" => PreviewProfile {
+            expected_side_effects: vec![
+                "a snap will be installed with classic confinement".to_string(),
+            ],
+            warnings: vec![
+                "classic confinement grants the snap full, unsandboxed system access".to_string(),
+                "approval required".to_string(),
+            ],
+        },
+
+        // ── GRUB kernel arguments ─────────────────────────────────────────
+        "GrubSetKargs" => PreviewProfile {
+            expected_side_effects: vec![
+                "GRUB kernel arguments will change".to_string(),
+                "update-grub will regenerate the boot configuration".to_string(),
+            ],
+            warnings: vec![
+                "takes effect on the next reboot".to_string(),
+                "a bad kernel argument can prevent the system from booting".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── resolvectl DNS ────────────────────────────────────────────────
+        "ResolvectlSetDns" => PreviewProfile {
+            expected_side_effects: vec!["DNS servers for the interface will change".to_string()],
+            warnings: vec![
+                "redirecting DNS can enable interception of name resolution".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── AppArmor profile modes ────────────────────────────────────────
+        "AppArmorEnforce" => PreviewProfile {
+            expected_side_effects: vec![
+                "an AppArmor profile will be switched to enforce mode".to_string(),
+            ],
+            warnings: vec![
+                "an over-tight profile can block a legitimate service".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+        "AppArmorComplain" => PreviewProfile {
+            expected_side_effects: vec![
+                "an AppArmor profile will be switched to complain mode".to_string(),
+            ],
+            warnings: vec![
+                "complain mode disables MAC enforcement for the profile".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+
+        // ── fail2ban ban / unban ──────────────────────────────────────────
+        "Fail2banBanIp" => PreviewProfile {
+            expected_side_effects: vec!["an IP address will be banned in a fail2ban jail".to_string()],
+            warnings: vec![
+                "banning can lock out legitimate access from that address".to_string(),
+                "exact approval required".to_string(),
+            ],
+        },
+        "Fail2banUnbanIp" => PreviewProfile {
+            expected_side_effects: vec![
+                "an IP address will be unbanned in a fail2ban jail".to_string(),
+            ],
+            warnings: vec!["approval required".to_string()],
+        },
+
+        // ── Ubuntu Flatpak (per-user) ─────────────────────────────────────
+        "UbuntuInstallFlatpak" | "UbuntuRemoveFlatpak" | "UbuntuUpdateFlatpak" => PreviewProfile {
+            expected_side_effects: vec!["a user's Flatpak apps will change".to_string()],
+            warnings: vec!["approval required".to_string()],
+        },
+
         _ => PreviewProfile {
             expected_side_effects: vec!["unclassified action".to_string()],
-            reboot_required: false,
-            rollback_available: false,
             warnings: vec!["action profile not recognized".to_string()],
         },
     }
@@ -847,6 +888,10 @@ mod tests {
 
     #[test]
     fn high_risk_system_reboot_actions() {
+        // All are High and reboot-required. Every deployment/layering mutation is
+        // rollback-capable EXCEPT RollbackDeployment itself — rolling back a
+        // rollback is not offered as an automatic undo (reboot/rollback are now
+        // derived from the ActionSpec, which the executor's rollback test pins).
         let actions = [
             "UpdateSystem",
             "InstallPackages",
@@ -870,9 +915,10 @@ mod tests {
                 "{action} should be High risk"
             );
             assert!(envelope.reboot_required, "{action} should require reboot");
-            assert!(
-                envelope.rollback_available,
-                "{action} should have rollback available"
+            let expect_rollback = *action != "RollbackDeployment";
+            assert_eq!(
+                envelope.rollback_available, expect_rollback,
+                "{action} rollback_available should be {expect_rollback}"
             );
         }
     }

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -49,7 +49,23 @@ pub fn preview_action(
     let risk_level = gate_risk(&request.action_name);
     let (reboot_required, rollback_available) = crate::actions::spec_meta(&request.action_name)
         .map(|m| (m.reboot_required, m.rollback_available))
-        .unwrap_or((false, false));
+        .unwrap_or_else(|| {
+            // Unlike risk (which falls back to High), reboot/rollback default to
+            // the *reassuring* (false, false). That is accurate only for the one
+            // spec-less action that legitimately reaches preview, the read-only
+            // `ListJobHistory`. For anything else a missing spec is a bug (a
+            // catalogued action must have one) or an unvalidated name off the
+            // wire — log it, since silently claiming "no reboot, no rollback" for
+            // a real mutating action would mislead the operator.
+            if request.action_name != "ListJobHistory" {
+                eprintln!(
+                    "[sysknife-daemon] preview_action: no ActionSpec for {:?}; defaulting \
+                     reboot_required=false, rollback_available=false (risk falls back to High)",
+                    request.action_name
+                );
+            }
+            (false, false)
+        });
 
     PreviewEnvelope {
         summary: preview_summary(&request.action_name, &risk_level),
@@ -984,6 +1000,52 @@ mod tests {
                 .any(|e| e.contains("unclassified action")),
             "expected_side_effects should contain 'unclassified action'"
         );
+    }
+
+    // The completeness guard proves every action has *a* profile, but not that
+    // the right one is wired to the right name. These pin the two easiest-to-swap
+    // pairs so a transposition (which would tell the operator the opposite of the
+    // real effect) fails the build.
+    #[test]
+    fn apparmor_enforce_and_complain_profiles_are_not_swapped() {
+        let enforce = preview_action(
+            &req("AppArmorEnforce"),
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        );
+        let complain = preview_action(
+            &req("AppArmorComplain"),
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        );
+        // Check the distinguishing side-effect phrase only ("enforce mode" vs
+        // "complain mode"); the complain warning legitimately says "enforcement",
+        // which would trip a bare "enforce" substring match.
+        let se = |e: &sysknife_types::PreviewEnvelope| e.expected_side_effects.join(" ");
+        assert!(se(&enforce).contains("enforce mode") && !se(&enforce).contains("complain"));
+        assert!(se(&complain).contains("complain mode") && !se(&complain).contains("enforce mode"));
+    }
+
+    #[test]
+    fn fail2ban_ban_and_unban_profiles_are_not_swapped() {
+        let ban = preview_action(
+            &req("Fail2banBanIp"),
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        );
+        let unban = preview_action(
+            &req("Fail2banUnbanIp"),
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        );
+        assert!(ban
+            .expected_side_effects
+            .iter()
+            .any(|e| e.contains("will be banned")));
+        assert!(unban
+            .expected_side_effects
+            .iter()
+            .any(|e| e.contains("will be unbanned")));
     }
 
     #[test]

--- a/crates/sysknife-daemon/tests/action_consistency.rs
+++ b/crates/sysknife-daemon/tests/action_consistency.rs
@@ -121,7 +121,7 @@ fn brain_known_actions_has_no_stale_entries() {
 // Single-source-of-truth invariants (risk defined once on the ActionSpec)
 // ---------------------------------------------------------------------------
 
-fn preview_risk(action_name: &str) -> RiskLevel {
+fn preview_envelope(action_name: &str) -> sysknife_types::PreviewEnvelope {
     let request = RequestEnvelope {
         action_name: action_name.to_string(),
         request_id: "action-consistency".to_string(),
@@ -129,7 +129,11 @@ fn preview_risk(action_name: &str) -> RiskLevel {
         caller_role: CallerRole::Dev,
         request_hash: RequestHash::new("hash".to_string()),
     };
-    preview_action(&request, serde_json::Value::Null, serde_json::Value::Null).risk_level
+    preview_action(&request, serde_json::Value::Null, serde_json::Value::Null)
+}
+
+fn preview_risk(action_name: &str) -> RiskLevel {
+    preview_envelope(action_name).risk_level
 }
 
 fn role_rank(role: CallerRole) -> u8 {
@@ -204,27 +208,67 @@ fn role_mirrors_risk_except_documented_monotonic_exceptions() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Known follow-ups (out of scope for the risk-SSOT change)
-// ---------------------------------------------------------------------------
-//
-// 1. reboot_required / rollback_available are still declared on PreviewProfile
-//    (preview.rs) in addition to the ActionSpec. An audit found ~15 preview↔spec
-//    divergences on these flags (display-only — the gate uses risk, and the
-//    executor uses ActionSpec.rollback_available). Some look like spec bugs
-//    (e.g. RollbackDeployment reboot_required=false, though rpm-ostree rollback
-//    applies on reboot). Consolidating them onto the spec needs a per-action
-//    reboot/rollback correctness review, so it is deferred rather than blindly
-//    deriving (which would propagate the spec bugs into the display).
-//
-// 2. prompt.rs risk-tier text (the LLM's risk taxonomy) still lists ~15 actions
-//    at tiers that disagree with the spec. In the MCP path this is harmless:
-//    `mcp_server::enrich_with_commands` overwrites each step's risk from the
-//    ActionSpec-derived preview before the plan is shown or executed. In the CLI
-//    one-shot path, though, the plan display and the `--yes`/`--max-risk`
-//    auto-approval decision (`runner::decide_plan`) read the LLM's proposed risk
-//    directly (the preview is fetched per-step only afterward). Server-side RBAC
-//    (spec-derived) remains the real gate, but the CLI's auto-approval friction
-//    can be mis-sized if the model mis-rates an action. Clean fixes: (a) generate
-//    the prompt risk-tier section from actions::all_specs(); (b) have the CLI
-//    gate on the spec-derived preview risk. Both are focused follow-ups.
+/// The displayed `reboot_required` / `rollback_available` flags must equal the
+/// values declared on each action's `ActionSpec`. `preview_action` derives them
+/// from `spec_meta`, so this holds by construction; the test guards against a
+/// future change that reintroduces a divergent source for these display flags.
+#[test]
+fn preview_reboot_and_rollback_match_spec_for_every_action() {
+    let mut mismatches = Vec::new();
+    for spec in all_specs() {
+        let env = preview_envelope(spec.action_name);
+        if env.reboot_required != spec.reboot_required
+            || env.rollback_available != spec.rollback_available
+        {
+            mismatches.push(format!(
+                "{}: spec reboot={}/rollback={} but preview reboot={}/rollback={}",
+                spec.action_name,
+                spec.reboot_required,
+                spec.rollback_available,
+                env.reboot_required,
+                env.rollback_available,
+            ));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "preview reboot/rollback diverged from ActionSpec (single source of truth):\n{}",
+        mismatches.join("\n")
+    );
+}
+
+/// Every catalogued action must have an explicit `preview_profile` arm. An
+/// action that falls through to the `_` default renders "unclassified action" /
+/// "action profile not recognized" to the operator — a sign the profile table
+/// drifted behind the catalogue (as the apt/PPA/GRUB/AppArmor/Fail2ban actions
+/// once did). This fails the build the moment a newly catalogued action lacks a
+/// profile.
+#[test]
+fn every_catalogued_action_has_a_preview_profile() {
+    let mut unclassified = Vec::new();
+    for spec in all_specs() {
+        let env = preview_envelope(spec.action_name);
+        let unrecognised = env
+            .expected_side_effects
+            .iter()
+            .any(|e| e.contains("unclassified action"))
+            || env
+                .warnings
+                .iter()
+                .any(|w| w.contains("action profile not recognized"));
+        if unrecognised {
+            unclassified.push(spec.action_name);
+        }
+    }
+    assert!(
+        unclassified.is_empty(),
+        "catalogued actions with no preview_profile arm (they render as \
+         'unclassified action'): {unclassified:?}"
+    );
+}
+
+// Former follow-ups now closed: (1) reboot_required/rollback_available are
+// derived from the ActionSpec in `preview_action` and pinned above; (2) the CLI
+// auto-approval gate derives risk from `preview::gate_risk` (the spec), so it can
+// no longer be mis-sized by the LLM's proposed risk. The prompt.rs risk labels
+// are advisory only — every risk-gated decision reads the spec.


### PR DESCRIPTION
Closes the two documented single-source-of-truth follow-ups from the risk-SSOT work (#98).

## Follow-up 1 — preview reboot/rollback
- `reboot_required` / `rollback_available` removed from `PreviewProfile`; `preview_action` derives them from `spec_meta`, so displayed flags can't diverge from the catalogue (the executor already gated auto-rollback on `ActionSpec.rollback_available`). Fixes **4 stale display divergences**: `RollbackDeployment`, `AddPpa`, `RemovePpa`, `GrubSetKargs`.
- The audit surfaced **24 catalogued actions** falling through to the `_` "unclassified action" preview arm (apt / PPA / GRUB / AppArmor / Fail2ban / resolvectl / Ubuntu-Flatpak). Each now has an accurate side-effects/warnings profile.
- New consistency tests pin `preview.reboot/rollback == spec` for every action and **fail the build if any catalogued action lacks a profile** (closes the drift class).

## Follow-up 2 — CLI approval gate
- Extracts `preview::gate_risk(action)` as the single risk authority (spec risk, conservative High fallback); `preview_action` uses it.
- `Plan::with_authoritative_risks` (brain) lets the CLI substitute the spec-derived risk for the LLM's *proposed* per-step risk. `run_intent` applies it right after planning, so the plan display **and** the `--yes`/`--max-risk` auto-approval decision derive from the spec, not a model guess.
- **Security:** an LLM that under-rates a truly-High action can no longer let `--yes --max-risk medium` auto-approve it (proved end-to-end by `authoritative_risks_close_the_llm_under_rating_gate`). prompt.rs risk labels are now advisory only.

## Verification
- 1356 tests pass (+5 new); `clippy -D warnings`, `fmt --check`, and `cargo doc -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)