### PR TITLE
chore(release): v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [0.2.7] — 2026-07-23
+
+### Security
+
+- The CLI's `--yes` / `--max-risk` auto-approval now derives each step's risk
+  from the daemon's `ActionSpec` (the single source of truth) instead of the
+  planner's proposed risk, so a plan that under-rates an action can no longer let
+  it auto-approve. A fail-closed guard also aborts before execution if the
+  running daemon rates a step higher than the CLI approved it — closing a
+  CLI/daemon version-skew window.
+
+### Changed
+
+- Preview `reboot_required` / `rollback_available` are now derived from the
+  `ActionSpec`, fixing stale display for `RollbackDeployment`, `AddPpa`,
+  `RemovePpa`, and `GrubSetKargs`.
+- Twenty-four apt / PPA / snap / GRUB / AppArmor / Fail2ban / resolvectl /
+  Flatpak actions that previously previewed as "unclassified" now show accurate
+  side effects and warnings; a completeness test prevents the drift from
+  recurring.
+
+### Added
+
+- Dependabot now tracks Docker base images and applies a supply-chain cooldown
+  to version updates; repository vulnerability alerts and automated security
+  updates are enabled.
+
 ## [0.2.6] — 2026-07-23
 
 ### Security
@@ -84,5 +111,6 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   (non-repudiable, third-party verifiable), with signed checkpoints guarding
   against truncation.
 
+[0.2.7]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.7
 [0.2.6]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.6
 [0.2.5]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "prost",
  "prost-build",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,11 +15,11 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.6" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.2.6" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.2.6" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.7" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.2.7" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.2.7" }
 chrono = "0.4"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.2.6" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.2.7" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "@vitest/coverage-v8": "^4.1.4",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.2.6" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.2.6" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.2.7" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.2.7" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -12,8 +12,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.2.6" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.6" }
+sysknife-core = { path = "../sysknife-core", version = "0.2.7" }
+sysknife-types = { path = "../sysknife-types", version = "0.2.7" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.6"
+version = "0.2.7"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.2.6" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.2.7" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -11,8 +11,8 @@ keywords = ["linux", "sysadmin", "daemon", "security"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.2.6" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.6" }
+sysknife-core = { path = "../sysknife-core", version = "0.2.7" }
+sysknife-types = { path = "../sysknife-types", version = "0.2.7" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -53,7 +53,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.2.6" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.2.7" }
 serde_json = { workspace = true }
 syslog_loose = "0.23"
 tempfile = "3"

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.2.6" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.2.7" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Zero-friction setup for SysKnife MCP server — Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {


### PR DESCRIPTION
Release prep for **v0.2.7**. Bumps all crate + package versions `0.2.6 → 0.2.7`, refreshes `Cargo.lock`, records the changelog.

## What ships in v0.2.7 (merged after v0.2.6)
- **Security (#102)** — CLI `--yes`/`--max-risk` auto-approval derives each step's risk from the `ActionSpec` (not the planner's guess); a fail-closed guard aborts if the live daemon rates a step higher than the CLI approved (CLI/daemon version-skew).
- **#102** — preview `reboot_required`/`rollback_available` derived from the `ActionSpec` (fixes 4 stale displays); 24 previously-"unclassified" actions now have accurate profiles + a completeness test.
- **#101** — Dependabot Docker base-image tracking + supply-chain cooldown; repo alerts + automated security updates enabled.
- **#103** — trufflehog CI action bump.

## Verification
- `check_release_versions.sh v0.2.7` ✓ · `release_rehearsal.sh --check` ✓
- `cargo nextest run --workspace --locked` → 1362/1362 pass

After merge, tag `v0.2.7` to trigger the release workflow (npm + crates.io + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)