### PR TITLE
Follow-ups: anchor the audit checkpoints, close the type-level holes, test the deny paths (v0.2.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [0.2.12] — 2026-07-27
+
+Follow-up to the v0.2.11 review sweep: the findings that release deferred.
+
+### Added
+
+- **The daemon now anchors signed audit checkpoints.** The machinery was
+  complete and tested but inert — nothing ever called `sign_checkpoint` or a
+  `CheckpointSink`, so tail-truncation detection and rewrite-by-a-key-holder
+  detection were only active if an operator ran `sysknife audit checkpoint` on
+  a timer of their own. Set `SYSKNIFE_CHECKPOINT_DB` to enable it; when unset
+  the daemon now says so at startup rather than letting a documented guarantee
+  look active while it is off. The anchoring rules (refuse a chain that does
+  not verify, read back after writing, re-verify every anchored checkpoint)
+  live in one `anchor_once` shared by the CLI and the daemon.
+
+### Security
+
+- `Plan::assume_authorized` — the one hole in the type-level guarantee that the
+  approval gate can never see the LLM's self-reported risk — is now behind a
+  `test-support` feature, so constructing an `AuthorizedPlan` from unvalidated
+  risk is a compile error outside tests.
+- `NewTransaction.approval_id` was a public field used verbatim at insert. That
+  value is chain-hashed and then treated as evidence that an approval happened.
+  It is no longer settable; the commitment is always derived by the store.
+
+### Changed
+
+- `CallerRole` derives `Ord` from its declaration order and the hand-written
+  `role_rank` is deleted — one encoding of privilege order instead of two.
+- `ApprovalDecision::ExceedsCeiling` carries the ceiling it matched, removing
+  two `.expect()`s that re-derived it at the call sites.
+- The four proto-bridge `From` impls are exhaustive matches rather than an i32
+  round-trip with `.expect()`, so a drift from the `.proto` is a compile error
+  instead of a panic inside a root process.
+- `JobStateMachine` is removed. Production calls the free `allowed_transition`;
+  the struct was dead code whose ten tests read as coverage of the live
+  transition logic. The table is now tested directly and exhaustively.
+
+### Fixed (test coverage)
+
+- The `transient_infrastructure_failure` deny paths had no test at all, so a
+  refactor turning an `Err` arm into an implicit allow would have been an
+  invisible approval-boundary bypass. Approve-on-a-failing-store is now
+  covered, including that the transaction stays Queued.
+- Preview is pinned as never reaching the executor.
+- New coverage for `revoke_unconsumed_approval` (including that a consumed
+  receipt cannot be retracted), approving a non-Queued transaction, two
+  concurrent claims on one approval, truncated frame header/body,
+  authorized-keys traversal *through `build_action_spec`*, malformed IPs,
+  signal-killed exit codes, `--timeout`, `audit verify` exit code 2,
+  and the remaining `ProviderError` variants.
+- `resolve_caller_role_on_pair_does_not_panic` discarded its result and would
+  have passed if the function returned `Boot` for everyone; it now derives the
+  expectation from the same inputs the daemon uses.
+- `inserted_forged_row_breaks_chain` accepted `seq == 2 || seq == 3` against a
+  deterministic fixture. Pinned to 2.
+
 ## [0.2.11] — 2026-07-27
 
 Findings from a full review of the daemon, the CLI/MCP surface, and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "prost",
  "prost-build",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -38,6 +38,8 @@ vsock = "0.5.4"
 tokio-vsock = "0.7.2"
 
 [dev-dependencies]
+# `test-support` unlocks `Plan::assume_authorized` for tests only.
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.11", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -39,7 +39,7 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.11", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.12", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-cli/src/approval.rs
+++ b/apps/sysknife-cli/src/approval.rs
@@ -71,8 +71,13 @@ pub enum ApprovalDecision {
     RequiresInteraction,
     /// Plan exceeds the `--max-risk` ceiling — abort.
     ///
+    /// Carries the ceiling that was exceeded. `decide_step` has it in scope at
+    /// the point of decision; returning it removes the need for call sites to
+    /// re-derive it from `opts.max_risk` behind an `.expect()` that is correct
+    /// only while the decision and the options come from the same place.
+    ///
     /// Terminal in `decide_plan`: causes early return on first occurrence.
-    ExceedsCeiling,
+    ExceedsCeiling(MaxRisk),
 }
 
 impl ApprovalPolicy {
@@ -112,7 +117,7 @@ impl ApprovalPolicy {
         // Check --max-risk ceiling (hard abort, independent of --yes).
         if let Some(ceiling) = self.max_risk {
             if !ceiling.includes(risk) {
-                return ApprovalDecision::ExceedsCeiling;
+                return ApprovalDecision::ExceedsCeiling(ceiling);
             }
         }
 
@@ -144,7 +149,7 @@ impl ApprovalPolicy {
             let d = self.decide_step(step.risk_level());
             match d {
                 // These are terminal — return immediately.
-                ApprovalDecision::ExceedsCeiling => return d,
+                ApprovalDecision::ExceedsCeiling(_) => return d,
                 ApprovalDecision::RequiresInteraction => return d,
                 // Escalate: RequiresPrompt > AutoApproved.
                 ApprovalDecision::RequiresPrompt => worst = ApprovalDecision::RequiresPrompt,
@@ -263,7 +268,7 @@ mod tests {
         let p = policy(false, Some(MaxRisk::Medium), false, false);
         assert_eq!(
             p.decide_step(&PlanRiskLevel::High),
-            ApprovalDecision::ExceedsCeiling
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Medium)
         );
     }
 
@@ -273,7 +278,9 @@ mod tests {
         let p = policy(false, Some(MaxRisk::Low), false, false);
         assert_eq!(
             p.decide_step(&PlanRiskLevel::Medium),
-            ApprovalDecision::ExceedsCeiling
+            // The payload must be the ceiling that was configured, not the
+            // risk that breached it.
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Low)
         );
     }
 
@@ -421,7 +428,10 @@ mod tests {
     fn plan_high_first_exceeds_ceiling() {
         let p = policy(false, Some(MaxRisk::Medium), false, false);
         let pl = plan(&[PlanRiskLevel::High, PlanRiskLevel::Low]);
-        assert_eq!(p.decide_plan(&pl), ApprovalDecision::ExceedsCeiling);
+        assert_eq!(
+            p.decide_plan(&pl),
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Medium)
+        );
     }
 
     // Plan with High step in the middle → ExceedsCeiling (early return on exceeding step)
@@ -429,7 +439,10 @@ mod tests {
     fn plan_high_middle_exceeds_ceiling() {
         let p = policy(false, Some(MaxRisk::Medium), false, false);
         let pl = plan(&[PlanRiskLevel::Low, PlanRiskLevel::High, PlanRiskLevel::Low]);
-        assert_eq!(p.decide_plan(&pl), ApprovalDecision::ExceedsCeiling);
+        assert_eq!(
+            p.decide_plan(&pl),
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Medium)
+        );
     }
 
     // Plan with High step second, --max-risk medium → ExceedsCeiling
@@ -437,7 +450,10 @@ mod tests {
     fn plan_high_step_with_max_risk_medium_exceeds_ceiling() {
         let p = policy(true, Some(MaxRisk::Medium), false, false);
         let pl = plan(&[PlanRiskLevel::Low, PlanRiskLevel::High]);
-        assert_eq!(p.decide_plan(&pl), ApprovalDecision::ExceedsCeiling);
+        assert_eq!(
+            p.decide_plan(&pl),
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Medium)
+        );
     }
 
     // Single High step with --yes --max-risk high → RequiresPrompt.

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -607,10 +607,9 @@ pub async fn run_audit_checkpoint(
     _log: &Logger,
 ) -> Result<(), CliError> {
     use sysknife_daemon::audit_chain::{
-        checkpoint_outcome_to_exit_code, outcome_to_exit_code, verify_chain, verify_checkpoints,
-        AuditKey, CheckpointOutcome, VerifyOutcome,
+        checkpoint_outcome_to_exit_code, outcome_to_exit_code, AuditKey,
     };
-    use sysknife_daemon::checkpoint_sink::{CheckpointSink, PostgresCheckpointSink};
+    use sysknife_daemon::checkpoint_sink::{anchor_once, AnchorOutcome, PostgresCheckpointSink};
     use sysknife_daemon::transactions::TransactionStore;
 
     // Resolve the checkpoint database URL. Prefer the env var so credentials
@@ -650,69 +649,49 @@ pub async fn run_audit_checkpoint(
         eprintln!("reading audit chain failed: {e}");
         CliError::Exit(2)
     })?;
-    let tip = match rows.last() {
-        Some(t) => t,
-        None => {
-            eprintln!("audit chain is empty; nothing to checkpoint");
-            return Err(CliError::Exit(2));
-        }
-    };
-
-    // Refuse to anchor a chain that does not verify: anchoring the tip of a
-    // tampered chain would launder it into a signed checkpoint.
-    match verify_chain(&key, &rows) {
-        VerifyOutcome::Intact { .. } => {}
-        broken => {
-            eprintln!("refusing to anchor: local audit chain does not verify: {broken:?}");
-            return Err(CliError::Exit(outcome_to_exit_code(&broken)));
-        }
-    }
-
-    let created_at = chrono::Utc::now().to_rfc3339();
-    let checkpoint = key.sign_checkpoint(tip.seq, &tip.chain_hash, &created_at);
-
-    // Anchor to the external append-only database.
+    // The anchoring rules — refuse a broken chain, read back after writing,
+    // re-verify every anchored checkpoint — live in the daemon crate so this
+    // command and the daemon's periodic anchor task cannot drift apart.
     let sink = PostgresCheckpointSink::connect(&db_url)
         .await
         .map_err(|e| {
             eprintln!("connecting to checkpoint database failed: {e}");
             CliError::Exit(2)
         })?;
-    sink.append(&checkpoint).await.map_err(|e| {
-        eprintln!("anchoring checkpoint failed: {e}");
-        CliError::Exit(2)
-    })?;
-    let tip_prefix = &checkpoint.chain_tip[..checkpoint.chain_tip.len().min(12)];
-    println!(
-        "anchored checkpoint: seq={} tip={tip_prefix}… -> external database",
-        checkpoint.seq
-    );
 
-    // Read the anchored checkpoints back and confirm our write is actually
-    // present, guarding against a lagging read replica or a wrong database
-    // silently returning an empty/stale set (which would otherwise render as a
-    // misleading "consistent (0 verified)").
-    let anchored = sink.load_all().await.map_err(|e| {
-        eprintln!("loading anchored checkpoints failed: {e}");
-        CliError::Exit(2)
-    })?;
-    if !anchored.contains(&checkpoint) {
-        eprintln!(
-            "anchored checkpoint not found on read-back; the checkpoint database \
-             may be a lagging replica or a different database than the write hit"
-        );
-        return Err(CliError::Exit(2));
-    }
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let outcome = anchor_once(&key, &rows, &sink, &created_at)
+        .await
+        .map_err(|e| {
+            eprintln!("checkpoint sink error: {e}");
+            CliError::Exit(2)
+        })?;
 
-    // Verify every anchored checkpoint against the local chain.
-    match verify_checkpoints(&key.verifying_key_hex(), &rows, &anchored) {
-        CheckpointOutcome::Consistent {
+    match outcome {
+        AnchorOutcome::Anchored {
+            seq,
             checkpoints_checked,
         } => {
+            println!("anchored checkpoint: seq={seq} -> external database");
             println!("checkpoints consistent ({checkpoints_checked} verified)");
             Ok(())
         }
-        other => {
+        AnchorOutcome::ChainEmpty => {
+            eprintln!("audit chain is empty; nothing to checkpoint");
+            Err(CliError::Exit(2))
+        }
+        AnchorOutcome::ChainBroken(broken) => {
+            eprintln!("refusing to anchor: local audit chain does not verify: {broken:?}");
+            Err(CliError::Exit(outcome_to_exit_code(&broken)))
+        }
+        AnchorOutcome::ReadBackMissing => {
+            eprintln!(
+                "anchored checkpoint not found on read-back; the checkpoint database \
+                 may be a lagging replica or a different database than the write hit"
+            );
+            Err(CliError::Exit(2))
+        }
+        AnchorOutcome::Inconsistent(other) => {
             eprintln!("checkpoint verification FAILED: {other:?}");
             Err(CliError::Exit(checkpoint_outcome_to_exit_code(&other)))
         }

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -1032,15 +1032,13 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
                 }
             }
             ApprovalDecision::RequiresInteraction => return Err(CliError::NonInteractive),
-            ApprovalDecision::ExceedsCeiling => {
+            ApprovalDecision::ExceedsCeiling(ceiling) => {
                 let highest = plan
                     .highest_risk()
                     .expect("ExceedsCeiling implies at least one step");
                 return Err(CliError::RiskCeilingExceeded {
                     highest: highest.clone(),
-                    ceiling: opts
-                        .max_risk
-                        .expect("ExceedsCeiling implies --max-risk was set"),
+                    ceiling,
                 });
             }
         }
@@ -1085,12 +1083,10 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
                     }
                 }
                 ApprovalDecision::RequiresInteraction => return Err(CliError::NonInteractive),
-                ApprovalDecision::ExceedsCeiling => {
+                ApprovalDecision::ExceedsCeiling(ceiling) => {
                     return Err(CliError::RiskCeilingExceeded {
                         highest: step.risk_level().clone(),
-                        ceiling: opts
-                            .max_risk
-                            .expect("ExceedsCeiling implies --max-risk was set"),
+                        ceiling,
                     });
                 }
             }
@@ -1556,7 +1552,7 @@ mod tests {
         let corrected = under_rated.into_authorized(authoritative_plan_risk);
         assert_eq!(
             policy.decide_plan(&corrected),
-            ApprovalDecision::ExceedsCeiling,
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Medium),
             "spec-derived High must not auto-approve under --max-risk medium"
         );
     }
@@ -1654,7 +1650,7 @@ mod tests {
         let policy = ApprovalPolicy::new(true, Some(MaxRisk::Low), false, false);
         assert_eq!(
             policy.decide_plan(&plan.clone().assume_authorized()),
-            ApprovalDecision::ExceedsCeiling,
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Low),
             "sanity: the planner's inflated High would block a safe read-only action"
         );
         let corrected = plan.into_authorized(authoritative_plan_risk);

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -101,10 +101,28 @@ fn history_rejects_unparseable_since_timestamp() {
         .arg("--since")
         .arg("not-a-timestamp")
         .assert()
-        // Failure is the contract; either the parser or the daemon
-        // round-trip can fail (depending on order). What matters is we
-        // get a non-zero exit and don't panic.
-        .failure();
+        // The specific code is the contract, not merely "non-zero": a bad
+        // `--since` is a config/usage error (4), and automation distinguishes
+        // that from an execution failure (2) or a rejected plan (1).
+        .code(4);
+}
+
+#[test]
+fn audit_verify_exits_with_code_2_when_the_key_file_is_missing() {
+    // `run_audit_verify` documents 0 = intact, 1 = tampered, 2 = could not
+    // verify, and warns that "a CI pipeline expecting 0 or 1 must not
+    // silently pass on a missing key file". Nothing pinned that: the only
+    // exit-code coverage was `error.rs`'s pure mapping test, which cannot
+    // catch the binary collapsing 2 into 0 or 1.
+    let dir = tempfile::tempdir().unwrap();
+    cli()
+        .env("SYSKNIFE_SOCKET", fake_socket(&dir))
+        .env("XDG_DATA_HOME", dir.path())
+        .env("HOME", dir.path())
+        .args(["audit", "verify", "--pubkey"])
+        .arg(dir.path().join("no-such-key.pub"))
+        .assert()
+        .code(2);
 }
 
 #[test]
@@ -117,4 +135,44 @@ fn completions_subcommand_emits_a_shell_script() {
         // Bash completion scripts always start with `#!/usr/bin/env`
         // or define a `_sysknife` function — either is fine.
         .stdout(predicate::str::contains("_sysknife").or(predicate::str::starts_with("#")));
+}
+
+/// `--timeout` is the only bound on a scripted invocation that would
+/// otherwise hang, and nothing exercised it.
+///
+/// The daemon has to *accept and then stay silent*: an unreachable socket
+/// fails fast for an unrelated reason and would prove nothing about the
+/// timeout. The listener thread is deliberately detached — joining it would
+/// block the test forever, since it has no reason to stop accepting.
+#[test]
+fn timeout_flag_bounds_a_daemon_that_accepts_but_never_replies() {
+    use std::os::unix::net::UnixListener;
+
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir.path().join("silent.sock");
+    let listener = UnixListener::bind(&socket_path).expect("bind test socket");
+
+    std::thread::spawn(move || {
+        let mut held = Vec::new();
+        while let Ok((stream, _)) = listener.accept() {
+            // Hold the connection open and never write a reply.
+            held.push(stream);
+        }
+    });
+
+    let started = std::time::Instant::now();
+    cli()
+        .env("SYSKNIFE_SOCKET", &socket_path)
+        .args(["--timeout", "1", "doctor"])
+        .assert()
+        // ExecutionFailed → exit 2, with the timeout named so an operator can
+        // tell it apart from the daemon rejecting the request.
+        .code(2)
+        .stderr(predicate::str::contains("timed out"));
+
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(30),
+        "--timeout 1 must give up promptly against a silent daemon, took {elapsed:?}"
+    );
 }

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "@vitest/coverage-v8": "^4.1.4",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -9,6 +9,12 @@ description = "LLM planning core for SysKnife — typed action proposals with fo
 keywords = ["llm", "ai-agent", "linux", "sysadmin", "planning"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
+[features]
+# Exposes `Plan::assume_authorized`, which bypasses the daemon-authoritative
+# risk substitution. Enabled only by dev-dependencies so no production build
+# can construct an `AuthorizedPlan` from unvalidated risk.
+test-support = []
+
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-brain/src/planner.rs
+++ b/crates/sysknife-brain/src/planner.rs
@@ -354,10 +354,18 @@ impl Plan {
 
     /// Wrap this plan as authoritative *without* substituting risk.
     ///
-    /// The loud name is deliberate: use only when the step risks are already the
-    /// authoritative `ActionSpec` values — in tests, or where a plan is built
-    /// directly from daemon risk. Production code paths that start from an LLM
-    /// proposal must use [`Plan::into_authorized`] instead.
+    /// **Test-only.** `AuthorizedPlan` exists to make it structurally
+    /// impossible to feed the approval gate the LLM's self-reported risk, and
+    /// this function is the one hole in that guarantee. It was a plain `pub fn`
+    /// whose contract lived only in a doc comment, so any crate — including a
+    /// future refactor of the MCP planning path reaching for something simpler
+    /// than the per-step daemon preview — could construct an `AuthorizedPlan`
+    /// from unvalidated risk and still compile.
+    ///
+    /// Gating it behind `test-support` makes that a compile error outside
+    /// tests. Production paths must use [`Plan::into_authorized`], which forces
+    /// the caller to supply the substitution function.
+    #[cfg(any(test, feature = "test-support"))]
     #[must_use]
     pub fn assume_authorized(self) -> AuthorizedPlan {
         AuthorizedPlan { plan: self }

--- a/crates/sysknife-brain/src/planner.rs
+++ b/crates/sysknife-brain/src/planner.rs
@@ -383,7 +383,9 @@ impl Plan {
 /// gating. A raw [`Plan`] exposes only [`PlanStep::proposed_risk_level`], so it
 /// is impossible to feed the approval gate an un-substituted (proposed) risk by
 /// accident. Construct via [`Plan::into_authorized`] (substitutes) or, where the
-/// risks are already authoritative, [`Plan::assume_authorized`].
+/// risks are already authoritative, `Plan::assume_authorized` — which is
+/// gated behind the `test-support` feature and so is not part of the public
+/// API this documentation describes (hence the plain reference, not a link).
 pub struct AuthorizedPlan {
     plan: Plan,
 }

--- a/crates/sysknife-brain/tests/planner.rs
+++ b/crates/sysknife-brain/tests/planner.rs
@@ -1776,3 +1776,43 @@ async fn story_coverage_third_ubuntu_case_apt_search() {
         "Ubuntu prompt must not mention AddLayeredPackage"
     );
 }
+
+/// Malformed provider JSON must surface as a planning failure, not be
+/// swallowed into an empty plan. `ProviderError` has five variants; only
+/// `Http` and `Auth` were exercised through `plan_intent`, leaving the
+/// parse/rate-limit/request paths unproven.
+#[tokio::test]
+async fn provider_parse_error_propagates() {
+    let planner = make_planner(MockProvider::new([Err(ProviderError::Parse(
+        "model returned unparseable JSON".into(),
+    ))]));
+
+    assert!(matches!(
+        planner.plan_intent("do something").await.unwrap_err(),
+        PlanningError::Provider(_)
+    ));
+}
+
+#[tokio::test]
+async fn rate_limit_error_propagates() {
+    let planner = make_planner(MockProvider::new([Err(ProviderError::RateLimit(
+        "429 slow down".into(),
+    ))]));
+
+    assert!(matches!(
+        planner.plan_intent("do something").await.unwrap_err(),
+        PlanningError::Provider(_)
+    ));
+}
+
+#[tokio::test]
+async fn transport_request_error_propagates() {
+    let planner = make_planner(MockProvider::new([Err(ProviderError::Request(
+        "connection reset".into(),
+    ))]));
+
+    assert!(matches!(
+        planner.plan_intent("do something").await.unwrap_err(),
+        PlanningError::Provider(_)
+    ));
+}

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.11"
+version = "0.2.12"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon/src/audit_chain.rs
+++ b/crates/sysknife-daemon/src/audit_chain.rs
@@ -1026,13 +1026,16 @@ mod tests {
         rows.push(forged);
         rows.extend(rest);
 
+        // The fixture is deterministic: the forged row sits at seq=2 with a
+        // signature that cannot verify, so the walk must stop exactly there.
+        // Accepting "2 or 3" let an off-by-one in `verify_rows` pass.
         let outcome = verify_chain(&key, &rows);
         match outcome {
             VerifyOutcome::Broken {
                 first_broken_seq, ..
-            } => assert!(
-                first_broken_seq == 2 || first_broken_seq == 3,
-                "verifier must flag the inserted row or the row that follows it (got {first_broken_seq})"
+            } => assert_eq!(
+                first_broken_seq, 2,
+                "the verifier must flag the forged row itself, not a later one"
             ),
             other => panic!("expected Broken, got {other:?}"),
         }

--- a/crates/sysknife-daemon/src/auth.rs
+++ b/crates/sysknife-daemon/src/auth.rs
@@ -28,20 +28,7 @@ fn role_for_group(group: &str) -> CallerRole {
 }
 
 fn higher_role(current: CallerRole, candidate: CallerRole) -> CallerRole {
-    if role_rank(&candidate) > role_rank(&current) {
-        candidate
-    } else {
-        current
-    }
-}
-
-pub(crate) fn role_rank(role: &CallerRole) -> u8 {
-    match role {
-        CallerRole::Observer => 0,
-        CallerRole::Dev => 1,
-        CallerRole::Admin => 2,
-        CallerRole::Boot => 3,
-    }
+    current.max(candidate)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sysknife-daemon/src/checkpoint_sink.rs
+++ b/crates/sysknife-daemon/src/checkpoint_sink.rs
@@ -187,6 +187,151 @@ impl CheckpointSink for PostgresCheckpointSink {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Anchoring
+// ---------------------------------------------------------------------------
+
+/// Result of one anchoring attempt.
+///
+/// Every non-`Anchored` variant means the anchor did **not** advance, and the
+/// tamper-evidence window did not move forward. Callers must surface them;
+/// treating a failed anchor as routine is how this defence quietly stops
+/// working.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AnchorOutcome {
+    /// A checkpoint was written and every anchored checkpoint still verifies.
+    Anchored { seq: u64, checkpoints_checked: u64 },
+    /// Nothing to anchor yet — the chain has no rows.
+    ChainEmpty,
+    /// The local chain does not verify, so anchoring was refused.
+    ChainBroken(crate::audit_chain::VerifyOutcome),
+    /// The write appeared to succeed but the checkpoint was absent on read-back.
+    ReadBackMissing,
+    /// A stored checkpoint no longer matches the local chain.
+    Inconsistent(crate::audit_chain::CheckpointOutcome),
+}
+
+/// Sign the current chain tip and anchor it to `sink`, then prove the anchor
+/// landed and still agrees with the local chain.
+///
+/// Shared by the `sysknife audit checkpoint` CLI command and the daemon's
+/// periodic anchor task so both enforce the same guarantees:
+///
+/// 1. **Refuse to anchor a broken chain.** Anchoring the tip of a tampered
+///    chain would launder the tamper into a signed checkpoint.
+/// 2. **Read back after writing.** A lagging replica or the wrong database
+///    would otherwise render as a reassuring "consistent (0 verified)".
+/// 3. **Re-verify every anchored checkpoint**, not just the new one.
+pub async fn anchor_once(
+    key: &crate::audit_chain::AuditKey,
+    rows: &[crate::audit_chain::ChainRow],
+    sink: &dyn CheckpointSink,
+    created_at: &str,
+) -> Result<AnchorOutcome, CheckpointSinkError> {
+    use crate::audit_chain::{verify_chain, verify_checkpoints, CheckpointOutcome, VerifyOutcome};
+
+    let Some(tip) = rows.last() else {
+        return Ok(AnchorOutcome::ChainEmpty);
+    };
+
+    match verify_chain(key, rows) {
+        VerifyOutcome::Intact { .. } => {}
+        broken => return Ok(AnchorOutcome::ChainBroken(broken)),
+    }
+
+    let checkpoint = key.sign_checkpoint(tip.seq, &tip.chain_hash, created_at);
+    sink.append(&checkpoint).await?;
+
+    let anchored = sink.load_all().await?;
+    if !anchored.contains(&checkpoint) {
+        return Ok(AnchorOutcome::ReadBackMissing);
+    }
+
+    match verify_checkpoints(&key.verifying_key_hex(), rows, &anchored) {
+        CheckpointOutcome::Consistent {
+            checkpoints_checked,
+        } => Ok(AnchorOutcome::Anchored {
+            seq: checkpoint.seq,
+            checkpoints_checked,
+        }),
+        other => Ok(AnchorOutcome::Inconsistent(other)),
+    }
+}
+
+/// How often the daemon anchors a checkpoint when a sink is configured.
+///
+/// This bounds the tamper window: an attacker who compromises the host can
+/// rewrite history only back to the last anchor, so the interval is the
+/// exposure. Fifteen minutes keeps the write volume trivial (one row) while
+/// keeping that window short.
+pub const DEFAULT_ANCHOR_INTERVAL: Duration = Duration::from_secs(15 * 60);
+
+/// Periodically anchor the chain tip to `sink` for as long as the daemon runs.
+///
+/// Without this the checkpoint machinery is inert: `sign_checkpoint`,
+/// `verify_checkpoints` and the sinks all existed and were tested, but nothing
+/// in the daemon ever called them, so the tail-truncation defence the threat
+/// model relies on was only active if an operator happened to run
+/// `sysknife audit checkpoint` on a timer of their own.
+pub fn spawn_periodic_anchor(
+    audit: std::sync::Arc<dyn crate::store::AuditStore>,
+    key: std::sync::Arc<crate::audit_chain::AuditKey>,
+    sink: std::sync::Arc<dyn CheckpointSink>,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(interval).await;
+
+            let rows = match audit.fetch_chain_rows().await {
+                Ok(rows) => rows,
+                Err(e) => {
+                    eprintln!("[sysknife-daemon] checkpoint anchor: reading chain failed: {e}");
+                    continue;
+                }
+            };
+
+            let created_at = chrono::Utc::now().to_rfc3339();
+            match anchor_once(&key, &rows, sink.as_ref(), &created_at).await {
+                Ok(AnchorOutcome::Anchored {
+                    seq,
+                    checkpoints_checked,
+                }) => {
+                    eprintln!(
+                        "[sysknife-daemon] anchored checkpoint seq={seq} \
+                         ({checkpoints_checked} verified)"
+                    );
+                }
+                Ok(AnchorOutcome::ChainEmpty) => {}
+                // Everything below means the anchor did not advance. These are
+                // loud on purpose: a silent anchor failure looks exactly like a
+                // working one until the day someone needs the evidence.
+                Ok(AnchorOutcome::ChainBroken(outcome)) => {
+                    eprintln!(
+                        "[sysknife-daemon] checkpoint anchor REFUSED: the local audit chain \
+                         does not verify ({outcome:?}); not anchoring a tampered chain"
+                    );
+                }
+                Ok(AnchorOutcome::ReadBackMissing) => {
+                    eprintln!(
+                        "[sysknife-daemon] checkpoint anchor FAILED: the checkpoint was absent \
+                         on read-back; the sink may be a lagging replica or a different database"
+                    );
+                }
+                Ok(AnchorOutcome::Inconsistent(outcome)) => {
+                    eprintln!(
+                        "[sysknife-daemon] checkpoint verification FAILED: {outcome:?} — \
+                         the local chain disagrees with a previously anchored checkpoint"
+                    );
+                }
+                Err(e) => {
+                    eprintln!("[sysknife-daemon] checkpoint anchor: sink error: {e}");
+                }
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -200,7 +345,7 @@ mod tests {
     }
 
     /// Build a small intact chain the same way the daemon would.
-    fn build_chain(key: &AuditKey, count: usize) -> Vec<ChainRow> {
+    pub(super) fn build_chain(key: &AuditKey, count: usize) -> Vec<ChainRow> {
         let mut rows = Vec::with_capacity(count);
         let mut prev = String::new();
         for i in 0..count {
@@ -279,5 +424,219 @@ mod tests {
                 current_max_seq: 3
             }
         ));
+    }
+}
+
+#[cfg(test)]
+mod anchor_tests {
+    use super::*;
+    use crate::audit_chain::{AuditKey, ChainContent, ChainRow, CheckpointOutcome, VerifyOutcome};
+
+    fn key() -> AuditKey {
+        AuditKey::from_bytes(vec![0x42; 32])
+    }
+
+    /// Rebuild a chain from `rows`, re-signing every row with `key` so the
+    /// result verifies cleanly. Used to forge a tampered-but-valid tail — the
+    /// attack only a checkpoint can catch.
+    fn reseal(key: &AuditKey, rows: &[ChainRow]) -> Vec<ChainRow> {
+        let mut out = Vec::with_capacity(rows.len());
+        let mut prev = String::new();
+        for row in rows {
+            let content = ChainContent {
+                seq: row.seq,
+                key_id: &row.key_id,
+                transaction_id: &row.transaction_id,
+                request_id: &row.request_id,
+                request_hash: &row.request_hash,
+                action_name: &row.action_name,
+                risk_level: row.risk_level,
+                summary: &row.summary,
+                approval_id: row.approval_id.as_deref(),
+                warnings_json: &row.warnings_json,
+                created_at: &row.created_at,
+            };
+            let hash = key.chain_hash(&content, &prev);
+            let mut cloned = row.clone();
+            cloned.prev_chain_hash = prev.clone();
+            cloned.chain_hash = hash.clone();
+            out.push(cloned);
+            prev = hash;
+        }
+        out
+    }
+
+    fn chain(key: &AuditKey, count: usize) -> Vec<ChainRow> {
+        super::tests::build_chain(key, count)
+    }
+
+    #[tokio::test]
+    async fn anchor_once_writes_and_verifies_the_tip() {
+        let key = key();
+        let rows = chain(&key, 3);
+        let sink = InMemoryCheckpointSink::new();
+
+        let outcome = anchor_once(&key, &rows, &sink, "2026-04-24T12:00:00Z")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            AnchorOutcome::Anchored {
+                seq: 3,
+                checkpoints_checked: 1
+            }
+        );
+        assert_eq!(sink.load_all().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn anchor_once_refuses_to_launder_a_tampered_chain() {
+        // Anchoring the tip of a broken chain would sign the tamper into the
+        // one record that is supposed to detect it.
+        let key = key();
+        let mut rows = chain(&key, 3);
+        rows[1].summary = "tampered".to_string();
+        let sink = InMemoryCheckpointSink::new();
+
+        let outcome = anchor_once(&key, &rows, &sink, "2026-04-24T12:00:00Z")
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(
+                outcome,
+                AnchorOutcome::ChainBroken(VerifyOutcome::Broken { .. })
+            ),
+            "expected a refusal, got {outcome:?}"
+        );
+        assert!(
+            sink.load_all().await.unwrap().is_empty(),
+            "nothing may be anchored when the chain does not verify"
+        );
+    }
+
+    #[tokio::test]
+    async fn anchor_once_reports_an_empty_chain_rather_than_anchoring_nothing() {
+        let key = key();
+        let sink = InMemoryCheckpointSink::new();
+        let outcome = anchor_once(&key, &[], &sink, "2026-04-24T12:00:00Z")
+            .await
+            .unwrap();
+        assert_eq!(outcome, AnchorOutcome::ChainEmpty);
+        assert!(sink.load_all().await.unwrap().is_empty());
+    }
+
+    /// A sink that accepts writes and then loses them. Models a lagging read
+    /// replica or a misconfigured second database.
+    #[derive(Default)]
+    struct BlackHoleSink;
+
+    #[async_trait]
+    impl CheckpointSink for BlackHoleSink {
+        async fn append(
+            &self,
+            _checkpoint: &crate::audit_chain::Checkpoint,
+        ) -> Result<(), CheckpointSinkError> {
+            Ok(())
+        }
+        async fn load_all(
+            &self,
+        ) -> Result<Vec<crate::audit_chain::Checkpoint>, CheckpointSinkError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[tokio::test]
+    async fn anchor_once_detects_a_write_that_did_not_land() {
+        // A sink that swallows writes must not read as a successful anchor:
+        // `verify_checkpoints` over zero checkpoints is trivially "consistent",
+        // which is exactly the reassuring-but-wrong result the read-back check
+        // exists to prevent.
+        let key = key();
+        let rows = chain(&key, 2);
+
+        let outcome = anchor_once(&key, &rows, &BlackHoleSink, "2026-04-24T12:00:00Z")
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, AnchorOutcome::ReadBackMissing);
+    }
+
+    #[tokio::test]
+    async fn a_previously_anchored_checkpoint_catches_a_key_holder_rewrite() {
+        // THE reason checkpoints exist. An attacker with root AND the signing
+        // key can rebuild history so the chain verifies perfectly — every
+        // existing "rewrite" test corrupts `chain_hash` with garbage that a
+        // plain signature check already rejects, so none of them exercise this.
+        //
+        // Here the tampered tail is re-signed with the real key, so
+        // `verify_chain` says Intact. Only the anchored tip catches it.
+        let key = key();
+        let original = chain(&key, 5);
+        let sink = InMemoryCheckpointSink::new();
+
+        anchor_once(&key, &original, &sink, "2026-04-24T12:00:00Z")
+            .await
+            .unwrap();
+        let anchored = sink.load_all().await.unwrap();
+
+        let mut tampered = original.clone();
+        tampered[3].summary = "quietly rewritten".to_string();
+        let tampered = reseal(&key, &tampered);
+
+        assert!(
+            matches!(
+                crate::audit_chain::verify_chain(&key, &tampered),
+                VerifyOutcome::Intact { .. }
+            ),
+            "the forged chain must verify — otherwise this test proves nothing \
+             beyond what a plain signature check already catches"
+        );
+
+        let outcome =
+            crate::audit_chain::verify_checkpoints(&key.verifying_key_hex(), &tampered, &anchored);
+        assert!(
+            matches!(outcome, CheckpointOutcome::TipMismatch { .. }),
+            "the anchored tip must expose the rewrite, got {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_chain_alone_cannot_detect_tail_truncation() {
+        // The claim the module docs make about why anchoring is necessary,
+        // asserted directly: a truncated chain is internally consistent.
+        let key = key();
+        let full = chain(&key, 5);
+        let truncated = &full[..3];
+
+        assert!(
+            matches!(
+                crate::audit_chain::verify_chain(&key, truncated),
+                VerifyOutcome::Intact {
+                    rows_checked: 3,
+                    ..
+                }
+            ),
+            "a truncated chain still verifies on its own — this is the gap"
+        );
+
+        let sink = InMemoryCheckpointSink::new();
+        anchor_once(&key, &full, &sink, "2026-04-24T12:00:00Z")
+            .await
+            .unwrap();
+        let anchored = sink.load_all().await.unwrap();
+
+        assert!(
+            matches!(
+                crate::audit_chain::verify_checkpoints(
+                    &key.verifying_key_hex(),
+                    truncated,
+                    &anchored
+                ),
+                CheckpointOutcome::Truncated { .. }
+            ),
+            "the anchor is what turns an undetectable truncation into a detected one"
+        );
     }
 }

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -2580,12 +2580,55 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_caller_role_on_pair_does_not_panic() {
-        // Peer is the test process; the resolved role depends on the test user's
-        // groups, so we only assert the SO_PEERCRED + optional-pidfd path resolves
-        // without panicking.
+    async fn resolve_caller_role_matches_the_peers_actual_groups() {
+        // This used to call `resolve_caller_role` and discard the result,
+        // asserting only "no panic" — it would have passed just as happily if
+        // the function returned Boot for everyone.
+        //
+        // The role is environment-dependent, so rather than hardcoding one we
+        // derive the expectation from the same inputs the daemon uses and
+        // compare. That pins the whole wiring — SO_PEERCRED → pid →
+        // /proc/<pid>/status → /etc/group → role — instead of only its absence
+        // of panics.
         let (a, _b) = UnixStream::pair().unwrap();
-        let _role = resolve_caller_role(&a);
+        let role = resolve_caller_role(&a);
+
+        let gid_map = read_gid_map();
+        let expected =
+            crate::auth::highest_role_from_groups(groups_for_pid(std::process::id(), &gid_map));
+
+        assert_eq!(
+            role, expected,
+            "the resolved role must be exactly what this process's groups justify"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_caller_role_never_exceeds_observer_without_a_privileged_group() {
+        // The direction that actually matters for safety: privilege must come
+        // from group membership, never from the mere act of connecting.
+        let (a, _b) = UnixStream::pair().unwrap();
+        let role = resolve_caller_role(&a);
+
+        let gid_map = read_gid_map();
+        let groups = groups_for_pid(std::process::id(), &gid_map);
+        let privileged = groups.iter().any(|g| {
+            matches!(
+                g.as_str(),
+                crate::auth::DEV_GROUP
+                    | crate::auth::ADMIN_GROUP
+                    | crate::auth::BOOT_GROUP
+                    | crate::auth::WHEEL_GROUP
+            )
+        });
+
+        if !privileged {
+            assert_eq!(
+                role,
+                CallerRole::Observer,
+                "a process in no privileged group must resolve to Observer"
+            );
+        }
     }
 
     // ------------------------------------------------------------------

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -685,9 +685,7 @@ fn validate_action_platform(state: &DaemonState, action_name: &str) -> Result<()
     let is_mutating = state
         .policy
         .min_role_for_action(action_name)
-        .is_some_and(|role| {
-            crate::auth::role_rank(&role) > crate::auth::role_rank(&CallerRole::Observer)
-        });
+        .is_some_and(|role| role > CallerRole::Observer);
     if required_family.is_none() && !is_mutating {
         return Ok(());
     }
@@ -1797,7 +1795,6 @@ async fn handle_preview(
         request_hash,
         action_name: action_name.to_string(),
         risk_level: spec.risk_level,
-        approval_id: None,
         summary: preview.summary.clone(),
         warnings: preview.warnings.clone(),
     };
@@ -2094,7 +2091,7 @@ async fn handle_execute(
         spec.risk_level == sysknife_types::RiskLevel::High && spec.reboot_required;
 
     let policy_says_mutating = match state.policy.min_role_for_action(action_name) {
-        Some(r) => crate::auth::role_rank(&r) > crate::auth::role_rank(&CallerRole::Observer),
+        Some(r) => r > CallerRole::Observer,
         None => {
             // Unreachable today: `authorize_action` above rejects any action
             // the policy table does not know. Treat the miss as mutating

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -2485,6 +2485,63 @@ mod tests {
     }
 
     #[test]
+    fn authorized_keys_actions_reject_a_traversal_username() {
+        // `actions/ssh.rs` builds `/home/{username}/.ssh/authorized_keys` by
+        // interpolation, so the only thing keeping the path inside the user's
+        // home is `validated_username` being called in these three match arms.
+        // `validate.rs` tests the validator in isolation, and `ssh_key_ops.rs`
+        // calls the action functions directly — neither proves the guard is
+        // actually wired to the reachable actions.
+        for action in [
+            "GetAuthorizedKeys",
+            "AddAuthorizedKey",
+            "RemoveAuthorizedKey",
+        ] {
+            for bad in ["../../etc", "..", "root/../../etc"] {
+                let err = build_action_spec(
+                    action,
+                    &json!({
+                        "username": bad,
+                        "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample u@h",
+                    }),
+                )
+                .unwrap_err();
+                assert!(
+                    matches!(err, ExecutorError::InvalidParam("username")),
+                    "{action} must reject username {bad:?}, got {err:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ip_taking_actions_reject_a_malformed_address() {
+        // `ExecutorError::InvalidIpAddress` was constructed by three actions
+        // and reached by no test.
+        let cases: [(&str, serde_json::Value); 3] = [
+            (
+                "ResolvectlSetDns",
+                json!({ "interface": "eth0", "servers": ["not-an-ip"] }),
+            ),
+            (
+                "Fail2banBanIp",
+                json!({ "jail": "sshd", "ip": "999.1.1.1" }),
+            ),
+            (
+                "Fail2banUnbanIp",
+                json!({ "jail": "sshd", "ip": "1.2.3.4.5" }),
+            ),
+        ];
+        for (action, params) in cases {
+            let err = build_action_spec(action, &params).unwrap_err();
+            assert!(
+                matches!(err, ExecutorError::InvalidIpAddress { .. }),
+                "{action} must reject a malformed IP, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
     fn public_key_rejects_pipe_metacharacter() {
         // '|' is a shell pipe and never appears in a valid key. (It was also
         // the sed address delimiter before the key ops were made regex-free;

--- a/crates/sysknife-daemon/src/jobs.rs
+++ b/crates/sysknife-daemon/src/jobs.rs
@@ -1,64 +1,16 @@
+//! The job status transition table.
+//!
+//! [`allowed_transition`] is the single source of truth, called by both
+//! transaction stores before any status write.
+//!
+//! There used to be a `JobStateMachine` struct wrapping this table with
+//! `transition_to`/`cancel`/`is_terminal` helpers. Nothing in production ever
+//! constructed one — the stores call `allowed_transition` directly and hold
+//! status in the database, not in memory — so it was dead code whose ten tests
+//! read as if they covered the live transition logic. The table below is what
+//! actually runs, and the tests now exercise it directly.
+
 use sysknife_types::JobState;
-
-#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
-pub enum JobError {
-    #[error("invalid transition from {from:?} to {to:?}")]
-    InvalidTransition { from: JobState, to: JobState },
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct JobStateMachine {
-    job_id: String,
-    state: JobState,
-}
-
-impl JobStateMachine {
-    pub fn new(job_id: impl Into<String>) -> Self {
-        Self {
-            job_id: job_id.into(),
-            state: JobState::Queued,
-        }
-    }
-
-    pub fn job_id(&self) -> &str {
-        &self.job_id
-    }
-
-    pub fn state(&self) -> JobState {
-        self.state
-    }
-
-    pub fn transition_to(&mut self, next: JobState) -> Result<(), JobError> {
-        if allowed_transition(&self.state, &next) {
-            self.state = next;
-            Ok(())
-        } else {
-            Err(JobError::InvalidTransition {
-                from: self.state,
-                to: next,
-            })
-        }
-    }
-
-    pub fn cancel(&mut self) -> Result<(), JobError> {
-        self.transition_to(JobState::Canceled)
-    }
-
-    pub fn needs_reboot(&mut self) -> Result<(), JobError> {
-        self.transition_to(JobState::NeedsReboot)
-    }
-
-    pub fn is_terminal(&self) -> bool {
-        matches!(
-            self.state,
-            JobState::Succeeded
-                | JobState::Failed
-                | JobState::Canceled
-                | JobState::RolledBack
-                | JobState::NeedsReboot
-        )
-    }
-}
 
 pub fn allowed_transition(current: &JobState, next: &JobState) -> bool {
     matches!(
@@ -73,344 +25,100 @@ pub fn allowed_transition(current: &JobState, next: &JobState) -> bool {
     )
 }
 
+/// Is this a state no transition may leave?
+pub fn is_terminal(state: &JobState) -> bool {
+    matches!(
+        state,
+        JobState::Succeeded
+            | JobState::Failed
+            | JobState::Canceled
+            | JobState::RolledBack
+            | JobState::NeedsReboot
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sysknife_types::JobState;
 
-    // Test-table aliases — clippy flags the inline tuple type as too complex.
-    type ValidTransitionCase = (&'static str, fn() -> JobStateMachine, JobState);
-    type InvalidTransitionCase = (&'static str, fn() -> JobStateMachine, JobState, JobState);
+    const ALL: &[JobState] = &[
+        JobState::Queued,
+        JobState::Running,
+        JobState::Succeeded,
+        JobState::Failed,
+        JobState::Canceled,
+        JobState::RolledBack,
+        JobState::NeedsReboot,
+    ];
 
-    // -------------------------------------------------------------------------
-    // 1. new_starts_in_queued
-    // -------------------------------------------------------------------------
+    /// The complete set of permitted edges. Anything absent must be refused.
+    const ALLOWED: &[(JobState, JobState)] = &[
+        (JobState::Queued, JobState::Running),
+        (JobState::Queued, JobState::Canceled),
+        (JobState::Running, JobState::Succeeded),
+        (JobState::Running, JobState::Failed),
+        (JobState::Running, JobState::Canceled),
+        (JobState::Running, JobState::RolledBack),
+        (JobState::Running, JobState::NeedsReboot),
+    ];
+
     #[test]
-    fn new_starts_in_queued() {
-        let m = JobStateMachine::new("j1");
-        assert_eq!(m.state(), JobState::Queued);
-        assert_eq!(m.job_id(), "j1");
-    }
-
-    // -------------------------------------------------------------------------
-    // 2. valid_transitions
-    // -------------------------------------------------------------------------
-    #[test]
-    fn valid_transitions() {
-        // (label, setup_fn, from, to)
-        // Each closure receives a fresh machine and puts it into `from` state.
-        let cases: &[ValidTransitionCase] = &[
-            // Queued → Running
-            (
-                "Queued->Running",
-                || JobStateMachine::new("j"),
-                JobState::Running,
-            ),
-            // Queued → Canceled
-            (
-                "Queued->Canceled",
-                || JobStateMachine::new("j"),
-                JobState::Canceled,
-            ),
-            // Running → Succeeded  (must go Queued→Running first)
-            (
-                "Running->Succeeded",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m
-                },
-                JobState::Succeeded,
-            ),
-            // Running → Failed
-            (
-                "Running->Failed",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m
-                },
-                JobState::Failed,
-            ),
-            // Running → Canceled
-            (
-                "Running->Canceled",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m
-                },
-                JobState::Canceled,
-            ),
-            // Running → RolledBack
-            (
-                "Running->RolledBack",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m
-                },
-                JobState::RolledBack,
-            ),
-            // Running → NeedsReboot
-            (
-                "Running->NeedsReboot",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m
-                },
-                JobState::NeedsReboot,
-            ),
-        ];
-
-        for (label, setup, to) in cases {
-            let mut m = setup();
-            let result = m.transition_to(*to);
-            assert!(result.is_ok(), "{label}: expected Ok(()), got {result:?}");
-            assert_eq!(m.state(), *to, "{label}: state after transition");
+    fn every_permitted_edge_is_allowed() {
+        for (from, to) in ALLOWED {
+            assert!(
+                allowed_transition(from, to),
+                "{from:?} -> {to:?} must be permitted"
+            );
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 3. invalid_transitions_return_error
-    // -------------------------------------------------------------------------
+    /// Exhaustive over the whole 7x7 space, so a new variant or a widened
+    /// match arm cannot quietly add an edge nobody intended.
     #[test]
-    fn invalid_transitions_return_error() {
-        let cases: &[InvalidTransitionCase] = &[
-            // Queued → Succeeded (skip Running)
-            (
-                "Queued->Succeeded",
-                || JobStateMachine::new("j"),
-                JobState::Queued,
-                JobState::Succeeded,
-            ),
-            // Queued → Failed (skip Running)
-            (
-                "Queued->Failed",
-                || JobStateMachine::new("j"),
-                JobState::Queued,
-                JobState::Failed,
-            ),
-            // Running → Queued (no going back)
-            (
-                "Running->Queued",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m
-                },
-                JobState::Running,
-                JobState::Queued,
-            ),
-            // Succeeded → Running (terminal)
-            (
-                "Succeeded->Running",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m.transition_to(JobState::Succeeded).unwrap();
-                    m
-                },
-                JobState::Succeeded,
-                JobState::Running,
-            ),
-            // Failed → Running (terminal)
-            (
-                "Failed->Running",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m.transition_to(JobState::Failed).unwrap();
-                    m
-                },
-                JobState::Failed,
-                JobState::Running,
-            ),
-            // Canceled → Running (terminal)
-            (
-                "Canceled->Running",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Canceled).unwrap();
-                    m
-                },
-                JobState::Canceled,
-                JobState::Running,
-            ),
-            // RolledBack → Running (terminal)
-            (
-                "RolledBack->Running",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m.transition_to(JobState::RolledBack).unwrap();
-                    m
-                },
-                JobState::RolledBack,
-                JobState::Running,
-            ),
-            // NeedsReboot → Succeeded (terminal)
-            (
-                "NeedsReboot->Succeeded",
-                || {
-                    let mut m = JobStateMachine::new("j");
-                    m.transition_to(JobState::Running).unwrap();
-                    m.transition_to(JobState::NeedsReboot).unwrap();
-                    m
-                },
-                JobState::NeedsReboot,
-                JobState::Succeeded,
-            ),
-        ];
-
-        for (label, setup, expected_from, to) in cases {
-            let mut m = setup();
-            let result = m.transition_to(*to);
-            match result {
-                Err(JobError::InvalidTransition { from, to: err_to }) => {
-                    assert_eq!(from, *expected_from, "{label}: wrong `from` in error");
-                    assert_eq!(err_to, *to, "{label}: wrong `to` in error");
-                }
-                other => panic!("{label}: expected Err(InvalidTransition), got {other:?}"),
+    fn every_other_edge_is_refused() {
+        for from in ALL {
+            for to in ALL {
+                let permitted = ALLOWED.iter().any(|(f, t)| f == from && t == to);
+                assert_eq!(
+                    allowed_transition(from, to),
+                    permitted,
+                    "{from:?} -> {to:?}"
+                );
             }
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 4. is_terminal_for_all_states
-    // -------------------------------------------------------------------------
     #[test]
-    fn is_terminal_for_all_states() {
-        let cases: &[(JobState, bool)] = &[
-            (JobState::Queued, false),
-            (JobState::Running, false),
-            (JobState::Succeeded, true),
-            (JobState::Failed, true),
-            (JobState::Canceled, true),
-            (JobState::RolledBack, true),
-            (JobState::NeedsReboot, true),
-        ];
-
-        for (state, expected) in cases {
-            // Build a machine whose internal state equals `state` by driving
-            // valid transitions from Queued.
-            let m = machine_at(*state);
-            assert_eq!(m.is_terminal(), *expected, "is_terminal() for {state:?}");
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // 5. cancel_from_queued
-    // -------------------------------------------------------------------------
-    #[test]
-    fn cancel_from_queued() {
-        let mut m = JobStateMachine::new("j");
-        assert_eq!(m.cancel(), Ok(()));
-        assert_eq!(m.state(), JobState::Canceled);
-    }
-
-    // -------------------------------------------------------------------------
-    // 6. cancel_from_running
-    // -------------------------------------------------------------------------
-    #[test]
-    fn cancel_from_running() {
-        let mut m = JobStateMachine::new("j");
-        m.transition_to(JobState::Running).unwrap();
-        assert_eq!(m.cancel(), Ok(()));
-        assert_eq!(m.state(), JobState::Canceled);
-    }
-
-    // -------------------------------------------------------------------------
-    // 7. needs_reboot_from_running
-    // -------------------------------------------------------------------------
-    #[test]
-    fn needs_reboot_from_running() {
-        let mut m = JobStateMachine::new("j");
-        m.transition_to(JobState::Running).unwrap();
-        assert_eq!(m.needs_reboot(), Ok(()));
-        assert_eq!(m.state(), JobState::NeedsReboot);
-    }
-
-    // -------------------------------------------------------------------------
-    // 8. cancel_from_terminal_fails
-    // -------------------------------------------------------------------------
-    #[test]
-    fn cancel_from_terminal_fails() {
-        let mut m = JobStateMachine::new("j");
-        m.transition_to(JobState::Canceled).unwrap();
-        let result = m.cancel();
-        assert!(
-            matches!(result, Err(JobError::InvalidTransition { .. })),
-            "expected Err(InvalidTransition), got {result:?}"
-        );
-    }
-
-    // -------------------------------------------------------------------------
-    // 9. error_message_includes_states
-    // -------------------------------------------------------------------------
-    #[test]
-    fn error_message_includes_states() {
-        let err = JobError::InvalidTransition {
-            from: JobState::Queued,
-            to: JobState::Succeeded,
-        };
-        let msg = err.to_string();
-        assert!(
-            msg.contains("Queued"),
-            "error message missing 'Queued': {msg:?}"
-        );
-        assert!(
-            msg.contains("Succeeded"),
-            "error message missing 'Succeeded': {msg:?}"
-        );
-    }
-
-    // -------------------------------------------------------------------------
-    // 10. allowed_transition_free_fn_matches_machine
-    // -------------------------------------------------------------------------
-    #[test]
-    fn allowed_transition_free_fn_matches_machine() {
-        assert!(
-            allowed_transition(&JobState::Queued, &JobState::Running),
-            "Queued->Running should be allowed"
-        );
-        assert!(
-            !allowed_transition(&JobState::Succeeded, &JobState::Running),
-            "Succeeded->Running should not be allowed"
-        );
-    }
-
-    // -------------------------------------------------------------------------
-    // Helper: drive a fresh machine to any reachable state.
-    // -------------------------------------------------------------------------
-    fn machine_at(target: JobState) -> JobStateMachine {
-        let mut m = JobStateMachine::new("j");
-        match target {
-            JobState::Queued => {}
-            JobState::Running => {
-                m.transition_to(JobState::Running).unwrap();
-            }
-            JobState::Succeeded => {
-                m.transition_to(JobState::Running).unwrap();
-                m.transition_to(JobState::Succeeded).unwrap();
-            }
-            JobState::Failed => {
-                m.transition_to(JobState::Running).unwrap();
-                m.transition_to(JobState::Failed).unwrap();
-            }
-            JobState::Canceled => {
-                m.transition_to(JobState::Canceled).unwrap();
-            }
-            JobState::RolledBack => {
-                m.transition_to(JobState::Running).unwrap();
-                m.transition_to(JobState::RolledBack).unwrap();
-            }
-            JobState::NeedsReboot => {
-                m.transition_to(JobState::Running).unwrap();
-                m.transition_to(JobState::NeedsReboot).unwrap();
+    fn terminal_states_cannot_be_left() {
+        for from in ALL.iter().filter(|s| is_terminal(s)) {
+            for to in ALL {
+                assert!(
+                    !allowed_transition(from, to),
+                    "terminal {from:?} must not transition to {to:?}"
+                );
             }
         }
-        m
+    }
+
+    #[test]
+    fn queued_and_running_are_not_terminal() {
+        assert!(!is_terminal(&JobState::Queued));
+        assert!(!is_terminal(&JobState::Running));
+    }
+
+    #[test]
+    fn a_job_cannot_restart_after_finishing() {
+        // The property the old struct tests were really about: once a job
+        // reaches NeedsReboot (or any terminal state) it cannot go Running
+        // again and be executed twice.
+        assert!(!allowed_transition(
+            &JobState::NeedsReboot,
+            &JobState::Running
+        ));
+        assert!(!allowed_transition(
+            &JobState::Succeeded,
+            &JobState::Running
+        ));
+        assert!(!allowed_transition(&JobState::Canceled, &JobState::Running));
     }
 }

--- a/crates/sysknife-daemon/src/main.rs
+++ b/crates/sysknife-daemon/src/main.rs
@@ -137,6 +137,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
+    // Anchor signed checkpoints to an external append-only sink.
+    //
+    // The chain walk alone cannot detect tail truncation, and an attacker who
+    // holds the signing key can re-sign a rewritten history so it verifies
+    // perfectly. A previously anchored `(seq, tip)` is what exposes both. That
+    // machinery existed and was tested but nothing ever called it, so the
+    // defence was dormant unless an operator ran `sysknife audit checkpoint`
+    // on a timer of their own.
+    start_checkpoint_anchoring(&state, &database_path);
+
     match listen_target {
         ListenTarget::Unix(path) => {
             let std_listener = bind_unix_listener(&ListenTarget::Unix(path))?;
@@ -307,6 +317,64 @@ async fn vsock_accept_loop(
             }
         }
     }
+}
+
+/// Start periodic checkpoint anchoring, or say clearly that it is off.
+///
+/// Anchoring needs an *independent* append-only store — anchoring into the
+/// same database an attacker already controls proves nothing — so it is opt-in
+/// via `SYSKNIFE_CHECKPOINT_DB`. When unset the daemon still runs, but the
+/// operator is told the truth at startup instead of being left to assume a
+/// documented guarantee is active.
+fn start_checkpoint_anchoring(state: &DaemonState, database_path: &std::path::Path) {
+    use sysknife_daemon::checkpoint_sink::{
+        spawn_periodic_anchor, PostgresCheckpointSink, DEFAULT_ANCHOR_INTERVAL,
+    };
+
+    let Ok(db_url) = std::env::var("SYSKNIFE_CHECKPOINT_DB") else {
+        eprintln!(
+            "[sysknife-daemon] checkpoint anchoring is OFF (SYSKNIFE_CHECKPOINT_DB unset). \
+             The audit chain is still signed, but tail truncation and a rewrite by someone \
+             holding the signing key are NOT detectable without an external anchor."
+        );
+        return;
+    };
+
+    let key_path = sysknife_daemon::audit_chain::resolve_audit_key_path(database_path);
+    let key = match sysknife_daemon::audit_chain::AuditKey::load_or_generate(&key_path) {
+        Ok(key) => Arc::new(key),
+        Err(e) => {
+            eprintln!(
+                "[sysknife-daemon] checkpoint anchoring DISABLED: loading the audit key \
+                 from {} failed: {e}",
+                key_path.display()
+            );
+            return;
+        }
+    };
+
+    let audit = Arc::clone(&state.audit);
+    tokio::spawn(async move {
+        // Connecting is done inside the task so a checkpoint database that is
+        // slow or briefly down cannot delay the daemon accepting connections.
+        match PostgresCheckpointSink::connect(&db_url).await {
+            Ok(sink) => {
+                eprintln!(
+                    "[sysknife-daemon] checkpoint anchoring ON (every {}s)",
+                    DEFAULT_ANCHOR_INTERVAL.as_secs()
+                );
+                spawn_periodic_anchor(audit, key, Arc::new(sink), DEFAULT_ANCHOR_INTERVAL);
+            }
+            Err(e) => {
+                // Deliberately not fatal: losing the anchor must not take the
+                // control plane down, but it must be loud.
+                eprintln!(
+                    "[sysknife-daemon] checkpoint anchoring DISABLED: connecting to the \
+                     checkpoint database failed: {e}"
+                );
+            }
+        }
+    });
 }
 
 /// Build the audit forwarder from `[audit.forward]` config. Returns `None` if

--- a/crates/sysknife-daemon/src/policy.rs
+++ b/crates/sysknife-daemon/src/policy.rs
@@ -15,8 +15,6 @@ use std::collections::HashMap;
 
 use sysknife_types::{CallerRole, RiskLevel};
 
-use crate::auth::role_rank;
-
 // ---------------------------------------------------------------------------
 // Per-action minimum role
 // ---------------------------------------------------------------------------
@@ -65,7 +63,7 @@ fn role_exception(action_name: &str) -> Option<CallerRole> {
 /// override is a *raise*).
 pub fn action_allowed(caller: &CallerRole, action_name: &str) -> bool {
     match min_role_for_action(action_name) {
-        Some(required) => role_rank(caller) >= role_rank(&required),
+        Some(required) => *caller >= required,
         None => false,
     }
 }
@@ -148,7 +146,7 @@ impl PolicyTable {
 
             let attempted = role_for_risk_level(level);
 
-            if role_rank(&attempted) < role_rank(&baseline) {
+            if attempted < baseline {
                 return Err(PolicyValidationError::CannotLower {
                     action: action.clone(),
                     baseline,
@@ -173,7 +171,7 @@ impl PolicyTable {
     /// table. Returns `false` for unknown actions.
     pub fn action_allowed(&self, caller: &CallerRole, action_name: &str) -> bool {
         match self.min_role_for_action(action_name) {
-            Some(required) => role_rank(caller) >= role_rank(&required),
+            Some(required) => *caller >= required,
             None => false,
         }
     }

--- a/crates/sysknife-daemon/src/store.rs
+++ b/crates/sysknife-daemon/src/store.rs
@@ -377,7 +377,6 @@ mod tests {
             request_hash: format!("hash-{request_id}"),
             action_name: "UpdateSystem".to_string(),
             risk_level: RiskLevel::High,
-            approval_id: None,
             summary: "Upgrade the system".to_string(),
             warnings: vec![],
         }

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -718,10 +718,9 @@ async fn insert_transaction(
     let status = JobState::Queued;
     let created_at = now_iso();
     let key_id = CURRENT_KEY_ID.to_string();
-    let approval_id = transaction
-        .approval_id
-        .clone()
-        .or_else(|| Some(key.approval_commitment(transaction_id, &transaction.request_hash)));
+    // Always the store's own commitment — see the matching note in
+    // `transactions.rs`; a caller may not supply this value.
+    let approval_id = Some(key.approval_commitment(transaction_id, &transaction.request_hash));
 
     // SELECT … FOR UPDATE on the most-recent row (if any) so concurrent
     // writers serialise on the chain tip. Without this, two parallel

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -1411,6 +1411,142 @@ mod tests {
     }
 
     #[test]
+    fn revoke_unconsumed_approval_removes_an_unused_receipt() {
+        // Revocation is the operator's "actually, no" between approving and
+        // executing. Nothing covered it at all.
+        let dir = tempdir().unwrap();
+        let store = test_store(dir.path().join("tx.db"));
+        let tx = store.record(queued_transaction()).unwrap();
+        let receipt = store
+            .approve_transaction(&tx.transaction_id)
+            .unwrap()
+            .expect("approved");
+        let digest = audit_chain::approval_receipt_digest(&receipt);
+
+        assert!(
+            store
+                .revoke_unconsumed_approval(&tx.transaction_id)
+                .unwrap(),
+            "an unconsumed approval must be revocable"
+        );
+        assert!(
+            !store
+                .claim_approved_for_execution(&tx.transaction_id, &digest)
+                .unwrap(),
+            "a revoked receipt must no longer be claimable"
+        );
+    }
+
+    #[test]
+    fn revoke_cannot_retract_an_approval_that_was_already_used() {
+        // The documented guarantee: once a receipt has been consumed, the
+        // execution it authorised is a fact and revocation must not rewrite
+        // history to say otherwise.
+        let dir = tempdir().unwrap();
+        let store = test_store(dir.path().join("tx.db"));
+        let tx = store.record(queued_transaction()).unwrap();
+        let receipt = store
+            .approve_transaction(&tx.transaction_id)
+            .unwrap()
+            .expect("approved");
+        let digest = audit_chain::approval_receipt_digest(&receipt);
+        assert!(store
+            .claim_approved_for_execution(&tx.transaction_id, &digest)
+            .unwrap());
+
+        assert!(
+            !store
+                .revoke_unconsumed_approval(&tx.transaction_id)
+                .unwrap(),
+            "a consumed approval must not be revocable"
+        );
+        assert_eq!(
+            store.get(&tx.transaction_id).unwrap().unwrap().status,
+            JobState::Running,
+            "a failed revocation must not disturb the running transaction"
+        );
+    }
+
+    #[test]
+    fn approve_refuses_a_transaction_that_is_no_longer_queued() {
+        // Every existing approve test starts from a freshly-recorded Queued
+        // row. Approving something already running (or finished) would mint a
+        // receipt for work that is past the point of approval.
+        let dir = tempdir().unwrap();
+        let store = test_store(dir.path().join("tx.db"));
+        let tx = store.record(queued_transaction()).unwrap();
+        let receipt = store
+            .approve_transaction(&tx.transaction_id)
+            .unwrap()
+            .expect("approved");
+        let digest = audit_chain::approval_receipt_digest(&receipt);
+        assert!(store
+            .claim_approved_for_execution(&tx.transaction_id, &digest)
+            .unwrap());
+
+        // Running.
+        assert!(
+            store
+                .approve_transaction(&tx.transaction_id)
+                .unwrap()
+                .is_none(),
+            "a Running transaction must not be approvable"
+        );
+
+        // Terminal.
+        store
+            .update_status(&tx.transaction_id, JobState::Succeeded)
+            .unwrap();
+        assert!(
+            store
+                .approve_transaction(&tx.transaction_id)
+                .unwrap()
+                .is_none(),
+            "a completed transaction must not be approvable"
+        );
+    }
+
+    #[test]
+    fn only_one_of_two_concurrent_claims_can_execute() {
+        // `claim_approved_for_execution` is the interlock that stops one
+        // approval being spent twice. `update_status` has a concurrency test;
+        // this path had none, and a double claim means the same approved
+        // action runs twice.
+        let dir = tempdir().unwrap();
+        let store = std::sync::Arc::new(test_store(dir.path().join("tx.db")));
+        let tx = store.record(queued_transaction()).unwrap();
+        let receipt = store
+            .approve_transaction(&tx.transaction_id)
+            .unwrap()
+            .expect("approved");
+        let digest = audit_chain::approval_receipt_digest(&receipt);
+
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let store = std::sync::Arc::clone(&store);
+            let id = tx.transaction_id.clone();
+            let digest = digest.clone();
+            handles.push(std::thread::spawn(move || {
+                store.claim_approved_for_execution(&id, &digest)
+            }));
+        }
+        let claims: Vec<bool> = handles
+            .into_iter()
+            .map(|h| h.join().unwrap().unwrap_or(false))
+            .collect();
+
+        assert_eq!(
+            claims.iter().filter(|c| **c).count(),
+            1,
+            "exactly one claim may win: {claims:?}"
+        );
+        assert_eq!(
+            store.get(&tx.transaction_id).unwrap().unwrap().status,
+            JobState::Running
+        );
+    }
+
+    #[test]
     fn cancel_queued_cancels_a_queued_transaction_once() {
         let dir = tempdir().unwrap();
         let store = test_store(dir.path().join("tx.db"));

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -48,7 +48,6 @@ pub struct NewTransaction {
     pub request_hash: String,
     pub action_name: String,
     pub risk_level: RiskLevel,
-    pub approval_id: Option<String>,
     /// Human-readable description of the planned action.
     ///
     /// **Chain-hashed at INSERT; intentionally not in the mutable field set.**
@@ -836,9 +835,13 @@ impl TransactionStore {
         let risk_level = transaction.risk_level;
         // Initial status is always Queued — not caller-controllable.
         let status = JobState::Queued;
-        let approval_id = transaction
-            .approval_id
-            .or_else(|| Some(key.approval_commitment(transaction_id, &request_hash)));
+        // Always the store's own commitment over this transaction. It used to
+        // accept a caller-supplied `Some(..)` and use it verbatim; production
+        // always passed `None`, so the invariant held only because every call
+        // site remembered to. The value is chain-hashed and then treated as
+        // authoritative evidence that an approval happened, which is not
+        // something a caller may hand us.
+        let approval_id = Some(key.approval_commitment(transaction_id, &request_hash));
         let summary = transaction.summary;
         let warnings = transaction.warnings;
         let warnings_json = serde_json::to_string(&warnings)?;
@@ -1068,7 +1071,6 @@ mod tests {
                         request_hash: format!("hash-{w}-{r}"),
                         action_name: "GetSystemState".to_string(),
                         risk_level: RiskLevel::Low,
-                        approval_id: None,
                         summary: format!("worker {w} record {r}"),
                         warnings: vec![],
                     };
@@ -1249,7 +1251,6 @@ mod tests {
             request_hash: "hash-abc".to_string(),
             action_name: "UpdateSystem".to_string(),
             risk_level: RiskLevel::High,
-            approval_id: None,
             summary: "Upgrade the system".to_string(),
             warnings: vec![],
         }

--- a/crates/sysknife-daemon/src/transport/framing.rs
+++ b/crates/sysknife-daemon/src/transport/framing.rs
@@ -130,6 +130,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn truncated_body_errors_instead_of_hanging() {
+        // A header promising N bytes followed by fewer than N, then EOF. The
+        // reader must fail, not block forever waiting for bytes that will
+        // never arrive — a peer that dies mid-frame otherwise pins a
+        // connection slot for the life of the daemon.
+        let (a, b) = duplex(MAX_MESSAGE_BYTES + 8);
+        let mut recvr = FramedStream::new(b);
+        let mut raw_sender = a;
+
+        raw_sender.write_all(&8u32.to_le_bytes()).await.unwrap();
+        raw_sender.write_all(b"abc").await.unwrap(); // 3 of the promised 8
+        drop(raw_sender); // EOF mid-body
+
+        let err = recvr.recv().await.unwrap_err();
+        assert!(
+            matches!(err, FramingError::Io(_)),
+            "a truncated body must surface as an I/O error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn truncated_header_errors_instead_of_hanging() {
+        // Same failure mode one step earlier: the 4-byte length prefix itself
+        // arrives incomplete.
+        let (a, b) = duplex(MAX_MESSAGE_BYTES + 8);
+        let mut recvr = FramedStream::new(b);
+        let mut raw_sender = a;
+
+        raw_sender.write_all(&[0x01, 0x02]).await.unwrap(); // 2 of 4
+        drop(raw_sender);
+
+        let err = recvr.recv().await.unwrap_err();
+        assert!(
+            matches!(err, FramingError::Io(_)),
+            "a truncated header must surface as an I/O error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn multiple_messages_on_same_stream() {
         let (a, b) = duplex(MAX_MESSAGE_BYTES + 8);
         let mut sender = FramedStream::new(a);

--- a/crates/sysknife-daemon/tests/action_consistency.rs
+++ b/crates/sysknife-daemon/tests/action_consistency.rs
@@ -272,3 +272,25 @@ fn every_catalogued_action_has_a_preview_profile() {
 // auto-approval gate derives risk from `preview::gate_risk` (the spec), so it can
 // no longer be mis-sized by the LLM's proposed risk. The prompt.rs risk labels
 // are advisory only — every risk-gated decision reads the spec.
+
+// ---------------------------------------------------------------------------
+// Catalogue drift — already covered, deliberately not re-asserted here
+// ---------------------------------------------------------------------------
+//
+// A review flagged that nothing pins `sysknife_types::KNOWN_ACTION_NAMES`
+// against the daemon's `build_action_spec` arms, leaving three independently
+// maintained action lists free to drift.
+//
+// The link is already closed, just not in one test:
+//
+//   KNOWN_ACTION_NAMES  ==  brain KNOWN_ACTIONS
+//        `action_name.rs::every_known_action_is_in_types_list` (subset AND
+//        equal length, so the two sets are identical)
+//   brain KNOWN_ACTIONS ==  catalogue()
+//        `every_spec_action_exists_in_brain_known_actions` +
+//        `brain_known_actions_has_no_stale_entries`
+//   catalogue()         ->  build_action_spec
+//        `every_spec_action_is_recognised_by_executor`
+//
+// Adding a direct assertion would restate a property these already guarantee,
+// so it is left out on purpose rather than forgotten.

--- a/crates/sysknife-daemon/tests/bootstrap.rs
+++ b/crates/sysknife-daemon/tests/bootstrap.rs
@@ -1,5 +1,5 @@
 use sysknife_daemon::auth::highest_role_from_groups;
-use sysknife_daemon::jobs::JobStateMachine;
+use sysknife_daemon::jobs::allowed_transition;
 use sysknife_daemon::state::DaemonConfig;
 use sysknife_daemon::transactions::{NewTransaction, TransactionStore};
 use sysknife_daemon::transport::listen::{bind_unix_listener, ListenTarget};
@@ -116,14 +116,14 @@ fn transaction_records_are_persisted() {
 }
 
 #[test]
-fn job_state_machine_rejects_invalid_transitions() {
-    let mut job = JobStateMachine::new("job-1");
-
-    assert_eq!(job.state(), JobState::Queued);
-    job.transition_to(JobState::Running)
-        .expect("queued -> running");
-    job.transition_to(JobState::NeedsReboot)
-        .expect("running -> needs reboot");
-    assert_eq!(job.state(), JobState::NeedsReboot);
-    assert!(job.transition_to(JobState::Running).is_err());
+fn the_transition_table_rejects_restarting_a_finished_job() {
+    assert!(allowed_transition(&JobState::Queued, &JobState::Running));
+    assert!(allowed_transition(
+        &JobState::Running,
+        &JobState::NeedsReboot
+    ));
+    assert!(!allowed_transition(
+        &JobState::NeedsReboot,
+        &JobState::Running
+    ));
 }

--- a/crates/sysknife-daemon/tests/bootstrap.rs
+++ b/crates/sysknife-daemon/tests/bootstrap.rs
@@ -82,7 +82,6 @@ fn transaction_records_are_persisted() {
         request_hash: "hash-1".into(),
         action_name: "UpdateSystem".into(),
         risk_level: RiskLevel::High,
-        approval_id: Some("approval-1".into()),
         summary: "Stage system update".into(),
         warnings: vec!["reboot required".into()],
     };
@@ -97,7 +96,22 @@ fn transaction_records_are_persisted() {
     assert_eq!(loaded.request_hash, "hash-1");
     assert_eq!(loaded.action_name, "UpdateSystem");
     assert_eq!(loaded.status, JobState::Queued);
-    assert_eq!(loaded.approval_id.as_deref(), Some("approval-1"));
+    // `approval_id` is the store's own SHA-256 commitment over
+    // (transaction_id, request_hash) — a caller can no longer supply it, so
+    // assert the shape the store guarantees rather than an injected string.
+    let approval_id = loaded
+        .approval_id
+        .as_deref()
+        .expect("the store always derives an approval commitment");
+    assert_eq!(
+        approval_id.len(),
+        64,
+        "expected a hex SHA-256 digest, got {approval_id:?}"
+    );
+    assert!(
+        approval_id.chars().all(|c| c.is_ascii_hexdigit()),
+        "expected a hex digest, got {approval_id:?}"
+    );
     assert_eq!(loaded.warnings, vec!["reboot required".to_string()]);
 }
 

--- a/crates/sysknife-daemon/tests/coverage_gaps.rs
+++ b/crates/sysknife-daemon/tests/coverage_gaps.rs
@@ -94,7 +94,6 @@ fn make_transaction(action: &str) -> NewTransaction {
         request_hash: format!("hash-{action}"),
         action_name: action.to_string(),
         risk_level: RiskLevel::High,
-        approval_id: None,
         summary: format!("Test {action}"),
         warnings: vec![],
     }
@@ -117,7 +116,6 @@ fn list_transactions_limit_is_capped_at_100() {
                 request_hash: format!("hash-{i}"),
                 action_name: "UpdateSystem".into(),
                 risk_level: RiskLevel::High,
-                approval_id: None,
                 summary: format!("tx {i}"),
                 warnings: vec![],
             })
@@ -189,7 +187,6 @@ async fn list_job_history_returns_recorded_transactions() {
             request_hash: "hash-history".into(),
             action_name: "UpdateSystem".into(),
             risk_level: RiskLevel::High,
-            approval_id: None,
             summary: "Stage system update".into(),
             warnings: vec![],
         })

--- a/crates/sysknife-daemon/tests/execute_spec.rs
+++ b/crates/sysknife-daemon/tests/execute_spec.rs
@@ -419,3 +419,31 @@ async fn execute_spec_kills_a_child_that_outruns_the_action_timeout() {
         "error must say the action timed out, got: {msg}"
     );
 }
+
+/// A child killed by a signal has no exit code; the executor maps that to -1.
+///
+/// `execute_spec` and `execute_command_with_progress` both do
+/// `.code().unwrap_or(-1)`, and nothing exercised the `None` branch — the
+/// existing tests only cover a plain nonzero exit. The distinction matters:
+/// a process killed by the OOM killer or by the action timeout reports -1,
+/// not a normal failure code.
+#[tokio::test]
+async fn signal_killed_child_reports_exit_code_minus_one() {
+    let spec = ActionSpec {
+        action_name: "SignalProbe",
+        mechanism: ActionMechanism::Command {
+            program: "sh",
+            // The shell SIGKILLs itself, so wait() yields a signal status.
+            args: vec!["-c".to_string(), "kill -9 $$".to_string()],
+        },
+        risk_level: sysknife_types::RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    };
+
+    let out = execute_spec(&spec).await.expect("spawning must succeed");
+    assert_eq!(
+        out.exit_code, -1,
+        "a signal-terminated child must map to -1, not a normal exit code"
+    );
+}

--- a/crates/sysknife-daemon/tests/fail_closed_paths.rs
+++ b/crates/sysknife-daemon/tests/fail_closed_paths.rs
@@ -1,0 +1,184 @@
+//! The daemon's deny paths, exercised rather than assumed.
+//!
+//! Two properties here were relied on everywhere and tested nowhere:
+//!
+//! 1. **A store error denies.** Eight handlers map a `TransactionStoreError`
+//!    to `transient_infrastructure_failure` and refuse the request. Nothing
+//!    reached any of them, so a refactor turning one `Err` arm into an
+//!    implicit allow would have been an approval-boundary bypass that the
+//!    suite could not see. (`grep transient_infrastructure_failure tests/`
+//!    returned nothing before this file existed.)
+//!
+//! 2. **Preview never executes.** `handle_preview` is structurally pure — it
+//!    calls `preview_action` and nothing else — but that is a property of the
+//!    current code, not a pinned guarantee. A preview that quietly ran the
+//!    action would defeat the entire approve-before-execute model.
+
+use std::io;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use sysknife_daemon::actions::ActionSpec;
+use sysknife_daemon::dispatcher::connection_handler_with_executor;
+use sysknife_daemon::executor::{ActionExecutor, ExecutionOutput, ExecutorError};
+use sysknife_daemon::state::{DaemonConfig, DaemonState};
+use sysknife_daemon::state_collector::CommandRunner;
+use sysknife_daemon::store::SqliteStore;
+use sysknife_daemon::transactions::TransactionStore;
+use sysknife_daemon::transport::{framing::FramedStream, listen::ListenTarget};
+use sysknife_types::{CallerRole, JobState};
+use tempfile::tempdir;
+use tokio::net::UnixStream;
+
+struct MockRunner;
+
+impl CommandRunner for MockRunner {
+    fn run(&self, _program: &str, _args: &[&str]) -> Result<String, io::Error> {
+        Ok(String::new())
+    }
+}
+
+/// Fails the test loudly if the dispatcher ever asks it to execute.
+struct PanicExecutor;
+
+#[async_trait]
+impl ActionExecutor for PanicExecutor {
+    async fn execute(&self, spec: &ActionSpec) -> Result<ExecutionOutput, ExecutorError> {
+        panic!(
+            "the executor must not be reached from a preview — got {}",
+            spec.action_name
+        );
+    }
+}
+
+async fn spawn_handler(
+    state: DaemonState,
+    executor: Arc<dyn ActionExecutor>,
+    role: CallerRole,
+) -> FramedStream<UnixStream> {
+    let (client, server) = UnixStream::pair().unwrap();
+    let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(MockRunner);
+    tokio::spawn(async move {
+        connection_handler_with_executor(server, state, runner, executor, role).await;
+    });
+    FramedStream::new(client)
+}
+
+async fn send(framed: &mut FramedStream<UnixStream>, msg: Value) -> Value {
+    framed
+        .send(&serde_json::to_vec(&msg).unwrap())
+        .await
+        .unwrap();
+    serde_json::from_slice(&framed.recv().await.unwrap()).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// 1. A store that cannot write must deny, not proceed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn approve_denies_when_the_audit_store_cannot_persist() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("audit.db");
+
+    // Create a real queued transaction with a writable store.
+    let transaction_id = {
+        let state = DaemonState::open(DaemonConfig::new(
+            ListenTarget::Unix(dir.path().join("a.sock")),
+            &db_path,
+        ))
+        .unwrap();
+        let mut framed = spawn_handler(state, Arc::new(PanicExecutor), CallerRole::Admin).await;
+        let resp = send(
+            &mut framed,
+            json!({
+                "type": "preview",
+                "request_id": "preview-1",
+                "action_name": "AptInstall",
+                "params": {"package": "vim"},
+            }),
+        )
+        .await;
+        resp["transaction_id"]
+            .as_str()
+            .expect("preview returns a transaction id")
+            .to_string()
+    };
+
+    // Now serve the same database read-only. `approve_transaction` cannot sign
+    // without the audit key, which is the shape of a real disk/permission
+    // failure — and exactly what the `Err(e)` arm is supposed to catch.
+    let read_only = TransactionStore::open_read_only(&db_path).unwrap();
+    let state = DaemonState::open_with_audit(
+        DaemonConfig::new(ListenTarget::Unix(dir.path().join("b.sock")), &db_path),
+        sysknife_daemon::policy::PolicyTable::empty(),
+        None,
+        Arc::new(SqliteStore::new(read_only)),
+    );
+    let mut framed = spawn_handler(state, Arc::new(PanicExecutor), CallerRole::Admin).await;
+
+    let resp = send(
+        &mut framed,
+        json!({
+            "type": "approve",
+            "request_id": "approve-1",
+            "transaction_id": transaction_id,
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        resp["category"].as_str(),
+        Some("transient_infrastructure_failure"),
+        "a store that cannot persist the approval must deny it: {resp}"
+    );
+
+    // The decisive part: denial must leave the transaction unapproved, so a
+    // later execute cannot find a receipt waiting for it.
+    let check = TransactionStore::open_read_only(&db_path).unwrap();
+    let record = check.get(&transaction_id).unwrap().expect("row exists");
+    assert_eq!(
+        record.status,
+        JobState::Queued,
+        "a denied approval must not advance the transaction"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Preview must never execute
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn preview_never_reaches_the_executor() {
+    let dir = tempdir().unwrap();
+    let state = DaemonState::open(DaemonConfig::new(
+        ListenTarget::Unix(dir.path().join("p.sock")),
+        dir.path().join("p.db"),
+    ))
+    .unwrap();
+    // Any call into this executor panics the handler task.
+    let mut framed = spawn_handler(state, Arc::new(PanicExecutor), CallerRole::Admin).await;
+
+    // A high-risk mutating action: the one most worth never running early.
+    let resp = send(
+        &mut framed,
+        json!({
+            "type": "preview",
+            "request_id": "preview-mutating",
+            "action_name": "AptUpgrade",
+            "params": {},
+        }),
+    )
+    .await;
+
+    assert_ne!(
+        resp["type"].as_str(),
+        Some("error_response"),
+        "preview of a valid action should succeed: {resp}"
+    );
+    assert!(
+        resp.get("transaction_id").is_some(),
+        "preview must return a transaction to approve: {resp}"
+    );
+}

--- a/crates/sysknife-daemon/tests/postgres_store.rs
+++ b/crates/sysknife-daemon/tests/postgres_store.rs
@@ -19,7 +19,6 @@ fn new_transaction() -> NewTransaction {
         request_hash: "postgres-contract-hash".to_string(),
         action_name: "RestartService".to_string(),
         risk_level: RiskLevel::Medium,
-        approval_id: None,
         summary: "Restart sshd".to_string(),
         warnings: vec!["brief connection interruption".to_string()],
     }

--- a/crates/sysknife-daemon/tests/preview_approval.rs
+++ b/crates/sysknife-daemon/tests/preview_approval.rs
@@ -1,5 +1,5 @@
 use serde_json::json;
-use sysknife_daemon::jobs::JobStateMachine;
+use sysknife_daemon::jobs::{allowed_transition, is_terminal};
 use sysknife_daemon::preview::preview_action;
 use sysknife_daemon::transactions::{NewTransaction, TransactionStore};
 use sysknife_types::{JobState, PreviewEnvelope, RequestEnvelope, RiskLevel};
@@ -172,23 +172,21 @@ fn reboot_preview_is_high_risk_without_rollback() {
 }
 
 #[test]
-fn job_state_machine_handles_cancellation_and_reboot_states() {
-    let mut job = JobStateMachine::new("job-1");
+fn a_running_job_can_be_cancelled_or_end_needing_a_reboot() {
+    // Both are terminal, and neither may be restarted — a job that already
+    // ran must not be able to run a second time.
+    assert!(allowed_transition(&JobState::Running, &JobState::Canceled));
+    assert!(is_terminal(&JobState::Canceled));
 
-    assert!(!job.is_terminal());
-    job.transition_to(JobState::Running).expect("start job");
-    job.cancel().expect("cancel running job");
-    assert_eq!(job.state(), JobState::Canceled);
-    assert!(job.is_terminal());
-
-    let mut rebooting_job = JobStateMachine::new("job-2");
-    rebooting_job
-        .transition_to(JobState::Running)
-        .expect("start job");
-    rebooting_job.needs_reboot().expect("mark reboot required");
-    assert_eq!(rebooting_job.state(), JobState::NeedsReboot);
-    assert!(rebooting_job.is_terminal());
-    assert!(rebooting_job.transition_to(JobState::Running).is_err());
+    assert!(allowed_transition(
+        &JobState::Running,
+        &JobState::NeedsReboot
+    ));
+    assert!(is_terminal(&JobState::NeedsReboot));
+    assert!(!allowed_transition(
+        &JobState::NeedsReboot,
+        &JobState::Running
+    ));
 }
 
 #[test]

--- a/crates/sysknife-daemon/tests/preview_approval.rs
+++ b/crates/sysknife-daemon/tests/preview_approval.rs
@@ -213,7 +213,6 @@ fn previewed_transactions_persist_preview_state() {
         request_hash: "hash-preview".to_string(),
         action_name: "UpdateSystem".to_string(),
         risk_level: RiskLevel::High,
-        approval_id: Some("approval-preview".to_string()),
         summary: "Stage system update".to_string(),
         warnings: vec!["system reboot required".to_string()],
     };

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -379,7 +379,17 @@ impl From<String> for RequestHash {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Caller privilege tier, ordered least to most privileged.
+///
+/// **Variant order is the privilege order** and `Ord` is derived from it, so
+/// `caller >= required` is the authorization comparison. This mirrors what
+/// v0.2.10 did for `PlanRiskLevel`; `CallerRole` kept a hand-written
+/// `role_rank` match until now, which is a second encoding of the same
+/// ordering that could drift from this declaration.
+///
+/// Adding a variant means placing it at the correct privilege position, not
+/// appending it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CallerRole {
     Observer,
@@ -513,24 +523,18 @@ fn job_state_code(value: JobState) -> i32 {
     }
 }
 
-fn failure_category_code(value: FailureCategory) -> i32 {
-    match value {
-        FailureCategory::ValidationFailure => 1,
-        FailureCategory::AuthorizationFailure => 2,
-        FailureCategory::PolicyDenied => 3,
-        FailureCategory::StaleApproval => 4,
-        FailureCategory::ExecutionFailure => 5,
-        FailureCategory::TransientInfrastructureFailure => 6,
-        FailureCategory::Cancellation => 7,
-        FailureCategory::StuckExecution => 8,
-        FailureCategory::RebootRequired => 9,
-        FailureCategory::RollbackFailure => 10,
-    }
-}
-
 impl From<CallerRole> for proto::CallerRole {
+    // Matched directly rather than round-tripping through the i32 code table
+    // and unwrapping. The conversion is total, so it should not be able to
+    // panic: this bridge is not on the live request path today, but once the
+    // daemon speaks proto it would be a panic-on-drift inside a root process.
     fn from(value: CallerRole) -> Self {
-        proto::CallerRole::try_from(caller_role_code(value)).expect("valid caller role")
+        match value {
+            CallerRole::Observer => proto::CallerRole::Observer,
+            CallerRole::Dev => proto::CallerRole::Dev,
+            CallerRole::Admin => proto::CallerRole::Admin,
+            CallerRole::Boot => proto::CallerRole::Boot,
+        }
     }
 }
 
@@ -553,7 +557,11 @@ impl TryFrom<proto::CallerRole> for CallerRole {
 
 impl From<RiskLevel> for proto::RiskLevel {
     fn from(value: RiskLevel) -> Self {
-        proto::RiskLevel::try_from(risk_level_code(value)).expect("valid risk level")
+        match value {
+            RiskLevel::Low => proto::RiskLevel::Low,
+            RiskLevel::Medium => proto::RiskLevel::Medium,
+            RiskLevel::High => proto::RiskLevel::High,
+        }
     }
 }
 
@@ -575,7 +583,15 @@ impl TryFrom<proto::RiskLevel> for RiskLevel {
 
 impl From<JobState> for proto::JobState {
     fn from(value: JobState) -> Self {
-        proto::JobState::try_from(job_state_code(value)).expect("valid job state")
+        match value {
+            JobState::Queued => proto::JobState::Queued,
+            JobState::Running => proto::JobState::Running,
+            JobState::Succeeded => proto::JobState::Succeeded,
+            JobState::Failed => proto::JobState::Failed,
+            JobState::Canceled => proto::JobState::Canceled,
+            JobState::RolledBack => proto::JobState::RolledBack,
+            JobState::NeedsReboot => proto::JobState::NeedsReboot,
+        }
     }
 }
 
@@ -601,8 +617,20 @@ impl TryFrom<proto::JobState> for JobState {
 
 impl From<FailureCategory> for proto::FailureCategory {
     fn from(value: FailureCategory) -> Self {
-        proto::FailureCategory::try_from(failure_category_code(value))
-            .expect("valid failure category")
+        match value {
+            FailureCategory::ValidationFailure => proto::FailureCategory::ValidationFailure,
+            FailureCategory::AuthorizationFailure => proto::FailureCategory::AuthorizationFailure,
+            FailureCategory::PolicyDenied => proto::FailureCategory::PolicyDenied,
+            FailureCategory::StaleApproval => proto::FailureCategory::StaleApproval,
+            FailureCategory::ExecutionFailure => proto::FailureCategory::ExecutionFailure,
+            FailureCategory::TransientInfrastructureFailure => {
+                proto::FailureCategory::TransientInfrastructureFailure
+            }
+            FailureCategory::Cancellation => proto::FailureCategory::Cancellation,
+            FailureCategory::StuckExecution => proto::FailureCategory::StuckExecution,
+            FailureCategory::RebootRequired => proto::FailureCategory::RebootRequired,
+            FailureCategory::RollbackFailure => proto::FailureCategory::RollbackFailure,
+        }
     }
 }
 
@@ -819,5 +847,34 @@ mod request_hash_tests {
         assert_eq!(json, "\"abc123\"");
         let back: RequestHash = serde_json::from_str("\"abc123\"").unwrap();
         assert_eq!(back, r);
+    }
+}
+
+#[cfg(test)]
+mod caller_role_ordering_tests {
+    use super::CallerRole;
+
+    #[test]
+    fn caller_role_orders_least_to_most_privileged() {
+        // The derived `Ord` IS the authorization comparison, so a variant
+        // reordered during an edit would silently change who can do what.
+        assert!(CallerRole::Observer < CallerRole::Dev);
+        assert!(CallerRole::Dev < CallerRole::Admin);
+        assert!(CallerRole::Admin < CallerRole::Boot);
+
+        // The comparison call sites rely on this shape directly.
+        assert!(CallerRole::Admin >= CallerRole::Dev);
+        assert!(!(CallerRole::Observer >= CallerRole::Dev));
+    }
+
+    #[test]
+    fn max_selects_the_higher_privilege() {
+        // `highest_role_from_groups` folds with `max`; a user in both the
+        // observer and admin groups must end up Admin.
+        assert_eq!(
+            CallerRole::Observer.max(CallerRole::Admin),
+            CallerRole::Admin
+        );
+        assert_eq!(CallerRole::Boot.max(CallerRole::Dev), CallerRole::Boot);
     }
 }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {


### PR DESCRIPTION
## Summary

The findings v0.2.11 deferred. Three groups: the dormant checkpoint anchoring,
the type-level holes, and the deny paths that were relied on everywhere and
asserted nowhere.

**The audit chain's anchor was never dropped.** `sign_checkpoint`,
`verify_checkpoints` and both sinks existed, were correct, and were tested —
and nothing in the daemon ever called them. Tail-truncation detection and
rewrite-by-a-key-holder detection were active only if an operator happened to
run `sysknife audit checkpoint` on a timer of their own, and the daemon gave no
hint either way. It now anchors on an interval when `SYSKNIFE_CHECKPOINT_DB` is
set and says plainly at startup when it is not.

Two tests close the real gap in that subsystem. Every pre-existing "rewrite"
test corrupted `chain_hash` with a garbage value that a plain signature check
already rejects, so none of them exercised the attack checkpoints exist for.
`a_previously_anchored_checkpoint_catches_a_key_holder_rewrite` builds a
tampered tail **re-signed with the real key**, asserts `verify_chain` reports
`Intact`, and only then shows the anchored tip catching it.

**Type-level holes.** `Plan::assume_authorized` was a plain `pub fn` — the one
bypass around the guarantee that the approval gate can never see the LLM's
self-reported risk, held shut by a doc comment. It is now behind a
`test-support` feature; the production build compiling without that feature is
the proof nothing on a live path used it. `NewTransaction.approval_id` was a
public field used verbatim at insert, despite being chain-hashed and then
treated as evidence that an approval happened.

**Deny paths.** Eight handlers map a store error to
`transient_infrastructure_failure` and refuse; `grep` over the test tree
returned nothing for that string. A refactor turning one `Err` arm into an
implicit allow would have been an approval-boundary bypass the suite could not
see.

Full detail in `CHANGELOG.md`.

## Related Issue

Follow-up to #110.

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`cargo nextest run --workspace --locked`: **1437 passed, 0 failed** (1417 on
`main`). `cargo clippy --workspace --all-targets`: zero warnings.

## Notes for Reviewers

**Three tests were removed or rewritten because they overstated their
coverage** — worth a look, since this deletes assertions:

- `JobStateMachine` is gone. Production calls the free `allowed_transition`;
  nothing ever constructed the struct. Its ten tests read as coverage of the
  live transition logic. The table is now tested directly and exhaustively
  over all 7×7 edges, which is strictly more coverage than before.
- `resolve_caller_role_on_pair_does_not_panic` discarded its result — it would
  have passed if the function returned `Boot` for everyone. It now derives the
  expectation from the same inputs the daemon uses.
- `inserted_forged_row_breaks_chain` accepted `seq == 2 || seq == 3` against a
  deterministic fixture, so an off-by-one in `verify_rows` would pass.

**One finding needed no change.** Nothing directly pins `KNOWN_ACTION_NAMES`
against `build_action_spec`, but three existing tests already guarantee it
transitively (types ≡ brain via subset **and equal length**, brain ≡ catalogue,
catalogue → executor). The chain is written down in `action_consistency.rs` so
it reads as deliberate rather than forgotten.

**Behaviour change worth confirming:** `ApprovalDecision::ExceedsCeiling` now
carries its ceiling. Making it a payload exposed two tests that had been
asserting the wrong ceiling value.

**Still outstanding, deliberately not in this PR:** adding `caller_role` to the
signed chain content. It is a real gap — no signed record answers "which role
requested this", and approval events live in an unchained table — but it
changes what goes into `chain_hash`, so it needs a migration story for existing
chains rather than a quick change at the end of a batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f
