### PR TITLE
Review sweep: preview/effect divergence in SSH key removal, dead apt sudo grant, Ubuntu validation (v0.2.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [0.2.11] — 2026-07-27
+
+Findings from a full review of the daemon, the CLI/MCP surface, and the
+Ubuntu action set, with the Ubuntu commands validated against a real
+Ubuntu 24.04 VM.
+
+### Security
+
+- **`RemoveAuthorizedKey` no longer builds a regular expression from the
+  caller's key.** It deleted the approved line with `sed -i '\|^KEY$|d'`,
+  which made the public key a basic regular expression: `ssh-ed25519 .*`
+  passes every check in `validated_public_key` and then matched and deleted
+  *every* ed25519 key in the file. `sed` exits 0, so the job recorded
+  `Succeeded` and the signed audit summary read as a routine single-key
+  removal. Both key operations now use `grep -Fxv` with the key passed as a
+  positional argument. Blocklisting regex metacharacters was not an option:
+  `.` is legal in a key comment.
+- **`GrantSudoAccess` can no longer mint `user ALL=(ALL) NOPASSWD: ALL`**, a
+  standing passwordless root credential. The unrestricted-plus-passwordless
+  combination is refused by both the daemon and the helper; scope the
+  commands or keep the password prompt.
+- **The vsock token file's permissions are now checked**, mirroring the
+  Ed25519 signing key. A token written under a default umask lands at `0644`,
+  and any local user who could read it could authenticate over vsock.
+- `validated_apt_package` was the only validator without a leading-dash
+  guard, so a package name could reach a command in flag position.
+
+### Fixed
+
+- **Every mutating apt action failed on a real Ubuntu host.** The code sent a
+  bare `apt-get` while the packaged sudoers grant spells `/usr/bin/apt-get`;
+  sudo PATH-resolves only its primary command and matches later tokens
+  literally, so the rule never applied and apt fell through to "a password is
+  required". `ConfigureWifi` had no `nmcli` grant at all. Both are covered by
+  a test that re-implements sudo's matching rule against the packaged file.
+- **The PostgreSQL backend signed a malformed timestamp into every audit
+  row.** `now_iso()` omitted `%S`, producing `2026-07-27T12:34:.567Z`.
+- **Two concurrent apt actions could collide on the dpkg lock.** The
+  concurrency gate only engaged for High-risk *reboot-required* actions, so
+  `AptUpgrade` claimed nothing. The gate is now keyed by the system lock an
+  action actually holds, derived from its argv. Actions holding no shared
+  lock are no longer serialised behind a long apt run.
+- **Privileged child processes had no deadline.** A hung command wedged its
+  connection forever and never released its lock. Now bounded, killed and
+  reaped; override with `SYSKNIFE_ACTION_TIMEOUT_SECS`.
+- **`dispatch_loop` had no idle timeout**, so an Observer-tier caller could
+  hold every connection slot with silent sockets and lock out approvers.
+- **The async daemon client had no socket bounds** (only the sync path did),
+  so a live-but-silent daemon froze the CLI and any MCP session with it.
+- `emit_via_systemd_cat` leaked a zombie per audit record when the pipe write
+  failed — one PID per preview and execute until the process table filled.
+- `mergeMcpServers` treated an unreadable config the same as malformed JSON
+  and then overwrote it, discarding the user's other MCP servers.
+- The `unattended-upgrades` helper was missing `NEEDRESTART_MODE=a`.
+
+### Changed
+
+- The concurrency invariant that a reboot-required action must be gated was a
+  `debug_assert!`, compiled out of released binaries; it is now a fail-closed
+  runtime check.
+- `tests/e2e/ubuntu-command-validity.sh` checks that the commands SysKnife
+  would run on Ubuntu exist and parse. Against Ubuntu 24.04.4: 33 pass, 0
+  fail, 2 skipped (auditd and fail2ban are not installed on a server image).
+
+### Documentation
+
+- Corrected comment rot the review surfaced: the audit-chain formula omitted
+  its `ROW_DOMAIN` prefix (an independent verifier copying it would never
+  reproduce a valid signature); the journald watermark documented a 64-char
+  SHA-256 hash where the field is a 128-char Ed25519 signature; the journal
+  module stated FSS tamper protection as automatic when it is opt-in; an MCP
+  test comment credited the approval interlock to advisory prompt text rather
+  than the receipt check that enforces it; and `apt.rs` described a
+  `fuser /var/lib/dpkg/lock` pre-flight that never existed.
+
 ## [0.2.10] — 2026-07-24
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "prost",
  "prost-build",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-cli/src/client.rs
+++ b/apps/sysknife-cli/src/client.rs
@@ -48,6 +48,15 @@ pub struct ApprovalDetails {
 use crate::error::CliError;
 
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Longest gap tolerated between frames while an action streams.
+///
+/// The short `SOCKET_TIMEOUT` is wrong here: a legitimate action can run
+/// for tens of minutes and say nothing while it works. This only has to be
+/// longer than the daemon's own action ceiling, so that a daemon that is
+/// alive but permanently silent eventually surfaces as an error instead of
+/// freezing the CLI — and, through it, an entire MCP session.
+const EXECUTE_FRAME_TIMEOUT: Duration = Duration::from_secs(2 * 60 * 60 + 300);
 const MAX_FRAME_BYTES: usize = 4 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
@@ -335,9 +344,21 @@ impl DaemonClient {
     async fn connect_async(&self) -> Result<AsyncStream, CliError> {
         match &self.target {
             SocketTarget::Unix(path) => {
-                let stream = tokio::net::UnixStream::connect(path).await.map_err(|e| {
-                    CliError::ConfigOrDaemon(format!("cannot connect to {}: {e}", path.display()))
-                })?;
+                let stream =
+                    tokio::time::timeout(SOCKET_TIMEOUT, tokio::net::UnixStream::connect(path))
+                        .await
+                        .map_err(|_| {
+                            CliError::ConfigOrDaemon(format!(
+                                "timed out connecting to {}",
+                                path.display()
+                            ))
+                        })?
+                        .map_err(|e| {
+                            CliError::ConfigOrDaemon(format!(
+                                "cannot connect to {}: {e}",
+                                path.display()
+                            ))
+                        })?;
                 Ok(AsyncStream::Unix(stream))
             }
             #[cfg(target_os = "linux")]
@@ -533,14 +554,22 @@ impl DaemonClient {
         }))
         .map_err(|e| CliError::ConfigOrDaemon(format!("serialize: {e}")))?;
 
-        stream
-            .write_frame(&req)
+        tokio::time::timeout(SOCKET_TIMEOUT, stream.write_frame(&req))
             .await
+            .map_err(|_| {
+                CliError::ConfigOrDaemon(format!(
+                    "timed out after {}s sending the request to the daemon",
+                    SOCKET_TIMEOUT.as_secs()
+                ))
+            })?
             .map_err(|e| CliError::ConfigOrDaemon(format!("send: {e}")))?;
 
-        let raw = stream
-            .read_frame()
+        let raw = tokio::time::timeout(SOCKET_TIMEOUT, stream.read_frame())
             .await
+            .map_err(|_| CliError::ConfigOrDaemon(format!(
+                "timed out after {}s waiting for the next frame from the daemon; the job may still be running server-side",
+                SOCKET_TIMEOUT.as_secs()
+            )))?
             .map_err(|e| CliError::ConfigOrDaemon(format!("recv: {e}")))?;
 
         let resp: Value = serde_json::from_slice(&raw)
@@ -589,13 +618,21 @@ impl DaemonClient {
             "transaction_id": transaction_id,
         }))
         .map_err(|e| CliError::ConfigOrDaemon(format!("serialize: {e}")))?;
-        stream
-            .write_frame(&req)
+        tokio::time::timeout(SOCKET_TIMEOUT, stream.write_frame(&req))
             .await
+            .map_err(|_| {
+                CliError::ConfigOrDaemon(format!(
+                    "timed out after {}s sending the request to the daemon",
+                    SOCKET_TIMEOUT.as_secs()
+                ))
+            })?
             .map_err(|e| CliError::ConfigOrDaemon(format!("send: {e}")))?;
-        let raw = stream
-            .read_frame()
+        let raw = tokio::time::timeout(SOCKET_TIMEOUT, stream.read_frame())
             .await
+            .map_err(|_| CliError::ConfigOrDaemon(format!(
+                "timed out after {}s waiting for the next frame from the daemon; the job may still be running server-side",
+                SOCKET_TIMEOUT.as_secs()
+            )))?
             .map_err(|e| CliError::ConfigOrDaemon(format!("recv: {e}")))?;
         let resp: Value = serde_json::from_slice(&raw)
             .map_err(|e| CliError::ConfigOrDaemon(format!("parse response: {e}")))?;
@@ -641,13 +678,21 @@ impl DaemonClient {
             "transaction_id": transaction_id,
         }))
         .map_err(|e| CliError::ConfigOrDaemon(format!("serialize: {e}")))?;
-        stream
-            .write_frame(&req)
+        tokio::time::timeout(SOCKET_TIMEOUT, stream.write_frame(&req))
             .await
+            .map_err(|_| {
+                CliError::ConfigOrDaemon(format!(
+                    "timed out after {}s sending the request to the daemon",
+                    SOCKET_TIMEOUT.as_secs()
+                ))
+            })?
             .map_err(|e| CliError::ConfigOrDaemon(format!("send: {e}")))?;
-        let raw = stream
-            .read_frame()
+        let raw = tokio::time::timeout(SOCKET_TIMEOUT, stream.read_frame())
             .await
+            .map_err(|_| CliError::ConfigOrDaemon(format!(
+                "timed out after {}s waiting for the next frame from the daemon; the job may still be running server-side",
+                SOCKET_TIMEOUT.as_secs()
+            )))?
             .map_err(|e| CliError::ConfigOrDaemon(format!("recv: {e}")))?;
         let resp: Value = serde_json::from_slice(&raw)
             .map_err(|e| CliError::ConfigOrDaemon(format!("parse response: {e}")))?;
@@ -689,14 +734,22 @@ impl DaemonClient {
         }))
         .map_err(|e| CliError::ConfigOrDaemon(format!("serialize: {e}")))?;
 
-        stream
-            .write_frame(&req)
+        tokio::time::timeout(SOCKET_TIMEOUT, stream.write_frame(&req))
             .await
+            .map_err(|_| {
+                CliError::ConfigOrDaemon(format!(
+                    "timed out after {}s sending the request to the daemon",
+                    SOCKET_TIMEOUT.as_secs()
+                ))
+            })?
             .map_err(|e| CliError::ConfigOrDaemon(format!("send: {e}")))?;
 
-        let raw = stream
-            .read_frame()
+        let raw = tokio::time::timeout(SOCKET_TIMEOUT, stream.read_frame())
             .await
+            .map_err(|_| CliError::ConfigOrDaemon(format!(
+                "timed out after {}s waiting for the next frame from the daemon; the job may still be running server-side",
+                SOCKET_TIMEOUT.as_secs()
+            )))?
             .map_err(|e| CliError::ConfigOrDaemon(format!("recv: {e}")))?;
 
         let resp: Value = serde_json::from_slice(&raw)
@@ -740,15 +793,23 @@ impl DaemonClient {
         }))
         .map_err(|e| CliError::ConfigOrDaemon(format!("serialize: {e}")))?;
 
-        stream
-            .write_frame(&req)
+        tokio::time::timeout(SOCKET_TIMEOUT, stream.write_frame(&req))
             .await
+            .map_err(|_| {
+                CliError::ConfigOrDaemon(format!(
+                    "timed out after {}s sending the request to the daemon",
+                    SOCKET_TIMEOUT.as_secs()
+                ))
+            })?
             .map_err(|e| CliError::ConfigOrDaemon(format!("send: {e}")))?;
 
         loop {
-            let raw = stream
-                .read_frame()
+            let raw = tokio::time::timeout(EXECUTE_FRAME_TIMEOUT, stream.read_frame())
                 .await
+                .map_err(|_| CliError::ExecutionFailed(format!(
+                    "timed out after {}s waiting for the next frame from the daemon; the job may still be running server-side",
+                    EXECUTE_FRAME_TIMEOUT.as_secs()
+                )))?
                 .map_err(|e| CliError::ExecutionFailed(format!("recv: {e}")))?;
 
             let resp: Value = serde_json::from_slice(&raw)

--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -556,10 +556,16 @@ async fn execute_steps_inner(steps: Vec<StepToExecute>) -> Result<ExecuteOutput,
             plan_needs_reboot = true;
         }
 
+        // `JobState` is a plain snake_case string enum, so this cannot fail
+        // today. Fail loudly rather than degrading to "unknown": silently
+        // replacing a real status with a placeholder would leave the calling
+        // agent unable to distinguish "the daemon said unknown" from "we lost
+        // the status", which is exactly the kind of quiet drift a future
+        // non-string `JobState` representation would introduce.
         let status = serde_json::to_value(result.status)
             .ok()
             .and_then(|v| v.as_str().map(String::from))
-            .unwrap_or_else(|| "unknown".into());
+            .expect("JobState always serializes to a JSON string");
 
         let succeeded = matches!(result.status, sysknife_types::JobState::Succeeded);
 
