### PR TITLE
chore(release): v0.2.9 — deep review hardening, doc-drift sweep, local-CI runner

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Local CI gate for `git push` (keeps GitHub Actions idle on obvious breakage).
+# Runs the fast subset of scripts/ci-local.sh: rust fmt/clippy/nextest plus
+# frontend tsc/vitest. Bypass with: git push --no-verify
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+printf '[pre-push] scripts/ci-local.sh --fast\n'
+exec "${repo_root}/scripts/ci-local.sh" --fast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [0.2.9] — 2026-07-23
+
+### Security
+
+- Destructive user/group actions (`DeleteUser`, `LockUserAccount`,
+  `DeleteGroup`) now reject critical accounts and groups (`root`, `sudo`,
+  `wheel`, core system accounts, uid/gid 0) via a hard denylist, independent of
+  the approval gate.
+- The GRUB kernel-argument allowlist now blocks Ubuntu LSM / mitigation-disable
+  arguments (`apparmor=0`, `mitigations=off`, `lockdown=`, `pti=off`, `nosmap`,
+  `nosmep`) in addition to the SELinux ones.
+- The `snap install` and `fail2ban` action builders now validate their
+  arguments in the constructor (defense in depth), not only at the executor
+  boundary.
+- Five High-risk actions (`ConfigureFirewall`, `SetDnsServers`, `ConfigureWifi`,
+  `MaskService`, `CreateUser`) now render accurate lockout / interception /
+  privilege warnings and require exact-name approval, instead of a generic
+  "service interruption" preview.
+- A `config.toml` that is present but unparseable now fails loudly instead of
+  silently falling back to defaults (which would have dropped `[storage]` /
+  `[policy]` — a silent security downgrade).
+
+### Fixed
+
+- **`npx sysknife-setup`'s approval gate is no longer broken by default.** The
+  wizard-installed user daemon now binds the same socket the CLI resolves with
+  no environment set (`%t` → `$XDG_RUNTIME_DIR/sysknife/daemon.sock`), so
+  `sysknife approve` works in a fresh terminal without exporting anything.
+- The default LLM rate limiter no longer silently disables itself on a fresh
+  install (its state directory was never created, so writes failed open).
+- Preview `rollback_available` is now honest: six Debian-family actions
+  (`AddPpa`, `RemovePpa`, `NetplanSet`, `GrubSetKargs`, `ProAttach`,
+  `ProDetach`) no longer advertise an automatic rollback that never ran; a
+  workspace-wide invariant test enforces `rollback_available` ⇔ a real rollback
+  command exists.
+- Ubuntu derivatives (Linux Mint, Pop!\_OS, …) are now recognized via `ID_LIKE`,
+  so `apt` / `snap` / `ufw` actions route correctly instead of being rejected
+  as an unknown distribution.
+- SQLite transaction status updates are now atomic (compare-and-set), matching
+  the PostgreSQL backend.
+- UFW application profiles containing spaces (`Nginx Full`, `Apache Full`) are
+  now accepted.
+- The MCP server now applies the same distro-routing guard as the CLI, and LLM
+  provider errors are no longer misclassified (e.g. "generate" → "rate limit").
+
+### Added
+
+- `scripts/ci-local.sh` and a `.githooks/pre-push` hook that mirror the CI jobs
+  locally, so failures are caught before pushing (saving GitHub Actions
+  minutes). Documented in the developer guide, alongside `act` for full
+  Docker-based workflow replay.
+
+### Changed
+
+- Documentation drift corrections: socket / database defaults (`cli.md`,
+  `configuration.md`), the vsock token walkthrough, the Ubuntu action reference
+  (netplan mechanism and added actions), the Observer action count, ADR-0002's
+  provider count, and others. Hardened the invisible-Unicode sanitizer and the
+  provider error-message redactor.
+
 ## [0.2.8] — 2026-07-23
 
 ### Security
@@ -142,6 +202,7 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   (non-repudiable, third-party verifiable), with signed checkpoints guarding
   against truncation.
 
+[0.2.9]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.9
 [0.2.8]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.8
 [0.2.7]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.7
 [0.2.6]: https://github.com/lacs-project/sysknife/releases/tag/v0.2.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ These are where contributions move the needle the most. Each links to a
 
 | Area | Why it matters | Difficulty |
 |---|---|---|
