### PR TITLE
fix(docs): use canonical Contributor Covenant 2.1 URL

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,7 +116,7 @@ community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct/][v2.1].
 
 Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder][mozilla].
@@ -126,7 +126,7 @@ For answers to common questions about this code of conduct, see the FAQ at
 [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
 [mozilla]: https://github.com/mozilla/diversity
 [faq]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
## Problem

The `ci` workflow went **red on `main`** immediately after the v0.2.7 release merge (run [30036640454](https://github.com/lacs-project/sysknife/actions/runs/30036640454)). The `docs-and-hygiene` → *Check markdown links* step failed:

```
ERROR: 1 dead link found!
[✖] https://www.contributor-covenant.org/version/2/1/code_of_conduct.html → Status: 0
```

`Status: 0` = the request errored (not a 404). In the **same run**, the canonical trailing-slash path `…/version/2/1/code_of_conduct/` resolved `[✓]`, as did the domain root, `/faq`, and `/translations` — so the `.html` form is stale, not the whole host. The `pull_request` event happened to pass on a transient; the push-to-`main` event caught it.

## Fix

Point both the inline attribution link and the `[v2.1]` reference definition in `CODE_OF_CONDUCT.md` at the canonical URL `https://www.contributor-covenant.org/version/2/1/code_of_conduct/`.

Deterministic fix (URL correction), not a retry/ignore band-aid — the link check stays meaningful.

## Verification

`markdown-link-check --config .markdown-link-check.json CODE_OF_CONDUCT.md` → `6 links checked`, 0 dead, locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)