### PR TITLE
chore(release): v0.2.8 — socket fix, postcss advisory, drop backwards-compat, simplify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [0.2.8] — 2026-07-23
+
+### Security
+
+- Bumped the transitive `postcss` dependency of the `sysknife-shell` GUI to
+  `>= 8.5.12` via an npm `overrides` pin, resolving a high-severity advisory
+  (arbitrary file read / information disclosure via an attacker-controlled
+  `sourceMappingURL` in CSS comments).
+
+### Fixed
+
+- The CLI (and the MCP server) now resolve the daemon socket via
+  `sysknife-core`'s `default_listen_uri()` — the same resolver the daemon and
+  the Tauri GUI already use — instead of a hardcoded production path. Previously
+  `sysknife doctor` and every CLI command failed to reach a dev/non-systemd
+  daemon until `SYSKNIFE_SOCKET` was set by hand. `$SYSKNIFE_SOCKET` still takes
+  precedence as an explicit override. Thanks to Raúl Cárdenas for the report.
+
+### Changed
+
+- Dropped backwards-compatibility cruft (the project has never been deployed at
+  scale, so matched versions are an invariant): the dead `fail2ban`
+  `InvalidIpAddress` type alias, the `--codex-only` setup-wizard flag alias, the
+  `install-key` VM-script alias, the `ubuntu-vm` "legacy noble" migration shim,
+  and a phantom `/tmp/sysknife-daemon.sock` path in the setup wizard.
+- Documented the `SYSKNIFE_SOCKET` override and corrected stale daemon
+  socket-default text (`$XDG_RUNTIME_DIR/sysknife/daemon.sock`, not
+  `/tmp/sysknife-daemon.sock`) in the developer and architecture docs.
+- Internal simplification of the CLI risk-gate/socket module and the daemon
+  preview gate (de-duplication and named constants); no behavior change.
+
 ## [0.2.7] — 2026-07-23
 
 ### Security
@@ -111,6 +142,7 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   (non-repudiable, third-party verifiable), with signed checkpoints guarding
   against truncation.
 
+[0.2.8]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.8
 [0.2.7]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.7
 [0.2.6]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.6
 [0.2.5]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "prost",
  "prost-build",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,11 +15,11 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.7" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.2.7" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.2.7" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.8" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.2.8" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.2.8" }
 chrono = "0.4"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.2.7" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.2.8" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/apps/sysknife-cli/src/client.rs