-| **Ubuntu LTS support** ([tracker](https://github.com/lacs-project/sysknife/issues?q=is%3Aopen+label%3Aubuntu)) | Ubuntu 22.04 (jammy), 24.04 (noble), and 26.04 (resolute) are all validated with the multi-LTS VM tooling. `ubuntu-vm.sh` accepts `UBUNTU_RELEASE=jammy\|noble\|resolute`. Remaining: E2E exec stories, additional apt / snap / ufw actions. | Medium |
+| **Ubuntu LTS support** ([tracker](https://github.com/lacs-project/sysknife/issues?q=is%3Aopen+label%3Aubuntu)) | Ubuntu 24.04 (noble) is validated with the full story suite; 22.04 (jammy) and 26.04 (resolute) are smoke-tested with the same multi-LTS VM tooling but not yet run against the full suite. `ubuntu-vm.sh` accepts `UBUNTU_RELEASE=jammy\|noble\|resolute`. Remaining: E2E exec stories, additional apt / snap / ufw actions. | Medium |
 | **Distro detection coverage** ([tracker](https://github.com/lacs-project/sysknife/issues?q=is%3Aopen+label%3Adistro-detection)) | Robust `/etc/os-release` parsing for every LTS we claim to support. Pure-function tests, no integration mocks. | Easy |
 | **Action catalogue gaps** | Add a typed action (e.g. `EnableFirewallZone`) — small, isolated, every PR includes the policy entry + risk level + tests. | Easy |
 | **E2E story coverage** | Real prompts, real LLM, real daemon. We have ~10 stories; we want 100+ across both distros. | Medium |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "prost",
  "prost-build",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "prost",
  "serde",

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,348 Rust tests and 72 frontend tests** form the current deterministic
+**1,403 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -128,7 +128,7 @@ Tracked in the v0.4.0 milestone.
 - ~~`sysknife_plan` / `sysknife_execute` MCP tools~~ — done; stdio
   transport via `rmcp`; returns typed plan JSON with resolved commands;
   execution gated on daemon-issued one-time approval receipts
-- extend MCP server with direct read-only tools — expose all ~25 Observer-level
+- extend MCP server with direct read-only tools — expose all ~59 Observer-level
   actions (`get_disk_usage`, `list_services`, `get_authorized_keys`, …) as
   individual MCP tools so Claude Desktop can read live system state in-context;
   mutating actions remain plan-only to preserve the approval gate

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,11 +15,11 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.8" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.2.8" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.2.8" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.9" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.2.9" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.2.9" }
 chrono = "0.4"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.2.8" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.2.9" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -467,7 +467,31 @@ async fn plan_intent_inner(intent: &str) -> Result<serde_json::Value, String> {
         .await
         .map_err(|e| format!("planning error: {e}"))?;
 
+    // Mirror the CLI's distro-routing guard (`runner::run_intent`) so MCP
+    // clients get a clear distro-mismatch message (e.g. "AptInstall is only
+    // valid on Debian-family distros") instead of a raw daemon error
+    // surfacing later out of `enrich_with_commands`/`preview`. The daemon
+    // remains the enforcement backstop regardless of this check.
+    check_plan_steps_distro(
+        plan.steps().iter().map(|s| s.action_name()),
+        distro.as_ref(),
+    )?;
+
     serde_json::to_value(&plan).map_err(|e| format!("serialization error: {e}"))
+}
+
+/// Validate every plan step's action name against the detected distro,
+/// reusing [`crate::distro_routing::check_action_distro`]. Extracted as a
+/// small pure function (taking action-name strings rather than a full
+/// `Plan`) so it can be unit-tested without constructing planner internals.
+fn check_plan_steps_distro<'a>(
+    action_names: impl Iterator<Item = &'a str>,
+    distro: Option<&sysknife_core::distro::DistroId>,
+) -> Result<(), String> {
+    for action_name in action_names {
+        crate::distro_routing::check_action_distro(action_name, distro)?;
+    }
+    Ok(())
 }
 
 /// Resolve and persist every step against the daemon. Planning fails closed if
@@ -905,6 +929,50 @@ pub async fn run_mcp_server() -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // check_plan_steps_distro — MCP planning-path distro guard
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn check_plan_steps_distro_rejects_mismatched_action() {
+        let distro = sysknife_core::distro::DistroId::Fedora { version: 41 };
+        let result = check_plan_steps_distro(["AptInstall"].into_iter(), Some(&distro));
+        assert!(
+            result.is_err(),
+            "AptInstall on Fedora must be rejected by the MCP planning path too"
+        );
+        assert!(result.unwrap_err().contains("Debian-family"));
+    }
+
+    #[test]
+    fn check_plan_steps_distro_allows_generic_action() {
+        let distro = sysknife_core::distro::DistroId::Fedora { version: 41 };
+        let result = check_plan_steps_distro(["GetSystemState"].into_iter(), Some(&distro));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn check_plan_steps_distro_allows_all_when_distro_unknown() {
+        // Detection failure (None) must never block planning -- the daemon
+        // is the enforcement backstop in that case.
+        let result = check_plan_steps_distro(["AptInstall", "RebaseSystem"].into_iter(), None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn check_plan_steps_distro_stops_at_first_mismatched_step() {
+        let distro = sysknife_core::distro::DistroId::Ubuntu {
+            major: 24,
+            minor: 4,
+        };
+        let result = check_plan_steps_distro(
+            ["GetSystemState", "RebaseSystem", "AptInstall"].into_iter(),
+            Some(&distro),
+        );
+        assert!(result.is_err(), "RebaseSystem on Ubuntu must be rejected");
+        assert!(result.unwrap_err().contains("Fedora-family"));
+    }
 
     #[tokio::test]
     async fn enrich_with_commands_fails_closed_when_daemon_unreachable() {

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "@vitest/coverage-v8": "^4.1.4",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.2.8" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.2.8" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.2.9" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.2.9" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -12,8 +12,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.2.8" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.8" }
+sysknife-core = { path = "../sysknife-core", version = "0.2.9" }
+sysknife-types = { path = "../sysknife-types", version = "0.2.9" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-brain/src/audit.rs
+++ b/crates/sysknife-brain/src/audit.rs
@@ -105,6 +105,16 @@ impl SafetyAuditLog {
             .join("safety-audit.jsonl")
     }
 
+    /// Async wrapper for [`Self::log_rejection`] that runs the file write on
+    /// the blocking pool. Call from `async fn` paths so the planner's reactor
+    /// is not parked on a slow filesystem (NFS, encrypted home).
+    pub async fn log_rejection_async(self, intent: String, reason: String, raw_plan: String) {
+        let _ = tokio::task::spawn_blocking(move || {
+            self.log_rejection(&intent, &reason, &raw_plan);
+        })
+        .await;
+    }
+
     /// Append a rejection entry to the log file and forward to journald.
     ///
     /// Creates parent directories if they do not exist. Errors are logged to
@@ -115,16 +125,6 @@ impl SafetyAuditLog {
     /// (CI, non-systemd hosts) the call is a no-op. On systemd systems the
     /// entry is protected by Forward Secure Sealing once FSS is enabled
     /// (`journalctl --setup-keys`), providing tamper-evident audit records.
-    /// Async wrapper for `log_rejection` that runs the file write on the
-    /// blocking pool. Call from `async fn` paths so the planner's reactor is
-    /// not parked on a slow filesystem (NFS, encrypted home).
-    pub async fn log_rejection_async(self, intent: String, reason: String, raw_plan: String) {
-        let _ = tokio::task::spawn_blocking(move || {
-            self.log_rejection(&intent, &reason, &raw_plan);
-        })
-        .await;
-    }
-
     pub fn log_rejection(&self, intent: &str, reason: &str, raw_plan: &str) {
         let timestamp = format_rfc3339(SystemTime::now());
         let entry = AuditEntry {

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -27,10 +27,7 @@
 //!
 //! Examples C, D, E, and F were added after this measurement. No re-measurement has been
 //! recorded for the current A+B+C+D+E+F configuration, but the requirement to keep
-//! all six examples is unchanged.
-//!
-//! Example A ("check disk usage") was removed — it is a strict subset of the
-//! general rule stated in prose and adds no coverage beyond Example B.
+//! all six examples — A through F, all present below — is unchanged.
 //!
 //! The examples encode the core planning rule:
 //!

--- a/crates/sysknife-brain/src/providers/mod.rs
+++ b/crates/sysknife-brain/src/providers/mod.rs
@@ -26,12 +26,27 @@ pub(super) fn classify_status(status: http::StatusCode) -> StatusClass {
     }
 }
 
-/// Redact common key-bearing query parameters from error messages to prevent
-/// API key leakage in logs. Handles both first-position (`?key=`, `?api_key=`)
-/// and subsequent-position (`&key=`, `&api_key=`) query params, and redacts
-/// all occurrences in the string (not just the first).
+/// Redact credential-bearing substrings from error messages before they are
+/// logged or propagated to a caller, to prevent API key leakage.
+///
+/// Handles, at every occurrence in the string (not just the first):
+/// - **URL query params**: `?key=`, `?api_key=`, and their `&`-joined
+///   continuations (`&key=`, `&api_key=`).
+/// - **HTTP-header-shaped credential carriers** that a provider SDK or an
+///   intermediate proxy sometimes echoes verbatim into error text:
+///   `Bearer <token>` (case-insensitive on the keyword) and
+///   `x-api-key<sep><token>` (case-insensitive on the header name; `<sep>`
+///   is `:`, `=`, or whitespace).
+///
+/// This is defense in depth, not a guarantee — it cannot catch every
+/// possible key-leaking shape an SDK might produce.
 pub(super) fn sanitize_error_msg(msg: &str) -> String {
     const KEY_PARAMS: &[&str] = &["?key=", "?api_key=", "&key=", "&api_key="];
+    // Header-shaped credential carriers. Unlike KEY_PARAMS (where the whole
+    // `key=<value>` segment is redacted), only the value after the keyword is
+    // redacted here, keeping the keyword itself visible as context for readers
+    // of the sanitized message.
+    const HEADER_KEYWORDS: &[&str] = &["bearer ", "x-api-key"];
 
     let lower = msg.to_lowercase();
     let mut ranges: Vec<std::ops::Range<usize>> = Vec::new();
@@ -47,6 +62,28 @@ pub(super) fn sanitize_error_msg(msg: &str) -> String {
                 .unwrap_or(msg.len());
             ranges.push(param_start..end);
             search_from = start + pattern.len();
+        }
+    }
+
+    for keyword in HEADER_KEYWORDS {
+        let mut search_from = 0;
+        while let Some(rel) = lower[search_from..].find(keyword) {
+            let start = search_from + rel;
+            let after_keyword = start + keyword.len();
+            // Skip separator characters between the keyword and the value,
+            // e.g. "Bearer  <token>", "x-api-key: <token>", "x-api-key=<token>".
+            let value_start = lower[after_keyword..]
+                .find(|c: char| !(c.is_whitespace() || c == ':' || c == '='))
+                .map(|s| after_keyword + s)
+                .unwrap_or(msg.len());
+            let value_end = lower[value_start..]
+                .find(|c: char| c.is_whitespace())
+                .map(|s| value_start + s)
+                .unwrap_or(msg.len());
+            if value_start < value_end {
+                ranges.push(value_start..value_end);
+            }
+            search_from = start + keyword.len();
         }
     }
 
@@ -121,5 +158,46 @@ mod tests {
             result,
             "first: https://api1.com?[REDACTED] second: https://api2.com?[REDACTED]"
         );
+    }
+
+    #[test]
+    fn sanitize_error_msg_strips_bearer_token() {
+        let input = "request failed: Authorization: Bearer sk-secret123 was rejected";
+        let result = sanitize_error_msg(input);
+        assert_eq!(
+            result,
+            "request failed: Authorization: Bearer [REDACTED] was rejected"
+        );
+    }
+
+    #[test]
+    fn sanitize_error_msg_bearer_is_case_insensitive() {
+        let input = "BEARER sk-secret123 rejected";
+        let result = sanitize_error_msg(input);
+        assert_eq!(result, "BEARER [REDACTED] rejected");
+    }
+
+    #[test]
+    fn sanitize_error_msg_strips_x_api_key_header() {
+        let input = "error calling endpoint with header x-api-key: sk-secret123 abc";
+        let result = sanitize_error_msg(input);
+        assert_eq!(
+            result,
+            "error calling endpoint with header x-api-key: [REDACTED] abc"
+        );
+    }
+
+    #[test]
+    fn sanitize_error_msg_strips_x_api_key_header_with_equals_separator() {
+        let input = "GET /v1?x-api-key=sk-secret123 failed";
+        let result = sanitize_error_msg(input);
+        assert_eq!(result, "GET /v1?x-api-key=[REDACTED] failed");
+    }
+
+    #[test]
+    fn sanitize_error_msg_no_bearer_or_api_key_unchanged() {
+        let input = "connection refused: https://api.example.com/v1";
+        let result = sanitize_error_msg(input);
+        assert_eq!(result, input);
     }
 }

--- a/crates/sysknife-brain/src/providers/rig_adapter.rs
+++ b/crates/sysknife-brain/src/providers/rig_adapter.rs
@@ -407,9 +407,19 @@ fn map_rig_error(err: rig::completion::CompletionError) -> ProviderError {
     // This fallback is inherently fragile — a Rig version bump could change
     // the wording and break our categorisation — but there is no structured
     // alternative in that case.
-    if msg.contains("401") || msg.to_lowercase().contains("auth") {
+    //
+    // Match whole phrases, not bare substrings: `"auth"` false-positives on
+    // "author"/"authorize", and `"rate"` false-positives on
+    // "generate"/"moderate" — e.g. "failed to generate response" would be
+    // misclassified as a rate-limit error. Mirrors `openai_adapter`'s
+    // substring-fallback phrasing.
+    let lower = msg.to_lowercase();
+    if msg.contains("401") || lower.contains("authentication") {
         ProviderError::Auth(AUTH_FAILURE_MSG.to_string())
-    } else if msg.contains("429") || msg.to_lowercase().contains("rate") {
+    } else if msg.contains("429")
+        || lower.contains("too many requests")
+        || lower.contains("rate limit")
+    {
         ProviderError::RateLimit(msg)
     } else {
         ProviderError::Request(msg)
@@ -621,7 +631,7 @@ mod tests {
     /// exercise the guard by verifying the error message on a response that
     /// contains only empty text (which is also filtered out).
     #[test]
-    fn from_rig_response_empty_text_only_returns_ok_empty() {
+    fn from_rig_response_empty_text_only_returns_parse_error() {
         // An empty text block is filtered, producing empty content.
         // The OneOrMany is non-empty, so the guard should fire.
         let choice = OneOrMany::one(AssistantContent::Text(Text {
@@ -727,6 +737,26 @@ mod tests {
         assert!(
             matches!(mapped, ProviderError::Auth(_)),
             "expected Auth via substring fallback, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_rig_error_does_not_misclassify_generate_as_rate_limit() {
+        // Regression: the old substring check `contains("rate")` also matches
+        // inside "generate", so an unrelated generation failure was wrongly
+        // reported as a rate limit. Same class of bug as `"auth"` matching
+        // inside "author".
+        let err =
+            rig::completion::CompletionError::ProviderError("failed to generate response".into());
+        assert_eq!(
+            err.provider_response_status(),
+            None,
+            "sanity check: this variant must carry no structured status"
+        );
+        let mapped = map_rig_error(err);
+        assert!(
+            matches!(mapped, ProviderError::Request(_)),
+            "expected Request (not RateLimit), got {mapped:?}"
         );
     }
 }

--- a/crates/sysknife-brain/src/rate_limit.rs
+++ b/crates/sysknife-brain/src/rate_limit.rs
@@ -72,6 +72,25 @@ impl RateLimiter {
     /// Panics if `max_per_minute` is zero.
     pub fn new(path: PathBuf, max_per_minute: usize) -> Self {
         assert!(max_per_minute >= 1, "max_per_minute must be at least 1");
+        // Create the parent directory up front, mirroring `prefs.rs::append_pref`
+        // and `audit.rs::append_entry`. Without this, the default path
+        // `$XDG_DATA_HOME/sysknife/rate-limit.log` never has its parent
+        // directory created on a fresh install: the first `check_and_consume`
+        // write fails, is logged as a warning, and fails OPEN (see module docs)
+        // -- meaning the rate limiter is silently disabled forever, not just for
+        // one call. Creating the directory here (best-effort; a failure here is
+        // still recoverable by the existing fail-open write-error path) closes
+        // that gap for the common case.
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                eprintln!(
+                    "[sysknife-brain] rate-limit: failed to create parent directory {}: {e} \
+                     -- persistence will keep failing (and the limiter will fail open) \
+                     until the directory exists",
+                    parent.display()
+                );
+            }
+        }
         let effective = std::env::var("SYSKNIFE_MAX_RPM")
             .ok()
             .and_then(|v| v.trim().parse::<usize>().ok())
@@ -347,5 +366,39 @@ mod tests {
     fn zero_max_per_minute_panics() {
         let dir = tempfile::tempdir().unwrap();
         RateLimiter::new(dir.path().join("rl.txt"), 0);
+    }
+
+    #[test]
+    fn new_creates_missing_parent_directory_and_timestamps_persist() {
+        // Simulates a fresh $XDG_DATA_HOME/sysknife/ that has never been
+        // written to: the nested directory does not exist before `new()`.
+        let dir = tempfile::tempdir().unwrap();
+        let nested_parent = dir.path().join("xdg-data").join("sysknife");
+        assert!(
+            !nested_parent.exists(),
+            "sanity check: parent must not pre-exist"
+        );
+        let path = nested_parent.join("rate-limit.log");
+
+        let rl = RateLimiter::new(path.clone(), 2);
+        assert!(
+            nested_parent.exists(),
+            "RateLimiter::new must create the missing parent directory"
+        );
+
+        // Two calls succeed (limit=2); a third must be rejected -- this only
+        // happens if the timestamp file was actually persisted across calls,
+        // proving the directory-creation fix unblocked real persistence
+        // rather than just avoiding a panic.
+        assert!(rl.check_and_consume().is_ok(), "call 1 within limit-2");
+        assert!(rl.check_and_consume().is_ok(), "call 2 within limit-2");
+        assert!(
+            rl.check_and_consume().is_err(),
+            "call 3 must exceed limit-2, proving timestamps persisted across calls"
+        );
+        assert!(
+            path.exists(),
+            "rate-limit.log must exist on disk after successful persists"
+        );
     }
 }

--- a/crates/sysknife-brain/src/sanitize.rs
+++ b/crates/sysknife-brain/src/sanitize.rs
@@ -271,6 +271,13 @@ fn next_char_boundary(s: &str, i: usize) -> usize {
 /// - **Bidirectional and zero-width formatting** controls
 ///   (`U+200B..=U+200F`, `U+202A..=U+202E`, `U+2066..=U+2069`, `U+FEFF`) —
 ///   used to swap rendered direction or hide text from a reviewer.
+/// - **Additional invisible/format characters** — `U+00AD` (soft hyphen),
+///   `U+034F` (combining grapheme joiner), `U+180E` (Mongolian vowel
+///   separator), and `U+2060..=U+2064` (word joiner plus the invisible math
+///   operators: function application, invisible times/separator/plus). Each
+///   renders as nothing (or as a no-op line-break hint) in normal fonts, so
+///   they are usable to split a keyword ("IGN\u{00AD}ORE") without any
+///   visible change to the text a reviewer sees.
 /// - **C0/C1 control codes** other than `\t`, `\n`, `\r`.
 fn strip_dangerous_unicode(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
@@ -282,8 +289,15 @@ fn strip_dangerous_unicode(s: &str) -> String {
             0x00..=0x08 | 0x0B | 0x0C | 0x0E..=0x1F |
             // C1 controls
             0x7F..=0x9F |
+            // Soft hyphen, combining grapheme joiner, Mongolian vowel
+            // separator — invisible-in-rendering keyword-splitting carriers.
+            0x00AD | 0x034F | 0x180E |
             // Bidi + zero-width formatting
             0x200B..=0x200F | 0x202A..=0x202E | 0x2066..=0x2069 | 0xFEFF |
+            // Word joiner + invisible math operators (function application,
+            // invisible times/separator/plus) — zero-width keyword-splitting
+            // carriers, same threat class as the bidi/zero-width block above.
+            0x2060..=0x2064 |
             // Tag block (the headline injection vector)
             0xE0000..=0xE007F |
             // Private Use Area
@@ -459,6 +473,18 @@ mod tests {
         let raw = "IGN\u{200B}ORE\u{200C}IN\u{FEFF}STRUCTIONS";
         let normalised = normalise_free_text(raw);
         assert_eq!(normalised, "IGNOREINSTRUCTIONS");
+    }
+
+    #[test]
+    fn additional_invisible_format_chars_are_stripped() {
+        // U+00AD soft hyphen, U+034F combining grapheme joiner, U+180E
+        // Mongolian vowel separator, U+2060 word joiner, U+2061 function
+        // application, U+2062 invisible times, U+2063 invisible separator,
+        // U+2064 invisible plus — all invisible-in-rendering carriers that
+        // can split a keyword without any visible change.
+        let raw = "IGN\u{00AD}ORE\u{034F}PRI\u{180E}OR\u{2060}IN\u{2061}STR\u{2062}UC\u{2063}TI\u{2064}ONS";
+        let normalised = normalise_free_text(raw);
+        assert_eq!(normalised, "IGNOREPRIORINSTRUCTIONS");
     }
 
     #[test]

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-core/src/config.rs
+++ b/crates/sysknife-core/src/config.rs
@@ -271,28 +271,47 @@ impl LacsConfig {
 
     /// Load `~/.config/sysknife/config.toml`.
     ///
-    /// Returns `LacsConfig::default()` (all `None`) if the file is absent.
-    /// Falls back to defaults on parse error (with a warning). I/O errors
-    /// other than `NotFound` (e.g. permission denied) are also warned so the
-    /// user knows their config file exists but could not be read.
+    /// Returns `LacsConfig::default()` (all `None`) if the file is absent —
+    /// this is the normal, unconfigured happy path and is unchanged.
+    ///
+    /// If the file IS present but cannot be parsed as TOML, or exists but
+    /// cannot be read (e.g. permission denied), this is treated as a fatal
+    /// misconfiguration rather than silently falling back to defaults: a clear
+    /// message is printed to stderr and the process exits with status 1.
+    /// Silently defaulting in that case would drop `[storage]` / `[policy]`
+    /// overrides (backend selection, risk-level overrides) without any
+    /// indication to the operator — a silent security downgrade. See
+    /// `try_load` for the non-exiting core used by tests.
     pub fn load() -> Self {
         let path = config_path();
-        match std::fs::read_to_string(&path) {
-            Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
-                eprintln!(
-                    "[sysknife] warning: could not parse {}: {e}; using defaults",
+        Self::try_load(&path).unwrap_or_else(|reason| {
+            eprintln!("[sysknife] FATAL: {reason}");
+            std::process::exit(1);
+        })
+    }
+
+    /// Core of [`Self::load`], factored out so the parse-error / read-error
+    /// paths can be exercised in tests without triggering `process::exit`.
+    ///
+    /// Returns `Ok(Self::default())` when `path` does not exist. Returns
+    /// `Err` for any other failure (present-but-unparseable, or a read
+    /// error) — see [`Self::load`] for why this must never silently
+    /// default instead.
+    fn try_load(path: &std::path::Path) -> Result<Self, String> {
+        match std::fs::read_to_string(path) {
+            Ok(content) => toml::from_str(&content).map_err(|e| {
+                format!(
+                    "config file {} is present but could not be parsed as TOML: {e}; \
+                     refusing to silently fall back to defaults",
                     path.display()
-                );
-                Self::default()
+                )
             }),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Self::default(),
-            Err(e) => {
-                eprintln!(
-                    "[sysknife] warning: could not read {}: {e}; using defaults",
-                    path.display()
-                );
-                Self::default()
-            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(format!(
+                "config file {} exists but could not be read: {e}; refusing to \
+                 silently fall back to defaults",
+                path.display()
+            )),
         }
     }
 
@@ -506,6 +525,39 @@ mod tests {
         }
         assert!(cfg.daemon.is_none());
         assert!(cfg.llm.is_none());
+    }
+
+    #[test]
+    fn try_load_returns_default_when_file_absent() {
+        // No env-var mutation needed: try_load takes the path directly.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist").join("config.toml");
+        let cfg = LacsConfig::try_load(&path).expect("absent file must be Ok(default)");
+        assert!(cfg.daemon.is_none());
+        assert!(cfg.llm.is_none());
+        assert!(cfg.storage.is_none());
+        assert!(cfg.policy.is_none());
+    }
+
+    #[test]
+    fn try_load_fails_loud_on_present_but_unparseable_file() {
+        // A present-but-broken config file must error, not silently fall
+        // back to defaults (which would drop [storage]/[policy] overrides
+        // without any indication to the operator).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "this is [ not valid toml at all").unwrap();
+
+        let result = LacsConfig::try_load(&path);
+        assert!(
+            result.is_err(),
+            "a present-but-unparseable config file must error, not silently default"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("could not be parsed"),
+            "error should explain the parse failure; got: {err}"
+        );
     }
 
     #[test]

--- a/crates/sysknife-core/src/distro.rs
+++ b/crates/sysknife-core/src/distro.rs
@@ -130,6 +130,10 @@ pub enum DistroId {
     Other {
         id: String,
         version_id: Option<String>,
+        /// `ID_LIKE` tokens, carried through so [`DistroId::family`] can
+        /// make a best-effort derivative-family guess (see that method's
+        /// doc comment). Empty when `ID_LIKE` was absent.
+        id_like: Vec<String>,
     },
 }
 
@@ -153,10 +157,12 @@ impl std::fmt::Display for DistroId {
             Self::Other {
                 id,
                 version_id: Some(v),
+                ..
             } => write!(f, "{id} {v}"),
             Self::Other {
                 id,
                 version_id: None,
+                ..
             } => write!(f, "{id}"),
         }
     }
@@ -164,16 +170,33 @@ impl std::fmt::Display for DistroId {
 
 impl DistroId {
     /// Returns the broad family this distro belongs to.
+    ///
+    /// # `ID_LIKE` fallback for unrecognised derivatives
+    ///
+    /// When `self` is `Other` (the running distro's `ID` did not match any
+    /// distro this crate detects directly — e.g. Linux Mint `ID=linuxmint`,
+    /// Pop!_OS `ID=pop`), this consults `ID_LIKE` before giving up: if it
+    /// contains `"debian"` or `"ubuntu"` the distro routes as
+    /// [`DistroFamily::Debian`]; if it contains `"fedora"` or `"rhel"` it
+    /// routes as [`DistroFamily::Fedora`]. This is **best-effort derivative
+    /// support, not full compatibility validation** — `ID_LIKE` is a hint
+    /// the distro maintainer supplies in `/etc/os-release` (see
+    /// os-release(5)), not a guarantee the derivative's package manager,
+    /// repositories, or service names are wire-compatible with the parent.
+    /// Actions may still fail at execution time on a derivative that
+    /// diverges from its stated parent.
     pub fn family(&self) -> DistroFamily {
         match self {
             Self::Fedora { .. } | Self::FedoraSilverblue { .. } => DistroFamily::Fedora,
             Self::Ubuntu { .. } | Self::UbuntuCore { .. } | Self::Debian { .. } => {
                 DistroFamily::Debian
             }
-            Self::Other { id, .. } => {
-                // Use id_like information is not available here, but we can
-                // make a best-effort guess from the id string.
+            Self::Other { id, id_like, .. } => {
                 if id.contains("fedora") {
+                    DistroFamily::Fedora
+                } else if id_like.iter().any(|p| p == "debian" || p == "ubuntu") {
+                    DistroFamily::Debian
+                } else if id_like.iter().any(|p| p == "fedora" || p == "rhel") {
                     DistroFamily::Fedora
                 } else {
                     DistroFamily::Other
@@ -347,6 +370,7 @@ pub fn detect_distro(release: &OsRelease) -> DistroId {
         _ => DistroId::Other {
             id: release.id.clone(),
             version_id: release.version_id.clone(),
+            id_like: release.id_like.clone(),
         },
     }
 }
@@ -368,6 +392,7 @@ fn detect_fedora(release: &OsRelease) -> DistroId {
         None => DistroId::Other {
             id: release.id.clone(),
             version_id: release.version_id.clone(),
+            id_like: release.id_like.clone(),
         },
     }
 }
@@ -384,6 +409,7 @@ fn detect_ubuntu(release: &OsRelease) -> DistroId {
         None => DistroId::Other {
             id: release.id.clone(),
             version_id: release.version_id.clone(),
+            id_like: release.id_like.clone(),
         },
     }
 }
@@ -909,9 +935,15 @@ SUPPORT_END="2028-03-15"
     fn detect_mint_falls_through_to_other() {
         let r = parse_os_release(LINUX_MINT_22).unwrap();
         assert!(matches!(detect_distro(&r), DistroId::Other { .. }));
-        if let DistroId::Other { id, version_id } = detect_distro(&r) {
+        if let DistroId::Other {
+            id,
+            version_id,
+            id_like,
+        } = detect_distro(&r)
+        {
             assert_eq!(id, "linuxmint");
             assert_eq!(version_id.as_deref(), Some("22"));
+            assert_eq!(id_like, vec!["ubuntu", "debian"]);
         }
     }
 
@@ -1018,6 +1050,7 @@ SUPPORT_END="2028-03-15"
         assert!(!DistroId::Other {
             id: "arch".to_string(),
             version_id: None,
+            id_like: Vec::new(),
         }
         .is_supported());
     }
@@ -1074,6 +1107,63 @@ SUPPORT_END="2028-03-15"
         assert_eq!(
             DistroId::Debian { version: Some(12) }.family(),
             DistroFamily::Debian
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // ID_LIKE family fallback for unrecognised derivatives
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn linux_mint_family_falls_back_to_debian_via_id_like() {
+        let r = parse_os_release(LINUX_MINT_22).unwrap();
+        let distro = detect_distro(&r);
+        assert!(
+            matches!(distro, DistroId::Other { .. }),
+            "detect_distro must still classify Mint as Other -- only family() changes"
+        );
+        assert_eq!(
+            distro.family(),
+            DistroFamily::Debian,
+            "Linux Mint (ID_LIKE=\"ubuntu debian\") must route to the Debian family"
+        );
+    }
+
+    #[test]
+    fn pop_os_family_falls_back_to_debian_via_id_like() {
+        let r = parse_os_release(POP_OS_2204).unwrap();
+        let distro = detect_distro(&r);
+        assert!(matches!(distro, DistroId::Other { .. }));
+        assert_eq!(
+            distro.family(),
+            DistroFamily::Debian,
+            "Pop!_OS (ID_LIKE=\"ubuntu debian\") must route to the Debian family"
+        );
+    }
+
+    #[test]
+    fn amazon_linux_family_falls_back_to_fedora_via_id_like() {
+        let r = parse_os_release(AMAZON_LINUX_2023).unwrap();
+        let distro = detect_distro(&r);
+        assert!(matches!(distro, DistroId::Other { .. }));
+        assert_eq!(
+            distro.family(),
+            DistroFamily::Fedora,
+            "Amazon Linux (ID_LIKE=\"fedora\") must route to the Fedora family"
+        );
+    }
+
+    #[test]
+    fn unknown_id_with_empty_id_like_stays_other() {
+        let distro = DistroId::Other {
+            id: "slackware".to_string(),
+            version_id: None,
+            id_like: Vec::new(),
+        };
+        assert_eq!(
+            distro.family(),
+            DistroFamily::Other,
+            "an unrecognised distro with no ID_LIKE hint must stay Other"
         );
     }
 

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.8"
+version = "0.2.9"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.2.8" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.2.9" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -11,8 +11,8 @@ keywords = ["linux", "sysadmin", "daemon", "security"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.2.8" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.8" }
+sysknife-core = { path = "../sysknife-core", version = "0.2.9" }
+sysknife-types = { path = "../sysknife-types", version = "0.2.9" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -53,7 +53,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.2.8" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.2.9" }
 serde_json = { workspace = true }
 syslog_loose = "0.23"
 tempfile = "3"

--- a/crates/sysknife-daemon/src/actions/fail2ban.rs
+++ b/crates/sysknife-daemon/src/actions/fail2ban.rs
@@ -16,6 +16,16 @@
 //! `std::net::IpAddr::from_str` before constructing the `ActionSpec`. An
 //! invalid address returns `Err(InvalidIpAddress)` immediately so a bad value
 //! cannot reach the daemon.
+//!
+//! ## Jail/name validation
+//!
+//! Every constructor that takes a jail name or drop-in name (`fail2ban_status`,
+//! `fail2ban_ban_ip`, `fail2ban_unban_ip`, `configure_fail2ban_jail`) validates
+//! it in-constructor via `jail_is_valid` before building the `ActionSpec`. This
+//! is defense in depth: the executor also validates (`validated_safe_arg` /
+//! `validated_sudoers_name`), but a future internal Rust caller that bypassed
+//! the executor could not otherwise be blocked from injecting through the
+//! interpolated `fail2ban-client`/helper argv.
 
 use std::net::IpAddr;
 use std::str::FromStr;
@@ -75,10 +85,11 @@ const JAIL_HELPER: &str = "/usr/lib/sysknife/fail2ban-jail-edit";
 /// Return one representative `ActionSpec` per fail2ban action name.
 pub fn specs() -> Vec<ActionSpec> {
     vec![
-        fail2ban_status(None),
+        fail2ban_status(None).expect("no jail filter in specs()"),
         fail2ban_ban_ip("sshd", "192.0.2.1").expect("valid IP in specs()"),
         fail2ban_unban_ip("sshd", "192.0.2.1").expect("valid IP in specs()"),
-        configure_fail2ban_jail("sshd", &["--maxretry".to_string(), "3".to_string()]),
+        configure_fail2ban_jail("sshd", &["--maxretry".to_string(), "3".to_string()])
+            .expect("sshd is a valid jail name in specs()"),
     ]
 }
 
@@ -91,18 +102,26 @@ pub fn specs() -> Vec<ActionSpec> {
 /// Risk: Low. Read-only; shows active jails, banned IPs, and hit counts.
 /// When `jail` is `None` the global status (list of all jails) is returned.
 /// When `jail` is `Some(name)` the detailed status for that jail is returned.
-pub fn fail2ban_status(jail: Option<&str>) -> ActionSpec {
+///
+/// Returns `Err(InvalidJail)` when `jail` is `Some` and fails `jail_is_valid`
+/// (in-constructor defense in depth — see the module doc).
+pub fn fail2ban_status(jail: Option<&str>) -> Result<ActionSpec, Fail2banError> {
     let args: Vec<&str> = match jail {
-        Some(j) => vec!["fail2ban-client", "status", j],
+        Some(j) => {
+            if !jail_is_valid(j) {
+                return Err(Fail2banError::InvalidJail(j.to_string()));
+            }
+            vec!["fail2ban-client", "status", j]
+        }
         None => vec!["fail2ban-client", "status"],
     };
-    ActionSpec {
+    Ok(ActionSpec {
         action_name: "Fail2banStatus",
         mechanism: command_mechanism("sudo", args),
         risk_level: RiskLevel::Low,
         reboot_required: false,
         rollback_available: false,
-    }
+    })
 }
 
 /// Ban an IP address in a fail2ban jail
@@ -158,20 +177,26 @@ pub fn fail2ban_unban_ip(jail: &str, ip: &str) -> Result<ActionSpec, Fail2banErr
 ///
 /// Risk: High — tuning a jail changes who gets banned (too strict → locks out
 /// legitimate users; too loose → weakens brute-force protection).
-pub fn configure_fail2ban_jail(name: &str, extra: &[String]) -> ActionSpec {
+///
+/// Returns `Err(InvalidJail)` when `name` fails `jail_is_valid` (in-constructor
+/// defense in depth — see the module doc).
+pub fn configure_fail2ban_jail(name: &str, extra: &[String]) -> Result<ActionSpec, Fail2banError> {
+    if !jail_is_valid(name) {
+        return Err(Fail2banError::InvalidJail(name.to_string()));
+    }
     let mut args = vec![
         JAIL_HELPER.to_string(),
         "--name".to_string(),
         name.to_string(),
     ];
     args.extend(extra.iter().cloned());
-    ActionSpec {
+    Ok(ActionSpec {
         action_name: "ConfigureFail2banJail",
         mechanism: command_mechanism("sudo", args),
         risk_level: RiskLevel::High,
         reboot_required: false,
         rollback_available: false,
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -194,17 +219,17 @@ mod tests {
 
     #[test]
     fn fail2ban_status_action_name() {
-        assert_eq!(fail2ban_status(None).action_name, "Fail2banStatus");
+        assert_eq!(fail2ban_status(None).unwrap().action_name, "Fail2banStatus");
     }
 
     #[test]
     fn fail2ban_status_risk_is_low() {
-        assert_eq!(fail2ban_status(None).risk_level, RiskLevel::Low);
+        assert_eq!(fail2ban_status(None).unwrap().risk_level, RiskLevel::Low);
     }
 
     #[test]
     fn fail2ban_status_global_argv() {
-        let spec = fail2ban_status(None);
+        let spec = fail2ban_status(None).unwrap();
         let (prog, args) = extract_args(&spec);
         assert_eq!(prog, "sudo");
         let a: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -215,11 +240,18 @@ mod tests {
 
     #[test]
     fn fail2ban_status_jail_argv() {
-        let spec = fail2ban_status(Some("sshd"));
+        let spec = fail2ban_status(Some("sshd")).unwrap();
         let (prog, args) = extract_args(&spec);
         assert_eq!(prog, "sudo");
         let a: Vec<&str> = args.iter().map(String::as_str).collect();
         assert_eq!(a, vec!["fail2ban-client", "status", "sshd"]);
+    }
+
+    #[test]
+    fn fail2ban_status_rejects_invalid_jail() {
+        // In-constructor defense in depth, mirroring fail2ban_ban_ip/unban_ip.
+        let err = fail2ban_status(Some("sshd; rm -rf /")).unwrap_err();
+        assert!(matches!(err, Fail2banError::InvalidJail(_)));
     }
 
     // ── fail2ban_ban_ip ──────────────────────────────────────────────────────
@@ -333,11 +365,20 @@ mod tests {
 
     #[test]
     fn configure_jail_routes_through_helper() {
-        let spec = configure_fail2ban_jail("sshd", &["--maxretry".to_string(), "3".to_string()]);
+        let spec =
+            configure_fail2ban_jail("sshd", &["--maxretry".to_string(), "3".to_string()]).unwrap();
         let (program, args) = extract_args(&spec);
         assert_eq!(program, "sudo");
         assert_eq!(args, vec![JAIL_HELPER, "--name", "sshd", "--maxretry", "3"]);
         assert_eq!(spec.risk_level, RiskLevel::High);
+    }
+
+    #[test]
+    fn configure_fail2ban_jail_rejects_invalid_name() {
+        // In-constructor defense in depth, mirroring fail2ban_ban_ip/unban_ip.
+        let err =
+            configure_fail2ban_jail("sshd; rm -rf /", &["--maxretry".to_string()]).unwrap_err();
+        assert!(matches!(err, Fail2banError::InvalidJail(_)));
     }
 
     // ── specs() completeness ─────────────────────────────────────────────────

--- a/crates/sysknife-daemon/src/actions/grub.rs
+++ b/crates/sysknife-daemon/src/actions/grub.rs
@@ -73,12 +73,27 @@ pub fn grub_get_kargs() -> ActionSpec {
     }
 }
 
+/// Error returned by [`grub_set_kargs`] when both `append` and `delete` are
+/// empty.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum KargsError {
+    #[error("at least one of append or delete must be non-empty")]
+    BothEmpty,
+}
+
 /// Modify kernel arguments in `GRUB_CMDLINE_LINUX_DEFAULT`, back up the
 /// original file, then run `update-grub`.
 ///
 /// Risk: High. Kernel argument changes affect every boot. Incorrect arguments
 /// can prevent the system from booting. The helper script writes a backup to
 /// `/etc/default/grub.sysknife.bak` and restores it on `update-grub` failure.
+///
+/// `rollback_available` is false: that backup-and-restore is scoped to a
+/// single failed `update-grub` run inside the helper, not the daemon's
+/// automatic rollback mechanism (`executor::rollback_spec_for`), which today
+/// only covers rpm-ostree deployment actions (see
+/// `docs/automatic-rollback.md`). The daemon does not automatically revert a
+/// *successful* `GrubSetKargs` call that later turns out to be wrong.
 ///
 /// `append` — arguments to add (validated before call).
 /// `delete` — arguments to remove (validated before call).
@@ -91,12 +106,6 @@ pub fn grub_get_kargs() -> ActionSpec {
 /// The underlying mechanism is a single `sudo` invocation of the root-owned
 /// helper script `GRUB_KARGS_HELPER` (no shell involved), which closes the
 /// unconstrained `python3`, `cp`, and `update-grub` sudoers grants.
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub enum KargsError {
-    #[error("at least one of append or delete must be non-empty")]
-    BothEmpty,
-}
-
 pub fn grub_set_kargs(append: &[&str], delete: &[&str]) -> Result<ActionSpec, KargsError> {
     if append.is_empty() && delete.is_empty() {
         return Err(KargsError::BothEmpty);
@@ -121,7 +130,7 @@ pub fn grub_set_kargs(append: &[&str], delete: &[&str]) -> Result<ActionSpec, Ka
         ),
         risk_level: RiskLevel::High,
         reboot_required: true,
-        rollback_available: true,
+        rollback_available: false,
     })
 }
 
@@ -250,8 +259,11 @@ mod tests {
     }
 
     #[test]
-    fn grub_set_kargs_rollback_available() {
-        assert!(grub_set_kargs(&["quiet"], &[]).unwrap().rollback_available);
+    fn grub_set_kargs_no_automatic_rollback() {
+        // The helper's backup/restore only covers a failed `update-grub` run
+        // within the same call; the daemon's automatic-rollback mechanism
+        // (rollback_available) only exists for rpm-ostree deployment actions.
+        assert!(!grub_set_kargs(&["quiet"], &[]).unwrap().rollback_available);
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/actions/netplan.rs
+++ b/crates/sysknife-daemon/src/actions/netplan.rs
@@ -82,6 +82,12 @@ pub fn netplan_get_config() -> ActionSpec {
 /// Risk: High / Admin. Modifies the active netplan configuration in-memory.
 /// Run `NetplanApply` afterward to apply the change to the live network stack.
 ///
+/// `rollback_available` is false: the daemon has no automatic rollback for
+/// netplan YAML — it edits `/etc/netplan/` directly with no rpm-ostree-style
+/// deployment to auto-revert to on failure (see
+/// `docs/automatic-rollback.md`). An operator can manually undo the change
+/// with another `NetplanSet` call, but that is not what this flag means.
+///
 /// The argv passes `<key>=<value>` as a single argument with no shell
 /// involvement — `validated_safe_arg` (applied at the executor boundary)
 /// rejects spaces in `value`, so any further quoting would only inject
@@ -93,7 +99,7 @@ pub fn netplan_set(key: &str, value: &str) -> ActionSpec {
         mechanism: command_mechanism("sudo", ["netplan", "set", &kv]),
         risk_level: RiskLevel::High,
         reboot_required: false,
-        rollback_available: true,
+        rollback_available: false,
     }
 }
 
@@ -230,8 +236,8 @@ mod tests {
     }
 
     #[test]
-    fn netplan_set_rollback_available() {
-        assert!(netplan_set("ethernets.eth0.dhcp4", "true").rollback_available);
+    fn netplan_set_no_automatic_rollback() {
+        assert!(!netplan_set("ethernets.eth0.dhcp4", "true").rollback_available);
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/actions/ppa.rs
+++ b/crates/sysknife-daemon/src/actions/ppa.rs
@@ -14,9 +14,16 @@
 //!
 //! ## Rollback availability
 //!
-//! Both `AddPpa` and `RemovePpa` are marked `rollback_available = true`
-//! because they have an exact inverse: adding a PPA can be undone by removing
-//! it and vice-versa.
+//! `rollback_available` means the daemon automatically reverts the action on
+//! failure (`executor::rollback_spec_for` returns `Some` and the dispatcher
+//! runs it as part of the same job — see `docs/automatic-rollback.md`). That
+//! mechanism exists only for rpm-ostree deployment actions today, so both
+//! `AddPpa` and `RemovePpa` are `rollback_available = false`: apt/PPA state is
+//! mutated directly on the live filesystem and the daemon does not stage or
+//! auto-revert it. `AddPpa` and `RemovePpa` remain each other's manual
+//! inverse — an operator (or agent) can undo one by explicitly running the
+//! other — but that is a distinct fact from automatic rollback and is not
+//! what this flag communicates.
 
 use super::{command_mechanism, ActionSpec};
 use sysknife_types::RiskLevel;
@@ -58,8 +65,13 @@ fn ppa_arg(name: &str) -> String {
 
 /// Add a PPA repository (`sudo add-apt-repository -y ppa:<user>/<ppa>`).
 ///
-/// Risk: Medium. Adds a third-party apt source; reversible with `RemovePpa`.
-/// Requires `software-properties-common` to be installed.
+/// Risk: High. Adds a third-party apt source, expanding the trusted software
+/// supply chain; manually reversible by running `RemovePpa`. Requires
+/// `software-properties-common` to be installed.
+///
+/// `rollback_available` is false: the daemon has no automatic rollback for
+/// apt/PPA state (see `docs/automatic-rollback.md`); manual reversibility via
+/// `RemovePpa` is a separate fact from that flag.
 ///
 /// `name` must be in `<user>/<ppa>` format (e.g. `"deadsnakes/ppa"`).
 /// Validation is enforced in the executor via `validated_ppa_name` before
@@ -70,14 +82,16 @@ pub fn add_ppa(name: &str) -> ActionSpec {
         mechanism: command_mechanism("sudo", [ADD_APT_REPOSITORY, YES_FLAG, &ppa_arg(name)]),
         risk_level: RiskLevel::High,
         reboot_required: false,
-        rollback_available: true,
+        rollback_available: false,
     }
 }
 
 /// Remove a PPA repository (`sudo add-apt-repository -y --remove ppa:<user>/<ppa>`).
 ///
-/// Risk: Medium. Removes the apt source entry; reversible with `AddPpa`.
-/// Requires `software-properties-common` to be installed.
+/// Risk: Medium. Removes the apt source entry; manually reversible by running
+/// `AddPpa`. Requires `software-properties-common` to be installed.
+///
+/// `rollback_available` is false — see [`add_ppa`]'s doc for why.
 ///
 /// `name` must be in `<user>/<ppa>` format (e.g. `"deadsnakes/ppa"`).
 pub fn remove_ppa(name: &str) -> ActionSpec {
@@ -89,7 +103,7 @@ pub fn remove_ppa(name: &str) -> ActionSpec {
         ),
         risk_level: RiskLevel::Medium,
         reboot_required: false,
-        rollback_available: true,
+        rollback_available: false,
     }
 }
 
@@ -144,8 +158,10 @@ mod tests {
     }
 
     #[test]
-    fn add_ppa_rollback_available() {
-        assert!(add_ppa("deadsnakes/ppa").rollback_available);
+    fn add_ppa_no_automatic_rollback() {
+        // apt/PPA state has no automatic-rollback mechanism; only rpm-ostree
+        // deployment actions do (see docs/automatic-rollback.md).
+        assert!(!add_ppa("deadsnakes/ppa").rollback_available);
     }
 
     // ── remove_ppa ───────────────────────────────────────────────────────────
@@ -175,8 +191,8 @@ mod tests {
     }
 
     #[test]
-    fn remove_ppa_rollback_available() {
-        assert!(remove_ppa("deadsnakes/ppa").rollback_available);
+    fn remove_ppa_no_automatic_rollback() {
+        assert!(!remove_ppa("deadsnakes/ppa").rollback_available);
     }
 
     // ── ppa_arg ──────────────────────────────────────────────────────────────

--- a/crates/sysknife-daemon/src/actions/services.rs
+++ b/crates/sysknife-daemon/src/actions/services.rs
@@ -47,7 +47,7 @@ pub fn get_service_resource_limits(unit: &str) -> ActionSpec {
 
 /// Set a service's cgroup resource limits (`sudo systemctl set-property …`).
 ///
-/// Risk: High. `set-property` both applies the limit live and writes a
+/// Risk: Medium. `set-property` both applies the limit live and writes a
 /// persistent drop-in under `/etc/systemd/system.control/<unit>.d/`; the change
 /// is undone with `systemctl revert <unit>`. Using systemd's own verb (rather
 /// than a hand-written drop-in helper) means systemd validates and manages the

--- a/crates/sysknife-daemon/src/actions/snap.rs
+++ b/crates/sysknife-daemon/src/actions/snap.rs
@@ -11,11 +11,55 @@
 //! Set `auto_update: true` in the plan params to skip the hold.
 //!
 //! The hold is applied by building a two-command spec using a shell fragment
-//! via `sh -c "snap install … && snap refresh --hold …"`. Both commands are
-//! validated through `validated_safe_arg` before interpolation.
+//! via `sh -c "snap install … && snap refresh --hold …"`. `name` and
+//! `channel` are validated by [`snap_install`] itself before interpolation
+//! (in addition to, not instead of, the executor's own `validated_safe_arg`
+//! check) — see the `SnapInstallError` doc below.
 
 use super::{command_mechanism, ActionSpec};
 use sysknife_types::RiskLevel;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Returned when `snap_install`'s `name` or `channel` fails validation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SnapInstallError {
+    /// `name`/`channel` contains a shell metacharacter or otherwise fails the
+    /// safe-arg allowlist. Carries the offending parameter and value.
+    ///
+    /// Defense in depth: the executor already validates both via
+    /// `validated_safe_arg` before calling this constructor, but the
+    /// `auto_update: false` path interpolates `name`/`channel` into a
+    /// `sh -c "snap install … && snap refresh --hold …"` fragment — a future
+    /// internal Rust caller (fleet plan/execute path) that skipped the
+    /// executor could not otherwise be blocked from injecting through it.
+    InvalidArg { param: &'static str, value: String },
+}
+
+impl std::fmt::Display for SnapInstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidArg { param, value } => write!(f, "invalid {param}: '{value}'"),
+        }
+    }
+}
+
+impl std::error::Error for SnapInstallError {}
+
+/// Allowlist for `name`/`channel`: alphanumeric plus `._:/+@-`, no leading
+/// dash, 1-254 bytes. Mirrors `validated_safe_arg`'s charset exactly, kept as
+/// a self-contained check here (rather than depending on `crate::executor`)
+/// so this action module has no dependency on the executor's error type —
+/// the same pattern `fail2ban::jail_is_valid` uses.
+fn safe_snap_arg_is_valid(s: &str) -> bool {
+    if s.is_empty() || s.len() > 254 || s.starts_with('-') {
+        return false;
+    }
+    s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | ':' | '/' | '+' | '@' | '-'))
+}
 
 // ---------------------------------------------------------------------------
 // specs() — for action_consistency tests
@@ -24,7 +68,7 @@ use sysknife_types::RiskLevel;
 /// Return one representative `ActionSpec` per snap action name.
 pub fn specs() -> Vec<ActionSpec> {
     vec![
-        snap_install("firefox", None, false),
+        snap_install("firefox", None, false).expect("firefox is a valid snap arg"),
         snap_remove("firefox"),
         snap_refresh(Some("firefox")),
         snap_hold("firefox"),
@@ -47,7 +91,29 @@ pub fn specs() -> Vec<ActionSpec> {
 /// system resources depending on interface connections.
 ///
 /// `channel` defaults to `stable` when `None`.
-pub fn snap_install(name: &str, channel: Option<&str>, auto_update: bool) -> ActionSpec {
+///
+/// Returns `Err(SnapInstallError::InvalidArg)` if `name` or `channel` fails
+/// the safe-arg allowlist — see [`SnapInstallError`].
+pub fn snap_install(
+    name: &str,
+    channel: Option<&str>,
+    auto_update: bool,
+) -> Result<ActionSpec, SnapInstallError> {
+    if !safe_snap_arg_is_valid(name) {
+        return Err(SnapInstallError::InvalidArg {
+            param: "name",
+            value: name.to_string(),
+        });
+    }
+    if let Some(ch) = channel {
+        if !safe_snap_arg_is_valid(ch) {
+            return Err(SnapInstallError::InvalidArg {
+                param: "channel",
+                value: ch.to_string(),
+            });
+        }
+    }
+
     if auto_update {
         // Plain install without hold.
         let mut args = vec!["install".to_string()];
@@ -55,7 +121,7 @@ pub fn snap_install(name: &str, channel: Option<&str>, auto_update: bool) -> Act
             args.push(format!("--channel={}", ch));
         }
         args.push(name.to_string());
-        ActionSpec {
+        Ok(ActionSpec {
             action_name: "SnapInstall",
             mechanism: command_mechanism(
                 "sudo",
@@ -64,7 +130,7 @@ pub fn snap_install(name: &str, channel: Option<&str>, auto_update: bool) -> Act
             risk_level: RiskLevel::Medium,
             reboot_required: false,
             rollback_available: false,
-        }
+        })
     } else {
         // Install + hold in one shell fragment to avoid a window where the snap
         // can be auto-refreshed between install and hold.
@@ -73,13 +139,13 @@ pub fn snap_install(name: &str, channel: Option<&str>, auto_update: bool) -> Act
             "snap install --channel={} {} && snap refresh --hold {}",
             channel_arg, name, name
         );
-        ActionSpec {
+        Ok(ActionSpec {
             action_name: "SnapInstall",
             mechanism: super::command_mechanism("sudo", ["sh", "-c", &cmd]),
             risk_level: RiskLevel::Medium,
             reboot_required: false,
             rollback_available: false,
-        }
+        })
     }
 }
 
@@ -223,14 +289,14 @@ mod tests {
     #[test]
     fn snap_install_action_name() {
         assert_eq!(
-            snap_install("firefox", None, false).action_name,
+            snap_install("firefox", None, false).unwrap().action_name,
             "SnapInstall"
         );
     }
 
     #[test]
     fn snap_install_default_includes_hold() {
-        let spec = snap_install("firefox", None, false);
+        let spec = snap_install("firefox", None, false).unwrap();
         let (prog, args) = extract_args(&spec);
         assert_eq!(prog, "sudo");
         // When auto_update=false the hold is embedded in a sh -c fragment.
@@ -247,7 +313,7 @@ mod tests {
 
     #[test]
     fn snap_install_auto_update_no_hold() {
-        let spec = snap_install("firefox", None, true);
+        let spec = snap_install("firefox", None, true).unwrap();
         let (prog, args) = extract_args(&spec);
         assert_eq!(prog, "sudo");
         let full = args.join(" ");
@@ -261,7 +327,7 @@ mod tests {
 
     #[test]
     fn snap_install_custom_channel() {
-        let spec = snap_install("firefox", Some("beta"), false);
+        let spec = snap_install("firefox", Some("beta"), false).unwrap();
         let (_, args) = extract_args(&spec);
         let full = args.join(" ");
         assert!(full.contains("beta"), "channel not present: {full}");
@@ -270,9 +336,40 @@ mod tests {
     #[test]
     fn snap_install_risk_medium() {
         assert_eq!(
-            snap_install("vim", None, false).risk_level,
+            snap_install("vim", None, false).unwrap().risk_level,
             RiskLevel::Medium
         );
+    }
+
+    #[test]
+    fn snap_install_rejects_shell_metacharacters_in_name() {
+        let err = snap_install("firefox; rm -rf /", None, false).unwrap_err();
+        assert!(matches!(
+            err,
+            SnapInstallError::InvalidArg { param: "name", .. }
+        ));
+    }
+
+    #[test]
+    fn snap_install_rejects_shell_metacharacters_in_channel() {
+        let err = snap_install("firefox", Some("beta && evil"), false).unwrap_err();
+        assert!(matches!(
+            err,
+            SnapInstallError::InvalidArg {
+                param: "channel",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn snap_install_rejects_leading_dash_name() {
+        // Option-injection guard: mirrors validated_safe_arg's leading-dash rule.
+        let err = snap_install("--classic", None, false).unwrap_err();
+        assert!(matches!(
+            err,
+            SnapInstallError::InvalidArg { param: "name", .. }
+        ));
     }
 
     // ── snap_remove ──────────────────────────────────────────────────────────

--- a/crates/sysknife-daemon/src/actions/ubuntu_pro.rs
+++ b/crates/sysknife-daemon/src/actions/ubuntu_pro.rs
@@ -86,7 +86,12 @@ pub fn pro_attach(token: &str) -> ActionSpec {
         mechanism: command_mechanism("sudo", ["pro", "attach", token]),
         risk_level: RiskLevel::High,
         reboot_required: false,
-        rollback_available: true,
+        // No automatic rollback: `rollback_available` means the daemon
+        // reverts the action on failure (`executor::rollback_spec_for`),
+        // which today only covers rpm-ostree deployment actions (see
+        // `docs/automatic-rollback.md`). `ProDetach` is a manual inverse an
+        // operator can run, not something the daemon does automatically.
+        rollback_available: false,
     }
 }
 
@@ -101,7 +106,8 @@ pub fn pro_detach() -> ActionSpec {
         mechanism: command_mechanism("sudo", ["pro", "detach", "--assume-yes"]),
         risk_level: RiskLevel::High,
         reboot_required: false,
-        rollback_available: true,
+        // No automatic rollback — see `pro_attach`'s doc for why.
+        rollback_available: false,
     }
 }
 
@@ -191,8 +197,8 @@ mod tests {
     }
 
     #[test]
-    fn pro_attach_rollback_available() {
-        assert!(pro_attach("tok123").rollback_available);
+    fn pro_attach_no_automatic_rollback() {
+        assert!(!pro_attach("tok123").rollback_available);
     }
 
     #[test]
@@ -251,8 +257,8 @@ mod tests {
     }
 
     #[test]
-    fn pro_detach_rollback_available() {
-        assert!(pro_detach().rollback_available);
+    fn pro_detach_no_automatic_rollback() {
+        assert!(!pro_detach().rollback_available);
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -30,6 +30,53 @@ pub fn validated_group(s: &str, param: &'static str) -> Result<String, ExecutorE
     validated_username(s, param)
 }
 
+/// Local accounts that must never be deleted or locked via SysKnife's account
+/// actions, even though they pass the generic username charset check: they
+/// gate package management, cron, syslog, sudo, or (for `root`) the ability
+/// to log in as anyone at all. This is enforced in addition to, not instead
+/// of, the RBAC gate — an Admin-role caller must still not be able to lock
+/// every account out of the box via a single `DeleteUser` or
+/// `LockUserAccount` call. `root` is also the canonical uid-0 account;
+/// SysKnife's account actions address accounts by name (there is no uid
+/// parameter), so a differently-named uid-0 alias is out of scope for this
+/// name-based denylist.
+const CRITICAL_ACCOUNTS: &[&str] = &["root", "daemon", "bin", "sys", "sudo", "adm"];
+
+/// Local groups that must never be deleted via `DeleteGroup`: `sudo`/`wheel`/
+/// `adm` gate privilege escalation; `sys`/`daemon`/`bin`/`staff`/`disk` are
+/// owned by core system tooling and file permissions; `shadow` gates access to
+/// the shadow password database. Removing any of them can strip access from
+/// every member or break core system tooling.
+const CRITICAL_GROUPS: &[&str] = &[
+    "root", "sudo", "wheel", "adm", "sys", "daemon", "bin", "staff", "shadow", "disk",
+];
+
+/// Validate a username for an irreversible or access-revoking account action
+/// (`DeleteUser`, `LockUserAccount`): the generic [`validated_username`]
+/// charset check, plus a hard denylist of critical system accounts. Mirrors
+/// the `CRITICAL_MOUNTPOINTS` pattern below — a fixed denylist checked before
+/// the command is ever built, independent of the RBAC gate.
+pub fn validated_username_not_critical(
+    s: &str,
+    param: &'static str,
+) -> Result<String, ExecutorError> {
+    let s = validated_username(s, param)?;
+    if CRITICAL_ACCOUNTS.contains(&s.as_str()) {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s)
+}
+
+/// Validate a group name for `DeleteGroup`: the generic [`validated_group`]
+/// charset check, plus a hard denylist of critical system groups.
+pub fn validated_group_not_critical(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    let s = validated_group(s, param)?;
+    if CRITICAL_GROUPS.contains(&s.as_str()) {
+        return Err(ExecutorError::InvalidParam(param));
+    }
+    Ok(s)
+}
+
 /// Validate a systemd unit name: must match `[a-zA-Z0-9@._:-]+` (no slashes, no
 /// spaces), and must not start with `-`.
 ///
@@ -218,8 +265,13 @@ const UFW_APP_NAME_MAX: usize = 64;
 ///
 /// - **Bare port** — `^\d+$` — integer 1–65535.
 /// - **Port/protocol** — `^\d+/(tcp|udp)$` — same numeric range.
-/// - **App profile name** — starts with a letter, then `[A-Za-z0-9_-]*`,
-///   length 1–[`UFW_APP_NAME_MAX`].
+/// - **App profile name** — starts with a letter, then `[A-Za-z0-9_ -]*` (a
+///   single interior space is allowed — real UFW profiles like `"Nginx
+///   Full"`/`"Apache Full"` are two words), length 1–[`UFW_APP_NAME_MAX`],
+///   must not end in a space. The value is passed as a single argv element
+///   (never through a shell), so a space carries no injection risk; every
+///   shell metacharacter and control character remains rejected by the
+///   allowlist.
 pub fn validated_port_or_service(s: &str, param: &'static str) -> Result<String, ExecutorError> {
     if s.is_empty() {
         return Err(ExecutorError::InvalidParam(param));
@@ -253,16 +305,19 @@ pub fn validated_port_or_service(s: &str, param: &'static str) -> Result<String,
         return Ok(s.to_string());
     }
 
-    // App profile name form: first char must be a letter.
+    // App profile name form: first char must be a letter. Internal spaces are
+    // allowed (real UFW profiles like "Nginx Full"/"Apache Full" contain
+    // them); a trailing space is rejected as almost certainly a copy-paste
+    // artifact rather than an intentional profile name.
     if !s.starts_with(|c: char| c.is_ascii_alphabetic()) {
         return Err(ExecutorError::InvalidParam(param));
     }
-    if s.len() > UFW_APP_NAME_MAX {
+    if s.len() > UFW_APP_NAME_MAX || s.ends_with(' ') {
         return Err(ExecutorError::InvalidParam(param));
     }
     let ok = s
         .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-'));
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | ' '));
     if !ok {
         return Err(ExecutorError::InvalidParam(param));
     }
@@ -970,6 +1025,51 @@ mod tests {
         assert!(validated_group("", "group").is_err());
     }
 
+    // ── validated_username_not_critical / validated_group_not_critical ────
+
+    #[test]
+    fn username_not_critical_rejects_denylisted_accounts() {
+        for name in CRITICAL_ACCOUNTS {
+            assert!(
+                validated_username_not_critical(name, "username").is_err(),
+                "{name} must be rejected as a critical account"
+            );
+        }
+    }
+
+    #[test]
+    fn username_not_critical_allows_normal_user() {
+        assert_eq!(
+            validated_username_not_critical("alice", "username").unwrap(),
+            "alice".to_string()
+        );
+    }
+
+    #[test]
+    fn username_not_critical_still_enforces_charset() {
+        // The denylist is layered on top of, not instead of, the charset check.
+        assert!(validated_username_not_critical("-alice", "username").is_err());
+        assert!(validated_username_not_critical("", "username").is_err());
+    }
+
+    #[test]
+    fn group_not_critical_rejects_denylisted_groups() {
+        for name in CRITICAL_GROUPS {
+            assert!(
+                validated_group_not_critical(name, "group").is_err(),
+                "{name} must be rejected as a critical group"
+            );
+        }
+    }
+
+    #[test]
+    fn group_not_critical_allows_normal_group() {
+        assert_eq!(
+            validated_group_not_critical("developers", "group").unwrap(),
+            "developers".to_string()
+        );
+    }
+
     // ── validated_unit_name ──────────────────────────────────────────────
 
     #[test]
@@ -1342,6 +1442,19 @@ mod tests {
     }
 
     #[test]
+    fn port_or_service_accepts_app_profile_names_with_internal_spaces() {
+        // Real UFW application profiles from /etc/ufw/applications.d/ commonly
+        // have two-word names; a leading-dash / bare-metachar guard is enough
+        // to keep these safe since the value is a single argv element, never
+        // interpolated through a shell.
+        assert_eq!(
+            validated_port_or_service("Nginx Full", "port_or_service").unwrap(),
+            "Nginx Full".to_string()
+        );
+        assert!(validated_port_or_service("Apache Full", "port_or_service").is_ok());
+    }
+
+    #[test]
     fn port_or_service_rejects_out_of_range_ports() {
         assert!(validated_port_or_service("0", "port_or_service").is_err());
         assert!(validated_port_or_service("65536", "port_or_service").is_err());
@@ -1377,8 +1490,16 @@ mod tests {
     }
 
     #[test]
-    fn port_or_service_rejects_space_in_app_name() {
-        assert!(validated_port_or_service("hello world", "port_or_service").is_err());
+    fn port_or_service_rejects_trailing_space_in_app_name() {
+        // Internal spaces are allowed ("Nginx Full"), but a trailing space is
+        // almost certainly a copy-paste artifact, not an intentional name.
+        assert!(validated_port_or_service("Nginx Full ", "port_or_service").is_err());
+    }
+
+    #[test]
+    fn port_or_service_rejects_metachar_with_space_in_app_name() {
+        // Spaces are allowed, but every shell metacharacter is still rejected.
+        assert!(validated_port_or_service("hello; rm -rf /", "port_or_service").is_err());
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -1987,14 +1987,25 @@ async fn handle_execute(
             // The approval is NOT consumed by a conflict (the claim happens
             // after this gate), so it remains valid for retry — but only until
             // its TTL elapses. A high-risk reboot job can outrun that window, so
-            // we tell the user up front that a long wait means re-approving,
-            // instead of letting the retry fail later with a bare stale_approval.
+            // we tell the user up front what a long wait means, instead of
+            // letting the retry fail later with a bare stale_approval.
+            //
+            // Re-approving the SAME transaction can never produce a "fresh"
+            // receipt: the TTL check in `approve_transaction` is anchored to
+            // the transaction's immutable `created_at`, not to when `approve`
+            // is called, so running `sysknife approve <transaction-id>` again
+            // after the window has elapsed fails identically every time. The
+            // only way to get a new TTL window is a new transaction, which
+            // means re-running the preview.
             let ttl = crate::transactions::APPROVAL_RECEIPT_TTL_MINUTES;
             let msg = format!(
                 "a High-risk reboot-required action is already executing (request_hash \
                  {running_hash}); retry after the current job completes. This approval \
-                 expires {ttl} minutes after it was issued — if the running job is still \
-                 going by then, run `sysknife approve <transaction-id>` again for a fresh receipt"
+                 expires {ttl} minutes after it was issued, and that window is anchored to \
+                 when the preview was created — re-running `sysknife approve` on this same \
+                 transaction will not renew it. If the running job is still going once the \
+                 window has passed, re-run the preview (which mints a fresh transaction) and \
+                 approve that new transaction instead"
             );
             drop(slot); // release before I/O
             return send_response(

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -7,14 +7,15 @@ use crate::actions::{
     validate::{
         validated_apparmor_profile, validated_apt_package, validated_apt_pin_expr,
         validated_apt_pin_name, validated_audit_path, validated_audit_perms, validated_cpu_quota,
-        validated_domain, validated_email, validated_fstype, validated_group, validated_hostname,
-        validated_journal_grep, validated_journal_priority, validated_journal_time,
-        validated_locale, validated_log_path, validated_lvm_name, validated_lvm_size,
-        validated_memory_limit, validated_mount_device, validated_mount_options,
-        validated_mount_point, validated_port_or_service, validated_ppa_name,
-        validated_pro_service, validated_safe_arg, validated_sudo_commands, validated_sudoers_name,
-        validated_swap_path, validated_sysctl_key, validated_sysctl_value, validated_syslog_host,
-        validated_tasks_max, validated_timezone, validated_unit_name, validated_username,
+        validated_domain, validated_email, validated_fstype, validated_group,
+        validated_group_not_critical, validated_hostname, validated_journal_grep,
+        validated_journal_priority, validated_journal_time, validated_locale, validated_log_path,
+        validated_lvm_name, validated_lvm_size, validated_memory_limit, validated_mount_device,
+        validated_mount_options, validated_mount_point, validated_port_or_service,
+        validated_ppa_name, validated_pro_service, validated_safe_arg, validated_sudo_commands,
+        validated_sudoers_name, validated_swap_path, validated_sysctl_key, validated_sysctl_value,
+        validated_syslog_host, validated_tasks_max, validated_timezone, validated_unit_name,
+        validated_username, validated_username_not_critical,
     },
     ActionMechanism, ActionSpec,
 };
@@ -914,7 +915,7 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
             ))
         }
         "DeleteUser" => {
-            let username = validated_username(resolve_username(params)?, "username")?;
+            let username = validated_username_not_critical(resolve_username(params)?, "username")?;
             Ok(users::delete_user(&username))
         }
         "AddUserToGroup" => {
@@ -936,11 +937,11 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
             Ok(users::create_group(&group, system))
         }
         "DeleteGroup" => {
-            let group = validated_group(require_str(params, "group")?, "group")?;
+            let group = validated_group_not_critical(require_str(params, "group")?, "group")?;
             Ok(users::delete_group(&group))
         }
         "LockUserAccount" => {
-            let username = validated_username(resolve_username(params)?, "username")?;
+            let username = validated_username_not_critical(resolve_username(params)?, "username")?;
             Ok(users::lock_user_account(&username))
         }
         "UnlockUserAccount" => {
@@ -1045,7 +1046,11 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
                 .get("auto_update")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-            Ok(snap::snap_install(&name, channel.as_deref(), auto_update))
+            snap::snap_install(&name, channel.as_deref(), auto_update).map_err(|e| match e {
+                snap::SnapInstallError::InvalidArg { param, .. } => {
+                    ExecutorError::InvalidParam(param)
+                }
+            })
         }
         "SnapRemove" => {
             let name = validated_safe_arg(require_str(params, "name")?, "name")?;
@@ -1294,7 +1299,10 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
                 .filter(|s| !s.is_empty())
                 .map(|s| validated_safe_arg(s, "jail"))
                 .transpose()?;
-            Ok(fail2ban::fail2ban_status(jail.as_deref()))
+            fail2ban::fail2ban_status(jail.as_deref()).map_err(|e| match e {
+                fail2ban::Fail2banError::InvalidIpAddress(_) => ExecutorError::InvalidParam("jail"),
+                fail2ban::Fail2banError::InvalidJail(_) => ExecutorError::InvalidParam("jail"),
+            })
         }
         "Fail2banBanIp" => {
             let jail = validated_safe_arg(require_str(params, "jail")?, "jail")?;
@@ -1344,7 +1352,10 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
             if extra.is_empty() {
                 return Err(ExecutorError::MissingParam("maxretry"));
             }
-            Ok(fail2ban::configure_fail2ban_jail(&name, &extra))
+            fail2ban::configure_fail2ban_jail(&name, &extra).map_err(|e| match e {
+                fail2ban::Fail2banError::InvalidIpAddress(_) => ExecutorError::InvalidParam("name"),
+                fail2ban::Fail2banError::InvalidJail(_) => ExecutorError::InvalidParam("name"),
+            })
         }
 
         // ── auditd file-watch rules ───────────────────────────────────────
@@ -1653,10 +1664,17 @@ fn str_array_or_empty(params: &Value, key: &'static str) -> Result<Vec<String>, 
 /// - `selinux=0`       — disables SELinux
 /// - `enforcing=0`     — sets SELinux to permissive
 /// - `security=`       — overrides LSM module selection
+/// - `apparmor=0`      — disables the AppArmor LSM (Ubuntu's default MAC)
 /// - `systemd.unit=emergency` / `systemd.unit=rescue` / `systemd.unit=single`
 ///   — unprotected root shell
 /// - `single` / `1` / `s` — single-user mode (root without password)
 /// - `module_blacklist=` — can disable security-critical kernel modules
+/// - `mitigations=off` — disables CPU speculative-execution vulnerability
+///   mitigations (Spectre/Meltdown/MDS/etc.)
+/// - `lockdown=`       — weakens or disables the kernel lockdown LSM
+/// - `pti=off`         — disables Page Table Isolation (Meltdown mitigation)
+/// - `nosmap` / `nosmep` — disable SMAP/SMEP, CPU features that block a large
+///   class of kernel-exploitation techniques
 fn validated_safe_kernel_arg(arg: &str, param: &'static str) -> Result<(), ExecutorError> {
     const BLOCKED_PREFIXES: &[&str] = &[
         "init=",
@@ -1664,8 +1682,12 @@ fn validated_safe_kernel_arg(arg: &str, param: &'static str) -> Result<(), Execu
         "enforcing=0",
         "security=",
         "module_blacklist=",
+        "apparmor=0",
+        "mitigations=off",
+        "lockdown=",
+        "pti=off",
     ];
-    const BLOCKED_EXACT: &[&str] = &["single", "s", "1"];
+    const BLOCKED_EXACT: &[&str] = &["single", "s", "1", "nosmap", "nosmep"];
     const BLOCKED_UNIT_PREFIXES: &[&str] = &["emergency", "rescue", "single"];
 
     let lower = arg.to_lowercase();
@@ -1939,7 +1961,7 @@ mod tests {
     fn build_spec_set_kernel_arguments_appends_and_deletes() {
         let spec = build_action_spec(
             "SetKernelArguments",
-            &json!({ "add": ["mitigations=off"], "remove": ["quiet"] }),
+            &json!({ "add": ["nomodeset"], "remove": ["quiet"] }),
         )
         .unwrap();
         assert_eq!(
@@ -1949,7 +1971,7 @@ mod tests {
                 args: vec![
                     "rpm-ostree".to_string(),
                     "kargs".to_string(),
-                    "--append=mitigations=off".to_string(),
+                    "--append=nomodeset".to_string(),
                     "--delete=quiet".to_string(),
                 ],
             }
@@ -1979,6 +2001,42 @@ mod tests {
                 args: vec!["rpm-ostree".to_string(), "kargs".to_string()],
             }
         );
+    }
+
+    // ── Critical-account denylist (DeleteUser/DeleteGroup/LockUserAccount) ──
+
+    #[test]
+    fn delete_user_rejects_critical_account() {
+        let err = build_action_spec("DeleteUser", &json!({ "username": "root" })).unwrap_err();
+        assert!(
+            matches!(err, ExecutorError::InvalidParam("username")),
+            "expected InvalidParam(username), got: {err}"
+        );
+    }
+
+    #[test]
+    fn delete_group_rejects_critical_group() {
+        let err = build_action_spec("DeleteGroup", &json!({ "group": "sudo" })).unwrap_err();
+        assert!(
+            matches!(err, ExecutorError::InvalidParam("group")),
+            "expected InvalidParam(group), got: {err}"
+        );
+    }
+
+    #[test]
+    fn lock_user_account_rejects_critical_account() {
+        let err = build_action_spec("LockUserAccount", &json!({ "username": "root" })).unwrap_err();
+        assert!(
+            matches!(err, ExecutorError::InvalidParam("username")),
+            "expected InvalidParam(username), got: {err}"
+        );
+    }
+
+    #[test]
+    fn delete_user_lock_user_account_and_delete_group_allow_normal_names() {
+        assert!(build_action_spec("DeleteUser", &json!({ "username": "alice" })).is_ok());
+        assert!(build_action_spec("LockUserAccount", &json!({ "username": "alice" })).is_ok());
+        assert!(build_action_spec("DeleteGroup", &json!({ "group": "developers" })).is_ok());
     }
 
     // ── execute_spec ──────────────────────────────────────────────────────
@@ -2410,7 +2468,7 @@ mod tests {
     #[test]
     fn kernel_arg_allows_safe_args() {
         assert!(validated_safe_kernel_arg("quiet", "add").is_ok());
-        assert!(validated_safe_kernel_arg("mitigations=off", "add").is_ok());
+        assert!(validated_safe_kernel_arg("splash", "add").is_ok());
         assert!(validated_safe_kernel_arg("rd.driver.blacklist=nouveau", "add").is_ok());
         assert!(validated_safe_kernel_arg("console=ttyS0,115200", "add").is_ok());
     }
@@ -2467,6 +2525,50 @@ mod tests {
         ));
         assert!(matches!(
             validated_safe_kernel_arg("systemd.unit=single.target", "add"),
+            Err(ExecutorError::InvalidParam("add"))
+        ));
+    }
+
+    #[test]
+    fn kernel_arg_blocks_apparmor_disable() {
+        assert!(matches!(
+            validated_safe_kernel_arg("apparmor=0", "add"),
+            Err(ExecutorError::InvalidParam("add"))
+        ));
+    }
+
+    #[test]
+    fn kernel_arg_blocks_mitigations_off() {
+        assert!(matches!(
+            validated_safe_kernel_arg("mitigations=off", "add"),
+            Err(ExecutorError::InvalidParam("add"))
+        ));
+    }
+
+    #[test]
+    fn kernel_arg_blocks_lockdown_override() {
+        assert!(matches!(
+            validated_safe_kernel_arg("lockdown=none", "add"),
+            Err(ExecutorError::InvalidParam("add"))
+        ));
+    }
+
+    #[test]
+    fn kernel_arg_blocks_pti_off() {
+        assert!(matches!(
+            validated_safe_kernel_arg("pti=off", "add"),
+            Err(ExecutorError::InvalidParam("add"))
+        ));
+    }
+
+    #[test]
+    fn kernel_arg_blocks_smap_smep_disable() {
+        assert!(matches!(
+            validated_safe_kernel_arg("nosmap", "add"),
+            Err(ExecutorError::InvalidParam("add"))
+        ));
+        assert!(matches!(
+            validated_safe_kernel_arg("nosmep", "add"),
             Err(ExecutorError::InvalidParam("add"))
         ));
     }
@@ -2701,24 +2803,14 @@ mod tests {
     /// drifting apart.
     #[test]
     fn rollback_available_matches_rollback_spec_for_all_actions() {
-        let all_specs: Vec<ActionSpec> = containers::specs()
-            .into_iter()
-            .chain(deployment::specs())
-            .chain(filesystem::specs())
-            .chain(flatpak::specs())
-            .chain(identity::specs())
-            .chain(layering::specs())
-            .chain(network::specs())
-            .chain(package_repos::specs())
-            .chain(processes::specs())
-            .chain(services::specs())
-            .chain(ssh::specs())
-            .chain(system_info::specs())
-            .chain(toolbox::specs())
-            .chain(users::specs())
-            .collect();
-
-        for spec in &all_specs {
+        // Iterate the FULL catalogue (`crate::actions::all_specs`), not a
+        // hand-picked subset of families — a manually-chained list here once
+        // silently omitted `ppa`, `netplan`, `grub`, and `ubuntu_pro`, which is
+        // exactly how `AddPpa`/`RemovePpa`/`NetplanSet`/`GrubSetKargs`/
+        // `ProAttach`/`ProDetach` were able to claim `rollback_available: true`
+        // with no matching `rollback_spec_for` entry for years without this
+        // test catching it.
+        for spec in crate::actions::all_specs() {
             let has_rollback = rollback_spec_for(spec.action_name).is_some();
             assert_eq!(
                 spec.rollback_available,

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -393,9 +393,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "SetServiceEnabled"
         | "StartService"
         | "StopService"
-        | "ConfigureWifi"
-        | "SetDnsServers"
-        | "ConfigureFirewall"
         | "CreateToolbox"
         | "RemoveToolbox"
         | "InstallFlatpak"
@@ -403,16 +400,76 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
         | "UpdateFlatpak"
         | "AddFlatpakRemote"
         | "RemoveFlatpakRemote"
-        | "MaskService"
         | "UnmaskService"
         | "SetHostname"
         | "SetTimezone"
         | "SetLocale"
-        | "SetNtp"
-        | "CreateUser" => PreviewProfile {
+        | "SetNtp" => PreviewProfile {
             expected_side_effects: vec!["service interruption".to_string()],
             warnings: vec![APPROVAL_REQUIRED.to_string()],
         },
+
+        // ── Wi-Fi association (High) ───────────────────────────────────────
+        "ConfigureWifi" => PreviewProfile {
+            expected_side_effects: vec![
+                "the host's Wi-Fi connection will change".to_string(),
+                "current network connectivity may be interrupted while reconnecting".to_string(),
+            ],
+            warnings: vec![
+                "a wrong SSID or password can disconnect the host from network access"
+                    .to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
+            ],
+        },
+
+        // ── DNS redirection (High) — same primitive as ResolvectlSetDns ────
+        "SetDnsServers" | "ResolvectlSetDns" => PreviewProfile {
+            expected_side_effects: vec!["DNS servers for the interface will change".to_string()],
+            warnings: vec![
+                "redirecting DNS can enable interception of name resolution".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
+            ],
+        },
+
+        // ── firewalld rule + reload (High) ─────────────────────────────────
+        "ConfigureFirewall" => PreviewProfile {
+            expected_side_effects: vec![
+                "a firewalld rule will change and reload immediately".to_string(),
+                "network access may be immediately affected".to_string(),
+            ],
+            warnings: vec![
+                "misconfigured rules can lock out SSH or other remote access".to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
+            ],
+        },
+
+        // ── mask a unit so it cannot be started (High) ─────────────────────
+        "MaskService" => PreviewProfile {
+            expected_side_effects: vec![
+                "the unit will be masked (symlinked to /dev/null)".to_string(),
+                "the unit cannot be started, even manually, until UnmaskService is run"
+                    .to_string(),
+            ],
+            warnings: vec![
+                "masking a unit other services depend on can cascade into unrelated failures"
+                    .to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
+            ],
+        },
+
+        // ── create a new local account (High) ──────────────────────────────
+        "CreateUser" => PreviewProfile {
+            expected_side_effects: vec![
+                "a new local user account will be created".to_string(),
+                "a home directory may be created".to_string(),
+            ],
+            warnings: vec![
+                "grants a new account with login access — review shell/home/group defaults"
+                    .to_string(),
+                EXACT_APPROVAL_REQUIRED.to_string(),
+            ],
+        },
+
         // ── Observability / journald maintenance ─────────────────────────
         "VacuumJournal" => PreviewProfile {
             expected_side_effects: vec![
@@ -694,15 +751,6 @@ fn preview_profile(action_name: &str) -> PreviewProfile {
             ],
         },
 
-        // ── resolvectl DNS ────────────────────────────────────────────────
-        "ResolvectlSetDns" => PreviewProfile {
-            expected_side_effects: vec!["DNS servers for the interface will change".to_string()],
-            warnings: vec![
-                "redirecting DNS can enable interception of name resolution".to_string(),
-                EXACT_APPROVAL_REQUIRED.to_string(),
-            ],
-        },
-
         // ── AppArmor profile modes ────────────────────────────────────────
         "AppArmorEnforce" => PreviewProfile {
             expected_side_effects: vec![
@@ -909,6 +957,63 @@ mod tests {
                 "{action} should have 'access control will change' in expected_side_effects"
             );
         }
+    }
+
+    /// `ConfigureWifi`, `SetDnsServers`, `ConfigureFirewall`, `MaskService`, and
+    /// `CreateUser` are all High risk. Before this test they rendered through
+    /// the generic Medium-styled "service interruption" arm, which only ever
+    /// carried the soft `APPROVAL_REQUIRED` warning — a High-risk action must
+    /// use `EXACT_APPROVAL_REQUIRED` like every other High-risk action.
+    #[test]
+    fn high_risk_actions_previously_misclassified_use_exact_approval() {
+        let actions = [
+            "ConfigureWifi",
+            "SetDnsServers",
+            "ConfigureFirewall",
+            "MaskService",
+            "CreateUser",
+        ];
+
+        for action in &actions {
+            let envelope = preview_action(
+                &req(action),
+                serde_json::Value::Null,
+                serde_json::Value::Null,
+            );
+            assert_eq!(
+                envelope.risk_level,
+                RiskLevel::High,
+                "{action} should be High risk"
+            );
+            assert!(
+                envelope
+                    .warnings
+                    .iter()
+                    .any(|w| w == EXACT_APPROVAL_REQUIRED),
+                "{action} should carry EXACT_APPROVAL_REQUIRED, got: {:?}",
+                envelope.warnings
+            );
+            assert!(
+                !envelope
+                    .expected_side_effects
+                    .iter()
+                    .any(|e| e == "service interruption"),
+                "{action} should have an accurate side-effect description, not the generic \
+                 'service interruption' placeholder"
+            );
+        }
+
+        // CreateUser specifically must not claim "service interruption" — it's
+        // useradd, not a service restart.
+        let create_user = preview_action(&req("CreateUser"), Value::Null, Value::Null);
+        assert!(
+            !create_user
+                .expected_side_effects
+                .iter()
+                .any(|e| e.contains("service interruption")),
+            "CreateUser must not claim service interruption: {:?}",
+            create_user.expected_side_effects
+        );
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/state.rs
+++ b/crates/sysknife-daemon/src/state.rs
@@ -45,10 +45,17 @@ pub struct DaemonState {
     /// `UbuntuReleaseUpgrade`, `AddLayeredPackage`, `RebaseSystem`). `None`
     /// when no such action is in flight.
     ///
-    /// The dispatcher checks this slot before claiming any mutating action.
-    /// If the slot is occupied the new request is rejected with a
-    /// `ConflictResponse` rather than racing the in-flight upgrade and
-    /// causing dpkg/rpm-ostree lock contention.
+    /// The guard is one-directional, not mutual exclusion between all
+    /// mutating actions: every mutating action checks this slot before it is
+    /// allowed to start, but only a High-risk + reboot-required action ever
+    /// *claims* it (sets it to `Some`). So while a High-risk +
+    /// reboot-required action is in flight, every other mutating action —
+    /// including another High-risk + reboot-required one — is rejected with
+    /// a `ConflictResponse` rather than racing the in-flight upgrade and
+    /// causing dpkg/rpm-ostree lock contention. An ordinary mutating action
+    /// (e.g. `StartService`) never claims the slot itself, so it neither
+    /// blocks other ordinary mutating actions nor blocks a High-risk +
+    /// reboot-required action that starts while it is still running.
     ///
     /// The slot is `Arc<Mutex<…>>` so cloned `DaemonState` values — one per
     /// IPC connection — all share the same underlying guard. `Mutex::lock`

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -364,7 +364,14 @@ impl AuditStore for PostgresStore {
         transaction_id: &str,
         new_status: JobState,
     ) -> Result<(), TransactionStoreError> {
-        // Read-validate-write with state-machine guard, mirroring SQLite path.
+        // Read-validate-write with a state-machine guard, same shape as the
+        // SQLite path but strictly stronger: `SELECT ... FOR UPDATE` takes a
+        // row lock for the lifetime of this transaction, so no concurrent
+        // writer can change `status` between our read and our `UPDATE` — the
+        // read-modify-write here is atomic by construction. SQLite has no
+        // equivalent row-level lock, so its `update_status` instead uses an
+        // explicit compare-and-swap (`UPDATE ... WHERE status = <observed>`,
+        // checking `rows_affected`) to get the same guarantee.
         let mut tx = self.pool.begin().await.map_err(map_sqlx_err)?;
         let current_str: Option<String> = sqlx_core::query_scalar::query_scalar(
             "SELECT status FROM transactions WHERE transaction_id = $1 FOR UPDATE",

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -114,6 +114,16 @@ pub enum TransactionStoreError {
 
     #[error("audit chain misconfiguration: {0}")]
     AuditChainMissing(&'static str),
+
+    /// `update_status`'s compare-and-swap `UPDATE ... WHERE status = <observed>`
+    /// matched zero rows: another writer changed `status` between our read and
+    /// our write. This is a lost race, not a validation failure — the caller
+    /// (see `dispatcher::update_terminal_status`) already retries on any error
+    /// and re-reads the current status, so surfacing this distinctly (rather
+    /// than silently overwriting a transition we never validated) is safe to
+    /// retry.
+    #[error("transaction {0} status changed concurrently; retry")]
+    ConcurrentStatusChange(String),
 }
 
 impl TransactionStore {
@@ -305,10 +315,30 @@ impl TransactionStore {
             });
         }
 
-        conn.execute(
-            "UPDATE transactions SET status = ?1 WHERE transaction_id = ?2",
-            params![serialize_field(&new_status)?, transaction_id],
+        // Compare-and-swap: only write if `status` still equals the value we
+        // just validated the transition against. Without the `AND status =
+        // ?3` guard this was a check-then-act race — a concurrent writer
+        // (e.g. two calls racing to move the same job to two different
+        // terminal states) could flip `status` between our SELECT and this
+        // UPDATE, and the loser would silently report success for a
+        // transition it never actually validated against the row's real
+        // prior value. `rows_affected == 0` means we lost that race (rows are
+        // never deleted, so it cannot mean the row vanished); the caller
+        // (`dispatcher::update_terminal_status`) already retries on any error
+        // and re-checks the final status, so failing closed here is safe.
+        let rows_affected = conn.execute(
+            "UPDATE transactions SET status = ?1 WHERE transaction_id = ?2 AND status = ?3",
+            params![
+                serialize_field(&new_status)?,
+                transaction_id,
+                current_status
+            ],
         )?;
+        if rows_affected == 0 {
+            return Err(TransactionStoreError::ConcurrentStatusChange(
+                transaction_id.to_string(),
+            ));
+        }
         Ok(())
     }
 
@@ -1283,6 +1313,71 @@ mod tests {
         assert_eq!(updated.action_name, "UpdateSystem");
         assert_eq!(updated.risk_level, RiskLevel::High);
         assert_eq!(updated.status, JobState::Failed);
+    }
+
+    /// `update_status` must be a compare-and-swap, not a check-then-act race.
+    /// Bring a transaction to `Running`, then fire two conflicting terminal
+    /// transitions (`Succeeded` and `Failed`) from concurrent threads. Both
+    /// read `Running` and both pass `allowed_transition`, but only one may
+    /// actually apply — the loser must see an explicit error, never a silent
+    /// double-write. Before the `AND status = ?<observed>` guard, both calls
+    /// would unconditionally UPDATE and both would return `Ok(())`, hiding the
+    /// fact that one of them clobbered a transition it never validated.
+    #[test]
+    fn update_status_is_atomic_under_concurrent_conflicting_transitions() {
+        let dir = tempdir().unwrap();
+        let store = std::sync::Arc::new(test_store(dir.path().join("tx.db")));
+        let tx = store.record(queued_transaction()).unwrap();
+        store
+            .update_status(&tx.transaction_id, JobState::Running)
+            .unwrap();
+
+        let store_a = std::sync::Arc::clone(&store);
+        let id_a = tx.transaction_id.clone();
+        let succeed = std::thread::spawn(move || store_a.update_status(&id_a, JobState::Succeeded));
+
+        let store_b = std::sync::Arc::clone(&store);
+        let id_b = tx.transaction_id.clone();
+        let fail = std::thread::spawn(move || store_b.update_status(&id_b, JobState::Failed));
+
+        let succeed_result = succeed.join().unwrap();
+        let fail_result = fail.join().unwrap();
+
+        // Exactly one of the two conflicting transitions may win.
+        let oks = [succeed_result.is_ok(), fail_result.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            oks, 1,
+            "exactly one concurrent transition should succeed: succeed={succeed_result:?} \
+             fail={fail_result:?}"
+        );
+
+        // The loser must fail with the dedicated race error, not silently
+        // succeed and clobber the winner.
+        let loser = if succeed_result.is_ok() {
+            &fail_result
+        } else {
+            &succeed_result
+        };
+        match loser {
+            Err(TransactionStoreError::ConcurrentStatusChange(id)) => {
+                assert_eq!(id, &tx.transaction_id);
+            }
+            other => {
+                panic!("the losing transition must report ConcurrentStatusChange, got: {other:?}")
+            }
+        }
+
+        // The stored status must match whichever transition actually won —
+        // never a mix, and never left at `Running`.
+        let final_status = store.get(&tx.transaction_id).unwrap().unwrap().status;
+        if succeed_result.is_ok() {
+            assert_eq!(final_status, JobState::Succeeded);
+        } else {
+            assert_eq!(final_status, JobState::Failed);
+        }
     }
 
     #[test]

--- a/crates/sysknife-daemon/tests/preview_approval.rs
+++ b/crates/sysknife-daemon/tests/preview_approval.rs
@@ -65,7 +65,7 @@ fn firewall_preview_is_classified_explicitly_as_high_risk() {
     assert!(preview
         .expected_side_effects
         .iter()
-        .any(|effect: &String| effect.contains("service interruption")));
+        .any(|effect: &String| effect.contains("firewalld rule")));
 }
 
 #[test]

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.2.8" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.2.9" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -50,11 +50,17 @@ pub const DISTRO_FAMILY_OTHER: &str = "other";
 /// Canonical names of every action in the SysKnife catalogue.
 ///
 /// This is the single source of truth for "is this string a valid action
-/// name?" — kept in `sysknife-types` (not `sysknife-brain`) so the
-/// `RequestEnvelope` deserializer can validate at the IPC boundary, and
-/// every other crate that touches an action name (the daemon's
-/// `policy::min_role_for_action`, the CLI's approval flow, the proto
-/// bridge) sees the same list without depending on the brain.
+/// name?" — kept in `sysknife-types` (not `sysknife-brain`) so every crate
+/// that validates an action name (the daemon's `policy::min_role_for_action`,
+/// the CLI's approval flow, the proto bridge) sees the same list without
+/// depending on the brain.
+///
+/// Note: [`RequestEnvelope::action_name`] itself is a plain `String` — it is
+/// **not** validated against this list at deserialization time; that would
+/// require a custom `Deserialize` impl this type does not have. Validation
+/// happens downstream, via [`ActionName::parse`] against the value once it
+/// has been pulled out of the envelope (the daemon does this before acting
+/// on a request).
 ///
 /// **Cross-module invariant:** `sysknife_brain::propose_plan::KNOWN_ACTIONS`
 /// (which pairs each name with an LLM-facing description) MUST list every

--- a/docs/action-reference.md
+++ b/docs/action-reference.md
@@ -311,8 +311,8 @@ Every row is derived from the live code: the command from each action's `ActionS
 
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
-| `AddPpa` | `sudo add-apt-repository -y ppa:deadsnakes/ppa` | High | Ubuntu | – | ✓ | add a Launchpad PPA — param: name\* in &lt;user&gt;/&lt;ppa&gt; format (e.g. 'deadsnakes/ppa'); Ubuntu only; requires software-properties-common |
-| `RemovePpa` | `sudo add-apt-repository -y --remove ppa:deadsnakes/ppa` | Medium | Ubuntu | – | ✓ | remove a Launchpad PPA — param: name\* in &lt;user&gt;/&lt;ppa&gt; format; Ubuntu only |
+| `AddPpa` | `sudo add-apt-repository -y ppa:deadsnakes/ppa` | High | Ubuntu | – | – | add a Launchpad PPA — param: name\* in &lt;user&gt;/&lt;ppa&gt; format (e.g. 'deadsnakes/ppa'); Ubuntu only; requires software-properties-common |
+| `RemovePpa` | `sudo add-apt-repository -y --remove ppa:deadsnakes/ppa` | Medium | Ubuntu | – | – | remove a Launchpad PPA — param: name\* in &lt;user&gt;/&lt;ppa&gt; format; Ubuntu only |
 
 ## snap
 
@@ -347,7 +347,7 @@ Every row is derived from the live code: the command from each action's `ActionS
 |---|---|---|---|---|---|---|
 | `NetplanGetConfig` | `find /etc/netplan -maxdepth 1 -name *.yaml -print -exec cat {} +` | Low | Ubuntu | – | – | read current netplan YAML config from /etc/netplan/ — no params; Ubuntu only; read-only |
 | `NetplanApply` | `sudo netplan apply` | High | Ubuntu | – | – | apply netplan network configuration immediately — no params; Ubuntu only; High risk; can disconnect SSH |
-| `NetplanSet` | `sudo netplan set ethernets.eth0.dhcp4=true` | High | Ubuntu | – | ✓ | set a single netplan key to a value — params: key\* (e.g. 'ethernets.eth0.dhcp4'), value\*; Ubuntu only; High risk; run NetplanApply to activate |
+| `NetplanSet` | `sudo netplan set ethernets.eth0.dhcp4=true` | High | Ubuntu | – | – | set a single netplan key to a value — params: key\* (e.g. 'ethernets.eth0.dhcp4'), value\*; Ubuntu only; High risk; run NetplanApply to activate |
 | `NetplanGenerate` | `sudo netplan generate` | Medium | Ubuntu | – | – | regenerate netplan backend config without applying — no params; Ubuntu only; Medium risk; dry-run before NetplanApply |
 
 ## distrobox
@@ -363,7 +363,7 @@ Every row is derived from the live code: the command from each action's `ActionS
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
 | `GrubGetKargs` | `grep -E ^GRUB_CMDLINE_LINUX /etc/default/grub` | Low | Ubuntu | – | – | read current GRUB_CMDLINE_LINUX from /etc/default/grub — no params; Ubuntu only; read-only |
-| `GrubSetKargs` | `sudo /usr/lib/sysknife/grub-kargs-edit --append quiet --delete splash` | High | Ubuntu | ✓ | ✓ | modify GRUB kernel arguments and run update-grub — params: append (list), delete (list); Ubuntu only; High risk; requires reboot |
+| `GrubSetKargs` | `sudo /usr/lib/sysknife/grub-kargs-edit --append quiet --delete splash` | High | Ubuntu | ✓ | – | modify GRUB kernel arguments and run update-grub — params: append (list), delete (list); Ubuntu only; High risk; requires reboot |
 
 ## Ubuntu release upgrade
 
@@ -376,8 +376,8 @@ Every row is derived from the live code: the command from each action's `ActionS
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
 | `ProStatus` | `pro status --all` | Low | Ubuntu | – | – | show Ubuntu Pro subscription status — no params; Ubuntu only; read-only |
-| `ProAttach` | `sudo pro attach <REDACTED>` | High | Ubuntu | – | ✓ | attach machine to an Ubuntu Pro subscription — param: token\* (credential, never log); Ubuntu only; High risk |
-| `ProDetach` | `sudo pro detach --assume-yes` | High | Ubuntu | – | ✓ | detach from Ubuntu Pro subscription — no params; Ubuntu only; High risk |
+| `ProAttach` | `sudo pro attach <REDACTED>` | High | Ubuntu | – | – | attach machine to an Ubuntu Pro subscription — param: token\* (credential, never log); Ubuntu only; High risk |
+| `ProDetach` | `sudo pro detach --assume-yes` | High | Ubuntu | – | – | detach from Ubuntu Pro subscription — no params; Ubuntu only; High risk |
 | `EnableProService` | `sudo pro enable esm-apps --assume-yes` | High | Ubuntu | – | – | enable one Ubuntu Pro service (pro enable &lt;service&gt;) — param: service\* (one of esm-apps, esm-infra, livepatch, usg, fips, fips-updates, cis, ros, ros-updates, cc-eal, realtime-kernel, landscape, anbox-cloud); Ubuntu only; High risk; needs an attached subscription |
 | `DisableProService` | `sudo pro disable esm-apps --assume-yes` | High | Ubuntu | – | – | disable one Ubuntu Pro service (pro disable &lt;service&gt;) — param: service\* (same allowlist as EnableProService); Ubuntu only; High risk |
 

--- a/docs/adr/0002-brain-provider-layer.md
+++ b/docs/adr/0002-brain-provider-layer.md
@@ -63,3 +63,16 @@ inside `sysknife-brain`. `ProviderConfig` and `BrainConfig.provider` are
   `ProviderConfig` variant; no changes to `LlmPlanner`.
 - The shell layer cannot accidentally read or log API keys.
 - Integration tests use `MockProvider` — no network calls in CI.
+
+## Amendment (2026-07-23)
+
+The original decision above described the two providers that shipped at the
+time (Anthropic, Ollama). The `LlmProvider` trait design anticipated more —
+see "Consequences" — and the provider set has since grown to **eight**:
+`anthropic`, `ollama`, `openai`, `gemini`, `groq`, `deepseek`, `mistral`, and
+`xai` (see `crates/sysknife-brain/src/config.rs`). Each new provider was a
+pure addition — a new `ProviderConfig` variant and a `require_api_key`-backed
+`from_env()` arm — with no change to `LlmPlanner` or the trait itself,
+confirming the extensibility this ADR designed for. The original Decision
+and Alternatives Considered sections above are left as written for historical
+context; this amendment records the outcome.

--- a/docs/automatic-rollback.md
+++ b/docs/automatic-rollback.md
@@ -37,6 +37,20 @@ and `RollbackDeployment` itself (to avoid recursion) are excluded by
 construction — `rollback_spec_for` returns `None` for them.
 ```
 
+**The flag is an equivalence, not a hint, and it's enforced by a test.**
+`ActionSpec.rollback_available` means exactly one thing: *the daemon will
+automatically revert this action if it fails*. It does not mean "there
+happens to be another action that manually undoes this one" — an action can
+be perfectly reversible by hand (e.g. `RemovePpa` undoes `AddPpa`) while still
+reporting `rollback_available: false`, because undoing it requires the
+operator or agent to explicitly issue that second call; the daemon does not
+do it for them on failure. `rollback_available_matches_rollback_spec_for_all_actions`
+in `crates/sysknife-daemon/src/executor.rs` asserts, for **every** action in
+`actions::all_specs()` — not a hand-picked subset — that
+`spec.rollback_available == rollback_spec_for(action_name).is_some()`. An
+action can't claim automatic rollback it doesn't have, or fail to claim
+rollback it does have, without breaking that test.
+
 ## The mechanism: `rpm-ostree rollback`
 
 On rpm-ostree-based systems (Fedora Atomic / Silverblue), every mutation to
@@ -80,7 +94,12 @@ or `AptUpgrade` is left as-is. Nothing in `rollback_spec_for` maps a
 Debian-family action name to a rollback command — the function returns
 `None` for all of them, and `DEBIAN_ONLY_ACTIONS` in
 `crates/sysknife-core/src/action_family.rs` contains no rollback actions at
-all.
+all. Every Debian-family/Ubuntu-only `ActionSpec` accordingly reports
+`rollback_available: false`, including ones with an obvious manual inverse —
+`AddPpa`/`RemovePpa`, `NetplanSet`, `GrubSetKargs`, and `ProAttach`/
+`ProDetach` can all be undone by hand (running the paired action, or another
+`NetplanSet`/`GrubSetKargs` call), but none of that is automatic, so none of
+them set the flag.
 ```
 
 This matches `docs/distro-support.md`, which states plainly: *"Atomic

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -323,7 +323,7 @@ above.
 
 | Variable | Description |
 |---|---|
-| `SYSKNIFE_SOCKET` | Path to the daemon Unix socket (default: `/run/sysknife/daemon.sock`) |
+| `SYSKNIFE_SOCKET` | Daemon socket the CLI dials (`unix://`, `vsock://`, or a bare path). Falls back to the same resolution as `SYSKNIFE_LISTEN_URI`: `$XDG_RUNTIME_DIR/sysknife/daemon.sock`, then `/tmp/sysknife-$UID.sock` as a last resort. Production deployments set this via the systemd unit to `/run/sysknife/daemon.sock`. |
 
 ---
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -52,7 +52,12 @@ On atomic hosts (Fedora/Silverblue via `rpm-ostree`), a failed change is
 automatically reverted to the prior deployment. No other tool in this space
 does this. Be aware of the scope limit: **on Ubuntu/apt there is no automatic
 rollback yet** — SysKnife still gates and audits, but does not undo package
-changes. See [Automatic Rollback](automatic-rollback.md).
+changes. That scope limit is enforced, not just documented: every catalogued
+action's `rollback_available` flag is tested against the actual rollback
+mechanism, so a Debian-family action (PPAs, netplan, GRUB kargs, Ubuntu Pro
+attach/detach included) cannot claim automatic rollback it doesn't have, even
+when it happens to have an obvious manual inverse. See
+[Automatic Rollback](automatic-rollback.md).
 
 ## Open beats closed — especially here
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,8 +85,8 @@ file's section.field path.
 
 | Variable | Default | What it sets |
 |---|---|---|
-| `SYSKNIFE_LISTEN_URI` | `unix:///run/sysknife/daemon.sock` | Daemon socket / vsock URI |
-| `SYSKNIFE_DATABASE_PATH` | `/var/lib/sysknife/daemon.sqlite` | SQLite audit log path |
+| `SYSKNIFE_LISTEN_URI` | `unix://$XDG_RUNTIME_DIR/sysknife/daemon.sock` (falls back to `unix:///tmp/sysknife-$UID.sock` if `XDG_RUNTIME_DIR` is unset; production systemd unit sets `unix:///run/sysknife/daemon.sock`) | Daemon socket / vsock URI |
+| `SYSKNIFE_DATABASE_PATH` | `$XDG_STATE_HOME/sysknife/daemon.sqlite` (falls back to `~/.local/state/sysknife/daemon.sqlite`; production systemd unit sets `/var/lib/sysknife/daemon.sqlite`) | SQLite audit log path |
 | `SYSKNIFE_LLM_PROVIDER` | auto-detect | LLM provider name (8 supported) |
 | `SYSKNIFE_LLM_MODEL` | provider default | Model identifier |
 | `SYSKNIFE_OLLAMA_URL` | `http://localhost:11434` | Ollama base URL |
@@ -96,7 +96,7 @@ file's section.field path.
 | `SYSKNIFE_MAX_RPM` | `20` | Rate limit (requests / 60s sliding window) |
 | `SYSKNIFE_AUDIT_KEY_PATH` | `<db_dir>/audit-key` | Ed25519 signing key path for the audit chain |
 | `SYSKNIFE_CHECKPOINT_DB` | — | Postgres URL for `audit checkpoint` external anchoring (keeps DB credentials off the command line) |
-| `SYSKNIFE_SOCKET` | `unix:///run/sysknife/daemon.sock` | CLI / MCP daemon address |
+| `SYSKNIFE_SOCKET` | falls back to the same default as `SYSKNIFE_LISTEN_URI` | CLI / MCP daemon address |
 | `SYSKNIFE_TOKEN` | — | Vsock auth token (when daemon runs in a VM) |
 | `XDG_CONFIG_HOME` | `~/.config` | Base path for `sysknife/config.toml` |
 
@@ -120,7 +120,6 @@ the CLI / shell:
 
 | Variable | Purpose |
 |---|---|
-| `SYSKNIFE_VSOCK_TOKEN_PATH` | Vsock auth token file (default: `/etc/sysknife/vsock-token`) |
 | `SYSKNIFE_AUDIT_KEY_PATH` | Ed25519 audit signing key path (default: alongside the database) |
 
 ## Validating your config

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -189,7 +189,8 @@ Subject line under 72 characters. Add a body for non-obvious changes.
 ## How to Add a New Daemon Action
 
 1. Add the action name to `KNOWN_ACTIONS` in
-   `crates/sysknife-brain/src/action_name.rs`.
+   `crates/sysknife-brain/src/planning_tools/propose_plan.rs`
+   (`action_name.rs` only imports and re-exports it).
 2. Add the execution spec to
    `crates/sysknife-daemon/src/executor.rs` (`build_action_spec`).
 3. Add the preview logic to
@@ -248,7 +249,7 @@ extra reviewer scrutiny:
 |---|---|---|
 | Intent validation | `crates/sysknife-brain/src/planner.rs` (`INTENT_MAX_BYTES`, guards in `plan_intent`) | First line of defense before any LLM call |
 | Secret patterns | `crates/sysknife-brain/src/prefs.rs` (`SENSITIVE_PATTERNS`, `SENSITIVE_PREFIXES`) | Controls what the planner and prefs storage will reject |
-| Action allowlist | `crates/sysknife-brain/src/action_name.rs` (`KNOWN_ACTIONS`) | Adding a name here makes it proposable by the LLM |
+| Action allowlist | `crates/sysknife-brain/src/planning_tools/propose_plan.rs` (`KNOWN_ACTIONS`) | Adding a name here makes it proposable by the LLM |
 | Role policy | `crates/sysknife-daemon/src/policy.rs` (`min_role_for_action`) | Governs which groups can execute which actions |
 | Approval / replay | `crates/sysknife-daemon/src/transactions.rs` | Hash freshness and TOCTOU protection |
 | Caller auth | `crates/sysknife-daemon/src/dispatcher.rs` (`resolve_caller_role`) | SO_PEERCRED group-to-role mapping |

--- a/docs/contributing/ubuntu-story-audit.md
+++ b/docs/contributing/ubuntu-story-audit.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-- Total stories audited: 115 (104 plan-structure + 11 exec)
+- Total stories audited: 116 (104 plan-structure + 12 exec)
 - Distro-agnostic: 35  (work on any Linux)
 - Fedora-only assertions needing Ubuntu equivalence: 19
 - Ubuntu-native (no Fedora equivalent, leave alone): 50
-- Destructive (gated by `SYSKNIFE_ALLOW_DESTRUCTIVE`): 11 plan-structure + 9 exec = 20
+- Destructive (gated by `SYSKNIFE_ALLOW_DESTRUCTIVE`): 11 plan-structure + 10 exec = 21
 - Exec stories safe on Ubuntu host: 3 (exec-1, exec-2, exec-6)
 - Exec stories Fedora-only (use firewalld/firewall-cmd): 2 (exec-7, exec-11)
 
@@ -127,13 +127,14 @@ story-93 (empty snap name)
 | exec-9 | timezone round-trip | destructive, distro-agnostic | yes |
 | exec-10 | user/group membership | destructive, distro-agnostic | yes |
 | exec-11 | ConfigureFirewall ftp cycle, asserts `firewall-cmd` | **Fedora-only** — uses `firewall-cmd --list-services` | no — needs Ubuntu replacement using `ufw status` |
+| exec-12 | UfwAllow + UfwDeny cycle → allow port 8080, assert open, deny port 8080, assert closed | destructive, **Ubuntu-only** — asserts `ufw status`; gated on `SYSKNIFE_DISTRO_FAMILY=ubuntu\|debian` | yes |
 
 **exec-7 Ubuntu fix:** change intent to a service present on Ubuntu (e.g. `restart ssh`)
 and replace `systemctl is-active firewalld` with `systemctl is-active ssh`.
 
-**exec-11 Ubuntu fix:** add a parallel `exec-12.sh` that exercises `UfwAllow`/`UfwDeny`
-cycle using `ufw status` for verification; gate exec-11 behind
-`SYSKNIFE_DISTRO_FAMILY=fedora`.
+**exec-11 Ubuntu fix:** `exec-12.sh` is the parallel Ubuntu story — it exercises
+`UfwAllow`/`UfwDeny` cycle using `ufw status` for verification; exec-11 stays
+gated behind `SYSKNIFE_DISTRO_FAMILY=fedora`.
 
 ---
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -257,6 +257,57 @@ cargo clippy --workspace --all-features --locked -- -D warnings
 cargo nextest run --workspace --locked
 ```
 
+## Running CI locally
+
+`scripts/ci-local.sh` mirrors the runnable jobs from
+`.github/workflows/ci.yml` (rust, frontend, hygiene, security, and the
+optional postgres-contract job) so you catch failures before pushing,
+without spending GitHub Actions minutes:
+
+```sh
+# Full run — everything CI runs, including the optional Postgres contract
+# test if docker/podman is available (or SYSKNIFE_TEST_POSTGRES_URL is set)
+scripts/ci-local.sh
+
+# Fast subset — rust fmt/clippy/nextest + frontend tsc/vitest only
+scripts/ci-local.sh --fast
+
+# Skip the postgres-contract job even if a container runtime is available
+scripts/ci-local.sh --no-postgres
+```
+
+It detects which tools are installed first: `cargo` and `node` are required
+(missing either is a hard failure with an install link); an optional linter
+that's missing (`cargo-nextest`, `cargo-audit`, `markdownlint-cli2`,
+`markdown-link-check`, `yamllint`, `shellcheck`) just prints a warning with
+an install hint and skips that one check. Every check still runs even after
+an earlier one fails — a PASS/FAIL/WARN/SKIP summary prints at the end, and
+the script exits non-zero only if something in the summary actually failed.
+
+### Pre-push hook
+
+`scripts/ci-local.sh --install-hooks` runs `git config core.hooksPath
+.githooks`, which wires up `.githooks/pre-push` to run `scripts/ci-local.sh
+--fast` automatically before every `git push` and block the push on
+failure. Bypass a single push with `git push --no-verify`; undo the hook
+entirely with `git config --unset core.hooksPath`.
+
+`.githooks/` already ships a `pre-commit` hook (`cargo fmt --all --check` +
+`cargo nextest run --workspace --locked`) alongside the new `pre-push` one.
+Both are opt-in via the same `core.hooksPath` setting. Note that
+`core.hooksPath` is a single switch: pointing it at `.githooks` means Git
+stops looking in `.git/hooks`, so it supersedes hooks installed by the
+`pre-commit` framework (see [Pre-commit Hooks](#pre-commit-hooks) above) —
+use one mechanism or the other, not both, per clone.
+
+### Full workflow replay
+
+`ci-local.sh` runs the same commands as CI, but not inside the same
+container/runner image, so it cannot catch environment-specific breakage.
+For an exact, Docker-based replay of the GitHub Actions workflow (all jobs,
+the real `ubuntu-latest` image), use
+[`act`](https://github.com/nektos/act) instead.
+
 ## Working Style
 
 - keep changes small and reviewable

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -26,7 +26,7 @@ release.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** until variant-specific VM evidence exists |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,348 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,403 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -117,7 +117,7 @@ SysKnife auto-detects it. See [Quick Start](quickstart.md).
 
 ## Status
 
-189 typed actions · 1,348 Rust tests + 72 frontend tests · MIT
+189 typed actions · 1,403 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/typed-actions.md
+++ b/docs/typed-actions.md
@@ -132,8 +132,9 @@ but it has a real cost:
   any command it comes up with."
 - **Coverage gaps.** A user's request that doesn't map to any action in the
   catalogue gets a "I can't do that yet" rather than a best-effort shell
-  command. `docs/ubuntu-action-gap-analysis.md` tracks known gaps in the
-  Debian/Ubuntu action set as one example of this in practice.
+  command. `docs/ubuntu-action-gap-analysis.md` is a historical (2026-04-25)
+  snapshot of this tradeoff playing out in the Debian/Ubuntu action set —
+  almost all of the gaps it identified have since been closed.
 
 SysKnife accepts this tradeoff deliberately: a finite, auditable vocabulary
 that the daemon fully understands is worth more than an open-ended one the

--- a/docs/ubuntu-action-gap-analysis.md
+++ b/docs/ubuntu-action-gap-analysis.md
@@ -1,5 +1,15 @@
 # Ubuntu action gap analysis
 
+> **Historical snapshot (2026-04-25).** This document is a point-in-time gap
+> analysis, not a live tracker. Almost every proposed action below has since
+> shipped — Tier 1, Tier 2, and Tier 3 are implemented in full except
+> `AptRollback` (Tier 1), which remains unimplemented (`apt-rollback` is not
+> pre-installed on Ubuntu Server, so it still needs a runtime-availability
+> check before it can land). For the current, code-generated action
+> catalogue see [`action-reference.md`](action-reference.md); for the
+> source-verified Ubuntu-specific families see
+> [`ubuntu-action-reference.md`](ubuntu-action-reference.md).
+
 Ubuntu sysadmins now represent a materially larger audience than Fedora Atomic users, and
 the Ubuntu action layer — apt, snap, ufw, netplan, distrobox — covers only a fraction of what
 a real server or desktop operator needs day-to-day. This document inventories the current Fedora

--- a/docs/ubuntu-action-reference.md
+++ b/docs/ubuntu-action-reference.md
@@ -120,6 +120,35 @@ Sources consulted:
 - **Status**: ✅ matches
 - **Notes**: Output is RFC 822 style (key: value). No sudo required.
 
+### AptListUpgradable — List packages with available upgrades
+
+- **Canonical**: `apt list --upgradable`
+- **SysKnife argv**: `["bash", "-c", "apt list --upgradable 2>/dev/null"]` (no sudo)
+- **Status**: ✅ matches
+- **Notes**: Read-only. `2>/dev/null` suppresses apt's "WARNING: apt does not
+  have a stable CLI interface" notice on stderr. No sudo required.
+
+### AptHistoryList — Show recent apt transaction history
+
+- **Canonical**: `grep -A 4 '^Start-Date' /var/log/apt/history.log | tail -n 80`
+- **SysKnife argv**: `["bash", "-c", "grep -A 4 '^Start-Date' /var/log/apt/history.log | tail -n 80"]` (no sudo)
+- **Status**: ✅ matches
+- **Notes**: Read-only file inspection of `/var/log/apt/history.log`. Returns
+  the 80 most recent log lines, covering the last several `Start-Date`
+  transaction blocks, for auditing what was installed/removed/upgraded.
+
+### ConfigureUnattendedUpgrades — Enable or disable automatic security updates
+
+- **Canonical**: no single canonical CLI — SysKnife ships a helper script
+- **SysKnife argv**: `["sudo", "/usr/lib/sysknife/unattended-upgrades-edit", "--enable"]`
+  or `--disable` — param: `enabled` (bool)
+- **Status**: ✅ implemented via bundled helper
+- **Notes**: the helper (`packaging/sysknife-unattended-upgrades-edit`) takes
+  no free-form input — it writes one of two fixed file contents to
+  `/etc/apt/apt.conf.d/20auto-upgrades` (no injection surface), and when
+  enabling, first ensures `unattended-upgrades` is installed. Risk: High —
+  toggles whether the host auto-applies security updates unattended.
+
 ---
 
 ## snap
@@ -135,10 +164,11 @@ Sources consulted:
   Default channel when none specified by SysKnife: `stable` (passed as `--channel=stable`).
   The hold-after-install pattern is correct: `snap refresh --hold <name>` pins the snap
   indefinitely. Exit code 0 = success.
-- **Missing flag consideration**: `--classic` is required for snaps with classic
-  confinement (e.g., VS Code: `snap install --classic code`). SysKnife does not
-  currently expose a `classic` flag. This is a gap for snaps requiring classic
-  confinement; they will fail with an error prompting the user to pass `--classic`.
+- **Classic confinement**: `--classic` is required for snaps with classic
+  confinement (e.g., VS Code: `snap install --classic code`). `SnapInstall`
+  itself does not expose a `classic` flag — that case is handled by a
+  separate action, `SnapClassicInstall` (see below), rather than a flag on
+  this one.
 
 ### SnapRemove — Remove snap
 
@@ -190,6 +220,26 @@ Sources consulted:
 - **Status**: ✅ matches
 - **Output**: Multi-section human-readable; includes name, summary, publisher,
   available channels, installed revision, and tracking channel.
+
+### SnapRevert — Revert to the previous revision
+
+- **Canonical**: `sudo snap revert [--revision=<rev>] <name>`
+- **SysKnife argv**: `["sudo", "snap", "revert", "<name>"]` — param: `name`
+- **Status**: ✅ matches (basic revert, no explicit `--revision`)
+- **Notes**: Rolls the snap back one revision; the reverted-from revision is
+  preserved on disk and the revert itself can be undone with `SnapRefresh`.
+  Risk: Medium.
+
+### SnapClassicInstall — Install with classic confinement
+
+- **Canonical**: `sudo snap install --classic <name>`
+- **SysKnife argv**: `["sudo", "snap", "install", "--classic", "<name>"]` —
+  param: `name`
+- **Status**: ✅ matches
+- **Notes**: Separate action from `SnapInstall` rather than a flag on it (see
+  the classic-confinement note above). Classic-confined snaps get full
+  system access with no sandbox, so this carries more risk than a sandboxed
+  install — Risk: Medium.
 
 ---
 
@@ -246,11 +296,33 @@ Sources consulted:
 - **Status**: ✅ matches
 - **Notes**: `verbose` adds default policies (incoming/outgoing/routed) to the
   output. Without `verbose`, `ufw status` shows only active rules and
-  the Enabled/Disabled state. `status numbered` adds rule numbers for deletion
-  targeting but is not needed here.
+  the Enabled/Disabled state. `status numbered` adds rule numbers, which is
+  how a user finds the `rule_number` argument for `UfwDeleteRule`.
 - **Output format**: Plain text, columns: `To  Action  From` with directional
   qualifiers (`ALLOW`, `ALLOW IN`, `ALLOW OUT`). No JSON output available.
 - **sudo required**: Yes — ufw reads privileged iptables state.
+
+### UfwDeleteRule — Delete a rule by number
+
+- **Canonical**: `sudo ufw --force delete <rule_number>`
+- **SysKnife argv**: `["sudo", "ufw", "--force", "delete", "<rule_number>"]` —
+  param: `rule_number` (positive integer from `ufw status numbered`)
+- **Status**: ✅ matches
+- **Notes**: `--force` suppresses the confirmation prompt, same as
+  `UfwEnable` / `UfwReset`. Risk: High — a mistaken deletion can expose
+  services or drop needed traffic. Rejects `rule_number == 0` (ufw rule
+  numbers are 1-based).
+
+### UfwLimit — Rate-limit connections
+
+- **Canonical**: `sudo ufw limit <port_or_service>`
+- **SysKnife argv**: `["sudo", "ufw", "limit", "<target>"]` — param: `target`
+  (port number, `port/proto`, or app profile name, e.g. `ssh`)
+- **Status**: ✅ matches
+- **Notes**: Blocks IPs making more than 6 connections within 30 seconds —
+  the standard ufw brute-force mitigation, commonly applied to SSH (port 22).
+  Risk: High — can inadvertently rate-limit legitimate traffic under
+  high-connection workloads.
 
 ---
 
@@ -258,20 +330,24 @@ Sources consulted:
 
 ### NetplanGetConfig — Read current configuration
 
-- **SysKnife approach**: `bash -c "cat /etc/netplan/*.yaml 2>/dev/null || echo 'no netplan files found'"`
+- **SysKnife argv**: `["find", "/etc/netplan", "-maxdepth", "1", "-name", "*.yaml", "-print", "-exec", "cat", "{}", "+"]`
 - **Canonical alternative**: `sudo netplan get` (merges all YAML from `/etc/netplan/`,
   `/lib/netplan/`, and `/run/netplan/` into a single output)
 - **Status**: ⚠ functional divergence — not wrong, but differs from canonical
-- **Notes**: SysKnife `bash -c "cat /etc/netplan/*.yaml"` returns raw YAML of each
-  file separately. `netplan get` returns a single merged representation. The cat
-  approach works but:
+- **Notes**: SysKnife shells out to `find` directly (no `bash -c`), printing each
+  matched file's path followed by its contents. `netplan get` returns a single
+  merged representation instead. The `find` approach:
   1. Does not merge configs across `/lib/netplan/` and `/run/netplan/` overlay paths.
   2. May include YAML comments; `netplan get` output is stripped and canonical.
-  3. If there are no files, the glob `*.yaml` fails with exit code 1 (handled by
-     the `|| echo` fallback — this part is correct).
-  - For read-only inspection, the cat approach is harmless and does not require sudo
-    for files readable by the daemon user. `netplan get` requires sudo on most Ubuntu
-    installs because `/etc/netplan/` is root-owned mode 600.
+  3. Surfaces three distinct states instead of collapsing them: a missing/
+     permission-denied `/etc/netplan` makes `find` exit non-zero with a stderr
+     diagnostic, while a directory with no `*.yaml` files exits 0 with empty
+     stdout. (An earlier version shelled out to `bash -c "cat /etc/netplan/*.yaml
+     2>/dev/null || echo 'no netplan files found'"`, which collapsed all three
+     states into one fake-success exit 0 — fixed by moving to `find` directly.)
+  - For read-only inspection, this is harmless and does not require sudo for
+    files readable by the daemon user. `netplan get` requires sudo on most
+    Ubuntu installs because `/etc/netplan/` is root-owned mode 600.
   - **Not a blocking bug.** Document as a known divergence.
 
 ### NetplanApply — Apply configuration
@@ -285,15 +361,33 @@ Sources consulted:
   implemented as a daemon action (documented in the source).
   Exit code 0 = success; non-zero on YAML parse or backend errors.
 
-### Missing actions — netplan generate, get, set
+### NetplanSet — Set a single netplan key
 
-- **netplan generate**: Generates backend config files but does not apply them.
-  Useful for previewing what netplan would write before `apply`. Not implemented.
-- **netplan get**: Returns merged netplan config as YAML. More canonical than
-  `cat /etc/netplan/*.yaml`. Could replace `NetplanGetConfig`.
-- **netplan set**: Writes a key=value into `/etc/netplan/`. Allows targeted edits
-  without reading/modifying YAML manually. Not implemented.
-- These are gaps in coverage, not bugs in existing code.
+- **Canonical**: `sudo netplan set <key>=<value>`
+- **SysKnife argv**: `["sudo", "netplan", "set", "<key>=<value>"]` — params: `key`
+  (e.g. `ethernets.eth0.dhcp4`), `value`
+- **Status**: ✅ matches
+- **Notes**: `key=value` is passed as a single argument with no shell involved;
+  `validated_safe_arg` (executor boundary) rejects spaces in `value`, so quoting
+  a multi-word value would only inject literal quote bytes. Risk: High —
+  modifies the active netplan configuration in-memory. Run `NetplanApply`
+  afterward to activate the change.
+
+### NetplanGenerate — Regenerate backend config without applying
+
+- **Canonical**: `sudo netplan generate`
+- **SysKnife argv**: `["sudo", "netplan", "generate"]`
+- **Status**: ✅ matches
+- **Notes**: Risk: Medium. Regenerates `systemd-networkd` / `NetworkManager`
+  backend config files from the current netplan YAML but does not reload
+  interfaces — safe to use as a dry-run check before `NetplanApply`.
+
+### Not implemented — netplan get
+
+- **netplan get**: Returns merged netplan config as YAML across `/etc/netplan/`,
+  `/lib/netplan/`, and `/run/netplan/`. More canonical than the `find`-based
+  `NetplanGetConfig`, which only reads `/etc/netplan/`. See the `NetplanGetConfig`
+  divergence above — this is a coverage gap, not a bug in existing code.
 
 ---
 
@@ -343,10 +437,9 @@ Sources consulted:
 
 | # | Family | Action | Description |
 |---|--------|--------|-------------|
-| D1 | netplan | NetplanGetConfig | Uses `cat /etc/netplan/*.yaml` instead of `netplan get`. Does not merge `/lib/netplan/` or `/run/netplan/` overlays. |
+| D1 | netplan | NetplanGetConfig | Uses `find /etc/netplan -maxdepth 1 -name '*.yaml' -print -exec cat {} +` instead of `netplan get`. Only reads `/etc/netplan/`; does not merge `/lib/netplan/` or `/run/netplan/` overlays. |
 | D2 | apt | AptListInstalled | Uses `dpkg -l` (human-oriented, wide output). `dpkg-query -W -f='${Package}\t${Version}\n'` is cleaner for machine parsing. |
-| D3 | snap | SnapInstall | No `--classic` flag exposed. Snaps requiring classic confinement (e.g., VS Code, Go toolchain) will fail without it. |
-| D4 | snap | SnapRemove | No `--purge` flag exposed. User data snapshots are retained (safe default). |
+| D3 | snap | SnapRemove | No `--purge` flag exposed. User data snapshots are retained (safe default). |
 
 ---
 
@@ -473,10 +566,17 @@ which netplan && netplan --version
 ls /etc/netplan/
 
 # NetplanGetConfig (SysKnife approach)
-bash -c "cat /etc/netplan/*.yaml 2>/dev/null || echo 'no netplan files found'"
+find /etc/netplan -maxdepth 1 -name '*.yaml' -print -exec cat {} +
 
 # Canonical alternative
 sudo netplan get
+
+# NetplanGenerate (dry run — regenerates backend config, does not apply)
+sudo netplan generate
+echo "exit=$?"
+
+# NetplanSet (in-memory change — run NetplanApply after to activate)
+sudo netplan set ethernets.eth0.dhcp4=true
 
 # NetplanApply (safe: only apply if no config change)
 # WARNING: can disconnect SSH — run only on a console or via OOB access if changing IP

--- a/docs/vm-daemon-setup.md
+++ b/docs/vm-daemon-setup.md
@@ -172,26 +172,39 @@ cat /sys/class/vsock/local_cid   # e.g. prints "10"
 vsock connections require a pre-shared token to authenticate the host to the
 daemon. This prevents other processes on the host from connecting.
 
+The token file holds **only the trimmed token itself** — no `role:` prefix.
+The role granted to a token-authenticated connection comes from a separate
+env var, `SYSKNIFE_TOKEN_ROLE` (default `Dev` if unset), read by the daemon
+process — not from the file contents.
+
+The default token path is `~/.config/sysknife/token` (the daemon's XDG config
+directory, next to `prefs.md`; respects `$XDG_CONFIG_HOME` if set), not
+`/etc/sysknife/token`.
+
 ```sh
 # On the host — generate a token
 openssl rand -hex 32
 # e.g.: a3f8c2d1e4b7a0f9...
 
 # On the guest — write the token to the daemon's token file
-sudo mkdir -p /etc/sysknife
-echo "admin:a3f8c2d1e4b7a0f9..." | sudo tee /etc/sysknife/token
-sudo chmod 600 /etc/sysknife/token
-sudo chown root:root /etc/sysknife/token
+mkdir -p ~/.config/sysknife
+echo "a3f8c2d1e4b7a0f9..." > ~/.config/sysknife/token
+chmod 600 ~/.config/sysknife/token
 
-# Restart the daemon to pick up the token
+# Grant Admin to token-authenticated vsock connections (default is Dev)
+sudo systemctl edit sysknife-daemon
+# Add under [Service]:
+#   Environment=SYSKNIFE_TOKEN_ROLE=admin
+
+# Restart the daemon to pick up the token and role
 sudo systemctl restart sysknife-daemon
 ```
 
-The token file format is `<role>:<hex-token>` on each line:
+The token file contains just the raw token, with no role prefix:
 
 ```text
-# /etc/sysknife/token
-admin:<paste-token-here>
+# ~/.config/sysknife/token
+<paste-token-here>
 ```
 
 ### Configure and connect (vsock)
@@ -259,8 +272,9 @@ Set `SYSKNIFE_TOKEN` in the `env` block of `.mcp.json` (see above).
 
 ### "authentication failed" on vsock
 
-The token on the host (`SYSKNIFE_TOKEN` in `.mcp.json`) does not match any
-entry in `/etc/sysknife/token` on the guest. Verify both match exactly.
+The token on the host (`SYSKNIFE_TOKEN` in `.mcp.json`) does not match the
+contents of `~/.config/sysknife/token` on the guest. Verify both match
+exactly (the file should hold just the raw token, no `role:` prefix).
 
 ### SSH tunnel drops when the terminal closes
 

--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -184,6 +184,31 @@ function tomlQuote(s) {
   return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
+// ---------------------------------------------------------------------------
+// Runtime socket path resolution (mirrors install-daemon.js — no shared
+// module dep)
+// ---------------------------------------------------------------------------
+//
+// sysknife_core::default_listen_uri() (crates/sysknife-core/src/lib.rs)
+// resolves, in order: 1) $SYSKNIFE_LISTEN_URI  2) $XDG_RUNTIME_DIR/sysknife/
+// daemon.sock  3) /tmp/sysknife-$UID.sock as a last resort. The wizard's
+// systemd --user unit (install-daemon.js) binds tier 2 via the `%t`
+// specifier with no env var needed. Offering that SAME resolved path here —
+// as both the default "Daemon socket" answer and the explicit SYSKNIFE_SOCKET
+// written into the MCP config — means the daemon, the MCP server subprocess,
+// and a human typing `sysknife approve <id>` in a bare terminal all agree on
+// one socket, with no shell-profile edits required.
+
+/** `$XDG_RUNTIME_DIR`, falling back to `/run/user/<uid>` when unset. */
+function runtimeDir() {
+  return process.env.XDG_RUNTIME_DIR || `/run/user/${process.getuid()}`;
+}
+
+/** The per-user daemon socket path — matches `default_listen_uri()` tier 2. */
+function runtimeSocketPath() {
+  return path.join(runtimeDir(), 'sysknife', 'daemon.sock');
+}
+
 /**
  * Write TOML for one mcpServer entry.
  *
@@ -394,7 +419,7 @@ async function collectTarget(rl, lineQueue, idx) {
   console.log(`    ${D}/tmp/sysknife-vm.sock${X}        ${D}SSH tunnel to a VM${X}`);
   console.log(`    ${D}vsock://10:9734${X}              ${D}virtio-vsock (CID:port)${X}`);
 
-  const defaultSocket = path.join(os.homedir(), '.local', 'share', 'sysknife', 'daemon.sock');
+  const defaultSocket = runtimeSocketPath();
   const socket = await ask(rl, lineQueue, 'Daemon socket', defaultSocket);
 
   // Optionally probe the socket so the user knows immediately if the daemon
@@ -438,7 +463,7 @@ function targetNextStep(target) {
   // Sockets that live on this machine, so the daemon starts locally rather than
   // over an SSH tunnel. Includes the default user-service socket written by the
   // wizard (matches install-daemon.js) and the systemd system-unit path.
-  const userServiceSocket = path.join(os.homedir(), '.local', 'share', 'sysknife', 'daemon.sock');
+  const userServiceSocket = runtimeSocketPath();
   const localSockets = new Set([
     userServiceSocket,
     '/run/sysknife/daemon.sock',

--- a/packages/setup/install-binary.js
+++ b/packages/setup/install-binary.js
@@ -305,7 +305,10 @@ function assetUrl(release, name) {
  * @param {string} filename    - asset filename to look up
  */
 function verifySha256(data, sumsText, filename) {
-  const lines = sumsText.split('\n').filter(l => l.trim());
+  const lines = sumsText
+    .split('\n')
+    .map(l => l.replace(/\r$/, '')) // tolerate CRLF-terminated sums files
+    .filter(l => l.trim());
   const entry = lines.find(l => l.endsWith(`  ${filename}`) || l.endsWith(`\t${filename}`));
   if (!entry) {
     throw new Error(
@@ -333,7 +336,7 @@ function verifySha256(data, sumsText, filename) {
  * Write `data` to `destPath` as an executable file (mode 0o755).
  * Creates the destination directory if needed.
  * If `destPath` is under /usr/local/bin or another root-owned directory,
- * falls back to writing via `sudo tee`.
+ * falls back to writing via `sudo install -o root -g root -m 755`.
  *
  * @param {Buffer} data
  * @param {string} destPath  absolute path

--- a/packages/setup/install-daemon.js
+++ b/packages/setup/install-daemon.js
@@ -48,14 +48,38 @@ function warn(msg) { console.log(`  ${Y}⚠${X}  ${msg}`); }
 function step(msg) { console.log(`  ${D}→${X}  ${msg}`); }
 
 // ---------------------------------------------------------------------------
+// Runtime socket path resolution
+// ---------------------------------------------------------------------------
+//
+// sysknife_core::default_listen_uri() (crates/sysknife-core/src/lib.rs)
+// resolves, in order: 1) $SYSKNIFE_LISTEN_URI  2) $XDG_RUNTIME_DIR/sysknife/
+// daemon.sock  3) /tmp/sysknife-$UID.sock as a last resort. The user unit
+// below binds tier 2 directly via systemd's `%t` specifier (equal to
+// $XDG_RUNTIME_DIR under a `systemctl --user` manager) so the daemon needs no
+// explicit env var at all. These two helpers mirror that same tier-2 formula
+// in JS — used for console output here, and for the MCP config's explicit
+// SYSKNIFE_SOCKET in index.js — so a human running `sysknife approve <id>`
+// in a bare terminal resolves to the exact socket the daemon bound, with no
+// shell-profile edits required.
+
+/** `$XDG_RUNTIME_DIR`, falling back to `/run/user/<uid>` when unset. */
+function runtimeDir() {
+  return process.env.XDG_RUNTIME_DIR || `/run/user/${process.getuid()}`;
+}
+
+/** The per-user daemon socket path — matches `default_listen_uri()` tier 2. */
+function runtimeSocketPath() {
+  return path.join(runtimeDir(), 'sysknife', 'daemon.sock');
+}
+
+// ---------------------------------------------------------------------------
 // Unit file templates
 // ---------------------------------------------------------------------------
 
 /** User-level service (no root, casual / dev use). */
 function userUnitContent(daemonBin) {
-  const socketDir  = path.join(os.homedir(), '.local', 'share', 'sysknife');
-  const dbPath     = path.join(socketDir, 'daemon.sqlite');
-  const socketPath = path.join(socketDir, 'daemon.sock');
+  const stateDir = path.join(os.homedir(), '.local', 'share', 'sysknife');
+  const dbPath   = path.join(stateDir, 'daemon.sqlite');
 
   return `[Unit]
 Description=SysKnife privileged daemon (user session)
@@ -64,7 +88,11 @@ After=default.target
 
 [Service]
 Type=simple
-Environment="SYSKNIFE_LISTEN_URI=unix://${socketPath}"
+# %t expands to $XDG_RUNTIME_DIR under \`systemctl --user\` — the exact socket
+# sysknife_core::default_listen_uri() falls back to with no env vars set, so
+# a human running \`sysknife approve <id>\` in a fresh terminal reaches this
+# daemon with zero shell-profile edits.
+Environment="SYSKNIFE_LISTEN_URI=unix://%t/sysknife/daemon.sock"
 Environment="SYSKNIFE_DATABASE_PATH=${dbPath}"
 ExecStart=${daemonBin}
 Restart=on-failure
@@ -199,7 +227,7 @@ async function _installUserService(daemonBinPath) {
   const started = systemctl(['enable', '--now', 'sysknife-daemon'], true);
   if (started) {
     ok('sysknife-daemon user service enabled and started.');
-    step('Socket: ' + path.join(os.homedir(), '.local', 'share', 'sysknife', 'daemon.sock'));
+    step('Socket: ' + runtimeSocketPath());
   } else {
     warn('Could not enable/start user service automatically.');
     step('Run:  systemctl --user enable --now sysknife-daemon');
@@ -237,4 +265,4 @@ async function _installSystemService(daemonBinPath) {
   step(`Daemon binary path that will be used:  ${daemonBinPath}`);
 }
 
-module.exports = { installDaemonService };
+module.exports = { installDaemonService, userUnitContent, runtimeSocketPath, runtimeDir };

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Zero-friction setup for SysKnife MCP server — Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/packages/setup/tests/install-binary.test.mjs
+++ b/packages/setup/tests/install-binary.test.mjs
@@ -59,6 +59,14 @@ test('verifySha256 is case-insensitive on hex', () => {
   assert.doesNotThrow(() => verifySha256(data, sums, 'mybin'));
 });
 
+test('verifySha256 tolerates a CRLF-terminated sums file', () => {
+  const data = Buffer.from('crlf sums test');
+  const hex  = crypto.createHash('sha256').update(data).digest('hex');
+  // Windows-style line endings: every line ends with \r\n, not just \n.
+  const sums = `${hex}  sysknife-v0.2.4-linux-x86_64\r\n`;
+  assert.doesNotThrow(() => verifySha256(data, sums, 'sysknife-v0.2.4-linux-x86_64'));
+});
+
 // ---------------------------------------------------------------------------
 // detectPlatform tests
 // ---------------------------------------------------------------------------

--- a/packages/setup/tests/install-daemon.test.mjs
+++ b/packages/setup/tests/install-daemon.test.mjs
@@ -89,7 +89,12 @@ test('userUnitContent does not reintroduce a resolved ~/.local/share socket', ()
 test('userUnitContent still persists the SQLite database under ~/.local/share (state, not the socket, stays there)', () => {
   const unit = userUnitContent('/home/x/.local/bin/sysknife-daemon');
   const expectedDb = path.join(os.homedir(), '.local', 'share', 'sysknife', 'daemon.sqlite');
-  assert.match(unit, new RegExp(`SYSKNIFE_DATABASE_PATH=${expectedDb.replace(/[/.]/g, '\\$&')}`));
+  // Plain substring assertion (no constructed RegExp) so a path containing
+  // regex metacharacters can't break the match or the escaping.
+  assert.ok(
+    unit.includes(`SYSKNIFE_DATABASE_PATH=${expectedDb}`),
+    `unit should contain SYSKNIFE_DATABASE_PATH=${expectedDb}`,
+  );
 });
 
 test('userUnitContent wires the given daemon binary path as ExecStart', () => {

--- a/packages/setup/tests/install-daemon.test.mjs
+++ b/packages/setup/tests/install-daemon.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * install-daemon.test.mjs
+ *
+ * Unit tests for install-daemon.js using the Node built-in test runner.
+ * Run with: node --test packages/setup/tests/install-daemon.test.mjs
+ *
+ * Requiring install-daemon.js is safe: unlike index.js, it has no top-level
+ * side effects — installDaemonService() only runs when explicitly called,
+ * which none of these tests do (that would touch the real systemd --user
+ * session on the machine running the tests).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { userUnitContent, runtimeSocketPath, runtimeDir } = require('../install-daemon.js');
+
+// ---------------------------------------------------------------------------
+// runtimeDir / runtimeSocketPath — the socket-mismatch regression guard
+// ---------------------------------------------------------------------------
+//
+// sysknife_core::default_listen_uri() (crates/sysknife-core/src/lib.rs) falls
+// back to $XDG_RUNTIME_DIR/sysknife/daemon.sock, else /tmp/sysknife-$UID.sock.
+// These helpers must mirror tier 2 of that resolution exactly, since the
+// wizard uses them to offer the same default a bare terminal's `sysknife
+// approve` will resolve to.
+
+function withEnv(name, value, fn) {
+  const prev = process.env[name];
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = prev;
+    }
+  }
+}
+
+test('runtimeDir uses XDG_RUNTIME_DIR when set', () => {
+  withEnv('XDG_RUNTIME_DIR', '/run/user/4242', () => {
+    assert.equal(runtimeDir(), '/run/user/4242');
+  });
+});
+
+test('runtimeDir falls back to /run/user/<uid> when XDG_RUNTIME_DIR is unset', () => {
+  withEnv('XDG_RUNTIME_DIR', undefined, () => {
+    assert.equal(runtimeDir(), `/run/user/${process.getuid()}`);
+  });
+});
+
+test('runtimeSocketPath appends sysknife/daemon.sock to the runtime dir', () => {
+  withEnv('XDG_RUNTIME_DIR', '/run/user/4242', () => {
+    assert.equal(runtimeSocketPath(), '/run/user/4242/sysknife/daemon.sock');
+  });
+});
+
+test('runtimeSocketPath falls back consistently when XDG_RUNTIME_DIR is unset', () => {
+  withEnv('XDG_RUNTIME_DIR', undefined, () => {
+    assert.equal(runtimeSocketPath(), `/run/user/${process.getuid()}/sysknife/daemon.sock`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// userUnitContent — the shipped systemd --user unit
+// ---------------------------------------------------------------------------
+
+test('userUnitContent binds unix://%t/sysknife/daemon.sock (matches the CLI default with zero env)', () => {
+  const unit = userUnitContent('/home/x/.local/bin/sysknife-daemon');
+  assert.match(unit, /Environment="SYSKNIFE_LISTEN_URI=unix:\/\/%t\/sysknife\/daemon\.sock"/);
+});
+
+test('userUnitContent does not reintroduce a resolved ~/.local/share socket', () => {
+  const unit = userUnitContent('/home/x/.local/bin/sysknife-daemon');
+  assert.doesNotMatch(unit, /SYSKNIFE_LISTEN_URI=unix:\/\/\/home/);
+  assert.doesNotMatch(unit, /SYSKNIFE_LISTEN_URI=unix:\/\/\$\{socketPath\}/);
+});
+
+test('userUnitContent still persists the SQLite database under ~/.local/share (state, not the socket, stays there)', () => {
+  const unit = userUnitContent('/home/x/.local/bin/sysknife-daemon');
+  const expectedDb = path.join(os.homedir(), '.local', 'share', 'sysknife', 'daemon.sqlite');
+  assert.match(unit, new RegExp(`SYSKNIFE_DATABASE_PATH=${expectedDb.replace(/[/.]/g, '\\$&')}`));
+});
+
+test('userUnitContent wires the given daemon binary path as ExecStart', () => {
+  const unit = userUnitContent('/opt/sysknife/sysknife-daemon');
+  assert.match(unit, /ExecStart=\/opt\/sysknife\/sysknife-daemon/);
+});

--- a/packages/setup/tests/setup-contract.test.mjs
+++ b/packages/setup/tests/setup-contract.test.mjs
@@ -23,9 +23,22 @@ test('MCP configs are merged, not overwritten (preserves other servers)', () => 
   assert.doesNotMatch(source, /const cursorMcp = \{ mcpServers \}/);
 });
 
-test('default MCP target and user service use the same socket', () => {
-  assert.match(source, /\.local', 'share', 'sysknife', 'daemon\.sock/);
-  assert.match(daemonInstaller, /\.local', 'share', 'sysknife', 'daemon\.sock/);
+test('default MCP target, wizard user unit, and CLI default all resolve to the same socket', () => {
+  // Regression guard: the wizard's systemd --user unit used to bind
+  // ~/.local/share/sysknife/daemon.sock while a bare terminal's
+  // `sysknife approve <id>` resolves sysknife_core::default_listen_uri() ->
+  // $XDG_RUNTIME_DIR/sysknife/daemon.sock (crates/sysknife-core/src/lib.rs).
+  // The two never matched with zero per-terminal env, so the mandatory
+  // human-approval gate was unreachable by default. Both files must now
+  // resolve the identical path via a shared runtimeSocketPath() formula, and
+  // the stale ~/.local/share default must be gone from both.
+  assert.doesNotMatch(source, /'\.local',\s*'share',\s*'sysknife',\s*'daemon\.sock'/);
+  assert.doesNotMatch(daemonInstaller, /SYSKNIFE_LISTEN_URI=unix:\/\/\$\{socketPath\}/);
+  assert.match(daemonInstaller, /SYSKNIFE_LISTEN_URI=unix:\/\/%t\/sysknife\/daemon\.sock/);
+  assert.match(source, /function runtimeSocketPath\(\)/);
+  assert.match(daemonInstaller, /function runtimeSocketPath\(\)/);
+  assert.match(source, /XDG_RUNTIME_DIR/);
+  assert.match(source, /process\.getuid\(\)/);
 });
 
 test('--no-prompts fails fast without an explicit integration', () => {

--- a/scripts/check_public_claims.sh
+++ b/scripts/check_public_claims.sh
@@ -30,7 +30,7 @@ reject_pattern() {
 }
 
 reject_pattern '1,(2[2-9][0-9]|3[0-3][0-9]|34[0-7])( Rust)? tests' \
-    'test count is stale; the release baseline is 1,348 Rust tests' \
+    'test count is stale; the release baseline is 1,403 Rust tests' \
     "${claim_files[@]}"
 reject_pattern 'until npm publish lands|publish[- ]pending' \
     'setup package is documented as unpublished' "${claim_files[@]}"
@@ -60,8 +60,8 @@ required_test_count_docs=(
     "$repo_root/docs/distro-support.md"
 )
 for path in "${required_test_count_docs[@]}"; do
-    if ! grep -Fq '1,348 Rust tests' "$path"; then
-        printf 'Verified test baseline missing from %s: expected 1,348 Rust tests\n' \
+    if ! grep -Fq '1,403 Rust tests' "$path"; then
+        printf 'Verified test baseline missing from %s: expected 1,403 Rust tests\n' \
             "$path" >&2
         exit 1
     fi

--- a/scripts/check_repo_completeness.sh
+++ b/scripts/check_repo_completeness.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 required=(
   "LICENSE"
   "README.md"
@@ -25,7 +27,7 @@ required=(
 
 missing=()
 for path in "${required[@]}"; do
-  if [[ ! -e "$path" ]]; then
+  if [[ ! -e "${repo_root}/${path}" ]]; then
     missing+=("$path")
   fi
 done

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ci-local.sh — mirror the runnable jobs from .github/workflows/ci.yml on a
+# contributor's machine, so failures are caught before pushing (and before
+# spending GitHub Actions minutes). See docs/developer-guide.md, "Running CI
+# locally", for the full write-up.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Host port for the throwaway postgres-contract container. Deliberately not
+# postgres's own default (5432) so a developer's already-running local
+# Postgres server, if any, is never shadowed or port-conflicted.
+readonly POSTGRES_HOST_PORT=5433
+readonly POSTGRES_CONTAINER_NAME="sysknife-ci-local-postgres"
+# Health-check budget: 30 retries * 1s = 30s, generous for a cold
+# `postgres:17-alpine` pull + start on a typical dev machine.
+readonly POSTGRES_HEALTH_RETRIES=30
+readonly POSTGRES_HEALTH_INTERVAL_SECS=1
+
+mode="full"
+run_postgres=true
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/ci-local.sh [--fast] [--no-postgres] [--install-hooks] [--help]
+
+Mirror the runnable jobs from .github/workflows/ci.yml locally so failures
+are caught before pushing (and before spending GitHub Actions minutes).
+
+  --fast           Rust fmt/clippy/nextest + frontend tsc/vitest only (the
+                    same subset the pre-push hook runs)
+  --no-postgres    Skip the optional postgres-contract job even when a
+                    container runtime or SYSKNIFE_TEST_POSTGRES_URL is present
+  --install-hooks  Set git core.hooksPath to .githooks (enables the pre-push
+                    gate: scripts/ci-local.sh --fast) and exit -- does not
+                    run any checks
+  --help           Show this help and exit
+
+Groups (default, full run): rust, frontend, hygiene, security,
+postgres-contract (optional -- skipped if no runtime/URL is available).
+
+For a full Docker-based replay of the exact GitHub Actions workflow (all
+jobs, exact runner image), see https://github.com/nektos/act instead.
+EOF
+}
+
+while (($# > 0)); do
+    case "$1" in
+        --fast) mode="fast" ;;
+        --no-postgres) run_postgres=false ;;
+        --install-hooks)
+            git -C "$repo_root" config core.hooksPath .githooks
+            printf 'ci-local: git core.hooksPath set to .githooks (pre-push gate enabled)\n'
+            printf 'ci-local: disable with: git config --unset core.hooksPath\n'
+            exit 0
+            ;;
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        *)
+            printf 'ci-local: unknown flag: %s\n' "$1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+cd "$repo_root"
+
+# ---------------------------------------------------------------------------
+# Result tracking
+# ---------------------------------------------------------------------------
+
+RESULTS=()
+hard_failures=0
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Record one outcome. status is one of PASS / FAIL / WARN / SKIP; only FAIL
+# counts toward the exit code.
+record() {
+    local status="$1" label="$2"
+    RESULTS+=("${status}  ${label}")
+    if [[ "$status" == "FAIL" ]]; then
+        hard_failures=$((hard_failures + 1))
+    fi
+}
+
+# Run a step, print its heading, and record PASS/FAIL. Always returns 0 so a
+# bare call never trips `set -e` -- every check runs even after an earlier one
+# fails, and the aggregate result is decided at the end from $hard_failures.
+run_step() {
+    local label="$1"
+    shift
+    printf '\n==> %s\n' "$label"
+    if "$@"; then
+        record PASS "$label"
+    else
+        record FAIL "$label"
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Tool detection
+# ---------------------------------------------------------------------------
+
+printf 'ci-local: detecting tools...\n'
+tools=(cargo cargo-nextest cargo-audit node npm markdownlint-cli2 markdown-link-check yamllint shellcheck)
+for t in "${tools[@]}"; do
+    if have "$t"; then
+        printf '  [x] %s\n' "$t"
+    else
+        printf '  [ ] %s (not found)\n' "$t"
+    fi
+done
+
+missing_required=()
+have cargo || missing_required+=(cargo)
+have node || missing_required+=(node)
+
+if ((${#missing_required[@]} > 0)); then
+    printf '\nci-local: FATAL missing required tool(s): %s\n' "${missing_required[*]}" >&2
+    printf 'Install cargo: https://rustup.rs\n' >&2
+    printf 'Install node:  https://nodejs.org\n' >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# rust
+# ---------------------------------------------------------------------------
+
+run_cargo_doc() {
+    RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --locked
+}
+
+run_rust_group() {
+    printf '\n### rust\n'
+    run_step 'rust: cargo fmt --all --check' cargo fmt --all --check
+    run_step 'rust: cargo clippy --workspace --all-features --locked -- -D warnings' \
+        cargo clippy --workspace --all-features --locked -- -D warnings
+
+    if [[ "$mode" == "full" ]]; then
+        run_step 'rust: cargo doc (RUSTDOCFLAGS=-D warnings)' run_cargo_doc
+    fi
+
+    if have cargo-nextest; then
+        run_step 'rust: cargo nextest run --workspace --locked' \
+            cargo nextest run --workspace --locked
+    else
+        record WARN 'rust: cargo nextest run -- SKIPPED (cargo-nextest not found; install: cargo install cargo-nextest --locked)'
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# frontend (apps/sysknife-shell)
+# ---------------------------------------------------------------------------
+
+frontend_install() (
+    cd "$repo_root/apps/sysknife-shell" || exit 1
+    if npm ci; then
+        exit 0
+    fi
+    printf 'ci-local: npm ci failed -- retrying with npm install (offline/lockfile-mismatch fallback)\n' >&2
+    npm install
+)
+
+frontend_audit() (
+    cd "$repo_root/apps/sysknife-shell" || exit 1
+    npm audit --omit=dev --audit-level=high
+)
+
+frontend_tsc() (
+    cd "$repo_root/apps/sysknife-shell" || exit 1
+    ./node_modules/.bin/tsc --noEmit
+)
+
+frontend_vitest() (
+    cd "$repo_root/apps/sysknife-shell" || exit 1
+    ./node_modules/.bin/vitest run
+)
+
+run_frontend_group() {
+    printf '\n### frontend (apps/sysknife-shell)\n'
+
+    if ! have npm; then
+        record WARN 'frontend: npm ci -- SKIPPED (npm not found; install: https://nodejs.org)'
+        return
+    fi
+
+    printf '\n==> frontend: npm ci (falls back to npm install)\n'
+    if frontend_install; then
+        record PASS 'frontend: npm ci (falls back to npm install)'
+    else
+        record FAIL 'frontend: npm ci (falls back to npm install)'
+        record SKIP 'frontend: npm audit / tsc / vitest -- SKIPPED (dependency install failed)'
+        return
+    fi
+
+    if [[ "$mode" == "full" ]]; then
+        printf '\n==> frontend: npm audit --omit=dev --audit-level=high (non-fatal)\n'
+        if frontend_audit; then
+            record PASS 'frontend: npm audit --omit=dev --audit-level=high'
+        else
+            record WARN 'frontend: npm audit --omit=dev --audit-level=high (non-fatal; review output above)'
+        fi
+    fi
+
+    run_step 'frontend: tsc --noEmit' frontend_tsc
+    run_step 'frontend: vitest run' frontend_vitest
+}
+
+# ---------------------------------------------------------------------------
+# hygiene
+# ---------------------------------------------------------------------------
+
+hygiene_markdownlint() (
+    cd "$repo_root" || exit 1
+    markdownlint-cli2 \
+        README.md \
+        CONTRIBUTING.md \
+        SECURITY.md \
+        CODE_OF_CONDUCT.md \
+        ROADMAP.md \
+        docs/architecture.md \
+        docs/developer-guide.md \
+        docs/adr/*.md
+)
+
+hygiene_markdown_link_check() (
+    cd "$repo_root" || exit 1
+    files=(
+        README.md
+        CONTRIBUTING.md
+        SECURITY.md
+        CODE_OF_CONDUCT.md
+        ROADMAP.md
+        docs/architecture.md
+        docs/developer-guide.md
+        docs/adr/0001-system-boundaries.md
+        docs/adr/0002-brain-provider-layer.md
+        docs/adr/0003-ipc-wire-protocol.md
+    )
+    for f in "${files[@]}"; do
+        markdown-link-check --config .markdown-link-check.json "$f" || exit 1
+    done
+)
+
+hygiene_yamllint() (
+    cd "$repo_root" || exit 1
+    yamllint .github/ISSUE_TEMPLATE/*.yml .github/workflows/*.yml
+)
+
+# Same scan as e2e.yml's "ShellCheck maintained scripts" step -- kept here too
+# since every script this task adds/touches must stay shellcheck-clean.
+hygiene_shellcheck() (
+    cd "$repo_root" || exit 1
+    find tests/e2e tests/release scripts assets/demo \
+        -type f -name '*.sh' -print0 \
+        | xargs -0 shellcheck --severity=warning
+)
+
+run_hygiene_group() {
+    printf '\n### hygiene\n'
+    run_step 'hygiene: check_repo_completeness.sh' bash "$repo_root/scripts/check_repo_completeness.sh"
+    run_step 'hygiene: check_release_versions.sh' bash "$repo_root/scripts/check_release_versions.sh"
+    run_step 'hygiene: public-claims.test.sh' bash "$repo_root/tests/release/public-claims.test.sh"
+    run_step 'hygiene: npm test --prefix packages/setup' npm test --prefix "$repo_root/packages/setup"
+    run_step 'hygiene: release-rehearsal.test.sh' bash "$repo_root/tests/release/release-rehearsal.test.sh"
+    run_step 'hygiene: ubuntu-vm-bootstrap.test.sh' bash "$repo_root/tests/e2e/ubuntu-vm-bootstrap.test.sh"
+
+    if have markdownlint-cli2; then
+        run_step 'hygiene: markdownlint-cli2' hygiene_markdownlint
+    else
+        record WARN 'hygiene: markdownlint-cli2 -- SKIPPED (not found; install: npm install --global markdownlint-cli2)'
+    fi
+
+    if have markdown-link-check; then
+        run_step 'hygiene: markdown-link-check' hygiene_markdown_link_check
+    else
+        record WARN 'hygiene: markdown-link-check -- SKIPPED (not found; install: npm install --global markdown-link-check)'
+    fi
+
+    if have yamllint; then
+        run_step 'hygiene: yamllint' hygiene_yamllint
+    else
+        record WARN 'hygiene: yamllint -- SKIPPED (not found; install: pip install yamllint)'
+    fi
+
+    if have shellcheck; then
+        run_step 'hygiene: shellcheck (tests/e2e tests/release scripts assets/demo)' hygiene_shellcheck
+    else
+        record WARN 'hygiene: shellcheck -- SKIPPED (not found; install: sudo apt-get install shellcheck)'
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# security
+# ---------------------------------------------------------------------------
+
+run_security_group() {
+    printf '\n### security\n'
+    if have cargo-audit; then
+        # RUSTSEC-2026-0097 is ignored here too -- see the matching comment in
+        # .github/workflows/ci.yml for why (GUI-only transitive dep, no fix yet).
+        run_step 'security: cargo audit --ignore RUSTSEC-2026-0097' \
+            cargo audit --ignore RUSTSEC-2026-0097
+    else
+        record WARN 'security: cargo audit -- SKIPPED (cargo-audit not found; install: cargo install cargo-audit --locked)'
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# postgres-contract (optional)
+# ---------------------------------------------------------------------------
+
+run_postgres_contract_group() {
+    printf '\n### postgres-contract (optional)\n'
+    local label="postgres-contract: cargo test -p sysknife-daemon --test postgres_store --locked"
+
+    if [[ "$run_postgres" != true ]]; then
+        record SKIP "${label} (--no-postgres)"
+        return
+    fi
+
+    if [[ -n "${SYSKNIFE_TEST_POSTGRES_URL:-}" ]]; then
+        run_step "$label" cargo test -p sysknife-daemon --test postgres_store --locked
+        return
+    fi
+
+    local runtime=""
+    if have docker; then
+        runtime="docker"
+    elif have podman; then
+        runtime="podman"
+    fi
+
+    if [[ -z "$runtime" ]]; then
+        record SKIP "${label} (no SYSKNIFE_TEST_POSTGRES_URL and no docker/podman found)"
+        return
+    fi
+
+    printf '\n==> postgres-contract: starting postgres:17-alpine via %s\n' "$runtime"
+    "$runtime" rm -f "$POSTGRES_CONTAINER_NAME" >/dev/null 2>&1 || true
+
+    if ! "$runtime" run -d --rm \
+        --name "$POSTGRES_CONTAINER_NAME" \
+        -e POSTGRES_USER=sysknife \
+        -e POSTGRES_PASSWORD=sysknife \
+        -e POSTGRES_DB=sysknife_test \
+        -p "127.0.0.1:${POSTGRES_HOST_PORT}:5432" \
+        postgres:17-alpine >/dev/null; then
+        record FAIL "${label} (failed to start postgres:17-alpine via ${runtime})"
+        return
+    fi
+
+    local tries=0
+    until "$runtime" exec "$POSTGRES_CONTAINER_NAME" pg_isready -U sysknife -d sysknife_test >/dev/null 2>&1; do
+        tries=$((tries + 1))
+        if ((tries > POSTGRES_HEALTH_RETRIES)); then
+            record FAIL "${label} (postgres container did not become healthy in time)"
+            "$runtime" rm -f "$POSTGRES_CONTAINER_NAME" >/dev/null 2>&1 || true
+            return
+        fi
+        sleep "$POSTGRES_HEALTH_INTERVAL_SECS"
+    done
+
+    SYSKNIFE_TEST_POSTGRES_URL="postgres://sysknife:sysknife@127.0.0.1:${POSTGRES_HOST_PORT}/sysknife_test?sslmode=disable" \
+        run_step "$label" cargo test -p sysknife-daemon --test postgres_store --locked
+
+    "$runtime" rm -f "$POSTGRES_CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+run_rust_group
+run_frontend_group
+
+if [[ "$mode" == "full" ]]; then
+    run_hygiene_group
+    run_security_group
+    run_postgres_contract_group
+fi
+
+printf '\n=========================================\n'
+printf ' ci-local summary (%s run)\n' "$mode"
+printf '=========================================\n'
+for r in "${RESULTS[@]}"; do
+    printf '%s\n' "$r"
+done
+printf '=========================================\n'
+
+if ((hard_failures > 0)); then
+    printf 'ci-local: FAIL (%d failing check(s))\n' "$hard_failures"
+    exit 1
+fi
+
+printf 'ci-local: PASS\n'

--- a/tests/release/public-claims.test.sh
+++ b/tests/release/public-claims.test.sh
@@ -47,7 +47,7 @@ assert_rejected() {
     fi
 }
 
-sed -i 's/1,348 Rust tests/1,256 Rust tests/' "$fixture/README.md"
+sed -i 's/1,403 Rust tests/1,256 Rust tests/' "$fixture/README.md"
 assert_rejected 'old test count'
 cp "$repo_root/README.md" "$fixture/README.md"
 


### PR DESCRIPTION
Large batched PR (one release per your batching directive to save Actions minutes). Deep review of the whole project by **five sonnet agents** — three functional parts (daemon/security core, CLI+MCP+planning, setup-wizard+scripts+CI) and two doc-drift passes (README/top docs, GitHub-Pages `docs/`). GUI findings (`apps/sysknife-shell`) deferred per request. Every implemented finding was verified for regressions; the invasive planner type-refactor and theoretical `pidfd` race were deferred with notes.

## Security (daemon)
- **Critical-account/group denylist** — `DeleteUser`/`LockUserAccount`/`DeleteGroup` now hard-reject `root`, `sudo`, `wheel`, core system accounts, and uid/gid 0, independent of the approval gate.
- **GRUB kernel-arg allowlist** now blocks Ubuntu LSM/mitigation bypasses (`apparmor=0`, `mitigations=off`, `lockdown=`, `pti=off`, `nosmap`, `nosmep`).
- `snap install` + `fail2ban` builders validate args **in-constructor** (defense in depth, matching `fail2ban_ban_ip`).
- Five High-risk actions (`ConfigureFirewall`, `SetDnsServers`, `ConfigureWifi`, `MaskService`, `CreateUser`) get accurate lockout/interception/privilege warnings + **exact-name approval** (were a generic "service interruption" preview).
- A present-but-unparseable `config.toml` now **fails loud** instead of silently dropping `[storage]`/`[policy]` (a silent security downgrade).

## Fixes
- 🔴 **`npx sysknife-setup`'s approval gate is no longer broken by default** — the wizard user daemon binds `%t/$XDG_RUNTIME_DIR/sysknife/daemon.sock`, exactly what the CLI resolves with no env, so `sysknife approve` works in a fresh terminal.
- Default LLM rate limiter no longer silently disabled on fresh install (state dir was never created → writes failed open).
- **`rollback_available` made honest** — 6 Debian actions (`AddPpa`, `RemovePpa`, `NetplanSet`, `GrubSetKargs`, `ProAttach`, `ProDetach`) no longer advertise a phantom auto-rollback; a **workspace-wide invariant test** enforces `rollback_available ⇔ rollback command exists`.
- Ubuntu derivatives (Mint, Pop!\_OS) recognized via `ID_LIKE` → `apt`/`snap`/`ufw` route correctly.
- SQLite `update_status` atomic (compare-and-set); UFW app-profile spaces (`Nginx Full`); MCP distro guard; LLM error misclassification; unicode sanitizer + provider error redaction.

## Added — local CI
- `scripts/ci-local.sh` (+ `--fast`, `--no-postgres`, `--install-hooks`) and `.githooks/pre-push` mirror the CI jobs locally so red is caught before it burns Actions minutes. Documented in the developer guide; `act` referenced for full Docker replay.

## Docs drift
Socket/DB defaults (`cli.md`, `configuration.md`), phantom `SYSKNIFE_VSOCK_TOKEN_PATH`, vsock-token walkthrough, Ubuntu action reference (netplan + missing actions), roadmap Observer count (~25→~59), ADR-0002 provider count (2→8), test counts (1,348→**1,403**), and more.

## Validation (all local, before push)
`cargo fmt/clippy(-D warnings)/doc(-D warnings)/nextest` **1403 pass** · frontend tsc + **72** · setup-contract **39** · **postgres-contract** (live PG) · `cargo audit` · markdownlint · markdown-link-check · version-consistency @ 0.2.9 — all green via `scripts/ci-local.sh`.

Release: bump workspace + JS manifests 0.2.8 → 0.2.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)