@@ -1053,11 +1059,20 @@ mod tests {
 
     #[test]
     fn rmcp_sysknife_plan_description_warns_to_stop_after_planning() {
-        // The plan tool's description carries a load-bearing instruction
-        // — "after presenting this plan, STOP" — that gates every
-        // hookify rule and the MCP-side approval flow.  A regression
-        // that drops this clause would let agents bypass the
-        // human-in-the-loop interlock.
+        // The plan tool's description carries an advisory instruction telling
+        // the calling agent to STOP after planning. This is prompt
+        // engineering, not enforcement, and this test guards the wording of
+        // an operator-facing hint — NOT the security boundary.
+        //
+        // The actual interlock is structural and lives elsewhere:
+        // `PlanOutput`/`PlanStepOutput` carry no `approval_receipt` field, so
+        // no code path lets `sysknife_plan` hand back something
+        // `sysknife_execute` can consume; receipts come only from a separate
+        // `sysknife approve <transaction-id>` run, and the daemon
+        // independently rejects forged or stale ones (see
+        // `mcp_tools_integrate_with_a_daemon_over_the_socket`). Deleting this
+        // clause would degrade the hint, not open a bypass — do not treat it
+        // as the thing keeping a human in the loop.
         let router = SysknifeMcpServer::tool_router();
         let tools = router.list_all();
         let plan = tools

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -10,8 +10,9 @@
 //!   1. `--help` returns 0 and prints something that mentions every
 //!      top-level subcommand.
 //!   2. `doctor` against an unreachable daemon returns non-zero and
-//!      writes the failure to stderr (not stdout — automation parses
-//!      stdout for the JSON `--json` form).
+//!      writes the failure to stderr while leaving stdout empty; with
+//!      `--json` the failure envelope goes to stdout instead, because
+//!      that is what automation parses.
 //!   3. `history --since "not-a-timestamp"` returns non-zero with a
 //!      clear error rather than panicking.
 //!   4. Unknown subcommands surface as clap usage errors.
@@ -69,7 +70,26 @@ fn doctor_fails_loudly_when_daemon_socket_is_unreachable() {
         .env("SYSKNIFE_SOCKET", fake_socket(&dir))
         .arg("doctor")
         .assert()
-        .failure();
+        .failure()
+        // The stream matters: automation parses stdout for the `--json` form,
+        // so a diagnostic that leaks onto stdout corrupts it. Assert the
+        // failure text lands on stderr and that stdout stays clean.
+        .stderr(predicate::str::contains("daemon"))
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn doctor_json_failure_goes_to_stdout_not_stderr() {
+    // The counterpart contract: with `--json`, the machine-readable failure
+    // envelope belongs on stdout so automation can parse it. Without this,
+    // nothing pins which stream carries which form.
+    let dir = tempfile::tempdir().unwrap();
+    cli()
+        .env("SYSKNIFE_SOCKET", fake_socket(&dir))
+        .args(["doctor", "--json"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("\"ok\":false"));
 }
 
 #[test]

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "@vitest/coverage-v8": "^4.1.4",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-brain/src/audit.rs
+++ b/crates/sysknife-brain/src/audit.rs
@@ -109,10 +109,19 @@ impl SafetyAuditLog {
     /// the blocking pool. Call from `async fn` paths so the planner's reactor
     /// is not parked on a slow filesystem (NFS, encrypted home).
     pub async fn log_rejection_async(self, intent: String, reason: String, raw_plan: String) {
-        let _ = tokio::task::spawn_blocking(move || {
+        // `log_rejection` swallows its own I/O errors by design, so the only
+        // way this join fails is a panic in the blocking closure. That would
+        // silently drop a safety-fence record, so surface it — a missing
+        // rejection entry is an audit blind spot, not a cosmetic problem.
+        if let Err(e) = tokio::task::spawn_blocking(move || {
             self.log_rejection(&intent, &reason, &raw_plan);
         })
-        .await;
+        .await
+        {
+            eprintln!(
+                "[sysknife-brain] audit: log_rejection task failed: {e} — rejection NOT recorded"
+            );
+        }
     }
 
     /// Append a rejection entry to the log file and forward to journald.

--- a/crates/sysknife-brain/src/journal.rs
+++ b/crates/sysknife-brain/src/journal.rs
@@ -15,8 +15,10 @@
 //!
 //! # Tamper detection
 //!
-//! Once journald receives an entry it is protected by systemd's Forward Secure
-//! Sealing (FSS). Enable FSS at deployment time with:
+//! Journald entries are tamper-evident **only if** systemd's Forward Secure
+//! Sealing (FSS) has been enabled on the host. FSS is opt-in and off by
+//! default, so assume it is absent unless an operator enabled it explicitly.
+//! Enable FSS at deployment time with:
 //!
 //! ```text
 //! journalctl --setup-keys

--- a/crates/sysknife-brain/src/prefs.rs
+++ b/crates/sysknife-brain/src/prefs.rs
@@ -176,6 +176,12 @@ pub fn remove_pref(path: &Path, fact: &str) -> Result<bool, io::Error> {
     Ok(true)
 }
 
+/// Heuristic check for well-known secret shapes (passwords, API keys, tokens).
+///
+/// This is a **denylist of known formats**, not an exhaustive scanner: any
+/// secret that does not match `SENSITIVE_PATTERNS`/`SENSITIVE_PREFIXES` passes
+/// through undetected. Treat a `false` result as "no known secret shape
+/// found", never as "definitely no secret".
 pub fn contains_sensitive(fact: &str) -> bool {
     let lower = fact.to_lowercase();
     if SENSITIVE_PATTERNS.iter().any(|p| lower.contains(p)) {

--- a/crates/sysknife-brain/src/providers/mod.rs
+++ b/crates/sysknife-brain/src/providers/mod.rs
@@ -48,7 +48,14 @@ pub(super) fn sanitize_error_msg(msg: &str) -> String {
     // of the sanitized message.
     const HEADER_KEYWORDS: &[&str] = &["bearer ", "x-api-key"];
 
-    let lower = msg.to_lowercase();
+    // ASCII-only lowercasing is deliberate: the byte ranges found in `lower`
+    // are applied to `msg` via `replace_range`, so the two strings must stay
+    // byte-for-byte aligned. `str::to_lowercase` performs full Unicode case
+    // mapping and is NOT length-preserving (e.g. `İ` U+0130 lowercases to two
+    // code points), which would skew every subsequent range and could redact
+    // the wrong span or panic on a non-char-boundary. Every pattern below is
+    // ASCII, so ASCII folding loses no matches.
+    let lower = msg.to_ascii_lowercase();
     let mut ranges: Vec<std::ops::Range<usize>> = Vec::new();
 
     for pattern in KEY_PARAMS {

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.10"
+version = "0.2.11"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon/src/actions/apt.rs
+++ b/crates/sysknife-daemon/src/actions/apt.rs
@@ -5,11 +5,18 @@
 //!
 //! ## Lock contention
 //!
-//! Before any mutating apt command the executor should detect dpkg lock
-//! contention via `fuser /var/lib/dpkg/lock`. That check lives in the
-//! executor; this module only builds the `ActionSpec` for the apt
-//! command itself. The executor layer is responsible for the retry-after
-//! hint when the lock is held.
+//! Concurrent apt runs are prevented by the dispatcher's exclusion gate, not
+//! by a pre-flight probe: every action whose argv names an apt/dpkg tool maps
+//! to [`ExclusiveResource::Dpkg`](super::ExclusiveResource::Dpkg), and a second
+//! one submitted while the first holds that lock gets a `ConflictResponse`.
+//!
+//! An earlier version of this doc claimed the executor ran
+//! `fuser /var/lib/dpkg/lock` before each mutating command. It never did —
+//! there is no such probe anywhere in the daemon. The gate above covers
+//! contention *between SysKnife actions*, which is what SysKnife can actually
+//! control; it does not detect a dpkg lock held by something outside SysKnife
+//! (an operator's own `apt` session, or unattended-upgrades). In that case apt
+//! itself reports the lock and the action fails with apt's own message.
 //!
 //! ## Environment variables
 //!
@@ -27,7 +34,20 @@ use sysknife_types::RiskLevel;
 // ---------------------------------------------------------------------------
 
 /// apt binary path.
-const APT_GET: &str = "apt-get";
+///
+/// **Must stay absolute.** These actions run as
+/// `sudo env DEBIAN_FRONTEND=… NEEDRESTART_MODE=a <APT_GET> …`, and sudo
+/// PATH-resolves only its *primary* command (`env`) — every later token is
+/// matched against the sudoers rule as a literal string. The grant in
+/// `packaging/sysknife-sudoers` spells `/usr/bin/apt-get`, so a bare
+/// `apt-get` here does not match the rule and sudo falls through to
+/// "a password is required", which a non-interactive daemon can never
+/// supply. Verified on Ubuntu 24.04 with sudo 1.9.15p5: the bare form is
+/// denied, the absolute form is permitted.
+///
+/// `tests/sudoers_grants_match_argv.rs` pins this against the packaged
+/// sudoers file so the two cannot drift apart again.
+const APT_GET: &str = "/usr/bin/apt-get";
 
 /// `DEBIAN_FRONTEND` value that suppresses all debconf interactive prompts.
 /// Required for non-interactive daemon invocations.
@@ -213,8 +233,12 @@ pub fn apt_purge(package: &str) -> ActionSpec {
 
 /// Remove automatically-installed packages no longer needed (`apt-get autoremove -y`).
 ///
-/// Risk: Low. Only removes packages that were installed as dependencies and
-/// are no longer required by any explicitly-installed package.
+/// Risk: Medium. The set of packages actually removed is chosen by the
+/// dependency resolver at execution time, not named by the caller, so the
+/// approved preview (`apt-get autoremove -y`) cannot show what will go. In
+/// practice that set has been known to include old kernels and driver or
+/// bootloader metapackages that were marked auto-installed. It stays below
+/// `AptUpgrade`'s High only because it never *installs* or upgrades anything.
 pub fn apt_autoremove() -> ActionSpec {
     ActionSpec {
         action_name: "AptAutoremove",
@@ -369,7 +393,10 @@ mod tests {
         let spec = apt_update();
         let (prog, args) = extract_args(&spec);
         assert_eq!(prog, "sudo");
-        assert!(args.contains(&"apt-get"));
+        assert!(
+            args.contains(&APT_GET),
+            "argv must carry the absolute apt-get path: {args:?}"
+        );
         assert!(args.contains(&"update"));
         assert!(args.contains(&DEBIAN_FRONTEND_VALUE));
         assert!(args.contains(&NEEDRESTART_MODE_VALUE));
@@ -399,7 +426,10 @@ mod tests {
         let spec = apt_upgrade();
         let (prog, args) = extract_args(&spec);
         assert_eq!(prog, "sudo");
-        assert!(args.contains(&"apt-get"));
+        assert!(
+            args.contains(&APT_GET),
+            "argv must carry the absolute apt-get path: {args:?}"
+        );
         assert!(args.contains(&"dist-upgrade"));
         assert!(args.contains(&"-y"));
         assert!(args.contains(&DEBIAN_FRONTEND_VALUE));

--- a/crates/sysknife-daemon/src/actions/mod.rs
+++ b/crates/sysknife-daemon/src/actions/mod.rs
@@ -74,6 +74,92 @@ pub struct ActionSpec {
     pub rollback_available: bool,
 }
 
+/// A system-wide lock that only one mutating action may hold at a time.
+///
+/// These are the real kernel/daemon locks that make two concurrent actions
+/// fail rather than merely interleave: `apt`/`dpkg` serialise on
+/// `/var/lib/dpkg/lock-frontend`, `snapd` on its change queue, `rpm-ostree`
+/// on its transaction lock. Two actions contending for the same resource do
+/// not produce a partial result — one of them errors out mid-way, which for a
+/// package operation can leave dpkg needing `--configure -a`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ExclusiveResource {
+    /// The whole machine. Claimed by any High-risk reboot-required action
+    /// (release upgrade, rebase, layered-package install), which conflicts
+    /// with every other mutating action regardless of resource.
+    System,
+    /// The dpkg/apt database lock. Ubuntu/Debian package operations.
+    Dpkg,
+    /// The snapd change queue.
+    Snap,
+    /// The rpm-ostree transaction lock.
+    RpmOstree,
+    /// The flatpak installation lock.
+    Flatpak,
+}
+
+impl ExclusiveResource {
+    /// Human-readable name used in the conflict message shown to the operator.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::System => "the system (a reboot-required action)",
+            Self::Dpkg => "the dpkg/apt lock",
+            Self::Snap => "the snapd change queue",
+            Self::RpmOstree => "the rpm-ostree transaction lock",
+            Self::Flatpak => "the flatpak installation lock",
+        }
+    }
+}
+
+/// Which system lock, if any, this action contends for.
+///
+/// Derived from the action's own argv rather than a hand-maintained action
+/// list, so a newly added `apt-get` action participates in the gate without
+/// anyone remembering to register it. The first recognised tool in
+/// `program`-then-`args` order wins, which is why a wrapper prefix
+/// (`sudo`, `env`, `VAR=VALUE`) is skipped naturally and why
+/// `apt-get install snap` resolves to `Dpkg`, not `Snap`.
+///
+/// Returning `None` means "no shared lock" — those actions are still blocked
+/// by a held [`ExclusiveResource::System`] but never block each other.
+pub fn exclusive_resource(spec: &ActionSpec) -> Option<ExclusiveResource> {
+    let ActionMechanism::Command { program, args } = &spec.mechanism else {
+        return None;
+    };
+    std::iter::once(*program)
+        .chain(args.iter().map(String::as_str))
+        // A token can itself be a whole shell script (`sh -c "snap install …
+        // && snap refresh --hold …"`), so look inside it too. Splitting on
+        // whitespace and shell operators finds the tool wherever it sits.
+        // Over-matching here costs a little extra serialisation; under-matching
+        // costs a corrupted package database, so this errs toward matching.
+        .flat_map(|token| {
+            token.split(|c: char| c.is_whitespace() || matches!(c, '&' | '|' | ';' | '(' | ')'))
+        })
+        .filter(|word| !word.is_empty())
+        .find_map(|token| {
+            // Match on the binary name so an absolute path still resolves.
+            let name = token.rsplit('/').next().unwrap_or(token);
+            match name {
+                "apt-get"
+                | "apt"
+                | "apt-mark"
+                | "aptitude"
+                | "dpkg"
+                | "dpkg-reconfigure"
+                | "add-apt-repository"
+                | "do-release-upgrade"
+                | "unattended-upgrade"
+                | "sysknife-apt-pin-edit"
+                | "apt-pin-edit" => Some(ExclusiveResource::Dpkg),
+                "snap" => Some(ExclusiveResource::Snap),
+                "rpm-ostree" | "ostree" => Some(ExclusiveResource::RpmOstree),
+                "flatpak" => Some(ExclusiveResource::Flatpak),
+                _ => None,
+            }
+        })
+}
+
 /// The canonical catalogue of every action the daemon recognises, grouped by
 /// domain. This is the **single source of truth** for per-action static
 /// metadata (`risk_level`, `reboot_required`, `rollback_available`): the

--- a/crates/sysknife-daemon/src/actions/ssh.rs
+++ b/crates/sysknife-daemon/src/actions/ssh.rs
@@ -46,22 +46,32 @@ pub fn get_authorized_keys(username: &str) -> ActionSpec {
     }
 }
 
+/// Shell body for `AddAuthorizedKey`.
+///
+/// The key and path arrive as positional arguments (`$1`, `$2`) rather than
+/// being interpolated into the script text, so no value the caller supplies is
+/// ever parsed as shell syntax. `printf '%s\n'` is used instead of `echo`
+/// because `echo` mangles values beginning with `-` and interprets backslash
+/// escapes on some shells.
+const ADD_KEY_SCRIPT: &str =
+    "key=$1; path=$2; grep -Fxq -- \"$key\" \"$path\" 2>/dev/null || printf '%s\\n' \"$key\" >> \"$path\"";
+
 pub fn add_authorized_key(username: &str, public_key: &str) -> ActionSpec {
     let keys_path = format!("/home/{username}/.ssh/authorized_keys");
-    // Use sudo sh -c with grep to check idempotency: only append if not already present.
     // sudo is required because the daemon runs as the sysknife system user, which has
     // no write permission to user home directories (files are 600 owned by the target user).
-    let script = format!(
-        "grep -Fxq '{key}' '{path}' 2>/dev/null || echo '{key}' >> '{path}'",
-        key = public_key,
-        path = keys_path,
-    );
-
     ActionSpec {
         action_name: "AddAuthorizedKey",
         mechanism: ActionMechanism::Command {
             program: "sudo",
-            args: vec!["sh".to_string(), "-c".to_string(), script],
+            args: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                ADD_KEY_SCRIPT.to_string(),
+                "sh".to_string(),
+                public_key.to_string(),
+                keys_path,
+            ],
         },
         risk_level: RiskLevel::High,
         reboot_required: false,
@@ -69,21 +79,49 @@ pub fn add_authorized_key(username: &str, public_key: &str) -> ActionSpec {
     }
 }
 
+/// Shell body for `RemoveAuthorizedKey`.
+///
+/// **The key must never reach a regex.** This action previously deleted the
+/// line with `sed -i '\|^KEY$|d'`, which made the caller-supplied key a *basic
+/// regular expression*: a value like `ssh-ed25519 .*` passes every check in
+/// `validated_public_key` (allowed prefix, printable ASCII, no shell
+/// metacharacters) and then matched — and deleted — every ed25519 key in the
+/// file. `sed` exits 0, so the job was recorded `Succeeded` and the signed
+/// audit summary read as a routine single-key removal: the executed effect
+/// silently diverged from the approved preview on a lockout-capable action.
+///
+/// Blocklisting regex metacharacters is NOT a viable fix: `.` is legal inside
+/// a key comment (`alice@example.com`), so rejecting it would refuse valid
+/// keys. The fix is structural — `grep -Fxv` compares fixed whole lines, so no
+/// metacharacter can widen the match, and the key travels as `$1` rather than
+/// being interpolated into the script.
+///
+/// The result is streamed to a temp file and copied back with `cat >` rather
+/// than moved: that preserves the original inode, owner, and mode, which
+/// matters because `authorized_keys` must stay owned by the target user.
+/// `grep` exits 1 when it selects no lines (the file is now empty) — that is a
+/// success here, so only an exit status above 1 is treated as an error.
+const REMOVE_KEY_SCRIPT: &str = "key=$1; path=$2; \
+tmp=$(mktemp) || exit 1; \
+grep -Fxv -- \"$key\" \"$path\" > \"$tmp\"; rc=$?; \
+if [ $rc -gt 1 ]; then rm -f \"$tmp\"; exit $rc; fi; \
+cat \"$tmp\" > \"$path\"; rm -f \"$tmp\"";
+
 pub fn remove_authorized_key(username: &str, public_key: &str) -> ActionSpec {
     let keys_path = format!("/home/{username}/.ssh/authorized_keys");
-    // Use sudo sed to delete the exact matching line.
     // sudo is required for the same reason as add_authorized_key.
-    let script = format!(
-        "sed -i '\\|^{key}$|d' '{path}'",
-        key = public_key,
-        path = keys_path,
-    );
-
     ActionSpec {
         action_name: "RemoveAuthorizedKey",
         mechanism: ActionMechanism::Command {
             program: "sudo",
-            args: vec!["sh".to_string(), "-c".to_string(), script],
+            args: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                REMOVE_KEY_SCRIPT.to_string(),
+                "sh".to_string(),
+                public_key.to_string(),
+                keys_path,
+            ],
         },
         // Revoking an authorized key is access-control + lockout-capable (remove
         // the wrong/only key and you lose SSH access) and cannot be rolled back

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -746,7 +746,12 @@ pub fn validated_syslog_host(s: &str, param: &'static str) -> Result<String, Exe
 
 /// Validate an apt package-name glob (`[A-Za-z0-9.+*?_:-]`, 1..=128).
 pub fn validated_apt_package(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    // A leading `-` would land in flag position when the value is passed as a
+    // bare argument (`apt-cache policy <package>`), letting a package name act
+    // as an option. Every sibling validator in this file rejects it; this one
+    // was the sole exception.
     if s.is_empty()
+        || s.starts_with('-')
         || s.len() > 128
         || !s.chars().all(|c| {
             c.is_ascii_alphanumeric() || matches!(c, '.' | '+' | '*' | '?' | '_' | ':' | '-')

--- a/crates/sysknife-daemon/src/audit_chain.rs
+++ b/crates/sysknife-daemon/src/audit_chain.rs
@@ -4,8 +4,13 @@
 //! On insert, the daemon computes
 //!
 //! ```text
-//! chain_hash = ed25519_sign(canonical(immutable_fields) || prev_chain_hash, signing_key)
+//! chain_hash = ed25519_sign(ROW_DOMAIN || canonical(immutable_fields) || prev_chain_hash, signing_key)
 //! ```
+//!
+//! The `ROW_DOMAIN` prefix is **part of the signed message**, not decoration:
+//! it is what stops a row signature from ever verifying as a checkpoint or
+//! approval-receipt signature. An independent verifier that omits it will
+//! never reproduce a valid `chain_hash`.
 //!
 //! and stores both (the signature is hex-encoded; the first row in a chain has
 //! `prev_chain_hash = ""`). Ed25519 signatures are deterministic (RFC 8032), so

--- a/crates/sysknife-daemon/src/audit_watermark.rs
+++ b/crates/sysknife-daemon/src/audit_watermark.rs
@@ -109,11 +109,19 @@ fn emit_via_systemd_cat(seq: u64, hash_hex: &str) {
         .stderr(std::process::Stdio::null())
         .spawn()
         .and_then(|mut child| {
-            if let Some(mut stdin) = child.stdin.take() {
-                stdin.write_all(message.as_bytes())?;
-                // Drop stdin to signal EOF before waiting.
-            }
-            child.wait()
+            // The write result is captured rather than propagated with `?`,
+            // because `Child::drop` does not reap: an early return here would
+            // leak a zombie on every audit record. This runs on every preview
+            // and every execute, so a journald outage used to burn one PID per
+            // chain insert until the table filled and the daemon could no
+            // longer fork — i.e. could no longer execute privileged actions.
+            let write_result = match child.stdin.take() {
+                Some(mut stdin) => stdin.write_all(message.as_bytes()),
+                // Dropping the handle signals EOF before we wait.
+                None => Ok(()),
+            };
+            let status = child.wait()?;
+            write_result.map(|()| status)
         });
 
     match result {

--- a/crates/sysknife-daemon/src/audit_watermark.rs
+++ b/crates/sysknife-daemon/src/audit_watermark.rs
@@ -12,7 +12,9 @@
 //! journalctl -t sysknife-audit-tip -o json | jq -r '.MESSAGE'
 //! ```
 //!
-//! Each message has the form `seq=<N> chain_hash=<hex64>`. If the journal
+//! Each message has the form `seq=<N> chain_hash=<hex128>` — `chain_hash` is a
+//! hex-encoded Ed25519 signature (64 raw bytes → 128 hex chars), not a
+//! SHA-256 digest. If the journal
 //! stream contains entries beyond the SQLite tail, tail truncation has occurred.
 //!
 //! ## Implementation
@@ -79,7 +81,8 @@ fn emit_watermark_impl(seq: u64, hash_hex: &str) {
 
 /// Shell out to `systemd-cat` to write the watermark into the journal.
 ///
-/// Message body: `seq=<N> chain_hash=<hex64>`
+/// Message body: `seq=<N> chain_hash=<hex128>` (a hex-encoded Ed25519
+/// signature — 64 raw bytes, so 128 hex chars, not a 64-char SHA-256 digest).
 ///
 /// The fields are embedded in the human-readable message body so they survive
 /// forwarding setups that strip structured journal metadata. SIEMs filter on

--- a/crates/sysknife-daemon/src/auth.rs
+++ b/crates/sysknife-daemon/src/auth.rs
@@ -54,9 +54,19 @@ pub(crate) fn role_rank(role: &CallerRole) -> u8 {
 /// `SYSKNIFE_TOKEN_ROLE` env var, defaulting to `Dev`) on success, or `None`
 /// if the token file is absent, unreadable, or the token does not match.
 ///
-/// Whitespace (including trailing newlines written by `echo`) is stripped from
-/// the stored token before comparison, so `echo TOKEN > ~/.config/sysknife/token`
-/// works without modification.
+/// Whitespace (including trailing newlines) is stripped from the stored token
+/// before comparison. Provision the file with `install -m 600` — a token file
+/// readable by group or other is rejected outright (see below).
+///
+/// # Permissions
+///
+/// The file must not be group- or world-accessible (`mode & 0o077 == 0`),
+/// mirroring the check `AuditKey::load_or_generate` applies to the Ed25519
+/// signing key. Without it, a token written under a default `umask 022` lands
+/// at `0644`, and any local user who can read it can authenticate over vsock
+/// and receive `token_role()` — bypassing the `SO_PEERCRED` → group →
+/// `CallerRole` mechanism that is the documented authorization model for the
+/// Unix path.
 pub fn validate_token_against_file(
     presented_token: &str,
     token_path: &std::path::Path,
@@ -64,8 +74,9 @@ pub fn validate_token_against_file(
     if presented_token.is_empty() {
         return None;
     }
-    let stored = match std::fs::read_to_string(token_path) {
-        Ok(s) => s,
+    match token_file_permissions_ok(token_path) {
+        Ok(true) => {}
+        Ok(false) => return None,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             eprintln!(
                 "[sysknife-daemon] WARNING: vsock token file {} does not exist; rejecting vsock auth (provision the token file to allow vsock connections)",
@@ -73,6 +84,18 @@ pub fn validate_token_against_file(
             );
             return None;
         }
+        Err(e) => {
+            eprintln!(
+                "[sysknife-daemon] WARNING: cannot stat token file {}: {e}; rejecting vsock auth",
+                token_path.display()
+            );
+            return None;
+        }
+    }
+    // Absence is already reported by the permission check above; anything
+    // reaching here is a genuine read failure (or a file removed in between).
+    let stored = match std::fs::read_to_string(token_path) {
+        Ok(s) => s,
         Err(e) => {
             eprintln!(
                 "[sysknife-daemon] WARNING: cannot read token file {}: {e}; rejecting vsock auth",
@@ -104,6 +127,29 @@ pub fn validate_token_against_file(
         return None;
     }
     Some(token_role())
+}
+
+/// Is the token file protected from other local users?
+///
+/// Returns `Ok(false)` (after warning) when the file is group- or
+/// world-accessible. The token is a bearer credential: anything that can read
+/// it can present it.
+fn token_file_permissions_ok(token_path: &std::path::Path) -> std::io::Result<bool> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = std::fs::metadata(token_path)?.permissions().mode();
+    if mode & 0o077 != 0 {
+        eprintln!(
+            "[sysknife-daemon] WARNING: vsock token file {} has mode {:04o}; it must not be \
+             readable by group or other (any local user could authenticate with it). \
+             Rejecting vsock auth — fix with: chmod 600 {}",
+            token_path.display(),
+            mode & 0o7777,
+            token_path.display()
+        );
+        return Ok(false);
+    }
+    Ok(true)
 }
 
 /// Return the `CallerRole` granted to token-authenticated vsock connections.
@@ -151,6 +197,14 @@ pub fn default_token_path() -> std::path::PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Provision a token file the way the daemon requires (`install -m 600`).
+    /// A default-umask write lands at 0644, which is refused: a token any
+    /// local user can read is not a credential.
+    fn secure(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
 
     fn role(groups: &[&str]) -> CallerRole {
         highest_role_from_groups(groups.iter().copied())
@@ -217,6 +271,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token");
         std::fs::write(&path, "secret123").unwrap();
+        secure(&path);
         assert_eq!(
             validate_token_against_file("secret123", &path),
             Some(CallerRole::Dev)
@@ -229,6 +284,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token");
         std::fs::write(&path, "secret123\n").unwrap();
+        secure(&path);
         assert_eq!(
             validate_token_against_file("secret123", &path),
             Some(CallerRole::Dev)
@@ -240,6 +296,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token");
         std::fs::write(&path, "correct\n").unwrap();
+        secure(&path);
         assert_eq!(validate_token_against_file("wrong", &path), None);
     }
 
@@ -255,6 +312,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token");
         std::fs::write(&path, "").unwrap();
+        secure(&path);
         assert_eq!(validate_token_against_file("", &path), None);
     }
 
@@ -263,6 +321,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token");
         std::fs::write(&path, "\n").unwrap();
+        secure(&path);
         assert_eq!(validate_token_against_file("", &path), None);
     }
 
@@ -282,6 +341,7 @@ mod tests {
         // exactly 9 bytes, so the length-mismatch shortcut does not apply
         // and we genuinely traverse the constant-time `ct_eq` path.
         std::fs::write(&path, "abcdefghi").unwrap();
+        secure(&path);
 
         // Exact match → accepted.
         assert_eq!(

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -929,6 +929,13 @@ async fn authenticate_vsock_token(
 // Main dispatch loop (shared by Unix and vsock paths)
 // ---------------------------------------------------------------------------
 
+/// How long a connection may wait for its next request before the daemon
+/// closes it and frees the connection slot. Generous enough for an
+/// interactive session (preview → read the plan → approve in another
+/// terminal → execute), short enough that idle sockets cannot pin the
+/// `MAX_CONNECTIONS` pool indefinitely.
+const IDLE_CONNECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+
 async fn dispatch_loop<S>(
     framed: &mut FramedStream<S>,
     state: DaemonState,
@@ -939,10 +946,29 @@ async fn dispatch_loop<S>(
     S: AsyncRead + AsyncWrite + Unpin,
 {
     loop {
-        let raw = match framed.recv().await {
-            Ok(bytes) => bytes,
-            Err(FramingError::Io(_)) => break, // peer closed
-            Err(FramingError::MessageTooLarge(_)) => break, // framing violation
+        // Bound how long a connection may sit idle between requests.
+        //
+        // Without this, the lowest-privilege caller can open MAX_CONNECTIONS
+        // sockets, never write a byte, and hold every semaphore permit
+        // forever — the next connection is dropped at accept, including one
+        // from an Admin trying to approve something. The pre-auth vsock path
+        // already bounds its handshake for exactly this reason; the post-auth
+        // loop had no equivalent on either transport.
+        //
+        // This is an *idle* bound: it only applies while waiting for the next
+        // request. A long-running action is executing inside a handler, not
+        // parked here, so a 45-minute upgrade is unaffected.
+        let raw = match tokio::time::timeout(IDLE_CONNECTION_TIMEOUT, framed.recv()).await {
+            Ok(Ok(bytes)) => bytes,
+            Ok(Err(FramingError::Io(_))) => break, // peer closed
+            Ok(Err(FramingError::MessageTooLarge(_))) => break, // framing violation
+            Err(_) => {
+                eprintln!(
+                    "[sysknife-daemon] closing connection idle for more than {}s",
+                    IDLE_CONNECTION_TIMEOUT.as_secs()
+                );
+                break;
+            }
         };
 
         let msg: Value = match serde_json::from_slice(&raw) {
@@ -1910,14 +1936,24 @@ fn forward_status_change_event(
     });
 }
 
-async fn release_high_risk_slot(state: &DaemonState, owns_slot: bool, request_hash: &str) {
-    if !owns_slot {
+/// Release every exclusion lock this request claimed.
+///
+/// Each entry is removed only when it still records *this* request's hash, so
+/// a late release can never evict a lock a different job has since taken.
+async fn release_exclusive_slots(
+    state: &DaemonState,
+    claimed: &[crate::actions::ExclusiveResource],
+    request_hash: &str,
+) {
+    if claimed.is_empty() {
         return;
     }
 
-    let mut slot = state.running_high_risk_reboot.lock().await;
-    if slot.as_deref() == Some(request_hash) {
-        *slot = None;
+    let mut slots = state.running_exclusive.lock().await;
+    for resource in claimed {
+        if slots.get(resource).map(String::as_str) == Some(request_hash) {
+            slots.remove(resource);
+        }
     }
 }
 
@@ -2054,36 +2090,65 @@ async fn handle_execute(
     // The slot is held for the duration of the action only when the new action
     // is itself High-risk + reboot-required; other mutating actions are blocked
     // while a high-risk action is in-flight but do not themselves set the slot.
-    let is_mutating = state
-        .policy
-        .min_role_for_action(action_name)
-        .map(|r| crate::auth::role_rank(&r) > crate::auth::role_rank(&CallerRole::Observer))
-        .unwrap_or(false);
-
     let is_high_risk_reboot =
         spec.risk_level == sysknife_types::RiskLevel::High && spec.reboot_required;
 
-    // Defensive invariant: the slot is only ever *claimed* inside `if
-    // is_mutating { ... }` below, but `release_high_risk_slot` runs
-    // unconditionally on every exit path (see calls further down). If a
-    // future action were classified High-risk + reboot-required yet not
-    // mutating (e.g. an Observer-role action), it would skip the claim but
-    // still attempt the release — harmless today (release is a no-op unless
-    // the hash matches a claimed slot) but a sign the risk/role policy tables
-    // have drifted out of sync. Policy validation prevents this today; this
-    // assertion catches a future regression cheaply rather than relying on
-    // that invariant holding silently forever.
-    debug_assert!(
-        !is_high_risk_reboot || is_mutating,
-        "high-risk+reboot action must be mutating (action {action_name:?} is High risk \
-         + reboot_required but policy does not require Dev/Admin to run it)"
-    );
+    let policy_says_mutating = match state.policy.min_role_for_action(action_name) {
+        Some(r) => crate::auth::role_rank(&r) > crate::auth::role_rank(&CallerRole::Observer),
+        None => {
+            // Unreachable today: `authorize_action` above rejects any action
+            // the policy table does not know. Treat the miss as mutating
+            // anyway — the failure direction of a lookup miss must be "gate
+            // it", never "let it through ungated".
+            eprintln!(
+                "[sysknife-daemon] WARNING: no policy entry for {action_name:?} at the \
+                 concurrency gate; treating it as mutating"
+            );
+            true
+        }
+    };
 
-    // Check the gate for any mutating action; only set it for high-risk+reboot.
+    // A High-risk reboot-required action is mutating by definition. Deriving
+    // this from the spec as well as the policy table means a drift between the
+    // two tables cannot silently downgrade an upgrade-class action to
+    // "ungated". The previous code asserted this relationship with
+    // `debug_assert!`, which is compiled out of release builds — precisely the
+    // binary that ships.
+    let is_mutating = policy_says_mutating || is_high_risk_reboot;
+    if is_high_risk_reboot && !policy_says_mutating {
+        eprintln!(
+            "[sysknife-daemon] WARNING: {action_name:?} is High-risk + reboot-required but the \
+             policy table does not require Dev/Admin for it; gating it as mutating anyway. \
+             The risk and role tables have drifted."
+        );
+    }
+
+    // Which system locks this request will hold while it runs.
+    let mut to_claim: Vec<crate::actions::ExclusiveResource> = Vec::new();
+    if is_high_risk_reboot {
+        to_claim.push(crate::actions::ExclusiveResource::System);
+    }
+    let own_resource = crate::actions::exclusive_resource(&spec);
+    if let Some(r) = own_resource {
+        if !to_claim.contains(&r) {
+            to_claim.push(r);
+        }
+    }
+    if !is_mutating {
+        to_claim.clear();
+    }
+
+    // Check the gate for any mutating action, and claim every lock it needs.
     if is_mutating {
-        let mut slot = state.running_high_risk_reboot.lock().await;
-        if let Some(running_hash) = slot.as_ref() {
-            // Another high-risk reboot-required action is already executing.
+        let mut slots = state.running_exclusive.lock().await;
+        // Conflict on a system-wide job first (it excludes everything), then
+        // on this action's own resource.
+        let blocking = slots
+            .get(&crate::actions::ExclusiveResource::System)
+            .map(|h| (crate::actions::ExclusiveResource::System, h.clone()))
+            .or_else(|| own_resource.and_then(|r| slots.get(&r).map(|h| (r, h.clone()))));
+        if let Some((blocking_resource, running_hash)) = blocking {
+            // Another mutating action already holds a lock this one needs.
             // Return a typed Conflict response so the shell can surface a
             // "wait, an upgrade is running" message rather than a generic error.
             //
@@ -2101,8 +2166,9 @@ async fn handle_execute(
             // only way to get a new TTL window is a new transaction, which
             // means re-running the preview.
             let ttl = crate::transactions::APPROVAL_RECEIPT_TTL_MINUTES;
+            let held = blocking_resource.label();
             let msg = format!(
-                "a High-risk reboot-required action is already executing (request_hash \
+                "another mutating action is already executing and holds {held} (request_hash \
                  {running_hash}); retry after the current job completes. This approval \
                  expires {ttl} minutes after it was issued, and that window is anchored to \
                  when the preview was created — re-running `sysknife approve` on this same \
@@ -2110,7 +2176,7 @@ async fn handle_execute(
                  window has passed, re-run the preview (which mints a fresh transaction) and \
                  approve that new transaction instead"
             );
-            drop(slot); // release before I/O
+            drop(slots); // release before I/O
             return send_response(
                 framed,
                 &DaemonResponse::ConflictResponse {
@@ -2121,10 +2187,10 @@ async fn handle_execute(
             )
             .await;
         }
-        if is_high_risk_reboot {
-            // Claim the slot before releasing the lock so no other connection
-            // can race between the check and the set.
-            *slot = Some(stored_hash.clone());
+        // Claim every lock before releasing the mutex so no other connection
+        // can race between the check and the set.
+        for resource in &to_claim {
+            slots.insert(*resource, stored_hash.clone());
         }
         // Lock drops here via RAII, releasing for other read-only actions.
     }
@@ -2136,7 +2202,7 @@ async fn handle_execute(
     {
         Ok(c) => c,
         Err(e) => {
-            release_high_risk_slot(state, is_high_risk_reboot, &stored_hash).await;
+            release_exclusive_slots(state, &to_claim, &stored_hash).await;
             return send_error(
                 framed,
                 request_id,
@@ -2147,7 +2213,7 @@ async fn handle_execute(
         }
     };
     if !claimed {
-        release_high_risk_slot(state, is_high_risk_reboot, &stored_hash).await;
+        release_exclusive_slots(state, &to_claim, &stored_hash).await;
         return send_error(
             framed,
             request_id,
@@ -2169,7 +2235,7 @@ async fn handle_execute(
     )
     .await
     {
-        release_high_risk_slot(state, is_high_risk_reboot, &stored_hash).await;
+        release_exclusive_slots(state, &to_claim, &stored_hash).await;
         if let Err(status_error) =
             update_terminal_status(state, transaction_id, JobState::Failed).await
         {
@@ -2296,7 +2362,7 @@ async fn handle_execute(
     // (success OR failure). The slot was only set when this action was
     // itself High-risk + reboot-required; for other mutating actions the
     // guard was read but never written, so there is nothing to clear.
-    release_high_risk_slot(state, is_high_risk_reboot, &stored_hash).await;
+    release_exclusive_slots(state, &to_claim, &stored_hash).await;
 
     // Update the transaction record. A failure here is an audit-trail loss —
     // log it and surface it as a warning in the job result so the client is
@@ -3609,8 +3675,8 @@ mod tests {
 
         assert!(result.is_err(), "the initial response write must fail");
         assert!(
-            state.running_high_risk_reboot.lock().await.is_none(),
-            "a disconnected client must not retain the global reboot slot"
+            state.running_exclusive.lock().await.is_empty(),
+            "a disconnected client must not retain any exclusion lock"
         );
         assert_eq!(
             state
@@ -4307,12 +4373,45 @@ mod tests {
             Arc::new(crate::executor::RealActionExecutor)
         }
 
+        /// The daemon refuses a token file other local users can read, so
+        /// tests must provision one the way an operator is told to
+        /// (`install -m 600`). `std::fs::write` alone lands at 0644 under the
+        /// usual umask and would be rejected.
+        fn write_token_mode(path: &std::path::Path, mode: u32) {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
+        }
+
+        /// A bearer token any local user can read is not a credential. The
+        /// daemon must refuse it rather than grant `token_role()` to whoever
+        /// presents it.
+        #[tokio::test]
+        async fn group_or_world_readable_token_file_is_rejected() {
+            let dir = tempdir().unwrap();
+            let token_path = dir.path().join("token");
+            std::fs::write(&token_path, "test-secret").unwrap();
+            write_token_mode(&token_path, 0o644);
+
+            assert!(
+                crate::auth::validate_token_against_file("test-secret", &token_path).is_none(),
+                "a 0644 token file must be rejected even when the token matches"
+            );
+
+            // Same file, same token, tightened permissions — now accepted.
+            write_token_mode(&token_path, 0o600);
+            assert!(
+                crate::auth::validate_token_against_file("test-secret", &token_path).is_some(),
+                "a 0600 token file with a matching token must be accepted"
+            );
+        }
+
         /// Send a valid auth frame then a `query_state` — connection must succeed.
         #[tokio::test]
         async fn valid_token_grants_access() {
             let dir = tempdir().unwrap();
             let token_path = dir.path().join("token");
             std::fs::write(&token_path, "test-secret").unwrap();
+            write_token_mode(&token_path, 0o600);
 
             let (client, server) = tokio::io::duplex(4 * 1024 * 1024);
             let state = test_state(&dir);
@@ -4347,6 +4446,7 @@ mod tests {
             let dir = tempdir().unwrap();
             let token_path = dir.path().join("token");
             std::fs::write(&token_path, "correct").unwrap();
+            write_token_mode(&token_path, 0o600);
 
             let (client, server) = tokio::io::duplex(4 * 1024 * 1024);
             let state = test_state(&dir);
@@ -4379,6 +4479,7 @@ mod tests {
             let dir = tempdir().unwrap();
             let token_path = dir.path().join("token");
             std::fs::write(&token_path, "secret").unwrap();
+            write_token_mode(&token_path, 0o600);
 
             let (client, server) = tokio::io::duplex(4 * 1024 * 1024);
 
@@ -4398,6 +4499,7 @@ mod tests {
             let dir = tempdir().unwrap();
             let token_path = dir.path().join("token");
             std::fs::write(&token_path, "secret").unwrap();
+            write_token_mode(&token_path, 0o600);
 
             let (client, server) = tokio::io::duplex(4 * 1024 * 1024);
 
@@ -4419,6 +4521,7 @@ mod tests {
             let dir = tempdir().unwrap();
             let token_path = dir.path().join("token");
             std::fs::write(&token_path, "secret").unwrap();
+            write_token_mode(&token_path, 0o600);
 
             let (client, server) = tokio::io::duplex(4 * 1024 * 1024);
 

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -25,6 +25,7 @@ use std::io;
 use std::net::IpAddr;
 use std::process::Stdio;
 use std::str::FromStr;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -130,6 +131,50 @@ impl ActionExecutor for RealActionExecutor {
     }
 }
 
+/// Wall-clock ceiling on a single privileged action.
+///
+/// Nothing else bounds these processes: without a deadline a child that never
+/// exits — `apt-get` waiting on a dead mirror, a helper blocked on a prompt
+/// that will never arrive — wedges its connection forever, and the exclusion
+/// lock it holds is never released, so every other action contending for that
+/// resource is refused from then on.
+///
+/// The ceiling is deliberately generous rather than tight. A release upgrade
+/// or an OSTree rebase legitimately runs for tens of minutes, and killing a
+/// half-finished package transaction is worse than waiting. This is a
+/// backstop against a hang, not a performance budget. Override with
+/// `SYSKNIFE_ACTION_TIMEOUT_SECS` when an action on a slow link needs longer.
+const DEFAULT_ACTION_TIMEOUT: Duration = Duration::from_secs(2 * 60 * 60);
+
+fn action_timeout() -> Duration {
+    match std::env::var("SYSKNIFE_ACTION_TIMEOUT_SECS") {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(secs) if secs > 0 => Duration::from_secs(secs),
+            _ => {
+                eprintln!(
+                    "[sysknife-daemon] WARNING: ignoring invalid \
+                     SYSKNIFE_ACTION_TIMEOUT_SECS={raw:?}; using the default"
+                );
+                DEFAULT_ACTION_TIMEOUT
+            }
+        },
+        Err(_) => DEFAULT_ACTION_TIMEOUT,
+    }
+}
+
+/// Kill a child that outran the deadline and reap it, so the timeout does not
+/// trade a hung task for a zombie.
+async fn kill_and_reap(child: &mut tokio::process::Child, program: &str) -> ExecutorError {
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+    let secs = action_timeout().as_secs();
+    eprintln!("[sysknife-daemon] {program} exceeded the {secs}s action timeout; killed");
+    ExecutorError::Io(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("{program} exceeded the {secs}s action timeout and was killed"),
+    ))
+}
+
 async fn execute_command_with_progress(
     program: &'static str,
     args: &[String],
@@ -152,9 +197,18 @@ async fn execute_command_with_progress(
             .map(|_| buf)
     });
 
+    let deadline = tokio::time::Instant::now() + action_timeout();
+
     let mut lines = BufReader::new(stdout).lines();
     let mut stdout_buf = String::new();
-    while let Some(line) = lines.next_line().await.map_err(ExecutorError::Io)? {
+    loop {
+        // The deadline covers the whole action, not each read: a process that
+        // emits one progress line an hour must still be cut off.
+        let next = match tokio::time::timeout_at(deadline, lines.next_line()).await {
+            Ok(result) => result.map_err(ExecutorError::Io)?,
+            Err(_) => return Err(kill_and_reap(&mut child, program).await),
+        };
+        let Some(line) = next else { break };
         if !line.is_empty() {
             let _ = progress.send(line.clone());
         }
@@ -162,7 +216,10 @@ async fn execute_command_with_progress(
         stdout_buf.push('\n');
     }
 
-    let exit_status = child.wait().await.map_err(ExecutorError::Io)?;
+    let exit_status = match tokio::time::timeout_at(deadline, child.wait()).await {
+        Ok(status) => status.map_err(ExecutorError::Io)?,
+        Err(_) => return Err(kill_and_reap(&mut child, program).await),
+    };
     let stderr_bytes = stderr_task
         .await
         .map_err(|_| ExecutorError::Io(io::Error::other("stderr reader task panicked")))?
@@ -690,6 +747,18 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
                 .get("nopasswd")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
+            // `commands = "ALL"` together with `nopasswd` mints a standing,
+            // passwordless, unrestricted root credential (`user ALL=(ALL)
+            // NOPASSWD: ALL`). Unlike every other action here, the effect
+            // outlives the job: it is a permanent privilege grant, not a
+            // one-time change, and it is indistinguishable from the daemon's
+            // own authority thereafter. Require the caller to give up one of
+            // the two dimensions — scope the commands, or keep the password
+            // prompt. `visudo` would happily accept the combination, so this
+            // is the only place it can be refused.
+            if commands == "ALL" && nopasswd {
+                return Err(ExecutorError::InvalidParam("commands"));
+            }
             Ok(sudoers::grant_sudo_access(
                 &name,
                 &user,
@@ -1411,14 +1480,50 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
 pub async fn execute_spec(spec: &ActionSpec) -> Result<ExecutionOutput, ExecutorError> {
     match &spec.mechanism {
         ActionMechanism::Command { program, args } => {
-            let output = tokio::process::Command::new(program)
+            // Spawned rather than `.output()`ed so the child can be killed on
+            // timeout; `.output()` gives no handle to kill, so a hung process
+            // would hold the task forever.
+            let mut child = tokio::process::Command::new(program)
                 .args(args)
-                .output()
-                .await?;
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()?;
+
+            // `wait_with_output` consumes the child, which would leave nothing
+            // to kill when the deadline fires. Drain the pipes in their own
+            // tasks instead — draining also stops a chatty process from
+            // blocking on a full pipe buffer while we wait.
+            let stdout_h = child.stdout.take().expect("stdout was piped");
+            let stderr_h = child.stderr.take().expect("stderr was piped");
+            let stdout_task = tokio::spawn(async move {
+                let mut buf = Vec::new();
+                BufReader::new(stdout_h)
+                    .read_to_end(&mut buf)
+                    .await
+                    .map(|_| buf)
+            });
+            let stderr_task = tokio::spawn(async move {
+                let mut buf = Vec::new();
+                BufReader::new(stderr_h)
+                    .read_to_end(&mut buf)
+                    .await
+                    .map(|_| buf)
+            });
+
+            let status = match tokio::time::timeout(action_timeout(), child.wait()).await {
+                Ok(status) => status?,
+                Err(_) => return Err(kill_and_reap(&mut child, program).await),
+            };
+            let join =
+                |e| ExecutorError::Io(io::Error::other(format!("reader task panicked: {e}")));
+            let stdout = stdout_task.await.map_err(join)??;
+            let stderr = stderr_task.await.map_err(join)??;
+
             Ok(ExecutionOutput {
-                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-                exit_code: output.status.code().unwrap_or(-1),
+                stdout: String::from_utf8_lossy(&stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&stderr).into_owned(),
+                exit_code: status.code().unwrap_or(-1),
             })
         }
         ActionMechanism::FileScan { path } => {
@@ -2781,7 +2886,10 @@ mod tests {
         // which accepts the bare `single`/`s`/`1` runlevel shortcuts. The
         // kernel-arg denylist must apply to `append` too — booting into a
         // single-user root shell is exactly the SetKernelArguments threat.
-        for dangerous in ["single", "s", "1"] {
+        // Every BLOCKED_EXACT entry is valueless, so it passes the charset
+        // check and this denylist call is the only thing stopping it — the
+        // call is load-bearing here, not redundant with `validated_safe_arg`.
+        for dangerous in ["single", "s", "1", "nosmap", "nosmep"] {
             let err = build_action_spec(
                 "GrubSetKargs",
                 &json!({ "append": [dangerous], "delete": [] }),
@@ -2803,6 +2911,10 @@ mod tests {
     #[test]
     fn kernel_arg_build_spec_rejects_dangerous_arg() {
         // End-to-end: build_action_spec must propagate the blocklist error.
+        // This action does NOT apply the `validated_safe_arg` charset check,
+        // so `init=/bin/bash` reaches `validated_safe_kernel_arg` and is
+        // caught by BLOCKED_PREFIXES — the `=`-bearing half of that denylist
+        // is live here even though GrubSetKargs never reaches it.
         let err = build_action_spec(
             "SetKernelArguments",
             &json!({ "add": ["init=/bin/bash"], "remove": [] }),
@@ -2812,6 +2924,30 @@ mod tests {
             matches!(err, ExecutorError::InvalidParam("add")),
             "expected InvalidParam(add), got {err:?}"
         );
+    }
+
+    #[test]
+    fn grub_set_kargs_cannot_delete_a_protective_karg() {
+        // A review flagged `delete: ["apparmor=1"]` as a way to strip AppArmor
+        // because the kernel-arg denylist is not applied to `delete`. It is
+        // not reachable: `delete` goes through `validated_safe_arg`, whose
+        // charset excludes `=`, so any `key=value` token is refused before the
+        // denylist would matter. Pinned here so a future widening of that
+        // charset cannot silently open the hole.
+        for karg in [
+            "apparmor=1",
+            "lockdown=confidentiality",
+            "mitigations=auto",
+            "pti=on",
+            "selinux=1",
+        ] {
+            let err = build_action_spec("GrubSetKargs", &json!({ "append": [], "delete": [karg] }))
+                .unwrap_err();
+            assert!(
+                matches!(err, ExecutorError::InvalidParam("delete")),
+                "deleting {karg:?} must be refused, got {err:?}"
+            );
+        }
     }
 
     /// Every action that claims `rollback_available: true` MUST have a

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -1578,7 +1578,8 @@ fn validated_public_key(s: &str) -> Result<String, ExecutorError> {
     //
     // Blocked characters and why:
     //   '\''  — breaks single-quoted shell strings in add_authorized_key
-    //   '|'   — sed address delimiter in remove_authorized_key (\|^key$|d)
+    //   '|'   — shell pipe (the ssh key ops no longer build a sed address,
+    //           but '|' never appears in a valid key, so keep rejecting it)
     //   ';'   — shell command separator
     //   '`'   — shell command substitution
     //   '$'   — shell variable expansion
@@ -2379,14 +2380,30 @@ mod tests {
     }
 
     #[test]
-    fn public_key_rejects_pipe_sed_injection() {
-        // '|' is the sed address delimiter in remove_authorized_key.
-        // Allowing it enables sed injection: \|^key|d where key contains '|'.
+    fn public_key_rejects_pipe_metacharacter() {
+        // '|' is a shell pipe and never appears in a valid key. (It was also
+        // the sed address delimiter before the key ops were made regex-free;
+        // the rejection stands on its own merits either way.)
         let key = "ssh-ed25519 AAAA|; rm -rf /etc user@host";
         assert!(matches!(
             validated_public_key(key),
             Err(ExecutorError::InvalidParam("public_key"))
         ));
+    }
+
+    #[test]
+    fn public_key_accepts_regex_metacharacters_so_consumers_must_not_use_regex() {
+        // Deliberate and load-bearing: `.` is legal inside a key comment
+        // (`alice@example.com`), so the validator cannot blocklist regex
+        // metacharacters without rejecting valid keys. Any consumer that
+        // interprets a key as a pattern is therefore the defect — see
+        // `actions::ssh::REMOVE_KEY_SCRIPT`, which uses `grep -Fxv` for
+        // exactly this reason.
+        let key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample alice@example.com";
+        assert!(validated_public_key(key).is_ok());
+        // The wildcard-shaped payload passes validation too. It is safe only
+        // because no consumer treats it as a pattern.
+        assert!(validated_public_key("ssh-ed25519 .*").is_ok());
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/state.rs
+++ b/crates/sysknife-daemon/src/state.rs
@@ -1,8 +1,10 @@
+use crate::actions::ExclusiveResource;
 use crate::audit_forward::AuditForwarder;
 use crate::policy::PolicyTable;
 use crate::store::{AuditStore, SqliteStore};
 use crate::transactions::{TransactionStore, TransactionStoreError};
 use crate::transport::listen::{bind_unix_listener, ListenTarget, ListenTargetError};
+use std::collections::HashMap;
 use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -38,34 +40,39 @@ pub struct DaemonState {
     /// sink is configured; events recorded by the dispatcher are then only
     /// written to the local hash-chained store.
     pub forwarder: Option<AuditForwarder>,
-    /// Coarse concurrency guard for High-risk reboot-required actions (ME4).
+    /// Concurrency guard keyed by the system lock each in-flight mutating
+    /// action holds (ME4).
     ///
-    /// Holds the `request_hash` of any currently executing action whose
-    /// `ActionSpec` has `risk_level == High && reboot_required == true` (e.g.
-    /// `UbuntuReleaseUpgrade`, `AddLayeredPackage`, `RebaseSystem`). `None`
-    /// when no such action is in flight.
+    /// Maps an [`ExclusiveResource`] to the `request_hash` of the action
+    /// currently holding it. A mutating action is rejected with a
+    /// `ConflictResponse` when either
     ///
-    /// The guard is one-directional, not mutual exclusion between all
-    /// mutating actions: every mutating action checks this slot before it is
-    /// allowed to start, but only a High-risk + reboot-required action ever
-    /// *claims* it (sets it to `Some`). So while a High-risk +
-    /// reboot-required action is in flight, every other mutating action —
-    /// including another High-risk + reboot-required one — is rejected with
-    /// a `ConflictResponse` rather than racing the in-flight upgrade and
-    /// causing dpkg/rpm-ostree lock contention. An ordinary mutating action
-    /// (e.g. `StartService`) never claims the slot itself, so it neither
-    /// blocks other ordinary mutating actions nor blocks a High-risk +
-    /// reboot-required action that starts while it is still running.
+    /// * [`ExclusiveResource::System`] is held — a reboot-required action
+    ///   (release upgrade, rebase, layered install) is in flight and conflicts
+    ///   with everything mutating; or
+    /// * its own resource is held — e.g. a second `AptUpgrade` while the first
+    ///   still owns [`ExclusiveResource::Dpkg`].
     ///
-    /// The slot is `Arc<Mutex<…>>` so cloned `DaemonState` values — one per
-    /// IPC connection — all share the same underlying guard. `Mutex::lock`
-    /// is held for at most a few microseconds; this does not become a
-    /// hot-path bottleneck because read-only actions skip the check entirely.
+    /// This replaced a single `Option<String>` slot that only High-risk
+    /// *reboot-required* actions ever claimed. Under that rule `AptUpgrade`
+    /// (High risk, `reboot_required: false`) claimed nothing, so two
+    /// concurrent `apt-get dist-upgrade` runs both passed the gate and then
+    /// collided on `/var/lib/dpkg/lock-frontend` — the exact contention the
+    /// gate exists to prevent, and one that can leave dpkg needing
+    /// `--configure -a`.
+    ///
+    /// Actions with no shared lock (`exclusive_resource` returns `None`, e.g.
+    /// `StartService`) still respect a held `System` but never block each
+    /// other, so unrelated work is not serialised behind a long `apt` run.
+    ///
+    /// The map is `Arc<Mutex<…>>` so cloned `DaemonState` values — one per IPC
+    /// connection — all share the same guard. `Mutex::lock` is held for at
+    /// most a few microseconds; read-only actions skip the check entirely.
     ///
     /// On daemon crash the in-memory guard is lost. That is correct: the
     /// daemon's SQLite store will show the orphaned `Running` row; the
     /// operator can inspect it via `ListJobHistory`.
-    pub running_high_risk_reboot: Arc<Mutex<Option<String>>>,
+    pub running_exclusive: Arc<Mutex<HashMap<ExclusiveResource, String>>>,
 }
 
 #[derive(Debug)]
@@ -116,7 +123,7 @@ impl DaemonState {
             policy,
             host_distro: sysknife_core::distro::detect().ok(),
             forwarder,
-            running_high_risk_reboot: Arc::new(Mutex::new(None)),
+            running_exclusive: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -136,7 +143,7 @@ impl DaemonState {
             policy,
             host_distro: sysknife_core::distro::detect().ok(),
             forwarder,
-            running_high_risk_reboot: Arc::new(Mutex::new(None)),
+            running_exclusive: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -271,9 +271,16 @@ fn deserialize<T: serde::de::DeserializeOwned>(s: &str) -> Result<T, Transaction
     serde_json::from_str(s).map_err(TransactionStoreError::Json)
 }
 
+/// UTC timestamp in the same RFC 3339 millisecond shape the SQLite backend
+/// produces via `strftime('%Y-%m-%dT%H:%M:%fZ','now')`.
+///
+/// `%S` is load-bearing: chrono's `%.3f` renders only the fractional part, so
+/// omitting `%S` yields `2026-07-27T12:34:.567Z`. That value is signed into
+/// `ChainContent.created_at` on every audit row and cast to `timestamptz` by
+/// approve, claim-for-execution, the stale sweep, and the history filter.
 fn now_iso() -> String {
     chrono::Utc::now()
-        .format("%Y-%m-%dT%H:%M:%.3fZ")
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
         .to_string()
 }
 
@@ -874,6 +881,50 @@ mod tests {
         .expect("standard URL parses");
         // Ensure binding via PgPoolOptions wouldn't reject it (just smoke-check).
         let _ = opts.statement_cache_capacity(0);
+    }
+
+    #[test]
+    fn now_iso_produces_a_parseable_rfc3339_timestamp() {
+        // `now_iso()` is signed into `ChainContent.created_at` on every
+        // audit row and is cast to `timestamptz` by approve, claim-for-
+        // execution, the stale sweep, and the history filter. The format
+        // string previously omitted `%S`, yielding `2026-07-27T12:34:.567Z`:
+        // seconds silently vanished, the chain attested to a broken value
+        // forever, and same-minute ordering became unrecoverable.
+        let ts = now_iso();
+        let parsed = chrono::DateTime::parse_from_rfc3339(&ts);
+        assert!(
+            parsed.is_ok(),
+            "now_iso() must emit a parseable RFC 3339 timestamp, got {ts:?} ({parsed:?})"
+        );
+        assert_eq!(
+            ts.len(),
+            "2026-07-27T12:34:56.789Z".len(),
+            "timestamp shape changed unexpectedly: {ts}"
+        );
+    }
+
+    #[test]
+    fn now_iso_matches_the_sqlite_backends_timestamp_shape() {
+        // Both backends feed the same signed chain, so a row written by
+        // Postgres must be byte-comparable with one written by SQLite
+        // (`strftime('%Y-%m-%dT%H:%M:%fZ','now')`, which yields
+        // milliseconds). Divergent shapes make cross-backend verification
+        // and time-ordered queries subtly wrong.
+        let ts = now_iso();
+        let (date, rest) = ts.split_once('T').expect("timestamp has a T separator");
+        assert_eq!(date.len(), "2026-07-27".len(), "date part: {ts}");
+        assert!(rest.ends_with('Z'), "must be UTC with a Z suffix: {ts}");
+        let time = rest.trim_end_matches('Z');
+        let fields: Vec<&str> = time.split(':').collect();
+        assert_eq!(fields.len(), 3, "expected HH:MM:SS.mmm, got {time:?}");
+        assert!(
+            fields[2].contains('.'),
+            "seconds field must carry fractional milliseconds: {time:?}"
+        );
+        let (secs, millis) = fields[2].split_once('.').expect("checked above");
+        assert_eq!(secs.len(), 2, "seconds must be two digits: {time:?}");
+        assert_eq!(millis.len(), 3, "expected millisecond precision: {time:?}");
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -1356,8 +1356,21 @@ mod tests {
              fail={fail_result:?}"
         );
 
-        // The loser must fail with the dedicated race error, not silently
-        // succeed and clobber the winner.
+        // The loser must be refused outright, not silently succeed and clobber
+        // the winner. *How* it is refused depends on whether the two threads
+        // actually overlapped, and both outcomes are correct:
+        //
+        //   ConcurrentStatusChange — they overlapped, so the loser read
+        //       `Running` and its compare-and-swap found the row already moved.
+        //   InvalidTransition      — they serialised, so the loser read the
+        //       winner's committed terminal status and rejected the transition
+        //       before reaching the CAS at all.
+        //
+        // Asserting only the first made this test depend on thread
+        // interleaving; it passes on a many-core dev machine and fails on a
+        // 2-core CI runner, where the first thread routinely finishes before
+        // the second starts. The invariant under test is "exactly one wins and
+        // the loser does not clobber it", which both errors satisfy.
         let loser = if succeed_result.is_ok() {
             &fail_result
         } else {
@@ -1367,9 +1380,23 @@ mod tests {
             Err(TransactionStoreError::ConcurrentStatusChange(id)) => {
                 assert_eq!(id, &tx.transaction_id);
             }
-            other => {
-                panic!("the losing transition must report ConcurrentStatusChange, got: {other:?}")
+            Err(TransactionStoreError::InvalidTransition { from, to }) => {
+                // The winner's terminal state must be what the loser saw.
+                let winner = if succeed_result.is_ok() {
+                    JobState::Succeeded
+                } else {
+                    JobState::Failed
+                };
+                assert_eq!(
+                    *from, winner,
+                    "the loser must have observed the winner's committed status"
+                );
+                assert_ne!(*to, winner, "the loser must be the other transition");
             }
+            other => panic!(
+                "the losing transition must be refused with either \
+                 ConcurrentStatusChange or InvalidTransition, got: {other:?}"
+            ),
         }
 
         // The stored status must match whichever transition actually won —

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -647,11 +647,13 @@ impl TransactionStore {
         // Schema additions for the append-tamper-evident hash chain (see
         // `audit_chain.rs` for the full threat model — note that truncation of
         // the tail is NOT detected by this chain alone; that requires the
-        // separate watermark mechanism documented there):
+        // signed checkpoints anchored to an append-only sink (`checkpoint_sink`),
+        // with the journald watermark as a lighter best-effort complement):
         //   seq             — monotonic ordering, 1-indexed
         //   key_id          — identifies the key generation (forward-compatible
         //                     with epoch rotation in a follow-up issue)
-        //   chain_hash      — ed25519_sign(canonical(immutable_fields) || prev_chain_hash, key)
+        //   chain_hash      — ed25519_sign(ROW_DOMAIN || canonical(immutable_fields)
+        //                     || prev_chain_hash, key)
         //   prev_chain_hash — chain_hash of the previous row, "" for the first row
         //
         // status is intentionally absent from the chain content — it is mutable.

--- a/crates/sysknife-daemon/tests/action_reference_doc.rs
+++ b/crates/sysknife-daemon/tests/action_reference_doc.rs
@@ -55,8 +55,18 @@ fn code_cell(s: &str) -> String {
 fn command(m: &ActionMechanism) -> String {
     match m {
         ActionMechanism::Command { program, args } => {
+            // Quote any argument that is not a single bare word. Without this,
+            // a multi-word argument — an `sh -c` script body, say — flattens
+            // into the surrounding argv and the reader cannot tell where one
+            // argument ends and the next begins.
             let mut parts = vec![(*program).to_string()];
-            parts.extend(args.iter().cloned());
+            parts.extend(args.iter().map(|a| {
+                if a.is_empty() || a.contains(|c: char| c.is_whitespace() || c == '\'') {
+                    format!("\"{}\"", a.replace('"', "\\\""))
+                } else {
+                    a.clone()
+                }
+            }));
             code_cell(&parts.join(" "))
         }
         ActionMechanism::FileScan { path } => format!("scan {}", code_cell(path)),

--- a/crates/sysknife-daemon/tests/concurrency_guard.rs
+++ b/crates/sysknife-daemon/tests/concurrency_guard.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::{json, Value};
+use sysknife_daemon::actions::{catalogue, ExclusiveResource};
 use sysknife_daemon::dispatcher::connection_handler_with_executor;
 use sysknife_daemon::executor::{ActionExecutor, ExecutionOutput, ExecutorError};
 use sysknife_daemon::state::{DaemonConfig, DaemonState};
@@ -169,47 +170,38 @@ async fn do_execute(
 // Tests
 // ---------------------------------------------------------------------------
 //
-// Strategy: the dispatcher's concurrency gate is split into two halves —
-// a CHECK side (read the slot, return ConflictResponse if occupied) and a
-// SET side (claim the slot for the duration of the in-flight action). Both
-// live in `dispatcher.rs::handle_execute`.
+// Strategy: the dispatcher's concurrency gate is split into two halves — a
+// CHECK side (read the resource map, return ConflictResponse if a needed lock
+// is held) and a SET side (claim the locks for the duration of the action).
+// Both live in `dispatcher.rs::handle_execute`.
 //
-// The CHECK side is fully testable here: pre-fill `state.running_high_risk_reboot`
-// with `Some(<dummy-hash>)` and send a request — the gate must respond
-// ConflictResponse for mutating actions and pass-through for read-only ones.
-//
-// The SET side requires real execution of a Command-mechanism action (because
-// `dispatcher.rs` routes Command actions through `stream_command_with_progress`,
-// not through the test's `ActionExecutor` mock). Real execution would need a
-// running daemon with sudoers + the GRUB helper installed, which is out of
-// scope for an in-process integration test. The SET side has unit-test
-// coverage in `dispatcher.rs::tests` against the `is_high_risk_reboot`
-// predicate; the live VM E2E suite covers the SET-CLEAR round-trip end-to-end.
+// The CHECK side is fully testable here: pre-fill `state.running_exclusive`
+// and send a request. The SET side requires real execution of a
+// Command-mechanism action (the dispatcher routes those through
+// `stream_command_with_progress`, not the test's `ActionExecutor` mock), which
+// needs a running daemon with sudoers installed — that is the live VM E2E
+// suite's job, not an in-process test's.
 
 const DUMMY_HASH: &str = "abc123-dummy-hash-for-testing-the-gate-check";
 
-/// Pre-fill the slot to simulate "a High-risk reboot-required action is
-/// already executing on a different connection."
-async fn pre_set_slot(state: &DaemonState) {
-    let mut slot = state.running_high_risk_reboot.lock().await;
-    *slot = Some(DUMMY_HASH.to_string());
+/// Pre-fill a lock to simulate "another action already holds it on a
+/// different connection".
+async fn hold(state: &DaemonState, resource: ExclusiveResource) {
+    state
+        .running_exclusive
+        .lock()
+        .await
+        .insert(resource, DUMMY_HASH.to_string());
 }
 
-/// While a High-risk reboot-required action is in flight (slot held), a second
-/// mutating action from the same or different connection must receive
-/// `conflict_response`.
+/// While a reboot-required action holds `System`, any mutating action must be
+/// refused — `System` excludes everything.
 #[tokio::test]
-async fn mutating_action_blocked_while_high_risk_in_flight() {
+async fn mutating_action_blocked_while_system_lock_held() {
     let dir = tempdir().unwrap();
     let state = test_state(&dir);
 
-    pre_set_slot(&state).await;
-
-    // Confirm the slot is held before we send anything.
-    {
-        let slot = state.running_high_risk_reboot.lock().await;
-        assert_eq!(slot.as_deref(), Some(DUMMY_HASH), "slot must be pre-set");
-    }
+    hold(&state, ExclusiveResource::System).await;
 
     let executor: Arc<dyn ActionExecutor> = Arc::new(InstantSuccessExecutor);
     let mut framed = spawn_handler(state.clone(), executor, CallerRole::Admin).await;
@@ -221,11 +213,14 @@ async fn mutating_action_blocked_while_high_risk_in_flight() {
     let last = msgs.last().unwrap();
     assert_eq!(
         last["type"], "conflict_response",
-        "AptInstall while high-risk in flight must receive conflict_response, got: {last}"
+        "AptInstall while the system lock is held must receive conflict_response, got: {last}"
     );
     assert!(
-        last["message"].as_str().unwrap_or("").contains("High-risk"),
-        "conflict message must mention High-risk, got: {last}"
+        last["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("reboot-required"),
+        "conflict message must name the lock that is held, got: {last}"
     );
     assert_eq!(
         last["request_id"].as_str().unwrap_or(""),
@@ -233,7 +228,7 @@ async fn mutating_action_blocked_while_high_risk_in_flight() {
         "conflict response must echo the request_id"
     );
 
-    *state.running_high_risk_reboot.lock().await = None;
+    state.running_exclusive.lock().await.clear();
     let retry = do_execute(
         &mut framed,
         "AptInstall",
@@ -249,14 +244,77 @@ async fn mutating_action_blocked_while_high_risk_in_flight() {
     );
 }
 
-/// Read-only actions must pass through normally even while the High-risk slot
-/// is held — they do not touch the concurrency gate.
+/// The regression this map exists for: a second apt action while the dpkg lock
+/// is held must be refused. Under the previous single-slot design only
+/// High-risk **reboot-required** actions ever claimed the slot, so `AptUpgrade`
+/// (High risk, `reboot_required: false`) claimed nothing and two concurrent
+/// `apt-get` runs both passed the gate and collided on
+/// `/var/lib/dpkg/lock-frontend`.
 #[tokio::test]
-async fn read_only_action_passes_while_high_risk_in_flight() {
+async fn second_apt_action_blocked_while_dpkg_lock_held() {
     let dir = tempdir().unwrap();
     let state = test_state(&dir);
 
-    pre_set_slot(&state).await;
+    hold(&state, ExclusiveResource::Dpkg).await;
+
+    let executor: Arc<dyn ActionExecutor> = Arc::new(InstantSuccessExecutor);
+    let mut framed = spawn_handler(state.clone(), executor, CallerRole::Admin).await;
+
+    let params = json!({"package": "vim"});
+    let (transaction_id, receipt) = do_preview(&mut framed, "AptInstall", params.clone()).await;
+    let msgs = do_execute(&mut framed, "AptInstall", params, &transaction_id, &receipt).await;
+
+    let last = msgs.last().unwrap();
+    assert_eq!(
+        last["type"], "conflict_response",
+        "a second dpkg-locking action must receive conflict_response, got: {last}"
+    );
+    assert!(
+        last["message"].as_str().unwrap_or("").contains("dpkg"),
+        "conflict message must name the dpkg lock, got: {last}"
+    );
+}
+
+/// A mutating action that holds no shared lock must NOT be serialised behind an
+/// unrelated one. Holding the dpkg lock must not block a systemd unit change —
+/// over-serialising every mutating action behind a long `apt` run would be a
+/// usability regression, not extra safety.
+#[tokio::test]
+async fn unrelated_mutating_action_passes_while_dpkg_lock_held() {
+    let dir = tempdir().unwrap();
+    let state = test_state(&dir);
+
+    hold(&state, ExclusiveResource::Dpkg).await;
+
+    let executor: Arc<dyn ActionExecutor> = Arc::new(InstantSuccessExecutor);
+    let mut framed = spawn_handler(state, executor, CallerRole::Admin).await;
+
+    let params = json!({"unit": "ssh.service"});
+    let (transaction_id, receipt) = do_preview(&mut framed, "RestartService", params.clone()).await;
+    let msgs = do_execute(
+        &mut framed,
+        "RestartService",
+        params,
+        &transaction_id,
+        &receipt,
+    )
+    .await;
+
+    let last = msgs.last().unwrap();
+    assert_ne!(
+        last["type"], "conflict_response",
+        "an action holding no shared lock must not be blocked by the dpkg lock: {last}"
+    );
+}
+
+/// Read-only actions must pass through normally even while a lock is held —
+/// they never reach the concurrency gate.
+#[tokio::test]
+async fn read_only_action_passes_while_system_lock_held() {
+    let dir = tempdir().unwrap();
+    let state = test_state(&dir);
+
+    hold(&state, ExclusiveResource::System).await;
 
     let executor: Arc<dyn ActionExecutor> = Arc::new(InstantSuccessExecutor);
     let mut framed = spawn_handler(state, executor, CallerRole::Admin).await;
@@ -279,21 +337,17 @@ async fn read_only_action_passes_while_high_risk_in_flight() {
         resp["type"], "conflict_response",
         "read-only action must NOT receive conflict_response: {resp}"
     );
-    // It may fail (no real disk command in CI) but must not be blocked by
-    // the concurrency gate — any non-conflict response is a pass.
 }
 
-/// After the slot is cleared, subsequent mutating actions must NOT receive
-/// `conflict_response` from the gate.
+/// With no lock held, a mutating action must NOT receive `conflict_response`.
 #[tokio::test]
-async fn mutating_action_passes_when_slot_is_clear() {
+async fn mutating_action_passes_when_no_lock_is_held() {
     let dir = tempdir().unwrap();
     let state = test_state(&dir);
 
-    // Slot must start empty.
     assert!(
-        state.running_high_risk_reboot.lock().await.is_none(),
-        "slot must start empty"
+        state.running_exclusive.lock().await.is_empty(),
+        "the lock map must start empty"
     );
 
     let executor: Arc<dyn ActionExecutor> = Arc::new(InstantSuccessExecutor);
@@ -303,68 +357,46 @@ async fn mutating_action_passes_when_slot_is_clear() {
     let (transaction_id, receipt) = do_preview(&mut framed, "AptInstall", params.clone()).await;
     let msgs = do_execute(&mut framed, "AptInstall", params, &transaction_id, &receipt).await;
 
-    // The action will go through to execution. Whether it succeeds or fails
-    // (because there's no real apt-get in the test sandbox) is irrelevant —
-    // what matters is that the response is NOT conflict_response.
     let last = msgs.last().unwrap();
     assert_ne!(
         last["type"], "conflict_response",
-        "AptInstall with empty slot must NOT receive conflict_response: {last}"
+        "AptInstall with no lock held must NOT receive conflict_response: {last}"
     );
 }
 
-/// The slot can be set, cleared, and re-set without dead-lock or stale state.
-#[tokio::test]
-async fn slot_state_machine_transitions_cleanly() {
-    let dir = tempdir().unwrap();
-    let state = test_state(&dir);
+/// Which lock an action contends for is derived from its own argv, so a new
+/// `apt-get` action joins the gate without anyone registering it. Pin the
+/// derivation for one action per resource class.
+#[test]
+fn exclusive_resource_is_derived_from_the_action_argv() {
+    use sysknife_daemon::actions::exclusive_resource;
 
-    // Start: None
-    assert!(state.running_high_risk_reboot.lock().await.is_none());
+    let find = |name: &str| {
+        catalogue()
+            .into_iter()
+            .flat_map(|(_, specs)| specs)
+            .find(|s| s.action_name == name)
+            .unwrap_or_else(|| panic!("{name} must exist in the catalogue"))
+    };
 
-    // Set
-    {
-        let mut s = state.running_high_risk_reboot.lock().await;
-        *s = Some("hash-1".to_string());
-    }
     assert_eq!(
-        state.running_high_risk_reboot.lock().await.as_deref(),
-        Some("hash-1")
+        exclusive_resource(&find("AptUpgrade")),
+        Some(ExclusiveResource::Dpkg),
+        "apt-get actions must contend for the dpkg lock"
     );
-
-    // Clear
-    {
-        let mut s = state.running_high_risk_reboot.lock().await;
-        *s = None;
-    }
-    assert!(state.running_high_risk_reboot.lock().await.is_none());
-
-    // Re-set
-    {
-        let mut s = state.running_high_risk_reboot.lock().await;
-        *s = Some("hash-2".to_string());
-    }
     assert_eq!(
-        state.running_high_risk_reboot.lock().await.as_deref(),
-        Some("hash-2")
+        exclusive_resource(&find("SnapInstall")),
+        Some(ExclusiveResource::Snap),
+        "snap actions must contend for the snapd change queue"
     );
-}
-
-/// The gate must allow concurrent connections to share the slot via
-/// `Arc<Mutex<…>>` — both `state.clone()` instances see the same slot.
-#[tokio::test]
-async fn cloned_state_shares_the_same_slot() {
-    let dir = tempdir().unwrap();
-    let state_a = test_state(&dir);
-    let state_b = state_a.clone();
-
-    {
-        let mut s = state_a.running_high_risk_reboot.lock().await;
-        *s = Some("via-a".to_string());
-    }
     assert_eq!(
-        state_b.running_high_risk_reboot.lock().await.as_deref(),
-        Some("via-a"),
-        "cloning DaemonState must share the running_high_risk_reboot Arc"
+        exclusive_resource(&find("UpdateSystem")),
+        Some(ExclusiveResource::RpmOstree),
+        "rpm-ostree actions must contend for the rpm-ostree lock"
+    );
+    assert_eq!(
+        exclusive_resource(&find("RestartService")),
+        None,
+        "a systemctl action holds no package-manager lock"
     );
 }

--- a/crates/sysknife-daemon/tests/execute_spec.rs
+++ b/crates/sysknife-daemon/tests/execute_spec.rs
@@ -376,3 +376,46 @@ async fn command_unknown_program_returns_io_error() {
         "spawning a nonexistent program must return ExecutorError::Io, not a zero exit_code"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Action timeout
+// ---------------------------------------------------------------------------
+
+/// A child that never exits must be killed, not awaited forever.
+///
+/// Without a deadline a hung process (`apt-get` on a dead mirror, a helper
+/// blocked on a prompt) wedges its connection permanently AND never releases
+/// the exclusion lock it holds, so every later action contending for that
+/// resource is refused from then on. Nextest runs each test in its own
+/// process, so setting the override env var here cannot leak into another test.
+#[tokio::test]
+async fn execute_spec_kills_a_child_that_outruns_the_action_timeout() {
+    std::env::set_var("SYSKNIFE_ACTION_TIMEOUT_SECS", "1");
+
+    let spec = ActionSpec {
+        action_name: "TimeoutProbe",
+        mechanism: ActionMechanism::Command {
+            program: "sh",
+            args: vec!["-c".to_string(), "sleep 300".to_string()],
+        },
+        risk_level: sysknife_types::RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    };
+
+    let started = std::time::Instant::now();
+    let err = execute_spec(&spec)
+        .await
+        .expect_err("a child that outruns the timeout must fail, not hang");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < std::time::Duration::from_secs(60),
+        "must give up near the 1s deadline, took {elapsed:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("timeout"),
+        "error must say the action timed out, got: {msg}"
+    );
+}

--- a/crates/sysknife-daemon/tests/ssh_key_ops.rs
+++ b/crates/sysknife-daemon/tests/ssh_key_ops.rs
@@ -4,8 +4,14 @@
 //! `actions_batch*.rs` prove the scripts are *constructed* correctly (right
 //! program, right template). These tests prove the scripts *execute* correctly:
 //!
-//!   AddAuthorizedKey  — idempotent append via `grep -Fxq … || echo … >>`
-//!   RemoveAuthorizedKey — exact-line deletion via `sed -i '\|^key$|d'`
+//!   AddAuthorizedKey  — idempotent append via `grep -Fxq … || printf … >>`
+//!   RemoveAuthorizedKey — exact-line deletion via `grep -Fxv` into a temp
+//!                         file copied back over the original
+//!
+//! Both scripts take the key and path as positional arguments, so no caller
+//! value is ever parsed as shell syntax or as a regular expression. The
+//! literal-not-pattern test below is the regression guard for the earlier
+//! `sed`-based removal, which let `ssh-ed25519 .*` wipe the whole file.
 //!
 //! Technique: call the real `ssh::add_authorized_key` / `ssh::remove_authorized_key`
 //! functions to build the ActionSpec, then redirect the path inside the generated
@@ -29,6 +35,14 @@ const OTHER_KEY: &str =
 
 // Username that passes `validated_username` — must match `[a-zA-Z0-9._-]{1,32}`.
 const USERNAME: &str = "testuser";
+
+// A value that passes every check in `validated_public_key` (allowed prefix,
+// printable ASCII, none of the blocked shell metacharacters) but which acts as
+// a WILDCARD if the removal path ever interprets the key as a regular
+// expression. This is the regression guard for the `sed '\|^KEY$|d'` design,
+// where `ssh-ed25519 .*` deleted every ed25519 key in the file while the audit
+// record showed a routine single-key removal.
+const WILDCARD_KEY: &str = "ssh-ed25519 .*";
 
 /// Build an ActionSpec for `add_authorized_key` or `remove_authorized_key` that
 /// operates on `temp_path` instead of the real `/home/{USERNAME}/.ssh/authorized_keys`.
@@ -116,7 +130,7 @@ async fn add_authorized_key_creates_file_when_absent() {
 #[tokio::test]
 async fn add_authorized_key_is_idempotent() {
     // Running add twice must NOT produce a duplicate line.
-    // The `grep -Fxq key path 2>/dev/null || echo key >> path` idiom
+    // The `grep -Fxq -- "$key" "$path" 2>/dev/null || printf … >> "$path"` idiom
     // only appends when the exact line is absent.
     let dir = tempdir().unwrap();
     let keys_path = dir
@@ -209,8 +223,67 @@ async fn remove_authorized_key_preserves_other_keys() {
 }
 
 #[tokio::test]
+async fn remove_authorized_key_treats_the_key_as_a_literal_not_a_pattern() {
+    // The approved effect is "remove exactly this one key". A key value that
+    // reads as a wildcard under BRE semantics must remove NOTHING here,
+    // because no such literal line exists in the file.
+    let dir = tempdir().unwrap();
+    let keys_path = dir
+        .path()
+        .join("authorized_keys")
+        .to_string_lossy()
+        .into_owned();
+    std::fs::write(&keys_path, format!("{TEST_KEY}\n{OTHER_KEY}\n")).unwrap();
+
+    let spec = redirect_spec_path(
+        ssh::remove_authorized_key(USERNAME, WILDCARD_KEY),
+        &keys_path,
+    );
+    let out = execute_spec(&spec).await.unwrap();
+
+    assert_eq!(out.exit_code, 0, "no-op removal must still exit 0");
+    let content = std::fs::read_to_string(&keys_path).unwrap();
+    assert!(
+        content.contains(TEST_KEY),
+        "a wildcard-shaped key must not delete an unrelated key: {content:?}"
+    );
+    assert!(
+        content.contains(OTHER_KEY),
+        "a wildcard-shaped key must not delete an unrelated key: {content:?}"
+    );
+}
+
+#[tokio::test]
+async fn remove_authorized_key_script_never_embeds_the_key_in_its_text() {
+    // Structural guard: the key must travel as a positional argument, never
+    // interpolated into the script body. If a future edit inlines it again,
+    // the quoting/metacharacter problem returns even if the behavioural test
+    // above happens to still pass for the specific payload it uses.
+    let spec = ssh::remove_authorized_key(USERNAME, TEST_KEY);
+    let ActionMechanism::Command { args, .. } = &spec.mechanism else {
+        panic!("remove_authorized_key must use a Command mechanism");
+    };
+    let script = args
+        .iter()
+        .find(|a| a.contains("grep") || a.contains("sed"))
+        .expect("script body must be present in argv");
+    assert!(
+        !script.contains(TEST_KEY),
+        "key must not be interpolated into the script body: {script:?}"
+    );
+    assert!(
+        !script.contains("sed"),
+        "removal must not build a sed address from caller data: {script:?}"
+    );
+    assert!(
+        args.iter().any(|a| a == TEST_KEY),
+        "key must be passed as its own argv element: {args:?}"
+    );
+}
+
+#[tokio::test]
 async fn remove_authorized_key_is_noop_when_key_absent() {
-    // `sed -i '\|^key$|d' path` is silent when the pattern doesn't match —
+    // `grep -Fxv` simply copies every line through when the key is absent —
     // exit code 0, file unchanged.
     let dir = tempdir().unwrap();
     let keys_path = dir

--- a/crates/sysknife-daemon/tests/sudoers_grants_match_argv.rs
+++ b/crates/sysknife-daemon/tests/sudoers_grants_match_argv.rs
@@ -1,0 +1,151 @@
+//! Every `sudo`-invoking action must be authorised by a rule in
+//! `packaging/sysknife-sudoers`.
+//!
+//! This exists because a mismatch here is invisible in unit tests and total in
+//! production. `apt.rs` used the bare binary name `apt-get` while the packaged
+//! grant spelled `/usr/bin/apt-get`; sudo PATH-resolves only its *primary*
+//! command and matches every later token literally, so the rule never applied
+//! and every mutating apt action died with "a password is required" — after
+//! the operator had approved a preview promising it would run.
+//!
+//! Verified against the real thing (Ubuntu 24.04, sudo 1.9.15p5):
+//!
+//! ```text
+//! $ sudo -u sysknife sudo -n env DEBIAN_FRONTEND=… NEEDRESTART_MODE=a apt-get --version
+//! sudo: a password is required
+//! $ sudo -u sysknife sudo -n env DEBIAN_FRONTEND=… NEEDRESTART_MODE=a /usr/bin/apt-get --version
+//! apt 2.8.3 (amd64)
+//! ```
+//!
+//! The matcher below implements the same rule sudo applies, so drift in either
+//! direction — a new sudo action with no grant, or a grant edited out of step
+//! with the argv — fails here instead of on a user's machine.
+
+use sysknife_daemon::actions::{catalogue, ActionMechanism};
+
+/// One `Cmnd_Spec` from the sudoers file, already split into tokens.
+struct Grant {
+    tokens: Vec<String>,
+}
+
+fn load_grants() -> Vec<Grant> {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../packaging/sysknife-sudoers"
+    );
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("cannot read the packaged sudoers file at {path}: {e}"));
+
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.starts_with('#') && !line.is_empty())
+        .filter_map(|line| line.split_once("NOPASSWD:"))
+        .map(|(_, cmd)| Grant {
+            tokens: cmd.split_whitespace().map(str::to_string).collect(),
+        })
+        .filter(|g| !g.tokens.is_empty())
+        .collect()
+}
+
+/// Does this grant authorise `argv`, using sudo's own matching rules?
+///
+/// * The first token is the command sudo executes. sudo resolves it via
+///   `PATH`, so an absolute grant matches a bare argv[0] with the same
+///   basename (this is why `sudo env …` matches a `/usr/bin/env` grant).
+/// * Every later token is compared **literally**. No PATH resolution, no
+///   canonicalisation — this is the rule that broke apt.
+/// * A trailing `*` matches all remaining arguments. A grant with no argument
+///   tokens at all permits any arguments.
+fn grant_allows(grant: &Grant, argv: &[String]) -> bool {
+    let Some((grant_cmd, grant_args)) = grant.tokens.split_first() else {
+        return false;
+    };
+    let Some((actual_cmd, actual_args)) = argv.split_first() else {
+        return false;
+    };
+
+    let basename = |s: &str| s.rsplit('/').next().unwrap_or(s).to_string();
+    if grant_cmd != actual_cmd && basename(grant_cmd) != basename(actual_cmd) {
+        return false;
+    }
+    // A bare command grant ("/usr/bin/sh") allows any arguments.
+    if grant_args.is_empty() {
+        return true;
+    }
+
+    let mut actual = actual_args.iter();
+    for (i, expected) in grant_args.iter().enumerate() {
+        if expected == "*" {
+            // Trailing wildcard swallows the rest. sudo only permits `*` as
+            // the final argument, which this file relies on.
+            return i == grant_args.len() - 1;
+        }
+        match actual.next() {
+            Some(got) if got == expected => {}
+            _ => return false,
+        }
+    }
+    actual.next().is_none()
+}
+
+#[test]
+fn every_sudo_action_is_authorised_by_a_packaged_grant() {
+    let grants = load_grants();
+    assert!(
+        !grants.is_empty(),
+        "parsed zero grants — the sudoers parser or file layout changed"
+    );
+
+    let mut unauthorised = Vec::new();
+    for (_section, specs) in catalogue() {
+        for spec in specs {
+            let ActionMechanism::Command { program, args } = &spec.mechanism else {
+                continue;
+            };
+            if *program != "sudo" {
+                continue;
+            }
+            if !grants.iter().any(|g| grant_allows(g, args)) {
+                unauthorised.push(format!("{}: sudo {}", spec.action_name, args.join(" ")));
+            }
+        }
+    }
+
+    assert!(
+        unauthorised.is_empty(),
+        "these actions invoke sudo with an argv no rule in packaging/sysknife-sudoers \
+         authorises, so they will fail at runtime with \"a password is required\":\n  {}",
+        unauthorised.join("\n  ")
+    );
+}
+
+#[test]
+fn matcher_rejects_a_bare_binary_name_against_an_absolute_argument_token() {
+    // Pins the exact semantics the apt bug turned on: sudo resolves argv[0]
+    // via PATH, but an argument token is only ever compared literally.
+    let grant = Grant {
+        tokens: "/usr/bin/env FOO=1 /usr/bin/apt-get *"
+            .split_whitespace()
+            .map(str::to_string)
+            .collect(),
+    };
+
+    let absolute: Vec<String> = "env FOO=1 /usr/bin/apt-get update"
+        .split_whitespace()
+        .map(str::to_string)
+        .collect();
+    assert!(
+        grant_allows(&grant, &absolute),
+        "an absolute argument token matching the grant must be allowed"
+    );
+
+    let bare: Vec<String> = "env FOO=1 apt-get update"
+        .split_whitespace()
+        .map(str::to_string)
+        .collect();
+    assert!(
+        !grant_allows(&grant, &bare),
+        "a bare argument token must NOT match an absolute grant token — sudo \
+         does not PATH-resolve arguments, only the primary command"
+    );
+}

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/docs/action-reference.md
+++ b/docs/action-reference.md
@@ -284,12 +284,12 @@ Every row is derived from the live code: the command from each action's `ActionS
 
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
-| `AptUpdate` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update` | Low | Ubuntu | – | – | refresh apt package index (apt-get update) — no params; Ubuntu only |
-| `AptUpgrade` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get dist-upgrade -y` | High | Ubuntu | – | – | upgrade all installed packages via dist-upgrade — no params; Ubuntu only; High risk |
-| `AptInstall` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y curl` | Medium | Ubuntu | – | – | install a package — param: package\* (string, e.g. nginx); Ubuntu only |
-| `AptRemove` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get remove -y curl` | Medium | Ubuntu | – | – | remove a package, keep config files — param: package\*; Ubuntu only |
-| `AptPurge` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get purge -y curl` | Medium | Ubuntu | – | – | remove a package AND its config files — param: package\*; Ubuntu only |
-| `AptAutoremove` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get autoremove -y` | Medium | Ubuntu | – | – | remove automatically-installed packages no longer needed — no params; Ubuntu only |
+| `AptUpdate` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a /usr/bin/apt-get update` | Low | Ubuntu | – | – | refresh apt package index (apt-get update) — no params; Ubuntu only |
+| `AptUpgrade` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a /usr/bin/apt-get dist-upgrade -y` | High | Ubuntu | – | – | upgrade all installed packages via dist-upgrade — no params; Ubuntu only; High risk |
+| `AptInstall` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a /usr/bin/apt-get install -y curl` | Medium | Ubuntu | – | – | install a package — param: package\* (string, e.g. nginx); Ubuntu only |
+| `AptRemove` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a /usr/bin/apt-get remove -y curl` | Medium | Ubuntu | – | – | remove a package, keep config files — param: package\*; Ubuntu only |
+| `AptPurge` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a /usr/bin/apt-get purge -y curl` | Medium | Ubuntu | – | – | remove a package AND its config files — param: package\*; Ubuntu only |
+| `AptAutoremove` | `sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a /usr/bin/apt-get autoremove -y` | Medium | Ubuntu | – | – | remove automatically-installed packages no longer needed — no params; Ubuntu only |
 | `AptHold` | `sudo apt-mark hold curl` | Medium | Ubuntu | – | – | pin a package at its current version (apt-mark hold) — param: package\*; Ubuntu only |
 | `AptUnhold` | `sudo apt-mark unhold curl` | Medium | Ubuntu | – | – | unpin a package to allow upgrades (apt-mark unhold) — param: package\*; Ubuntu only |
 | `AptSearch` | `apt-cache search curl` | Low | Ubuntu | – | – | search apt repos for packages — param: term\*; Ubuntu only; read-only |

--- a/docs/action-reference.md
+++ b/docs/action-reference.md
@@ -65,9 +65,9 @@ Every row is derived from the live code: the command from each action's `ActionS
 
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
-| `ListToolboxes` | `sudo runuser -l testuser -c XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox list` | Low | All | – | – | list toolbox containers for a user — param: username\* |
-| `CreateToolbox` | `sudo runuser -l testuser -c XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox create --container 'sysknife-dev' --release '41'` | Medium | All | – | – | create a toolbox container — params: username\*, name\*; optional: image, release |
-| `RemoveToolbox` | `sudo runuser -l testuser -c XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox rm 'sysknife-dev'` | Medium | All | – | – | remove a toolbox container — params: username\*, name\* |
+| `ListToolboxes` | `sudo runuser -l testuser -c "XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox list"` | Low | All | – | – | list toolbox containers for a user — param: username\* |
+| `CreateToolbox` | `sudo runuser -l testuser -c "XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox create --container 'sysknife-dev' --release '41'"` | Medium | All | – | – | create a toolbox container — params: username\*, name\*; optional: image, release |
+| `RemoveToolbox` | `sudo runuser -l testuser -c "XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox rm 'sysknife-dev'"` | Medium | All | – | – | remove a toolbox container — params: username\*, name\* |
 
 ## Services
 
@@ -85,7 +85,7 @@ Every row is derived from the live code: the command from each action's `ActionS
 | `ReloadService` | `sudo systemctl reload nginx.service` | Medium | All | – | – | reload a service config without restart (SIGHUP) — param: unit\* |
 | `ListTimers` | `systemctl list-timers --all --no-legend --no-pager` | Low | All | – | – | list all systemd timer units with next trigger time — no params |
 | `ReloadDaemon` | `sudo systemctl daemon-reload` | Medium | All | – | – | run systemctl daemon-reload to pick up changed unit files — no params |
-| `CreateScheduledJob` | `sudo /usr/lib/sysknife/scheduled-job-edit --name sysknife-example --command /usr/bin/true --schedule *-*-* 02:00:00` | High | All | – | – | schedule a recurring command as a systemd timer — params: name\* (unit-safe id), command\* (executable line), schedule\* (systemd OnCalendar, e.g. "\*-\*-\* 02:00:00" or "daily") |
+| `CreateScheduledJob` | `sudo /usr/lib/sysknife/scheduled-job-edit --name sysknife-example --command /usr/bin/true --schedule "*-*-* 02:00:00"` | High | All | – | – | schedule a recurring command as a systemd timer — params: name\* (unit-safe id), command\* (executable line), schedule\* (systemd OnCalendar, e.g. "\*-\*-\* 02:00:00" or "daily") |
 | `GetServiceResourceLimits` | `systemctl show nginx.service --property=MemoryMax,MemoryHigh,CPUQuotaPerSecUSec,TasksMax` | Low | All | – | – | show a service's cgroup limits (MemoryMax/CPUQuota/TasksMax) via systemctl show — param: unit\*; read-only |
 | `SetServiceResourceLimits` | `sudo systemctl set-property nginx.service MemoryMax=500M CPUQuota=50%` | Medium | All | – | – | cap a service's resources via systemctl set-property (applies live + persists) — params: unit\*, plus at least one of memory_max (e.g. '500M' or 'infinity'), memory_high, cpu_quota (e.g. '50%'), tasks_max (integer or 'infinity'); Medium risk; undo with systemctl revert |
 
@@ -178,7 +178,7 @@ Every row is derived from the live code: the command from each action's `ActionS
 |---|---|---|---|---|---|---|
 | `ConfigureWifi` | `sudo nmcli device wifi connect CafeHotspot` | High | All | – | – | connect to a Wi-Fi network — params: ssid\*, password (optional for open networks) |
 | `SetDnsServers` | `sudo resolvectl dns wlp1s0 1.1.1.1 8.8.8.8` | High | All | – | – | set DNS servers for an interface — params: interface\* (e.g. wlp1s0), servers\* (string\[\]) |
-| `ConfigureFirewall` | `sudo sh -c firewall-cmd --permanent --zone='public' --add-service='ssh' && firewall-cmd --reload` | High | All | – | – | add/remove a service in a firewalld zone — params: zone\*, service\*, enabled\* (bool) |
+| `ConfigureFirewall` | `sudo sh -c "firewall-cmd --permanent --zone='public' --add-service='ssh' && firewall-cmd --reload"` | High | All | – | – | add/remove a service in a firewalld zone — params: zone\*, service\*, enabled\* (bool) |
 | `GetFirewallState` | `firewall-cmd --list-all` | Low | All | – | – | show current firewalld zones, open services, and port rules — no params |
 | `GetNetworkStatus` | `ip -brief addr` | Low | All | – | – | show network interfaces, IP addresses, and connection state — no params |
 | `GetListeningPorts` | `ss -tulpnH` | Low | All | – | – | show listening TCP/UDP sockets and the process bound to each (ss -tulpn) — no params; read-only; use for "what is listening on port X?" |
@@ -208,8 +208,8 @@ Every row is derived from the live code: the command from each action's `ActionS
 | `ListGroups` | `getent group` | Low | All | – | – | list all local groups — no params |
 | `CreateUser` | `sudo useradd --create-home --home-dir /home/alice --shell /bin/bash alice` | High | All | – | – | create a local user account — param: username\*; optional: shell, home |
 | `DeleteUser` | `sudo userdel alice` | High | All | – | – | delete a local user account — param: username\* |
-| `AddUserToGroup` | `sudo sh -c grep -q '^wheel:' /etc/group \|\| getent group 'wheel' >> /etc/group; usermod --append --groups 'wheel' 'alice'` | High | All | – | – | add a user to a group — params: username\*, group\* |
-| `RemoveUserFromGroup` | `sudo sh -c grep -q '^wheel:' /etc/group \|\| getent group 'wheel' >> /etc/group; gpasswd --delete 'alice' 'wheel'` | High | All | – | – | remove a user from a group — params: username\*, group\* |
+| `AddUserToGroup` | `sudo sh -c "grep -q '^wheel:' /etc/group \|\| getent group 'wheel' >> /etc/group; usermod --append --groups 'wheel' 'alice'"` | High | All | – | – | add a user to a group — params: username\*, group\* |
+| `RemoveUserFromGroup` | `sudo sh -c "grep -q '^wheel:' /etc/group \|\| getent group 'wheel' >> /etc/group; gpasswd --delete 'alice' 'wheel'"` | High | All | – | – | remove a user from a group — params: username\*, group\* |
 | `CreateGroup` | `sudo groupadd developers` | Medium | All | – | – | create a local group — param: group\*; optional: system (bool → system GID range) |
 | `DeleteGroup` | `sudo groupdel developers` | High | All | – | – | delete a local group — param: group\*; irreversible |
 | `LockUserAccount` | `sudo usermod --lock alice` | High | All | – | – | disable password login for a user without deleting it — param: username\* |
@@ -220,8 +220,8 @@ Every row is derived from the live code: the command from each action's `ActionS
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
 | `GetAuthorizedKeys` | `cat /home/alice/.ssh/authorized_keys` | Low | All | – | – | list SSH authorized_keys for a user — param: username\* |
-| `AddAuthorizedKey` | `sudo sh -c grep -Fxq 'ssh-ed25519 AAAA...' '/home/alice/.ssh/authorized_keys' 2>/dev/null \|\| echo 'ssh-ed25519 AAAA...' >> '/home/alice/.ssh/authorized_keys'` | High | All | – | – | append an SSH public key to a user's authorized_keys — params: username\*, public_key\* (full key string) |
-| `RemoveAuthorizedKey` | `sudo sh -c sed -i '\\\|^ssh-ed25519 AAAA...$\|d' '/home/alice/.ssh/authorized_keys'` | High | All | – | – | remove an SSH public key from a user's authorized_keys — params: username\*, public_key\* (full key string) |
+| `AddAuthorizedKey` | `sudo sh -c "key=$1; path=$2; grep -Fxq -- \\"$key\\" \\"$path\\" 2>/dev/null \|\| printf '%s\\n' \\"$key\\" >> \\"$path\\"" sh "ssh-ed25519 AAAA..." /home/alice/.ssh/authorized_keys` | High | All | – | – | append an SSH public key to a user's authorized_keys — params: username\*, public_key\* (full key string) |
+| `RemoveAuthorizedKey` | `sudo sh -c "key=$1; path=$2; tmp=$(mktemp) \|\| exit 1; grep -Fxv -- \\"$key\\" \\"$path\\" > \\"$tmp\\"; rc=$?; if [ $rc -gt 1 ]; then rm -f \\"$tmp\\"; exit $rc; fi; cat \\"$tmp\\" > \\"$path\\"; rm -f \\"$tmp\\"" sh "ssh-ed25519 AAAA..." /home/alice/.ssh/authorized_keys` | High | All | – | – | remove an SSH public key from a user's authorized_keys — params: username\*, public_key\* (full key string) |
 | `SetSshdOption` | `sudo /usr/lib/sysknife/sshd-option-edit --option PermitRootLogin --value prohibit-password` | High | All | – | – | harden sshd by setting an allowlisted option via a validated drop-in — params: option\* (one of PermitRootLogin, PasswordAuthentication, PubkeyAuthentication, X11Forwarding, PermitEmptyPasswords), value\* (per-option: yes/no, or prohibit-password/forced-commands-only for PermitRootLogin) |
 
 ## Package repositories
@@ -244,18 +244,18 @@ Every row is derived from the live code: the command from each action's `ActionS
 
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
-| `ListContainers` | `sudo runuser -l testuser -c podman ps --all --format json` | Low | All | – | – | list Podman containers for a user — param: username\* |
-| `CreateContainer` | `sudo runuser -l testuser -c podman create --name 'sysknife-dev' 'registry.fedoraproject.org/fedora-toolbox:41'` | Medium | All | – | – | create a Podman container — params: username\*, name\*, image\* (e.g. ubuntu:22.04) |
-| `StartContainer` | `sudo runuser -l testuser -c podman start 'sysknife-dev'` | Medium | All | – | – | start a Podman container — params: username\*, name\* |
-| `StopContainer` | `sudo runuser -l testuser -c podman stop 'sysknife-dev'` | Medium | All | – | – | stop a Podman container — params: username\*, name\* |
-| `RemoveContainer` | `sudo runuser -l testuser -c podman rm 'sysknife-dev'` | Medium | All | – | – | remove a stopped Podman container — params: username\*, name\* |
-| `GetContainerInfo` | `sudo runuser -l testuser -c podman inspect 'sysknife-dev'` | Low | All | – | – | inspect a Podman container — params: username\*, name\* |
+| `ListContainers` | `sudo runuser -l testuser -c "podman ps --all --format json"` | Low | All | – | – | list Podman containers for a user — param: username\* |
+| `CreateContainer` | `sudo runuser -l testuser -c "podman create --name 'sysknife-dev' 'registry.fedoraproject.org/fedora-toolbox:41'"` | Medium | All | – | – | create a Podman container — params: username\*, name\*, image\* (e.g. ubuntu:22.04) |
+| `StartContainer` | `sudo runuser -l testuser -c "podman start 'sysknife-dev'"` | Medium | All | – | – | start a Podman container — params: username\*, name\* |
+| `StopContainer` | `sudo runuser -l testuser -c "podman stop 'sysknife-dev'"` | Medium | All | – | – | stop a Podman container — params: username\*, name\* |
+| `RemoveContainer` | `sudo runuser -l testuser -c "podman rm 'sysknife-dev'"` | Medium | All | – | – | remove a stopped Podman container — params: username\*, name\* |
+| `GetContainerInfo` | `sudo runuser -l testuser -c "podman inspect 'sysknife-dev'"` | Low | All | – | – | inspect a Podman container — params: username\*, name\* |
 
 ## Reboot
 
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
-| `CheckPendingReboot` | `bash -c if test -f /var/run/reboot-required; then cat /var/run/reboot-required; cat /var/run/reboot-required-pkgs 2>/dev/null; else echo 'No reboot required.'; fi` | Low | Ubuntu | – | – | check whether a reboot is pending (/var/run/reboot-required) — no params; Ubuntu/Debian only; read-only |
+| `CheckPendingReboot` | `bash -c "if test -f /var/run/reboot-required; then cat /var/run/reboot-required; cat /var/run/reboot-required-pkgs 2>/dev/null; else echo 'No reboot required.'; fi"` | Low | Ubuntu | – | – | check whether a reboot is pending (/var/run/reboot-required) — no params; Ubuntu/Debian only; read-only |
 
 ## AppArmor
 
@@ -295,8 +295,8 @@ Every row is derived from the live code: the command from each action's `ActionS
 | `AptSearch` | `apt-cache search curl` | Low | Ubuntu | – | – | search apt repos for packages — param: term\*; Ubuntu only; read-only |
 | `AptListInstalled` | `dpkg -l` | Low | Ubuntu | – | – | list all installed packages (dpkg -l) — no params; Ubuntu only; read-only |
 | `AptShow` | `apt-cache show curl` | Low | Ubuntu | – | – | show package details (version, deps, description) — param: package\*; Ubuntu only; read-only |
-| `AptListUpgradable` | `bash -c apt list --upgradable 2>/dev/null` | Low | Ubuntu | – | – | list packages with available upgrades — no params; Ubuntu only; read-only. Use for 'are there pending updates?' or 'what updates are available?' |
-| `AptHistoryList` | `bash -c grep -A 4 '^Start-Date' /var/log/apt/history.log \| tail -n 80` | Low | Ubuntu | – | – | show recent apt transaction history — no params; Ubuntu only; read-only |
+| `AptListUpgradable` | `bash -c "apt list --upgradable 2>/dev/null"` | Low | Ubuntu | – | – | list packages with available upgrades — no params; Ubuntu only; read-only. Use for 'are there pending updates?' or 'what updates are available?' |
+| `AptHistoryList` | `bash -c "grep -A 4 '^Start-Date' /var/log/apt/history.log \| tail -n 80"` | Low | Ubuntu | – | – | show recent apt transaction history — no params; Ubuntu only; read-only |
 | `ConfigureUnattendedUpgrades` | `sudo /usr/lib/sysknife/unattended-upgrades-edit --enable` | High | Ubuntu | – | – | enable or disable automatic security updates (unattended-upgrades) — param: enabled\* (bool); Ubuntu only; High risk |
 
 ## apt preferences / pinning
@@ -304,7 +304,7 @@ Every row is derived from the live code: the command from each action's `ActionS
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
 | `GetAptPins` | `apt-cache policy` | Low | Ubuntu | – | – | show apt pin priorities (apt-cache policy) — param: package (optional); Ubuntu only; read-only |
-| `SetAptPin` | `sudo /usr/lib/sysknife/apt-pin-edit --op set --name hold-nginx --package nginx --pin version 1.24.* --priority 990` | Medium | Ubuntu | – | – | pin a package to a version/release via /etc/apt/preferences.d — params: name\*, package\* (glob), pin\* (e.g. 'version 1.24.\*' or 'release a=noble-security'), priority\* (int -1..1000); Ubuntu only; Medium risk |
+| `SetAptPin` | `sudo /usr/lib/sysknife/apt-pin-edit --op set --name hold-nginx --package nginx --pin "version 1.24.*" --priority 990` | Medium | Ubuntu | – | – | pin a package to a version/release via /etc/apt/preferences.d — params: name\*, package\* (glob), pin\* (e.g. 'version 1.24.\*' or 'release a=noble-security'), priority\* (int -1..1000); Ubuntu only; Medium risk |
 | `RemoveAptPin` | `sudo /usr/lib/sysknife/apt-pin-edit --op remove --name hold-nginx` | Medium | Ubuntu | – | – | remove a SysKnife-managed apt pin — param: name\*; Ubuntu only; Medium risk |
 
 ## PPA
@@ -318,7 +318,7 @@ Every row is derived from the live code: the command from each action's `ActionS
 
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
-| `SnapInstall` | `sudo sh -c snap install --channel=stable firefox && snap refresh --hold firefox` | Medium | Ubuntu | – | – | install a snap (auto-holds to prevent auto-refresh) — params: name\*; optional: channel (default stable), auto_update (bool, default false); Ubuntu only |
+| `SnapInstall` | `sudo sh -c "snap install --channel=stable firefox && snap refresh --hold firefox"` | Medium | Ubuntu | – | – | install a snap (auto-holds to prevent auto-refresh) — params: name\*; optional: channel (default stable), auto_update (bool, default false); Ubuntu only |
 | `SnapRemove` | `sudo snap remove firefox` | Medium | Ubuntu | – | – | remove a snap — param: name\*; Ubuntu only |
 | `SnapRefresh` | `sudo snap refresh firefox` | Medium | Ubuntu | – | – | update a snap or all snaps — param: name (optional, omit for all); Ubuntu only |
 | `SnapHold` | `sudo snap refresh --hold firefox` | Medium | Ubuntu | – | – | pin a snap at its current version (snap refresh --hold) — param: name\*; Ubuntu only |

--- a/packages/setup/mcp-config.js
+++ b/packages/setup/mcp-config.js
@@ -18,16 +18,31 @@ const fs = require('fs');
  */
 function mergeMcpServers(filePath, servers) {
   let existing = {};
-  try {
-    if (fs.existsSync(filePath)) {
-      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  if (fs.existsSync(filePath)) {
+    let raw;
+    try {
+      raw = fs.readFileSync(filePath, 'utf8');
+    } catch (e) {
+      // A read failure is NOT the same as malformed JSON. Treating EACCES,
+      // EIO, or a symlink loop as "start empty" makes the caller write a
+      // fresh file over the top, silently deleting every other MCP server the
+      // user had configured — the exact clobbering this function exists to
+      // prevent. Refuse instead.
+      throw new Error(
+        `could not read existing MCP config at ${filePath}: ${e.message} — ` +
+          'refusing to overwrite it, since that would discard your other MCP servers'
+      );
+    }
+    try {
+      const parsed = JSON.parse(raw);
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         existing = parsed;
       }
+    } catch {
+      // Malformed JSON — start from an empty config rather than crashing the
+      // wizard. There is nothing to preserve in a file we cannot parse.
+      existing = {};
     }
-  } catch {
-    // Malformed JSON — start from an empty config rather than crashing the wizard.
-    existing = {};
   }
   const existingServers =
     existing.mcpServers && typeof existing.mcpServers === 'object' ? existing.mcpServers : {};

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.10",
-  "description": "Zero-friction setup for SysKnife MCP server — Claude Code, Cursor, and Codex CLI",
+  "version": "0.2.11",
+  "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {
     "type": "git",

--- a/packages/setup/tests/mcp-config.test.mjs
+++ b/packages/setup/tests/mcp-config.test.mjs
@@ -54,3 +54,38 @@ test('handles a file with no mcpServers key', () => {
   assert.equal(merged.somethingElse, true);
   assert.deepEqual(Object.keys(merged.mcpServers), ['sysknife']);
 });
+
+test('refuses to merge when the existing config cannot be read', () => {
+  // A read failure is not malformed JSON. Silently starting from {} would make
+  // the caller write a fresh file over the top, discarding every other MCP
+  // server the user had configured.
+  const file = tmpFile('{"mcpServers":{"other":{"command":"x"}}}');
+  fs.chmodSync(file, 0o000);
+  try {
+    // Running as root defeats the permission check; skip rather than assert
+    // something the environment cannot demonstrate.
+    let readable = true;
+    try {
+      fs.readFileSync(file, 'utf8');
+    } catch {
+      readable = false;
+    }
+    if (readable) return;
+
+    assert.throws(
+      () => mergeMcpServers(file, SYSKNIFE),
+      /refusing to overwrite/,
+      'an unreadable config must abort the merge, not silently reset it'
+    );
+  } finally {
+    fs.chmodSync(file, 0o600);
+  }
+});
+
+test('still starts fresh when the existing config is malformed JSON', () => {
+  // The other half of the contract: unparseable content has nothing worth
+  // preserving, so the wizard proceeds instead of dying.
+  const file = tmpFile('{not valid json');
+  const merged = mergeMcpServers(file, SYSKNIFE);
+  assert.deepEqual(merged.mcpServers, SYSKNIFE);
+});

--- a/packaging/sysknife-apt-pin-edit
+++ b/packaging/sysknife-apt-pin-edit
@@ -31,7 +31,9 @@ PREFS_D = "/etc/apt/preferences.d"
 PREFIX = "sysknife-"
 
 NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
-PACKAGE_RE = re.compile(r"^[A-Za-z0-9.+*?_:-]{1,128}$")
+# Mirrors validated_apt_package in actions/validate.rs, including its
+# refusal of a leading "-" so a package name can never act as a flag.
+PACKAGE_RE = re.compile(r"^(?!-)[A-Za-z0-9.+*?_:-]{1,128}$")
 PIN_RE = re.compile(r"^[A-Za-z0-9 =.,:/*_+-]{1,200}$")
 
 

--- a/packaging/sysknife-sudoers
+++ b/packaging/sysknife-sudoers
@@ -86,8 +86,10 @@ sysknife ALL=(root) NOPASSWD: /usr/sbin/lvcreate
 
 # Shell for the few multi-step root operations with no argv-only equivalent:
 #   - ConfigureFirewall (network.rs): `firewall-cmd --permanent … && firewall-cmd --reload`
-#   - AddAuthorizedKey / RemoveAuthorizedKey (ssh.rs): grep-guarded append / sed delete
-#     against a user's authorized_keys file (0600, owned by the target user).
+#   - AddAuthorizedKey / RemoveAuthorizedKey (ssh.rs): grep-guarded append /
+#     fixed-string (`grep -Fxv`) delete against a user's authorized_keys file
+#     (0600, owned by the target user). Both pass the key and path as positional
+#     arguments to `sh -c`, so no caller value is parsed as shell syntax.
 #
 # SECURITY NOTE — this is the widest grant in this file, and it means sudoers is NOT the
 # security boundary. `sudo sh -c '<script>'` has no argument constraint, so the sysknife

--- a/packaging/sysknife-sudoers
+++ b/packaging/sysknife-sudoers
@@ -67,6 +67,14 @@ sysknife ALL=(root) NOPASSWD: /usr/bin/localectl
 # writes to /etc/firewalld/ which requires root.
 sysknife ALL=(root) NOPASSWD: /usr/bin/resolvectl
 
+# nmcli — ConfigureWifi (`nmcli device wifi connect <ssid> [password <pw>]`) on
+# Ubuntu Desktop, where NetworkManager owns the interfaces rather than netplan.
+# Narrowed to the wifi-connect subcommand: a bare nmcli grant would also permit
+# `nmcli connection modify` to rewrite any saved connection profile.
+# Missing entirely until now, so ConfigureWifi failed at runtime with
+# "a password is required" — caught by tests/sudoers_grants_match_argv.rs.
+sysknife ALL=(root) NOPASSWD: /usr/bin/nmcli device wifi connect *
+
 # OS deployment management — rpm-ostree upgrade/install/rollback/cleanup/rebase/kargs
 # communicate with rpm-ostreed via D-Bus and require root authorization.
 # rpm-ostree status/kargs (read-only) still work without root but sudo does not hurt.

--- a/packaging/sysknife-sudoers-edit
+++ b/packaging/sysknife-sudoers-edit
@@ -55,6 +55,14 @@ def validated_ident(value: str, what: str) -> str:
 
 
 def build_rule(user: str, runas: str, nopasswd: bool, commands: str) -> str:
+    if commands == "ALL" and nopasswd:
+        # A standing passwordless unrestricted root credential. visudo accepts
+        # it, so this is the only layer that can refuse it. Mirrors the same
+        # refusal in executor.rs so the helper is safe when called directly.
+        die(
+            "refusing to grant unrestricted commands with NOPASSWD: scope "
+            "--commands to specific absolute paths, or drop --nopasswd"
+        )
     if commands == "ALL":
         cmd_spec = "ALL"
     else:

--- a/packaging/sysknife-unattended-upgrades-edit
+++ b/packaging/sysknife-unattended-upgrades-edit
@@ -44,11 +44,17 @@ def main() -> None:
     if args.enable:
         # Ensure the package is present (idempotent). We already run as root via
         # sudo, so apt-get needs no further privilege escalation.
+        # NEEDRESTART_MODE=a is as load-bearing as DEBIAN_FRONTEND here: without
+        # it the needrestart post-install hook can open an interactive TUI and
+        # block forever on terminal input this process will never provide.
+        # Absolute apt-get path for the same reason apt.rs uses one — sudo
+        # matches argument tokens literally against the sudoers rule.
         result = subprocess.run(
             [
                 "/usr/bin/env",
                 "DEBIAN_FRONTEND=noninteractive",
-                "apt-get",
+                "NEEDRESTART_MODE=a",
+                "/usr/bin/apt-get",
                 "install",
                 "-y",
                 "unattended-upgrades",

--- a/tests/e2e/ubuntu-command-validity.sh
+++ b/tests/e2e/ubuntu-command-validity.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# ubuntu-command-validity.sh — check that the commands SysKnife would run on
+# Ubuntu actually exist and actually parse.
+#
+# The unit tests prove the daemon *builds* the argv it intends to. They cannot
+# prove that argv is real: a flag that does not exist, a subcommand renamed
+# between releases, or a binary that is not installed all look identical to a
+# passing unit test and only fail on a user's machine, after the operator has
+# approved a preview promising it would work.
+#
+# This is also how the `apt-get` sudoers mismatch was caught: the argv was
+# well-formed and every unit test passed, but sudo refused it on a real host
+# because the grant spells `/usr/bin/apt-get` and the code sent a bare name.
+#
+# Run INSIDE an Ubuntu VM (it inspects the live system):
+#
+#   tests/e2e/ubuntu-vm.sh ssh 'bash -s' < tests/e2e/ubuntu-command-validity.sh
+#
+# Exit status: 0 if every check passes. Tools that are simply not installed are
+# reported as SKIP, not failure — an action whose tool is absent fails loudly
+# at runtime anyway, which is the correct behaviour.
+#
+# Safety: read-only or dry-run everywhere. ufw is never enabled (that would
+# sever the SSH connection this script arrives on); its rule syntax is checked
+# with `--dry-run`.
+
+set -uo pipefail
+
+pass=0
+fail=0
+skip=0
+
+ok()   { printf 'OK    %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf 'FAIL  %s -- %s\n' "$1" "$2"; fail=$((fail + 1)); }
+skipf(){ printf 'SKIP  %s (%s not installed)\n' "$1" "$2"; skip=$((skip + 1)); }
+
+# Run a check, but only if the tool is present.
+need() {
+  local tool="$1" desc="$2"
+  shift 2
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    skipf "$desc" "$tool"
+    return
+  fi
+  local out
+  if out=$("$@" 2>&1); then
+    ok "$desc"
+  else
+    bad "$desc" "$(printf '%s' "$out" | head -1)"
+  fi
+}
+
+# Assert a flag or subcommand appears in a tool's own help output.
+has_flag() {
+  local tool="$1" desc="$2" flag="$3"
+  shift 3
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    skipf "$desc" "$tool"
+    return
+  fi
+  if "$@" 2>&1 | grep -q -- "$flag"; then
+    ok "$desc"
+  else
+    bad "$desc" "$flag absent from help output"
+  fi
+}
+
+echo "== apt (simulate: no packages are changed) =="
+need apt-get "apt-get update"                 sudo apt-get update -qq
+need apt-get "apt-get dist-upgrade -y"        sudo apt-get -s dist-upgrade -y
+need apt-get "apt-get install -y"             sudo apt-get -s install -y hello
+need apt-get "apt-get remove -y"              sudo apt-get -s remove -y hello
+need apt-get "apt-get purge -y"               sudo apt-get -s purge -y hello
+need apt-get "apt-get autoremove -y"          sudo apt-get -s autoremove -y
+need apt-mark "apt-mark hold / unhold"        sudo sh -c 'apt-mark hold bash >/dev/null && apt-mark unhold bash >/dev/null'
+need apt-cache "apt-cache policy"             apt-cache policy
+need apt-cache "apt-cache show"               apt-cache show bash
+need apt-cache "apt-cache search"             apt-cache search bash
+need dpkg      "dpkg -l"                      sh -c 'dpkg -l >/dev/null'
+need apt       "apt list --upgradable"        sh -c 'apt list --upgradable 2>/dev/null >/dev/null'
+
+echo "== sudoers grant actually matches the argv =="
+# The grant is the whole reason apt-get must be spelled absolutely. If the
+# sysknife user exists with the packaged sudoers installed, prove sudo accepts
+# the real invocation rather than falling through to a password prompt.
+if id sysknife >/dev/null 2>&1 && sudo test -f /etc/sudoers.d/sysknife; then
+  if sudo -u sysknife sudo -n env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
+      /usr/bin/apt-get --version >/dev/null 2>&1; then
+    ok "sudo accepts the env-wrapped absolute apt-get"
+  else
+    bad "sudo accepts the env-wrapped absolute apt-get" "denied — grant and argv disagree"
+  fi
+else
+  skipf "sudo grant check" "sysknife user or /etc/sudoers.d/sysknife"
+fi
+
+echo "== ufw (dry-run only — never enabled, that would cut SSH) =="
+need ufw "ufw allow"          sudo ufw --dry-run allow 22
+need ufw "ufw deny"           sudo ufw --dry-run deny 23
+need ufw "ufw limit"          sudo ufw --dry-run limit 22
+need ufw "ufw status verbose" sudo ufw status verbose
+# `--force` is not advertised in `ufw --help`, so prove it parses instead:
+# with no rules present ufw complains about the *rule*, not the flag. Any
+# "unknown option"-style rejection would mean the argv is wrong.
+if command -v ufw >/dev/null 2>&1; then
+  ufw_out=$(sudo ufw --dry-run --force delete 1 2>&1 || true)
+  if printf '%s' "$ufw_out" | grep -qi "could not find rule\|Rules updated\|^\*filter"; then
+    ok "ufw --force delete N"
+  else
+    bad "ufw --force delete N" "$(printf '%s' "$ufw_out" | head -1)"
+  fi
+else
+  skipf "ufw --force delete N" "ufw"
+fi
+
+echo "== snap =="
+has_flag snap "snap install --classic" "--classic" snap install --help
+has_flag snap "snap refresh --hold"    "--hold"    snap refresh --help
+has_flag snap "snap refresh --unhold"  "--unhold"  snap refresh --help
+need snap "snap list" sh -c 'snap list >/dev/null'
+
+echo "== netplan =="
+need netplan "netplan set"      sh -c 'netplan set --help >/dev/null'
+need netplan "netplan get"      sh -c 'netplan get --help >/dev/null'
+need netplan "netplan generate" sh -c 'netplan generate --help >/dev/null'
+
+echo "== release upgrade / Ubuntu Pro =="
+has_flag do-release-upgrade "do-release-upgrade -f <frontend>" "frontend" do-release-upgrade --help
+need pro "pro status --all" sh -c 'pro status --all >/dev/null'
+has_flag pro "pro enable --assume-yes" "--assume-yes" pro enable --help
+
+echo "== identity, DNS, security tooling =="
+need chage      "chage -l"            sudo chage -l root
+need resolvectl "resolvectl status"   sh -c 'resolvectl status >/dev/null'
+need aa-status  "aa-status"           sudo aa-status
+need cloud-init "cloud-init status"   sh -c 'cloud-init status --long >/dev/null'
+need auditctl   "auditctl -l"         sudo auditctl -l
+need fail2ban-client "fail2ban-client status" sudo fail2ban-client status
+need add-apt-repository "add-apt-repository --help" sh -c 'add-apt-repository --help >/dev/null'
+
+echo "---"
+printf 'pass=%d fail=%d skip=%d\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

A full review of the codebase, split along the trust boundary — the privileged
daemon on one side, the CLI/MCP/planner surfaces on the other — plus a
dedicated security pass over the Ubuntu action set, with the Ubuntu commands
validated against a real Ubuntu 24.04 VM.

Two defects made the executed effect diverge from the approved preview, which
is the one guarantee this project exists to provide:

- **`RemoveAuthorizedKey` built a regular expression from the caller's key.**
  It deleted the approved line with `sed -i '\|^KEY$|d'`, so the public key was
  a basic regular expression. `ssh-ed25519 .*` passes every check in
  `validated_public_key` — allowed prefix, printable ASCII, no blocked shell
  metacharacters — and then matched and deleted *every* ed25519 key in the
  file. `sed` exits 0, so the job recorded `Succeeded` and the signed audit
  summary read as a routine single-key removal. Proven by a test that observes
  the file emptied, then fixed structurally with `grep -Fxv` and positional
  arguments. Blocklisting regex metacharacters was not an option: `.` is legal
  in a key comment (`alice@example.com`).

- **Every mutating apt action was dead on a real Ubuntu host.** The code sent a
  bare `apt-get` while the packaged sudoers grant spells `/usr/bin/apt-get`.
  sudo PATH-resolves only its primary command (`env`) and matches later tokens
  literally, so the rule never applied and apt fell through to "a password is
  required", which a non-interactive daemon cannot answer. Confirmed on the VM:
  the bare form is denied, the absolute form completes a real dry-run install.

The apt bug motivated a new test that re-implements sudo's matching rule and
checks every sudo-invoking action against the packaged grants. It immediately
found a second instance: `ConfigureWifi` shells out to `sudo nmcli` with no
grant at all.

Also fixed: a malformed timestamp signed into every Postgres audit row
(`now_iso()` omitted `%S`), two apt actions able to collide on the dpkg lock,
missing deadlines on privileged children and on the async client, an unchecked
vsock token file mode, a zombie leak per audit record, a standing passwordless
root grant, and an MCP config merge that discarded the user's other servers.

Full detail in `CHANGELOG.md`.

## Related Issue

No tracking issue — this is the output of a review sweep.

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`cargo nextest run --workspace --locked`: **1417 passed, 0 failed** (was 1405 on
`main`; the new tests are the difference). `scripts/ci-local.sh --fast`: PASS.

Ubuntu 24.04.4 VM, `tests/e2e/ubuntu-command-validity.sh`: **33 pass, 0 fail, 2
skip** (auditd and fail2ban are not installed on a server image). Every
behavioural fix has a test that fails on the previous code.

## Notes for Reviewers

**Two reported findings did not survive verification** and are pinned as tests
rather than "fixed", so the reasoning is not lost:

- `GrubSetKargs` was reported as able to strip `apparmor=1`. It cannot —
  `delete` goes through `validated_safe_arg`, whose charset excludes `=`.
- The kernel-arg denylist was called dead code. It is not: `SetKernelArguments`
  reaches it without the charset check, and every valueless entry (`single`,
  `nosmap`) depends on it.

**Behaviour changes worth a second look:**

- `GrantSudoAccess` now refuses `commands = "ALL"` together with `nopasswd`.
  That combination mints a standing, passwordless, unrestricted root
  credential, which outlives the job unlike every other action here. Scoped
  commands, or `ALL` with a password prompt, both still work.
- The concurrency gate is now keyed by the system lock an action holds, derived
  from its argv, rather than by "High risk AND reboot_required". Actions that
  hold no shared lock are no longer serialised behind a long apt run — that is
  a deliberate loosening, alongside the tightening for apt.
- Privileged actions now have a 2-hour ceiling (`SYSKNIFE_ACTION_TIMEOUT_SECS`).
  Deliberately generous: killing a half-finished package transaction is worse
  than waiting, so this is a backstop against a hang, not a budget.

**One local-only oddity, not a code issue:** the optional `postgres-contract`
job fails on my machine — sqlx gets `Connection reset by peer` against a healthy
`postgres:17-alpine` — and fails identically on unmodified `main`. It passes in
GitHub Actions on this PR, which confirms it is local Docker networking rather
than anything in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f