+++ b/apps/sysknife-cli/src/client.rs
@@ -73,7 +73,7 @@ impl SocketTarget {
     /// Accepted forms:
     /// - `vsock://CID:PORT`  — virtio-vsock (Linux only)
     /// - `unix:///path`      — Unix domain socket
-    /// - `/absolute/path`    — bare path → Unix socket (backward compat)
+    /// - `/absolute/path`    — bare path → Unix socket
     pub fn try_from_str(s: &str) -> Result<Self, String> {
         #[cfg(target_os = "linux")]
         if let Some(rest) = s.strip_prefix("vsock://") {

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -16,12 +16,11 @@
 //! `--dry-run` short-circuits before any execution: the plan is printed and
 //! the function returns `Ok(())`.
 
-use std::io::{self, Write as _};
+use std::io::{self, IsTerminal, Write as _};
 use std::path::PathBuf;
 
 use clap::CommandFactory;
 use serde_json::{json, Value};
-use std::io::IsTerminal;
 use sysknife_brain::config::BrainConfig;
 use sysknife_brain::planner::{LlmPlanner, PlanRiskLevel};
 use sysknife_brain::PlanEvent;
@@ -62,18 +61,26 @@ pub fn distro_id_to_hint(distro: &sysknife_core::distro::DistroId) -> DistroHint
 // resolve_socket / resolve_socket_target
 // ---------------------------------------------------------------------------
 
-/// Returns the daemon [`SocketTarget`] from `$SYSKNIFE_SOCKET`.
+/// Resolve the daemon [`SocketTarget`] the CLI (and MCP server) should dial.
 ///
-/// Falls back to the system-wide Unix socket default when the env var is absent.
-/// Exits the process with an error message if the env var is set but unparseable.
+/// Precedence:
+/// 1. `$SYSKNIFE_SOCKET` — explicit override; accepts `unix://`, `vsock://`, or
+///    a bare path.
+/// 2. Otherwise [`sysknife_core::default_listen_uri`] — the *same* resolver the
+///    daemon and Tauri GUI use (`$SYSKNIFE_LISTEN_URI` →
+///    `$XDG_RUNTIME_DIR/sysknife/daemon.sock` → `/tmp/sysknife-$UID.sock`). This
+///    keeps the CLI pointed at wherever the daemon actually bound in both dev
+///    and production, rather than a hardcoded production path that only matches
+///    under systemd.
+///
+/// Exits the process if the resolved target string is unparseable.
 pub fn resolve_socket_target() -> SocketTarget {
-    match std::env::var("SYSKNIFE_SOCKET") {
-        Ok(s) => SocketTarget::try_from_str(&s).unwrap_or_else(|e| {
-            eprintln!("sysknife: invalid SYSKNIFE_SOCKET: {e}");
-            std::process::exit(1);
-        }),
-        Err(_) => SocketTarget::Unix(PathBuf::from("/run/sysknife/daemon.sock")),
-    }
+    let raw =
+        std::env::var("SYSKNIFE_SOCKET").unwrap_or_else(|_| sysknife_core::default_listen_uri());
+    SocketTarget::try_from_str(&raw).unwrap_or_else(|e| {
+        eprintln!("sysknife: invalid socket target {raw:?}: {e}");
+        std::process::exit(1);
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -173,11 +180,7 @@ fn rfc3339_to_unix(s: &str) -> Option<i64> {
 pub fn highest_risk(plan: &sysknife_brain::planner::Plan) -> Option<&PlanRiskLevel> {
     plan.steps()
         .iter()
-        .max_by_key(|s| match s.risk_level() {
-            PlanRiskLevel::Low => 0u8,
-            PlanRiskLevel::Medium => 1,
-            PlanRiskLevel::High => 2,
-        })
+        .max_by_key(|s| plan_risk_rank(s.risk_level()))
         .map(|s| s.risk_level())
 }
 
@@ -650,20 +653,14 @@ pub async fn run_audit_checkpoint(
 
     // Load the private signing key (same location rules as `verify`).
     let key_path = sysknife_daemon::audit_chain::resolve_audit_key_path(&db_path);
-    if !key_path.exists() {
-        eprintln!("audit key not found at {}", key_path.display());
-        return Err(CliError::Exit(2));
-    }
+    require_exists(&key_path, "audit key")?;
     let key = AuditKey::load_or_generate(&key_path).map_err(|e| {
         eprintln!("audit key load failed: {e}");
         CliError::Exit(2)
     })?;
 
     // Read the current chain tip from the local sqlite store.
-    if !db_path.exists() {
-        eprintln!("audit database not found at {}", db_path.display());
-        return Err(CliError::Exit(2));
-    }
+    require_exists(&db_path, "audit database")?;
     let store = TransactionStore::open_read_only(&db_path).map_err(|e| {
         eprintln!("opening audit database failed: {e}");
         CliError::Exit(2)
@@ -950,13 +947,8 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
     }
 
     // Layer 1: spinner — auto-hidden by indicatif when stderr is not a TTY.
-    let spinner = if !opts.json {
-        Some(crate::render::make_spinner(format!(
-            "Planning \"{intent}\"…"
-        )))
-    } else {
-        None
-    };
+    let spinner =
+        (!opts.json).then(|| crate::render::make_spinner(format!("Planning \"{intent}\"…")));
 
     // Spawn event updater: receives PlanEvent and updates the spinner message.
     // The task exits naturally when the channel closes (i.e. when the planner
@@ -989,9 +981,7 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
         eprintln!("sysknife: event task panicked: {e}");
     }
 
-    if let Some(ref pb) = spinner {
-        pb.finish_and_clear();
-    }
+    finish_spinner(&spinner);
 
     let plan = plan_result.map_err(|e| CliError::PlanningFailed(e.to_string()))?;
 
@@ -1172,14 +1162,8 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
 
         // Spinner clears on the first output line so execution output
         // streams naturally without a spinner in the way.
-        let exec_spinner: Option<indicatif::ProgressBar> = if !opts.json {
-            Some(crate::render::make_spinner(format!(
-                "Executing {}…",
-                step.action_name()
-            )))
-        } else {
-            None
-        };
+        let exec_spinner: Option<indicatif::ProgressBar> = (!opts.json)
+            .then(|| crate::render::make_spinner(format!("Executing {}…", step.action_name())));
         let exec_spinner_ref = exec_spinner.clone();
         let mut first_line = true;
 
@@ -1192,9 +1176,7 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
                 &approval_receipt,
                 |line| {
                     if first_line {
-                        if let Some(ref pb) = exec_spinner_ref {
-                            pb.finish_and_clear();
-                        }
+                        finish_spinner(&exec_spinner_ref);
                         first_line = false;
                     }
                     if opts.json {
@@ -1207,12 +1189,10 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
             .await;
 
         // Always clear the exec spinner regardless of success or error.
-        // If the callback already fired, finish_and_clear() is idempotent.
-        // If execute() errored before the first output line, this prevents
-        // the spinner artifact from being left on the terminal.
-        if let Some(ref pb) = exec_spinner {
-            pb.finish_and_clear();
-        }
+        // finish_spinner() is idempotent, so this is safe even if the callback
+        // already fired. If execute() errored before the first output line,
+        // this prevents the spinner artifact from being left on the terminal.
+        finish_spinner(&exec_spinner);
 
         exec_result.map(|result| {
             if opts.json {
@@ -1312,6 +1292,26 @@ pub async fn run_repl(opts: &RunOpts, log: &Logger) -> Result<(), CliError> {
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
+
+/// Clear `spinner` if one is present. A no-op when `spinner` is `None` (e.g.
+/// `--json` mode, where no spinner was ever created) or already finished.
+fn finish_spinner(spinner: &Option<indicatif::ProgressBar>) {
+    if let Some(pb) = spinner {
+        pb.finish_and_clear();
+    }
+}
+
+/// Check that `path` exists; if not, print `"{what} not found at <path>"` to
+/// stderr and fail with exit code 2 (used by `run_audit_checkpoint`, which
+/// checks both the audit key file and the audit database file this way).
+fn require_exists(path: &std::path::Path, what: &str) -> Result<(), CliError> {
+    if path.exists() {
+        Ok(())
+    } else {
+        eprintln!("{what} not found at {}", path.display());
+        Err(CliError::Exit(2))
+    }
+}
 
 /// Ask the user a yes/no question on stderr; return `true` iff they answer "y"
 /// or "yes" (case-insensitive).
@@ -1802,13 +1802,25 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn resolve_socket_target_defaults_to_unix_when_unset() {
+    fn resolve_socket_target_falls_back_to_core_default_listen_uri() {
+        // With no explicit SYSKNIFE_SOCKET override, the CLI must resolve to the
+        // same target the daemon binds — sysknife_core::default_listen_uri(),
+        // whose top precedence is SYSKNIFE_LISTEN_URI. Regression guard for the
+        // dev/non-systemd socket mismatch (the production path used to be
+        // hardcoded here, so `sysknife doctor` could not reach a dev daemon).
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::remove_var("SYSKNIFE_SOCKET") };
+        unsafe {
+            std::env::remove_var("SYSKNIFE_SOCKET");
+            std::env::set_var(
+                "SYSKNIFE_LISTEN_URI",
+                "unix:///run/user/4242/sysknife/daemon.sock",
+            );
+        }
         let t = resolve_socket_target();
+        unsafe { std::env::remove_var("SYSKNIFE_LISTEN_URI") };
         assert_eq!(
             t,
-            crate::client::SocketTarget::Unix(PathBuf::from("/run/sysknife/daemon.sock"))
+            crate::client::SocketTarget::Unix(PathBuf::from("/run/user/4242/sysknife/daemon.sock"))
         );
     }
 

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "@vitest/coverage-v8": "^4.1.4",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -25,5 +25,8 @@
     "typescript": "^7.0.2",
     "vite": "^8.0.10",
     "vitest": "^4.1.4"
+  },
+  "overrides": {
+    "postcss": "^8.5.12"
   }
 }

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.2.7" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.2.7" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.2.8" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.2.8" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -12,8 +12,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.2.7" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.7" }
+sysknife-core = { path = "../sysknife-core", version = "0.2.8" }
+sysknife-types = { path = "../sysknife-types", version = "0.2.8" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.7"
+version = "0.2.8"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.2.7" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.2.8" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -11,8 +11,8 @@ keywords = ["linux", "sysadmin", "daemon", "security"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.2.7" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.7" }
+sysknife-core = { path = "../sysknife-core", version = "0.2.8" }
+sysknife-types = { path = "../sysknife-types", version = "0.2.8" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -53,7 +53,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.2.7" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.2.8" }
 serde_json = { workspace = true }
 syslog_loose = "0.23"
 tempfile = "3"

--- a/crates/sysknife-daemon/src/actions/fail2ban.rs
+++ b/crates/sysknife-daemon/src/actions/fail2ban.rs
@@ -51,9 +51,6 @@ impl std::fmt::Display for Fail2banError {
 
 impl std::error::Error for Fail2banError {}
 
-/// Backwards-compat alias so existing call sites keep compiling.
-pub type InvalidIpAddress = Fail2banError;
-
 /// Allowlist for fail2ban jail names: alphanumeric + `_-` + `.` (no leading
 /// dash, no shell metachars, length ≤ 64). Mirrors the `validated_safe_arg`
 /// shape used at the executor seam.

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -34,6 +34,15 @@ struct PreviewProfile {
     warnings: Vec<String>,
 }
 
+/// The two standard approval-gate warning phrases, threaded through nearly
+/// every mutating action's profile below. Named so every arm spells the same
+/// wording instead of re-typing the literal ~50 times; a copy-paste typo here
+/// would only be a cosmetic wording drift (`tests/action_consistency.rs` pins
+/// risk/role/reboot/rollback, not warning text), but a shared constant makes
+/// that drift impossible rather than merely unlikely.
+const APPROVAL_REQUIRED: &str = "approval required";
+const EXACT_APPROVAL_REQUIRED: &str = "exact approval required";
+
 pub fn preview_action(
     request: &RequestEnvelope,
     current_state: Value,
@@ -186,7 +195,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "package state will change".to_string(),
                 "services may be restarted by needrestart".to_string(),
             ],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
 
         // ── Ubuntu snap medium-risk ───────────────────────────────────────
@@ -194,7 +203,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             PreviewProfile {
                 expected_side_effects: vec!["snap state will change".to_string()],
                 warnings: vec![
-                    "approval required".to_string(),
+                    APPROVAL_REQUIRED.to_string(),
                     "snap auto-refresh: install is paired with --hold by default".to_string(),
                 ],
             }
@@ -203,7 +212,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         // ── Ubuntu distrobox medium-risk ──────────────────────────────────
         "DistroboxCreate" | "DistroboxRemove" => PreviewProfile {
             expected_side_effects: vec!["container lifecycle will change".to_string()],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
 
         // ── Ubuntu apt high-risk ──────────────────────────────────────────
@@ -218,7 +227,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "dist-upgrade may remove packages".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -230,7 +239,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "misconfigured rules can lock out SSH access".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -242,7 +251,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "can disconnect the current SSH session if config is wrong".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -251,7 +260,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "backend network config files will be regenerated".to_string(),
             ],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
 
         // ── Ubuntu netplan high-risk (Tier 3) ─────────────────────────────
@@ -262,7 +271,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "run NetplanApply to activate the change".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -274,7 +283,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "misconfigured rules can lock out SSH access".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -285,7 +294,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "Pro services (ESM, Livepatch, FIPS) may be enabled".to_string(),
             ],
             warnings: vec![
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
                 "token is redacted from the preview, audit log, and diagnostic output".to_string(),
             ],
         },
@@ -297,7 +306,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "ESM, Livepatch, and FIPS services will be disabled".to_string(),
             ],
             warnings: vec![
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
                 "after detach, this machine no longer receives Pro security patches".to_string(),
             ],
         },
@@ -309,7 +318,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "requires the auditd package installed to take effect".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -322,14 +331,14 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             warnings: vec![
                 "contacts a public ACME CA over the network".to_string(),
                 "requires certbot installed + a reachable DNS/HTTP challenge".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "RenewCertificates" => PreviewProfile {
             expected_side_effects: vec!["certbot will renew due certificates".to_string()],
             warnings: vec![
                 "contacts a public ACME CA over the network".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -341,7 +350,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             warnings: vec![
                 "changes who gets banned (too strict can lock out real users)".to_string(),
                 "requires the fail2ban package installed to take effect".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -351,7 +360,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "a single Ubuntu Pro service will be enabled/disabled".to_string(),
             ],
             warnings: vec![
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
                 "requires an attached Pro subscription + network to take effect".to_string(),
             ],
         },
@@ -366,14 +375,14 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             warnings: vec![
                 "reboot required to complete the upgrade".to_string(),
                 "long-running operation — configure timeout >= 3600 seconds".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
         "ReloadService" => PreviewProfile {
             expected_side_effects: vec!["service config will be reloaded".to_string()],
             warnings: vec![
-                "approval required".to_string(),
+                APPROVAL_REQUIRED.to_string(),
                 "requires ExecReload= to be defined in the unit file; \
                  if not defined, use RestartService instead"
                     .to_string(),
@@ -402,7 +411,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "SetNtp"
         | "CreateUser" => PreviewProfile {
             expected_side_effects: vec!["service interruption".to_string()],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
         // ── Observability / journald maintenance ─────────────────────────
         "VacuumJournal" => PreviewProfile {
@@ -420,7 +429,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "resizes a live filesystem; a wrong volume target risks data".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "CreateLogicalVolume" | "CreateLvSnapshot" => PreviewProfile {
@@ -429,7 +438,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "consumes VG capacity; snapshots fill as the origin changes".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -441,7 +450,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "too tight a MemoryMax can OOM-kill the service".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -450,7 +459,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "a logrotate drop-in will be written/removed".to_string(),
             ],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
         "ConfigureRemoteSyslog" | "RemoveRemoteSyslog" => PreviewProfile {
             expected_side_effects: vec![
@@ -459,7 +468,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "forwarding sends log data off-host (exfiltration surface)".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -468,7 +477,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "the target account's password-aging limits will change".to_string(),
             ],
-            warnings: vec!["exact approval required".to_string()],
+            warnings: vec![EXACT_APPROVAL_REQUIRED.to_string()],
         },
         "SetPasswordPolicy" | "SetAccountLockout" => PreviewProfile {
             expected_side_effects: vec![
@@ -477,7 +486,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             warnings: vec![
                 "affects password/lockout rules for all accounts".to_string(),
                 "takes effect only if the PAM module is enabled in the auth stack".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -487,7 +496,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "apt version/origin preferences will change".to_string(),
                 "a /etc/apt/preferences.d drop-in will be written/removed".to_string(),
             ],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
 
         // ── Scoped sudoers.d ──────────────────────────────────────────────
@@ -498,7 +507,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "this configures privilege escalation — review the rule carefully".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -510,7 +519,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "a wrong device or mountpoint risks data or availability".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "AddSwap" | "RemoveSwap" => PreviewProfile {
@@ -518,7 +527,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
                 "swap will be enabled/disabled".to_string(),
                 "a swap file will be created/removed and /etc/fstab updated".to_string(),
             ],
-            warnings: vec!["exact approval required".to_string()],
+            warnings: vec![EXACT_APPROVAL_REQUIRED.to_string()],
         },
 
         // ── Kernel / sysctl mutation ──────────────────────────────────────
@@ -529,7 +538,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "a wrong net.*/vm.*/kernel.* value can degrade or lock the host".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -537,14 +546,14 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec!["the target process will be terminated".to_string()],
             warnings: vec![
                 "the process and its in-flight work will stop".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "ConfigureUnattendedUpgrades" => PreviewProfile {
             expected_side_effects: vec![
                 "the automatic security-update policy will change".to_string()
             ],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
         "CreateScheduledJob" => PreviewProfile {
             expected_side_effects: vec![
@@ -552,7 +561,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "persistent root-scheduled execution".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "AddUserToGroup"
@@ -570,7 +579,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec!["access control will change".to_string()],
             warnings: vec![
                 "privilege change".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "AddPackageRepository"
@@ -578,12 +587,12 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "EnablePackageRepository"
         | "DisablePackageRepository" => PreviewProfile {
             expected_side_effects: vec!["package repository configuration will change".to_string()],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
         "CreateContainer" | "StartContainer" | "StopContainer" | "RemoveContainer" => {
             PreviewProfile {
                 expected_side_effects: vec!["container lifecycle will change".to_string()],
-                warnings: vec!["approval required".to_string()],
+                warnings: vec![APPROVAL_REQUIRED.to_string()],
             }
         }
         "UpdateSystem"
@@ -602,30 +611,30 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "reboot required".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "SetKernelArguments" => PreviewProfile {
             expected_side_effects: vec!["boot arguments will change".to_string()],
             warnings: vec![
                 "reboot required".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "RebootSystem" => PreviewProfile {
             expected_side_effects: vec!["system reboot will interrupt running work".to_string()],
             warnings: vec![
                 "reboot required".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "CleanupDeployments" => PreviewProfile {
             expected_side_effects: vec!["old deployments may be removed".to_string()],
-            warnings: vec!["exact approval required".to_string()],
+            warnings: vec![EXACT_APPROVAL_REQUIRED.to_string()],
         },
         "PinDeployment" | "UnpinDeployment" => PreviewProfile {
             expected_side_effects: vec!["deployment pin state will change".to_string()],
-            warnings: vec!["exact approval required".to_string()],
+            warnings: vec![EXACT_APPROVAL_REQUIRED.to_string()],
         },
         // ── Ubuntu apt: index refresh + autoremove ───────────────────────
         "AptUpdate" => PreviewProfile {
@@ -636,7 +645,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "automatically-installed packages no longer needed will be removed".to_string(),
             ],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
 
         // ── Launchpad PPAs ────────────────────────────────────────────────
@@ -647,12 +656,12 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "a PPA is a third-party package source outside the distro archive".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "RemovePpa" => PreviewProfile {
             expected_side_effects: vec!["a Launchpad PPA will be removed".to_string()],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
 
         // ── snap revert / classic install ─────────────────────────────────
@@ -660,7 +669,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec![
                 "the snap will be reverted to its previous revision".to_string(),
             ],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
         "SnapClassicInstall" => PreviewProfile {
             expected_side_effects: vec![
@@ -668,7 +677,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "classic confinement grants the snap full, unsandboxed system access".to_string(),
-                "approval required".to_string(),
+                APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -681,7 +690,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             warnings: vec![
                 "takes effect on the next reboot".to_string(),
                 "a bad kernel argument can prevent the system from booting".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -690,7 +699,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec!["DNS servers for the interface will change".to_string()],
             warnings: vec![
                 "redirecting DNS can enable interception of name resolution".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -701,7 +710,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "an over-tight profile can block a legitimate service".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "AppArmorComplain" => PreviewProfile {
@@ -710,7 +719,7 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
             warnings: vec![
                 "complain mode disables MAC enforcement for the profile".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
 
@@ -719,20 +728,20 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             expected_side_effects: vec!["an IP address will be banned in a fail2ban jail".to_string()],
             warnings: vec![
                 "banning can lock out legitimate access from that address".to_string(),
-                "exact approval required".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
             ],
         },
         "Fail2banUnbanIp" => PreviewProfile {
             expected_side_effects: vec![
                 "an IP address will be unbanned in a fail2ban jail".to_string(),
             ],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
 
         // ── Ubuntu Flatpak (per-user) ─────────────────────────────────────
         "UbuntuInstallFlatpak" | "UbuntuRemoveFlatpak" | "UbuntuUpdateFlatpak" => PreviewProfile {
             expected_side_effects: vec!["a user's Flatpak apps will change".to_string()],
-            warnings: vec!["approval required".to_string()],
+            warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
 
         _ => PreviewProfile {

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -12,9 +12,8 @@
 //! retry on broken connections, and TLS via rustls.
 //!
 //! On connect, `PostgresStore::initialize` runs ordered, transactional schema
-//! migrations under a database advisory lock. Existing installations created
-//! before migration tracking are adopted by migration 1 without dropping or
-//! rewriting rows. The schema mirrors SQLite field-for-field; the only dialect
+//! migrations under a database advisory lock. The schema mirrors SQLite
+//! field-for-field; the only dialect
 //! difference is `BIGINT NOT NULL UNIQUE` for `seq`. `created_at` remains
 //! `TEXT` (RFC 3339 with `Z` suffix) in both backends and is cast to
 //! `timestamptz` for interval arithmetic.

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -76,7 +76,7 @@ pub struct NewTransaction {
 pub struct TransactionStore {
     path: PathBuf,
     /// Ed25519 signing key used to compute the forward audit chain on insert.
-    /// `None` only in legacy callers that never write rows (read-only access).
+    /// `None` only for read-only callers that never write rows.
     audit_key: Option<Arc<AuditKey>>,
 }
 

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.2.7" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.2.8" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,7 @@ running anything.
 ## IPC Protocol
 
 The shell and daemon communicate over a Unix domain socket
-(`/tmp/sysknife-daemon.sock` by default, overridable via `SYSKNIFE_LISTEN_URI`).
+(`$XDG_RUNTIME_DIR/sysknife/daemon.sock` by default, overridable via `SYSKNIFE_LISTEN_URI`).
 
 The framing is a 4-byte little-endian `u32` length prefix followed by
 a UTF-8 JSON body. Each message carries a `"type"` discriminant so
@@ -161,7 +161,7 @@ dropped immediately rather than queued.
 The protocol is human-readable. You can inspect live traffic with:
 
 ```sh
-socat - UNIX-CONNECT:/tmp/sysknife-daemon.sock
+socat - UNIX-CONNECT:"$XDG_RUNTIME_DIR/sysknife/daemon.sock"
 ```
 
 See [ADR 0003](adr/0003-ipc-wire-protocol.md) for the rationale

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -210,7 +210,7 @@ sudo chmod +r /boot/vmlinuz-*
 #    and SSH key. (Implemented via guestfish so it works offline,
 #    bypassing Silverblue's interactive first-boot wizard which has
 #    gnome-initial-setup quirks on some hosts.)
-./tests/e2e/atomic-vm.sh install-key
+./tests/e2e/atomic-vm.sh bootstrap
 ```
 
 > Why no `enable-ssh` step? Earlier versions of this script tried to

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -73,7 +73,9 @@ You need two terminals.
 **Terminal 1 — daemon**
 
 ```sh
-# Starts on /tmp/sysknife-daemon.sock by default.
+# Binds $SYSKNIFE_LISTEN_URI, else $XDG_RUNTIME_DIR/sysknife/daemon.sock
+# (last resort /tmp/sysknife-$UID.sock). The CLI resolves the same default,
+# so `sysknife doctor` works without setting a socket env var.
 # Privileged system actions (rpm-ostree, useradd, etc.) require root.
 # For development you can run without root — read-only queries still work.
 cargo run -p sysknife-daemon
@@ -119,7 +121,7 @@ poke it manually without the GUI:
 
 ```sh
 cargo run -p sysknife-daemon &
-socat - UNIX-CONNECT:/tmp/sysknife-daemon.sock
+socat - UNIX-CONNECT:"$XDG_RUNTIME_DIR/sysknife/daemon.sock"
 ```
 
 Type or paste a JSON message (with a 4-byte LE length prefix). This
@@ -172,7 +174,8 @@ Config file values act as defaults. Environment variables always win.
 
 | Variable | Default | Description |
 |---|---|---|
-| `SYSKNIFE_LISTEN_URI` | `$XDG_RUNTIME_DIR/sysknife/daemon.sock` (prod: `/run/sysknife/daemon.sock`) | Daemon socket URI |
+| `SYSKNIFE_LISTEN_URI` | `$XDG_RUNTIME_DIR/sysknife/daemon.sock` (prod: `/run/sysknife/daemon.sock`) | Daemon socket URI (where the daemon binds) |
+| `SYSKNIFE_SOCKET` | falls back to the same default as `SYSKNIFE_LISTEN_URI` | CLI / MCP-server socket override — where the client dials (`unix://`, `vsock://`, or a bare path) |
 | `SYSKNIFE_DATABASE_PATH` | `$XDG_STATE_HOME/sysknife/daemon.sqlite` (fallback `~/.local/state/sysknife/daemon.sqlite`) | SQLite database path |
 | `SYSKNIFE_LLM_PROVIDER` | auto-detect | `anthropic`, `openai`, `gemini`, `ollama`, `groq`, `deepseek`, `mistral`, or `xai` |
 | `ANTHROPIC_API_KEY` | — | Required for the Anthropic provider |

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -41,8 +41,8 @@ a new release commit.
 ## Data and operations
 
 - [ ] SQLite backup plus audit-key restore is tested on an isolated host.
-- [ ] PostgreSQL migration from a legacy schema and a backup/PITR restore drill
-      both pass against the production provider.
+- [ ] PostgreSQL migration and a backup/PITR restore drill both pass against
+      the production provider.
 - [ ] Audit retention, backup encryption, recovery objectives, restore owner,
       and deletion authorization are documented for operators.
 - [ ] Monitoring covers daemon startup, database failures/capacity, dropped

--- a/docs/storage-cloud.md
+++ b/docs/storage-cloud.md
@@ -36,9 +36,7 @@ On startup, the daemon:
 3. Applies each pending migration once and records its version.
 4. Refuses to start if the database schema is newer than the binary.
 
-Migration 1 adopts databases created by pre-migration SysKnife builds without
-dropping or rewriting existing transaction rows. The CI contract verifies
-legacy-row preservation, migration idempotence, approval claims, history, and
+The CI contract verifies migration idempotence, approval claims, history, and
 hash-chain validation against a live PostgreSQL server.
 
 Transaction-mode PgBouncer deployments may require

--- a/packages/setup/README.md
+++ b/packages/setup/README.md
@@ -80,7 +80,6 @@ entry (`sysknife-web`, `sysknife-db`, …) across all written config files.
 --claude      Configure Claude Code only
 --cursor      Configure Cursor only
 --codex       Configure Codex CLI only
---codex-only  Alias for --codex
 --all         Configure Claude Code, Cursor, and Codex CLI
 --no-binary   Skip prebuilt binary download (build from source instead)
 --no-prompts  Accept all defaults non-interactively (useful for scripts/tests)

--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -226,7 +226,7 @@ const { PROVIDERS, MODEL_DEFAULTS, API_KEY_VARS } = require('./providers.js');
 const ARG_SET = new Set(process.argv.slice(2));
 const WANT_CLAUDE     = ARG_SET.has('--claude');
 const WANT_CURSOR     = ARG_SET.has('--cursor');
-const WANT_CODEX      = ARG_SET.has('--codex') || ARG_SET.has('--codex-only');
+const WANT_CODEX      = ARG_SET.has('--codex');
 const WANT_ALL        = ARG_SET.has('--all');
 const NO_BINARY       = ARG_SET.has('--no-binary');
 const NO_PROMPTS      = ARG_SET.has('--no-prompts');
@@ -437,12 +437,11 @@ function targetNextStep(target) {
 
   // Sockets that live on this machine, so the daemon starts locally rather than
   // over an SSH tunnel. Includes the default user-service socket written by the
-  // wizard (matches install-daemon.js) and the two legacy system paths.
+  // wizard (matches install-daemon.js) and the systemd system-unit path.
   const userServiceSocket = path.join(os.homedir(), '.local', 'share', 'sysknife', 'daemon.sock');
   const localSockets = new Set([
     userServiceSocket,
     '/run/sysknife/daemon.sock',
-    '/tmp/sysknife-daemon.sock',
   ]);
 
   if (socket.startsWith('vsock://')) {
@@ -890,7 +889,6 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   --claude      Configure Claude Code only.
   --cursor      Configure Cursor only.
   --codex       Configure Codex CLI only.
-  --codex-only  Alias for --codex.
   --all         Configure Claude Code, Cursor, and Codex CLI.
   --no-binary   Skip prebuilt binary download (build from source instead).
   --no-prompts  Accept all defaults non-interactively (useful for scripts/tests).

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Zero-friction setup for SysKnife MCP server — Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/tests/e2e/atomic-vm.sh
+++ b/tests/e2e/atomic-vm.sh
@@ -22,7 +22,6 @@
 #                 stopped): create user, set passwords + sudoers, install
 #                 SSH key, enable sshd, set SELinux permissive, skip
 #                 gnome-initial-setup. Idempotent.
-#   install-key — alias for `bootstrap` (kept for older docs)
 #   start       — boot the installed VM headlessly with SSH forwarding
 #   ssh        — open an SSH shell into the VM (or run a command)
 #   sync       — rsync the repo to the VM (no build, no provision)
@@ -256,7 +255,7 @@ cmd_start() {
         if ssh $(ssh_opts) -o BatchMode=yes -o ConnectTimeout=5 \
                -p "$port" "${VM_USER}@127.0.0.1" true 2>&1 \
                | grep -qE 'Permission denied|publickey|password'; then
-            log "sshd responding on port $port (key not installed; run '$0 install-key')"
+            log "sshd responding on port $port (key not installed; run '$0 bootstrap')"
             return 0
         fi
         sleep 5
@@ -288,7 +287,7 @@ cmd_sync() {
 
 cmd_provision() {
     require_tools rsync
-    [ -f "$SSH_KEY" ] || die "SSH key $SSH_KEY not found. Run '$0 keygen' then '$0 install-key' first."
+    [ -f "$SSH_KEY" ] || die "SSH key $SSH_KEY not found. Run '$0 keygen' then '$0 bootstrap' first."
     local port repo_root
     port="$(vm_ssh_port)"
     repo_root="$(git rev-parse --show-toplevel)"
@@ -427,11 +426,6 @@ EOF
     log "Bootstrap complete. Boot the VM with '$0 start'."
 }
 
-# Backwards-compatible alias (older docs/cmd).
-cmd_install_key() {
-    log "Note: 'install-key' is now a subset of 'bootstrap'. Running bootstrap..."
-    cmd_bootstrap "$@"
-}
 
 cmd_run() {
     if [ "${SYSKNIFE_ALLOW_DESTRUCTIVE:-}" = "1" ]; then
@@ -577,7 +571,6 @@ case "$cmd" in
     enable-ssh)     cmd_enable_ssh "$@" ;;
     keygen)         cmd_keygen "$@" ;;
     bootstrap)      cmd_bootstrap "$@" ;;
-    install-key)    cmd_install_key "$@" ;;
     start)          cmd_start "$@" ;;
     ssh)            cmd_ssh "$@" ;;
     sync)           cmd_sync "$@" ;;

--- a/tests/e2e/ubuntu-vm.sh
+++ b/tests/e2e/ubuntu-vm.sh
@@ -82,11 +82,6 @@ SEED="${VM_DIR}/seed.iso"
 PID_FILE="${VM_DIR}/vm.pid"
 CLOUD_INIT_DIR="${VM_DIR}/cloud-init"
 
-# ---------------------------------------------------------------------------
-# Legacy noble migration shim
-# ---------------------------------------------------------------------------
-# Prior to the multi-LTS refactor, noble used tests/e2e/ubuntu-vm/ with
-# different filenames (ubuntu-overlay.qcow2, ubuntu-vm.pid).  When running
 # Dedicated passphrase-less SSH key for the VM. Shared with atomic-vm.sh.
 SSH_KEY="${SYSKNIFE_VM_SSH_KEY:-$HOME/.ssh/sysknife-vm}"
 SSH_OPTIONS=(
@@ -107,36 +102,9 @@ _MIN_IMAGE_SIZE=314572800
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-#
-# Defined BEFORE the legacy-noble migration shim below so that calling `log`
-# at module-load time does not abort with `log: command not found` under
-# `set -euo pipefail`.
 
 log()  { printf '[ubuntu-vm:%s] %s\n' "$UBUNTU_RELEASE" "$*" >&2; }
 die()  { log "ERROR: $*"; exit 1; }
-
-# ---------------------------------------------------------------------------
-# Legacy-noble migration shim (now uses log/die above)
-# ---------------------------------------------------------------------------
-# When run as noble and the per-release directory does not yet exist but the
-# legacy path does, emit a one-time migration notice. The user must either:
-#   a) run 'download' to create a fresh noble overlay in the new location, or
-#   b) manually move the files:
-#        mv tests/e2e/ubuntu-vm/ubuntu-overlay.qcow2 tests/e2e/ubuntu-vm/noble/overlay.qcow2
-#        mv tests/e2e/ubuntu-vm/seed.iso             tests/e2e/ubuntu-vm/noble/seed.iso
-# Noble VMs provisioned before this change are unaffected until merge.
-if [ "$UBUNTU_RELEASE" = "noble" ] && [ ! -d "$VM_DIR" ]; then
-    _LEGACY_DIR="${REPO_ROOT}/tests/e2e/ubuntu-vm"
-    if [ -f "${_LEGACY_DIR}/ubuntu-overlay.qcow2" ]; then
-        log "MIGRATION NOTICE: Noble VM files found at legacy path ${_LEGACY_DIR}."
-        log "  New path: ${VM_DIR}/"
-        log "  To migrate, run:"
-        log "    mkdir -p '${VM_DIR}'"
-        log "    mv '${_LEGACY_DIR}/ubuntu-overlay.qcow2' '${VM_DIR}/overlay.qcow2'"
-        log "    mv '${_LEGACY_DIR}/seed.iso'             '${VM_DIR}/seed.iso'"
-        log "  Or run '$0 download' to create a fresh noble overlay."
-    fi
-fi
 
 require_tools() {
     local missing=()


### PR DESCRIPTION
Combined release PR for **v0.2.8**. All work on one branch per request.

## Fixes
- **CLI/MCP daemon socket resolution** (`apps/sysknife-cli/src/runner.rs`): now derives the socket from `sysknife-core::default_listen_uri()` — the same resolver the daemon (`daemon/src/main.rs`) and Tauri GUI already use — instead of a hardcoded production `/run/sysknife/daemon.sock`. Previously `sysknife doctor` and every CLI command (and the MCP server) couldn't reach a dev/non-systemd daemon until `SYSKNIFE_SOCKET` was set by hand. `$SYSKNIFE_SOCKET` still takes precedence as an explicit override (`unix://`, `vsock://`, or a bare path). Regression test rewritten (it previously *asserted* the buggy prod path). **Reported by Raúl Cárdenas.**

## Security
- Pin transitive `postcss` `>= 8.5.12` in `sysknife-shell` via npm `overrides` — resolves Dependabot alert #14 (high; arbitrary file read via attacker-controlled `sourceMappingURL`). Dependabot couldn't auto-fix it (transitive under vite).

## Backwards-compat removal
Project has never been deployed at scale → matched versions are an invariant, so compat cruft is gone:
- dead `fail2ban::InvalidIpAddress` type alias
- `--codex-only` setup-wizard flag alias
- `install-key` VM-script alias
- `ubuntu-vm.sh` "legacy noble" migration shim
- phantom `/tmp/sysknife-daemon.sock` path in the setup wizard

Documented `SYSKNIFE_SOCKET`; corrected stale socket-default docs (`$XDG_RUNTIME_DIR/...`, not `/tmp/sysknife-daemon.sock`).

**Kept deliberately** (not backwards-compat): the SQLite/Postgres schema-migration frameworks (forward DB infra + audit integrity; gutting them would break the postgres contract) and all security fail-safes.

## Internal simplification (no behavior change)
- `runner.rs`: de-duplicated risk ranking, extracted `finish_spinner`/`require_exists` helpers, merged an import.
- `preview.rs`: named constants for the repeated gate-vocabulary strings (`approval required`, `exact approval required`).

## Validation (local)
`cargo fmt --check` ✓ · `cargo clippy --all-targets` 0 warnings ✓ · `cargo nextest` **1362 pass** ✓ · frontend `vitest` **72 pass** ✓ · setup-contract **30 pass** ✓ · `check_release_versions.sh 0.2.8` ✓ · markdown-link-check ✓

Merge → tag `v0.2.8` → release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)