### PR TITLE
Sign the caller's role into the audit chain, chain approval events, fence the read paths (v0.2.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
-## [Unreleased]
+## [0.2.13] — 2026-07-27
 
 The last item v0.2.12 deferred: the audit chain could say what was authorised,
 but not who asked for it, and nothing signed recorded that an approval ever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [Unreleased]
+
+The last item v0.2.12 deferred: the audit chain could say what was authorised,
+but not who asked for it, and nothing signed recorded that an approval ever
+happened.
+
+### Added
+
+- **`caller_role` is now part of the signed chain content.** Every transaction
+  row commits to the privilege tier the daemon resolved for the connection that
+  requested the action (from `SO_PEERCRED`, or the vsock token — never from the
+  request body). "Which role asked for this" is the first question any audit of
+  a privileged action starts with, and until now no signed record answered it.
+- **An approval-event chain.** `approval_granted`, `approval_consumed` and
+  `approval_revoked` are recorded in a second forward Ed25519 chain under its
+  own domain tag, each event committing in the same database transaction as the
+  state change it records. Previously these lifecycle facts lived only in
+  `transaction_approvals`, a plain mutable table: deleting a row left
+  `sysknife audit verify` reporting `Intact`, so the record that a privileged
+  action had been approved was the one part of the trail that could be erased
+  without leaving a mark.
+- **Cross-chain binding.** Each transaction row signs the approval-event chain
+  tip as of its insert. Deleting events from the *end* of the event chain
+  leaves a self-consistent remainder that the chain walk cannot see; the
+  committed tip catches it. Because checkpoints anchor the transaction chain,
+  this extends off-host anchoring to the event chain without a second sink.
+- `sysknife audit verify` reports all three checks and fails on any of them.
+  A detected tamper (exit `1`) outranks an inconclusive check (exit `2`), so a
+  broken chain is never reported as "could not verify". The MCP
+  `sysknife_audit_verify` report gains `events_checked`,
+  `approval_events_status` and `binding_status`, and its top-level `status` is
+  now the worst of the three rather than the transaction chain alone.
+
+### Changed
+
+- **Schema version 2, with a real migration.** Rows carry a `chain_version`
+  column and verification reproduces the exact encoding each row was signed
+  under, so a chain written by v0.2.12 or earlier still verifies after the
+  upgrade and new rows append onto it in the same walk. Backfilling the new
+  fields instead would have changed every historical message and reported the
+  whole chain as broken — an upgrade that looks identical to a compromise. The
+  SQLite backend gained an ordered migration list mirroring the Postgres one;
+  its previous `CREATE TABLE IF NOT EXISTS` batch had no way to express "add a
+  column to an existing database".
+- `CallerRole::as_str` replaces `format!("{role:?}")` for anything that is
+  written down. `Debug` carries no stability promise, and this string is inside
+  a signature.
+- `TransactionStore::revoke_unconsumed_approval` and
+  `claim_approved_for_execution` now require the signing key and refuse on a
+  read-only store, since both append to the event chain.
+
 ## [0.2.12] — 2026-07-27
 
 Follow-up to the v0.2.11 review sweep: the findings that release deferred.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,26 @@ happened.
   `claim_approved_for_execution` now require the signing key and refuse on a
   read-only store, since both append to the event chain.
 
+- `PlanningError::Provider` carries a `ProviderError` instead of its rendered
+  string. The shell recovered the classification by searching that string for
+  `"429"` and `"http"`, so editing a `#[error(...)]` format string in
+  `provider.rs` could silently reclassify a rate limit as a parse error. The
+  three planner tests that all asserted `Provider(_)` now assert the variant.
+- New `TransactionId` and `ApprovalReceipt` newtypes.
+  `DaemonClient::execute(transaction_id, action_name, params, approval_receipt, …)`
+  took three bare `&str` in a row, so transposing two of them compiled and
+  surfaced at runtime as a stale-approval error — which reads like an expiry,
+  not a call-site bug. `ApprovalReceipt` is a bearer credential, so its `Debug`
+  is redacted and it has no `Display`; the one place it is meant to be printed
+  calls `as_str()` explicitly. The MCP wire structs keep plain strings so the
+  published JSON Schema is unchanged.
+
 ### Fixed
 
+- **The MCP server introduced itself as `rmcp`.** `Implementation::from_build_env()`
+  resolves `CARGO_PKG_*` at the crate where the macro expands, which is `rmcp`,
+  so `initialize` reported the name and version of the transport library rather
+  than of SysKnife — the string clients and registry listings display.
 - **`describe` had no authorization check.** It renders the exact command an
   action would run, so any caller could enumerate the argv of every privileged
   action on the host. It now applies the same authorization gate and platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,21 @@ happened.
   `claim_approved_for_execution` now require the signing key and refuse on a
   read-only store, since both append to the event chain.
 
+### Fixed
+
+- **`describe` had no authorization check.** It renders the exact command an
+  action would run, so any caller could enumerate the argv of every privileged
+  action on the host. It now applies the same authorization gate and platform
+  fence as `preview`; an unknown action is still a `validation_failure`.
+- **`query_action` had no platform fence.** A Fedora-only read-only action
+  reached the executor on a Debian host and failed as "rpm-ostree: No such file
+  or directory" instead of the clean `unsupported_platform` refusal `preview`
+  and `execute` return.
+- **`[policy.risk_overrides]` no longer leaks into the platform fence.** Whether
+  an action mutates the system is a property of the action; the fence now reads
+  the compile-time baseline. Previously, raising a read-only action's required
+  role also made that read fail whenever the host distro could not be detected.
+
 ## [0.2.12] — 2026-07-27
 
 Follow-up to the v0.2.11 review sweep: the findings that release deferred.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,15 @@ happened.
   calls `as_str()` explicitly. The MCP wire structs keep plain strings so the
   published JSON Schema is unchanged.
 
+- Tests for three paths that had none: the MCP server over real stdio JSON-RPC
+  (`initialize` → `tools/list` against the spawned binary — everything else
+  called the handlers directly and skipped the wire), the approval gate
+  `run_intent` actually runs, and `PostgresCheckpointSink` against a live
+  database. The last one immediately caught a real bug: `fetch_chain_rows_from_pool`
+  still selected the pre-migration column list, so every Postgres chain read
+  would have failed with "no column found for name: chain_version". Both
+  backends now build that list from one constant.
+
 ### Fixed
 
 - **The MCP server introduced itself as `rmcp`.** `Implementation::from_build_env()`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "prost",
  "prost-build",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-cli/src/client.rs
+++ b/apps/sysknife-cli/src/client.rs
@@ -30,17 +30,17 @@ use std::time::Duration;
 use serde_json::Value;
 use sysknife_brain::planner::PlanningError;
 use sysknife_brain::state_client::{CuratedState, StateClient};
-use sysknife_types::{PreviewEnvelope, ResultEnvelope};
+use sysknife_types::{ApprovalReceipt, PreviewEnvelope, ResultEnvelope, TransactionId};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PreparedPreview {
-    pub transaction_id: String,
+    pub transaction_id: TransactionId,
     pub preview: PreviewEnvelope,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ApprovalDetails {
-    pub transaction_id: String,
+    pub transaction_id: TransactionId,
     pub action_name: String,
     pub preview: PreviewEnvelope,
 }
@@ -590,7 +590,7 @@ impl DaemonClient {
                         )
                     })?;
                 Ok(PreparedPreview {
-                    transaction_id: transaction_id.to_string(),
+                    transaction_id: TransactionId::new(transaction_id),
                     preview: envelope,
                 })
             }
@@ -609,7 +609,7 @@ impl DaemonClient {
     /// Fetch the daemon-authoritative preview before asking for approval.
     pub async fn approval_details(
         &self,
-        transaction_id: &str,
+        transaction_id: &TransactionId,
     ) -> Result<ApprovalDetails, CliError> {
         let mut stream = self.connect_async().await?;
         let req = serde_json::to_vec(&serde_json::json!({
@@ -650,7 +650,7 @@ impl DaemonClient {
                         })
                 };
                 Ok(ApprovalDetails {
-                    transaction_id: required("transaction_id")?,
+                    transaction_id: TransactionId::new(required("transaction_id")?),
                     action_name: required("action_name")?,
                     preview: serde_json::from_value(resp["preview"].clone()).map_err(|e| {
                         CliError::ConfigOrDaemon(format!("parse approval preview: {e}"))
@@ -670,7 +670,10 @@ impl DaemonClient {
     }
 
     /// Approve one exact preview and receive its one-time execution receipt.
-    pub async fn approve(&self, transaction_id: &str) -> Result<String, CliError> {
+    pub async fn approve(
+        &self,
+        transaction_id: &TransactionId,
+    ) -> Result<ApprovalReceipt, CliError> {
         let mut stream = self.connect_async().await?;
         let req = serde_json::to_vec(&serde_json::json!({
             "type": "approve",
@@ -700,7 +703,7 @@ impl DaemonClient {
             Some("approval_response") => resp["approval_receipt"]
                 .as_str()
                 .filter(|receipt| !receipt.is_empty())
-                .map(str::to_string)
+                .map(ApprovalReceipt::new)
                 .ok_or_else(|| {
                     CliError::ConfigOrDaemon(
                         "approval_response missing approval_receipt".to_string(),
@@ -775,10 +778,10 @@ impl DaemonClient {
     /// progress line with ANSI escapes already stripped.
     pub async fn execute(
         &self,
-        transaction_id: &str,
+        transaction_id: &TransactionId,
         action_name: &str,
         params: &Value,
-        approval_receipt: &str,
+        approval_receipt: &ApprovalReceipt,
         mut on_line: impl FnMut(&str),
     ) -> Result<ResultEnvelope, CliError> {
         let mut stream = self.connect_async().await?;
@@ -789,7 +792,7 @@ impl DaemonClient {
             "transaction_id": transaction_id,
             "action_name": action_name,
             "params": params,
-            "approval_receipt": approval_receipt,
+            "approval_receipt": approval_receipt.as_str(),
         }))
         .map_err(|e| CliError::ConfigOrDaemon(format!("serialize: {e}")))?;
 
@@ -1055,7 +1058,7 @@ mod tests {
         mock.await.unwrap();
         let _ = tokio::fs::remove_file(&socket_path).await;
 
-        assert_eq!(envelope.transaction_id, "tx-abc123");
+        assert_eq!(envelope.transaction_id.as_str(), "tx-abc123");
         assert_eq!(envelope.preview.request_hash.as_str(), "abcdef1234");
         assert_eq!(envelope.preview.summary, "Collect disk usage statistics");
         assert_eq!(envelope.preview.risk_level, RiskLevel::Low);
@@ -1086,13 +1089,13 @@ mod tests {
         });
 
         let receipt = DaemonClient::new(socket_path.clone())
-            .approve("tx-abc123")
+            .approve(&TransactionId::new("tx-abc123"))
             .await
             .unwrap();
 
         mock.await.unwrap();
         let _ = tokio::fs::remove_file(&socket_path).await;
-        assert_eq!(receipt, "receipt-abc");
+        assert_eq!(receipt.as_str(), "receipt-abc");
     }
 
     #[tokio::test]
@@ -1129,13 +1132,13 @@ mod tests {
         });
 
         let details = DaemonClient::new(socket_path.clone())
-            .approval_details("tx-abc123")
+            .approval_details(&TransactionId::new("tx-abc123"))
             .await
             .unwrap();
         mock.await.unwrap();
         let _ = tokio::fs::remove_file(&socket_path).await;
 
-        assert_eq!(details.transaction_id, "tx-abc123");
+        assert_eq!(details.transaction_id.as_str(), "tx-abc123");
         assert_eq!(details.action_name, "AptInstall");
         assert_eq!(details.preview.summary, "Install vim");
         assert_eq!(details.preview.proposed_change["package"], "vim");
@@ -1199,10 +1202,10 @@ mod tests {
         let mut lines: Vec<String> = Vec::new();
         let result = client
             .execute(
-                "tx-abc123",
+                &TransactionId::new("tx-abc123"),
                 "GetDiskUsage",
                 &serde_json::json!({}),
-                "receipt-abc",
+                &ApprovalReceipt::new("receipt-abc"),
                 |line| lines.push(line.to_owned()),
             )
             .await
@@ -1413,10 +1416,10 @@ mod tests {
         let mut lines: Vec<String> = Vec::new();
         let err = client
             .execute(
-                "tx-xyz",
+                &TransactionId::new("tx-xyz"),
                 "InstallPackage",
                 &serde_json::json!({"name": "vim"}),
-                "receipt-abc",
+                &ApprovalReceipt::new("receipt-abc"),
                 |line| lines.push(line.to_owned()),
             )
             .await
@@ -1468,10 +1471,10 @@ mod tests {
         let client = DaemonClient::new(socket_path.clone());
         let err = client
             .execute(
-                "tx-xyz",
+                &TransactionId::new("tx-xyz"),
                 "InstallPackage",
                 &serde_json::json!({"name": "vim"}),
-                "receipt-abc",
+                &ApprovalReceipt::new("receipt-abc"),
                 |_line| {},
             )
             .await

--- a/apps/sysknife-cli/src/main.rs
+++ b/apps/sysknife-cli/src/main.rs
@@ -74,7 +74,13 @@ async fn dispatch(
 
         // --- sysknife approve <transaction-id> ---
         Some(Command::Approve { transaction_id }) => {
-            runner::run_approve(transaction_id, socket, cli.json, log).await
+            runner::run_approve(
+                &sysknife_types::TransactionId::new(transaction_id.clone()),
+                socket,
+                cli.json,
+                log,
+            )
+            .await
         }
 
         // --- sysknife mcp-server ---

--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -264,6 +264,16 @@ pub struct AuditVerifyReport {
     pub actual: Option<String>,
     /// Human-readable explanation. Only set when `status == "cannot_verify"`.
     pub reason: Option<String>,
+    /// Number of approval events (grant / consume / revoke) checked in the
+    /// second chain.
+    pub events_checked: u64,
+    /// Result of the approval-event chain walk: `"intact"`, `"broken"`, or
+    /// `"cannot_verify"`. Reported separately from `status` so a clean
+    /// authorisation trail can never paper over a tampered approval trail.
+    pub approval_events_status: String,
+    /// `"consistent"` or `"missing_event"`: whether every event tip committed
+    /// by a transaction row is still present in the event chain.
+    pub binding_status: String,
     /// Backend label: a filesystem path for SQLite, the literal `"postgres"`
     /// for Postgres deployments.
     pub backend: String,
@@ -766,7 +776,7 @@ async fn audit_chain_quick_check(
     lacs_config: &sysknife_core::config::LacsConfig,
     warnings: &mut Vec<String>,
 ) -> VerifyOutcomeKind {
-    use sysknife_daemon::audit_chain::{AuditKey, VerifyOutcome};
+    use sysknife_daemon::audit_chain::{AuditKey, BindingOutcome, VerifyOutcome};
 
     let db_path = sysknife_core::default_database_path();
     let key_path = std::env::var("SYSKNIFE_AUDIT_KEY_PATH")
@@ -799,13 +809,29 @@ async fn audit_chain_quick_check(
         _ => verify_sqlite(&db_path, &verifier).await,
     };
 
-    match outcome {
-        VerifyOutcome::Intact { .. } => VerifyOutcomeKind::Intact,
-        VerifyOutcome::Broken { .. } => VerifyOutcomeKind::Broken,
-        VerifyOutcome::CannotVerify { reason } => {
-            warnings.push(format!("audit chain cannot be verified: {reason}"));
-            VerifyOutcomeKind::Unknown
+    // The doctor summary reports the worst of the three checks. Reporting only
+    // the transaction chain would call a deployment healthy while its approval
+    // trail was broken.
+    for (label, sub) in [
+        ("audit chain", &outcome.chain),
+        ("approval-event chain", &outcome.events),
+    ] {
+        if let VerifyOutcome::CannotVerify { reason } = sub {
+            warnings.push(format!("{label} cannot be verified: {reason}"));
         }
+    }
+    if let BindingOutcome::MissingEvent {
+        transaction_seq, ..
+    } = &outcome.binding
+    {
+        warnings.push(format!(
+            "transaction seq={transaction_seq} commits to an approval event that no longer exists"
+        ));
+    }
+    match outcome.exit_code() {
+        0 => VerifyOutcomeKind::Intact,
+        1 => VerifyOutcomeKind::Broken,
+        _ => VerifyOutcomeKind::Unknown,
     }
 }
 
@@ -861,12 +887,40 @@ async fn audit_verify_inner() -> AuditVerifyReport {
     outcome_to_report(outcome, backend_label)
 }
 
-fn outcome_to_report(
-    outcome: sysknife_daemon::audit_chain::VerifyOutcome,
-    backend: String,
-) -> AuditVerifyReport {
+/// Short label for one chain walk.
+fn outcome_label(outcome: &sysknife_daemon::audit_chain::VerifyOutcome) -> &'static str {
     use sysknife_daemon::audit_chain::VerifyOutcome;
     match outcome {
+        VerifyOutcome::Intact { .. } => "intact",
+        VerifyOutcome::Broken { .. } => "broken",
+        VerifyOutcome::CannotVerify { .. } => "cannot_verify",
+    }
+}
+
+fn outcome_to_report(
+    verification: sysknife_daemon::audit_chain::AuditVerification,
+    backend: String,
+) -> AuditVerifyReport {
+    use sysknife_daemon::audit_chain::{BindingOutcome, VerifyOutcome};
+
+    let events_checked = match &verification.events {
+        VerifyOutcome::Intact { rows_checked } | VerifyOutcome::Broken { rows_checked, .. } => {
+            *rows_checked
+        }
+        VerifyOutcome::CannotVerify { .. } => 0,
+    };
+    let approval_events_status = outcome_label(&verification.events).to_string();
+    let binding_status = match &verification.binding {
+        BindingOutcome::Consistent { .. } => "consistent",
+        BindingOutcome::MissingEvent { .. } => "missing_event",
+    }
+    .to_string();
+
+    // The detail fields describe the first *break*, wherever it was found. A
+    // broken transaction chain is reported ahead of a broken event chain
+    // because it is the one checkpoints anchor.
+    let overall = verification.exit_code();
+    let mut report = match verification.chain {
         VerifyOutcome::Intact { rows_checked } => AuditVerifyReport {
             status: "intact".to_string(),
             rows_checked,
@@ -876,6 +930,9 @@ fn outcome_to_report(
             actual: None,
             reason: None,
             backend,
+            events_checked,
+            approval_events_status,
+            binding_status,
         },
         VerifyOutcome::Broken {
             rows_checked,
@@ -892,9 +949,30 @@ fn outcome_to_report(
             actual: Some(actual),
             reason: None,
             backend,
+            events_checked,
+            approval_events_status,
+            binding_status,
         },
-        VerifyOutcome::CannotVerify { reason } => cannot_verify_report(backend, reason),
+        VerifyOutcome::CannotVerify { reason } => {
+            let mut r = cannot_verify_report(backend, reason);
+            r.events_checked = events_checked;
+            r.approval_events_status = approval_events_status;
+            r.binding_status = binding_status;
+            r
+        }
+    };
+
+    // `status` is the headline an MCP client is most likely to read alone, so
+    // it must reflect the worst of the three checks, not just the first.
+    if report.status == "intact" {
+        report.status = match overall {
+            0 => "intact",
+            1 => "broken",
+            _ => "cannot_verify",
+        }
+        .to_string();
     }
+    report
 }
 
 fn cannot_verify_report(backend: String, reason: String) -> AuditVerifyReport {
@@ -907,6 +985,9 @@ fn cannot_verify_report(backend: String, reason: String) -> AuditVerifyReport {
         actual: None,
         reason: Some(reason),
         backend,
+        events_checked: 0,
+        approval_events_status: "cannot_verify".to_string(),
+        binding_status: "consistent".to_string(),
     }
 }
 

--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -46,7 +46,7 @@ use rmcp::{
     ErrorData, ServerHandler, ServiceExt,
 };
 use serde::{Deserialize, Serialize};
-use sysknife_types::RiskLevel;
+use sysknife_types::{ApprovalReceipt, RiskLevel, TransactionId};
 
 use sysknife_brain::config::BrainConfig;
 use sysknife_brain::planner::LlmPlanner;
@@ -390,6 +390,20 @@ impl SysknifeMcpServer {
     }
 }
 
+/// Identity this server reports in `initialize`.
+///
+/// `Implementation::from_build_env()` resolves `CARGO_PKG_*` at the crate where
+/// the macro expands — which is `rmcp` — so the server introduced itself to
+/// every client, and to directory listings, as "rmcp" at rmcp's version. The
+/// struct is `#[non_exhaustive]`, so the fields are overwritten rather than
+/// rebuilt, which also keeps any future field at its upstream default.
+fn sysknife_implementation() -> Implementation {
+    let mut implementation = Implementation::from_build_env();
+    implementation.name = "sysknife".to_string();
+    implementation.version = env!("CARGO_PKG_VERSION").to_string();
+    implementation
+}
+
 #[tool_handler]
 impl ServerHandler for SysknifeMcpServer {
     fn get_info(&self) -> ServerInfo {
@@ -399,7 +413,11 @@ impl ServerHandler for SysknifeMcpServer {
                 .enable_resources()
                 .build(),
         )
-        .with_server_info(Implementation::from_build_env())
+        // Not `Implementation::from_build_env()`: that macro resolves
+        // `CARGO_PKG_*` at the crate where it is expanded, which is `rmcp`, so
+        // the server introduced itself to every client as "rmcp" at rmcp's
+        // version. Directory listings and client UIs show this string.
+        .with_server_info(sysknife_implementation())
         .with_instructions(
             "SysKnife provides planning and execution tools for Linux system administration.",
         )
@@ -523,7 +541,11 @@ async fn enrich_with_commands(
             .preview(&step.action_name, &step.params)
             .await
             .map_err(|e| format!("preview failed for {}: {e}", step.action_name))?;
-        step.transaction_id = prepared.transaction_id;
+        // The MCP wire structs keep plain strings: their JSON Schema is what
+        // the agent sees, and a bare string is the honest description of an
+        // opaque identifier. The newtypes guard the internal call sites, so the
+        // conversion happens once, here at the boundary.
+        step.transaction_id = prepared.transaction_id.into_inner();
         step.risk_level = match prepared.preview.risk_level {
             RiskLevel::Low => "low",
             RiskLevel::Medium => "medium",
@@ -552,10 +574,10 @@ async fn execute_steps_inner(steps: Vec<StepToExecute>) -> Result<ExecuteOutput,
         let mut output_lines: Vec<String> = Vec::new();
         let result = client
             .execute(
-                &step.transaction_id,
+                &TransactionId::new(step.transaction_id.clone()),
                 &step.action_name,
                 &step.params,
-                &step.approval_receipt,
+                &ApprovalReceipt::new(step.approval_receipt.clone()),
                 |line| output_lines.push(line.to_owned()),
             )
             .await
@@ -1181,6 +1203,16 @@ mod tests {
             Some(SYSKNIFE_DISCOVERY_DESCRIPTION)
         );
         assert_eq!(resource.mime_type.as_deref(), Some("text/plain"));
+    }
+
+    #[test]
+    fn the_server_introduces_itself_as_sysknife() {
+        // `Implementation::from_build_env()` expands inside the rmcp crate, so
+        // it reported name "rmcp" and rmcp's version — the string clients and
+        // registry listings display for this server.
+        let info = SysknifeMcpServer.get_info();
+        assert_eq!(info.server_info.name, "sysknife");
+        assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
     }
 
     #[test]

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -511,7 +511,7 @@ impl RunOpts {
 /// underlying access problem.
 pub async fn run_audit_verify(args: AuditVerifyArgs, log: &Logger) -> Result<(), CliError> {
     use sysknife_core::config::LacsConfig;
-    use sysknife_daemon::audit_chain::{self, AuditKey, VerifyOutcome};
+    use sysknife_daemon::audit_chain::AuditKey;
 
     // Honour the same `[storage]` config the daemon uses, so `sysknife audit
     // verify` works against whichever backend is in production. Without this,
@@ -537,12 +537,7 @@ pub async fn run_audit_verify(args: AuditVerifyArgs, log: &Logger) -> Result<(),
                     "public key file {} could not be read: {e}",
                     pubkey_path.display()
                 );
-                emit_verify_outcome(
-                    &args,
-                    log,
-                    &VerifyOutcome::CannotVerify { reason },
-                    &label_for_diag,
-                );
+                emit_verification(&args, log, &cannot_verify_all(reason), &label_for_diag);
                 return Err(CliError::Exit(2));
             }
         }
@@ -556,12 +551,7 @@ pub async fn run_audit_verify(args: AuditVerifyArgs, log: &Logger) -> Result<(),
                  the exported public key",
                 key_path.display()
             );
-            emit_verify_outcome(
-                &args,
-                log,
-                &VerifyOutcome::CannotVerify { reason },
-                &label_for_diag,
-            );
+            emit_verification(&args, log, &cannot_verify_all(reason), &label_for_diag);
             return Err(CliError::Exit(2));
         }
 
@@ -569,12 +559,7 @@ pub async fn run_audit_verify(args: AuditVerifyArgs, log: &Logger) -> Result<(),
             Ok(k) => Verifier::Private(Box::new(k)),
             Err(e) => {
                 let reason = format!("audit key load failed: {e}");
-                emit_verify_outcome(
-                    &args,
-                    log,
-                    &VerifyOutcome::CannotVerify { reason },
-                    &label_for_diag,
-                );
+                emit_verification(&args, log, &cannot_verify_all(reason), &label_for_diag);
                 return Err(CliError::Exit(2));
             }
         }
@@ -589,8 +574,8 @@ pub async fn run_audit_verify(args: AuditVerifyArgs, log: &Logger) -> Result<(),
         _ => verify_sqlite(&db_path, &verifier).await,
     };
 
-    let exit_code = audit_chain::outcome_to_exit_code(&outcome);
-    emit_verify_outcome(&args, log, &outcome, &label_for_diag);
+    let exit_code = outcome.exit_code();
+    emit_verification(&args, log, &outcome, &label_for_diag);
     if exit_code == 0 {
         Ok(())
     } else {
@@ -707,64 +692,75 @@ pub(crate) enum Verifier {
     Public(String),
 }
 
+use sysknife_daemon::audit_chain::AuditVerification;
+
+/// Lift a single "we could not even read the rows" reason into all three
+/// checks, so the caller never has to special-case a partially populated
+/// result.
+fn cannot_verify_all(reason: String) -> AuditVerification {
+    use sysknife_daemon::audit_chain::{BindingOutcome, VerifyOutcome};
+    AuditVerification {
+        chain: VerifyOutcome::CannotVerify {
+            reason: reason.clone(),
+        },
+        events: VerifyOutcome::CannotVerify { reason },
+        binding: BindingOutcome::Consistent {
+            bindings_checked: 0,
+        },
+    }
+}
+
 pub(crate) async fn verify_sqlite(
     db_path: &std::path::Path,
     verifier: &Verifier,
-) -> sysknife_daemon::audit_chain::VerifyOutcome {
-    use sysknife_daemon::audit_chain::VerifyOutcome;
+) -> AuditVerification {
+    use sysknife_daemon::audit_chain::{verify_all, verify_all_with_pubkey};
     use sysknife_daemon::transactions::TransactionStore;
 
     if !db_path.exists() {
-        return VerifyOutcome::CannotVerify {
-            reason: format!(
-                "audit database not found at {}; set $SYSKNIFE_DATABASE_PATH \
-                 or run the daemon first",
-                db_path.display()
-            ),
-        };
+        return cannot_verify_all(format!(
+            "audit database not found at {}; set $SYSKNIFE_DATABASE_PATH \
+             or run the daemon first",
+            db_path.display()
+        ));
     }
     let store = match TransactionStore::open_read_only(db_path) {
         Ok(s) => s,
-        Err(e) => {
-            return VerifyOutcome::CannotVerify {
-                reason: format!("opening audit database failed: {e}"),
-            };
-        }
+        Err(e) => return cannot_verify_all(format!("opening audit database failed: {e}")),
     };
-    let result = match verifier {
-        Verifier::Private(key) => store.verify_audit_chain(key),
-        Verifier::Public(vk_hex) => store.verify_audit_chain_with_pubkey(vk_hex),
+    let tx_rows = match store.fetch_chain_rows() {
+        Ok(rows) => rows,
+        Err(e) => return cannot_verify_all(format!("audit chain query failed: {e}")),
     };
-    match result {
-        Ok(o) => o,
-        Err(e) => VerifyOutcome::CannotVerify {
-            reason: format!("audit chain query failed: {e}"),
-        },
+    let event_rows = match store.fetch_event_rows() {
+        Ok(rows) => rows,
+        Err(e) => return cannot_verify_all(format!("approval-event query failed: {e}")),
+    };
+    match verifier {
+        Verifier::Private(key) => verify_all(key, &tx_rows, &event_rows),
+        Verifier::Public(vk_hex) => verify_all_with_pubkey(vk_hex, &tx_rows, &event_rows),
     }
 }
 
 pub(crate) async fn verify_postgres(
     storage: &sysknife_core::config::StorageSection,
     verifier: &Verifier,
-) -> sysknife_daemon::audit_chain::VerifyOutcome {
+) -> AuditVerification {
     use sysknife_core::config::StorageBackend;
-    use sysknife_daemon::audit_chain::VerifyOutcome;
     use sysknife_daemon::store::postgres::{PostgresConfig, PostgresStore};
-    use sysknife_daemon::store::AuditStore;
 
     // Project the relaxed config form into the type-state-checked enum;
     // the match below makes future backends a compile-time decision.
     let parsed = match storage.parsed() {
         Ok(p) => p,
-        Err(reason) => return VerifyOutcome::CannotVerify { reason },
+        Err(reason) => return cannot_verify_all(reason),
     };
     let (url, pool) =
         match parsed {
-            StorageBackend::Sqlite => return VerifyOutcome::CannotVerify {
-                reason:
-                    "verify_postgres called with backend = \"sqlite\" — caller picks the wrong path"
-                        .to_string(),
-            },
+            StorageBackend::Sqlite => return cannot_verify_all(
+                "verify_postgres called with backend = \"sqlite\" — caller picks the wrong path"
+                    .to_string(),
+            ),
             StorageBackend::Postgres { url, pool } => (url, pool),
         };
 
@@ -789,93 +785,155 @@ pub(crate) async fn verify_postgres(
             let store =
                 match PostgresStore::connect(&cfg, std::sync::Arc::new((**key).clone())).await {
                     Ok(s) => s,
-                    Err(e) => {
-                        return VerifyOutcome::CannotVerify {
-                            reason: format!("postgres connect failed: {e}"),
-                        };
-                    }
+                    Err(e) => return cannot_verify_all(format!("postgres connect failed: {e}")),
                 };
-            match store.verify_audit_chain(key).await {
-                Ok(outcome) => outcome,
-                Err(e) => VerifyOutcome::CannotVerify {
-                    reason: format!("postgres audit chain query failed: {e}"),
-                },
+            match store.verify_all(key).await {
+                Ok(verification) => verification,
+                Err(e) => cannot_verify_all(format!("postgres audit chain query failed: {e}")),
             }
         }
         Verifier::Public(verifying_key_hex) => {
-            match PostgresStore::verify_with_pubkey(&cfg, verifying_key_hex).await {
-                Ok(outcome) => outcome,
-                Err(e) => VerifyOutcome::CannotVerify {
-                    reason: format!("postgres audit chain query failed: {e}"),
-                },
+            match PostgresStore::verify_all_with_pubkey(&cfg, verifying_key_hex).await {
+                Ok(verification) => verification,
+                Err(e) => cannot_verify_all(format!("postgres audit chain query failed: {e}")),
             }
         }
     }
 }
 
-fn emit_verify_outcome(
+/// Render all three checks. The transaction chain stays the headline line so
+/// existing output and exit codes are unchanged for a clean chain; the other
+/// two are reported underneath and can independently fail the command.
+fn emit_verification(
     args: &AuditVerifyArgs,
     log: &Logger,
-    outcome: &sysknife_daemon::audit_chain::VerifyOutcome,
+    verification: &AuditVerification,
     backend_label: &str,
 ) {
-    use sysknife_daemon::audit_chain::VerifyOutcome;
+    use sysknife_daemon::audit_chain::{BindingOutcome, VerifyOutcome};
+
     if args.json {
-        let payload = match outcome {
-            VerifyOutcome::Intact { rows_checked } => json!({
-                "status": "intact",
-                "rows_checked": rows_checked,
-                "backend": backend_label,
-            }),
-            VerifyOutcome::Broken {
-                rows_checked,
-                first_broken_seq,
-                first_broken_transaction_id,
-                expected,
-                actual,
-            } => json!({
-                "status": "broken",
-                "rows_checked": rows_checked,
-                "first_broken_seq": first_broken_seq,
-                "first_broken_transaction_id": first_broken_transaction_id,
-                "expected": expected,
-                "actual": actual,
-                "backend": backend_label,
-            }),
-            VerifyOutcome::CannotVerify { reason } => json!({
-                "status": "cannot_verify",
-                "reason": reason,
-                "backend": backend_label,
-            }),
-        };
+        let payload = json!({
+            "status": status_word(verification.exit_code()),
+            "backend": backend_label,
+            "chain": outcome_json(&verification.chain),
+            "approval_events": outcome_json(&verification.events),
+            "binding": match &verification.binding {
+                BindingOutcome::Consistent { bindings_checked } => json!({
+                    "status": "consistent",
+                    "bindings_checked": bindings_checked,
+                }),
+                BindingOutcome::MissingEvent { transaction_seq, event_tip } => json!({
+                    "status": "missing_event",
+                    "transaction_seq": transaction_seq,
+                    "event_tip": event_tip,
+                }),
+            },
+        });
         log.println(
             &serde_json::to_string_pretty(&payload)
                 .expect("verify outcome payload is serializable"),
         );
-    } else {
-        match outcome {
-            VerifyOutcome::Intact { rows_checked } => {
-                log.println(&format!(
-                    "OK: {rows_checked} row(s) verified in {backend_label}"
-                ));
-            }
-            VerifyOutcome::Broken {
-                rows_checked,
-                first_broken_seq,
-                first_broken_transaction_id,
-                expected,
-                actual,
-            } => {
-                log.println(&format!(
-                    "BROKEN: chain intact for first {rows_checked} row(s); \
-                     row seq={first_broken_seq} (transaction {first_broken_transaction_id}) \
-                     does not chain.\n  expected: {expected}\n  actual:   {actual}"
-                ));
-            }
-            VerifyOutcome::CannotVerify { reason } => {
-                log.println(&format!("CANNOT VERIFY: {reason}"));
-            }
+        return;
+    }
+
+    match &verification.chain {
+        VerifyOutcome::Intact { rows_checked } => {
+            log.println(&format!(
+                "OK: {rows_checked} row(s) verified in {backend_label}"
+            ));
         }
+        VerifyOutcome::Broken {
+            rows_checked,
+            first_broken_seq,
+            first_broken_transaction_id,
+            expected,
+            actual,
+        } => {
+            log.println(&format!(
+                "BROKEN: chain intact for first {rows_checked} row(s); \
+                 row seq={first_broken_seq} (transaction {first_broken_transaction_id}) \
+                 does not chain.\n  expected: {expected}\n  actual:   {actual}"
+            ));
+        }
+        VerifyOutcome::CannotVerify { reason } => {
+            log.println(&format!("CANNOT VERIFY: {reason}"));
+        }
+    }
+
+    match &verification.events {
+        VerifyOutcome::Intact { rows_checked } => {
+            log.println(&format!("OK: {rows_checked} approval event(s) verified"));
+        }
+        VerifyOutcome::Broken {
+            rows_checked,
+            first_broken_seq,
+            first_broken_transaction_id,
+            ..
+        } => {
+            log.println(&format!(
+                "BROKEN: approval events intact for first {rows_checked}; \
+                 event seq={first_broken_seq} (transaction {first_broken_transaction_id}) \
+                 does not chain"
+            ));
+        }
+        VerifyOutcome::CannotVerify { reason } => {
+            log.println(&format!("CANNOT VERIFY approval events: {reason}"));
+        }
+    }
+
+    match &verification.binding {
+        BindingOutcome::Consistent { bindings_checked } => {
+            log.println(&format!(
+                "OK: {bindings_checked} row(s) still match the approval event they committed to"
+            ));
+        }
+        BindingOutcome::MissingEvent {
+            transaction_seq,
+            event_tip,
+        } => {
+            log.println(&format!(
+                "BROKEN: transaction seq={transaction_seq} committed to approval event \
+                 {event_tip}, which is no longer in the event chain — approval events \
+                 were deleted from the end of the chain"
+            ));
+        }
+    }
+}
+
+fn status_word(exit_code: i32) -> &'static str {
+    match exit_code {
+        0 => "intact",
+        1 => "broken",
+        _ => "cannot_verify",
+    }
+}
+
+fn outcome_json(outcome: &sysknife_daemon::audit_chain::VerifyOutcome) -> serde_json::Value {
+    use sysknife_daemon::audit_chain::VerifyOutcome;
+    match outcome {
+        VerifyOutcome::Intact { rows_checked } => json!({
+            "status": "intact",
+            "rows_checked": rows_checked,
+        }),
+        VerifyOutcome::Broken {
+            rows_checked,
+            first_broken_seq,
+            first_broken_transaction_id,
+            expected,
+            actual,
+        } => json!({
+            "status": "broken",
+            "rows_checked": rows_checked,
+            "first_broken_seq": first_broken_seq,
+            "first_broken_transaction_id": first_broken_transaction_id,
+            "expected": expected,
+            "actual": actual,
+        }),
+        VerifyOutcome::CannotVerify { reason } => json!({
+            "status": "cannot_verify",
+            "reason": reason,
+        }),
     }
 }
 

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -25,7 +25,8 @@ use sysknife_brain::config::BrainConfig;
 use sysknife_brain::planner::{LlmPlanner, PlanRiskLevel};
 use sysknife_brain::PlanEvent;
 use sysknife_types::{
-    DistroHint, RiskLevel, DISTRO_FAMILY_DEBIAN, DISTRO_FAMILY_FEDORA, DISTRO_FAMILY_OTHER,
+    DistroHint, RiskLevel, TransactionId, DISTRO_FAMILY_DEBIAN, DISTRO_FAMILY_FEDORA,
+    DISTRO_FAMILY_OTHER,
 };
 
 use sysknife_brain::state_client::StateClient as _;
@@ -220,7 +221,7 @@ fn daemon_risk_within_approved(approved: &PlanRiskLevel, daemon: &PlanRiskLevel)
 }
 
 pub async fn run_approve(
-    transaction_id: &str,
+    transaction_id: &TransactionId,
     socket: SocketTarget,
     json: bool,
     log: &Logger,
@@ -255,13 +256,15 @@ pub async fn run_approve(
     if json {
         log.println(
             &serde_json::json!({
-                "transaction_id": transaction_id,
-                "approval_receipt": receipt,
+                "transaction_id": transaction_id.as_str(),
+                "approval_receipt": receipt.as_str(),
             })
             .to_string(),
         );
     } else {
-        log.println(&format!("Approval receipt: {receipt}"));
+        // The one place the receipt is meant to leave the process: the
+        // operator has to be able to paste it into `sysknife execute`.
+        log.println(&format!("Approval receipt: {}", receipt.as_str()));
     }
     Ok(())
 }

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -944,6 +944,40 @@ fn outcome_json(outcome: &sysknife_daemon::audit_chain::VerifyOutcome) -> serde_
 // run_intent
 // ---------------------------------------------------------------------------
 
+/// What `run_intent` does with one [`ApprovalDecision`].
+///
+/// Extracted from the two gates in `run_intent` (plan-level and, under
+/// `--step-by-step`, per step). They were near-identical `match` blocks over
+/// the same enum, so the two could disagree about what a decision means — and
+/// neither was reachable in a test without an LLM provider and a live daemon.
+#[derive(Debug)]
+enum GateAction {
+    /// Execute without asking.
+    Proceed,
+    /// Ask the operator; a "no" is a rejection.
+    AskOperator,
+    /// Do not execute, and do not ask.
+    Refuse(CliError),
+}
+
+/// Map an approval decision onto the gate's behaviour.
+///
+/// `highest` is the risk being gated: the plan's highest for the plan-level
+/// gate, the step's own under `--step-by-step`.
+fn gate_action(decision: ApprovalDecision, highest: &PlanRiskLevel) -> GateAction {
+    match decision {
+        ApprovalDecision::AutoApproved => GateAction::Proceed,
+        ApprovalDecision::RequiresPrompt => GateAction::AskOperator,
+        ApprovalDecision::RequiresInteraction => GateAction::Refuse(CliError::NonInteractive),
+        ApprovalDecision::ExceedsCeiling(ceiling) => {
+            GateAction::Refuse(CliError::RiskCeilingExceeded {
+                highest: highest.clone(),
+                ceiling,
+            })
+        }
+    }
+}
+
 /// Plan and (optionally) execute a single natural-language intent.
 pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<(), CliError> {
     let config = BrainConfig::from_env().map_err(|e| CliError::ConfigOrDaemon(e.to_string()))?;
@@ -1073,11 +1107,12 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
     let policy = opts.approval_policy();
 
     if !opts.step_by_step {
-        match policy.decide_plan(&plan) {
-            ApprovalDecision::AutoApproved => {}
-            ApprovalDecision::RequiresPrompt => {
+        let highest = plan.highest_risk().expect("plan has steps").clone();
+        match gate_action(policy.decide_plan(&plan), &highest) {
+            GateAction::Proceed => {}
+            GateAction::Refuse(err) => return Err(err),
+            GateAction::AskOperator => {
                 let n = plan.steps().len();
-                let highest = plan.highest_risk().expect("plan has steps");
                 let msg = if opts.json {
                     "Execute this plan?".to_owned()
                 } else {
@@ -1085,22 +1120,12 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
                         "  {} step{}, {} risk — execute?",
                         n,
                         if n == 1 { "" } else { "s" },
-                        crate::render::risk_colored(highest),
+                        crate::render::risk_colored(&highest),
                     )
                 };
                 if !prompt_confirm(&msg).await {
                     return Err(CliError::Rejected);
                 }
-            }
-            ApprovalDecision::RequiresInteraction => return Err(CliError::NonInteractive),
-            ApprovalDecision::ExceedsCeiling(ceiling) => {
-                let highest = plan
-                    .highest_risk()
-                    .expect("ExceedsCeiling implies at least one step");
-                return Err(CliError::RiskCeilingExceeded {
-                    highest: highest.clone(),
-                    ceiling,
-                });
             }
         }
     }
@@ -1127,9 +1152,10 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
     for step in plan.steps() {
         // Step-by-step: approve each step before previewing it.
         if opts.step_by_step {
-            match policy.decide_step(step.risk_level()) {
-                ApprovalDecision::AutoApproved => {}
-                ApprovalDecision::RequiresPrompt => {
+            match gate_action(policy.decide_step(step.risk_level()), step.risk_level()) {
+                GateAction::Proceed => {}
+                GateAction::Refuse(err) => return Err(err),
+                GateAction::AskOperator => {
                     let msg = if opts.json {
                         format!("Execute {} ({})?", step.action_name(), step.summary())
                     } else {
@@ -1142,13 +1168,6 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
                     if !prompt_confirm(&msg).await {
                         return Err(CliError::Rejected);
                     }
-                }
-                ApprovalDecision::RequiresInteraction => return Err(CliError::NonInteractive),
-                ApprovalDecision::ExceedsCeiling(ceiling) => {
-                    return Err(CliError::RiskCeilingExceeded {
-                        highest: step.risk_level().clone(),
-                        ceiling,
-                    });
                 }
             }
         }
@@ -1868,5 +1887,66 @@ mod tests {
         let t = resolve_socket_target();
         unsafe { std::env::remove_var("SYSKNIFE_SOCKET") };
         assert_eq!(t, crate::client::SocketTarget::Vsock { cid: 3, port: 7777 });
+    }
+
+    // ── the approval gate `run_intent` actually runs ──────────────────────
+
+    #[test]
+    fn only_an_auto_approved_decision_reaches_execution() {
+        // The safety property of both gates in `run_intent`, checked over every
+        // decision the policy can return. `ApprovalPolicy` itself is well
+        // covered; what was untested is that `run_intent` obeys it — the two
+        // gates were inline `match` blocks unreachable without an LLM provider
+        // and a live daemon.
+        let risk = PlanRiskLevel::High;
+        let decisions = [
+            ApprovalDecision::AutoApproved,
+            ApprovalDecision::RequiresPrompt,
+            ApprovalDecision::RequiresInteraction,
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Low),
+        ];
+        for decision in decisions {
+            let expected_to_proceed = matches!(decision, ApprovalDecision::AutoApproved);
+            let label = format!("{decision:?}");
+            let proceeds = matches!(gate_action(decision, &risk), GateAction::Proceed);
+            assert_eq!(
+                proceeds, expected_to_proceed,
+                "only AutoApproved may execute without asking; {label} did not match"
+            );
+        }
+    }
+
+    #[test]
+    fn a_prompt_decision_asks_rather_than_refusing_or_running() {
+        assert!(matches!(
+            gate_action(ApprovalDecision::RequiresPrompt, &PlanRiskLevel::Medium),
+            GateAction::AskOperator
+        ));
+    }
+
+    #[test]
+    fn non_interactive_refuses_without_prompting() {
+        // Prompting here would block forever on a closed stdin in CI or a
+        // systemd unit; the refusal must be silent and immediate.
+        match gate_action(ApprovalDecision::RequiresInteraction, &PlanRiskLevel::High) {
+            GateAction::Refuse(CliError::NonInteractive) => {}
+            other => panic!("expected a NonInteractive refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exceeding_the_ceiling_reports_both_the_risk_and_the_ceiling() {
+        // The error has to name both numbers or the operator cannot tell what
+        // to raise `--max-risk` to.
+        match gate_action(
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Low),
+            &PlanRiskLevel::High,
+        ) {
+            GateAction::Refuse(CliError::RiskCeilingExceeded { highest, ceiling }) => {
+                assert_eq!(highest, PlanRiskLevel::High);
+                assert_eq!(ceiling, MaxRisk::Low);
+            }
+            other => panic!("expected a RiskCeilingExceeded refusal, got {other:?}"),
+        }
     }
 }

--- a/apps/sysknife-cli/tests/mcp_stdio.rs
+++ b/apps/sysknife-cli/tests/mcp_stdio.rs
@@ -1,0 +1,178 @@
+//! End-to-end test of `sysknife mcp-server` over real stdio JSON-RPC.
+//!
+//! Everything else about the MCP surface is tested by calling the handler
+//! functions directly, which skips the part most likely to break: the wire.
+//! `run_mcp_server` wires `SysknifeMcpServer` to rmcp's stdio transport, and a
+//! change to rmcp's framing, a stray `println!` on stdout, or a panic during
+//! `initialize` would leave every unit test green while no agent could speak to
+//! the server at all.
+//!
+//! The exchange here is the one every client performs on connect —
+//! `initialize`, the `notifications/initialized` acknowledgement, then
+//! `tools/list`. It needs no daemon: the tool catalogue is registered
+//! statically by `#[tool_router]`.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// Cap on how long to wait for any single response frame. Generous enough for
+/// a cold process start under a loaded CI runner, short enough that a hang is
+/// a test failure rather than a job timeout.
+const FRAME_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// A spawned `sysknife mcp-server` with its stdio pipes.
+///
+/// Reading happens on a worker thread so a server that accepts a request and
+/// never answers fails the test on `recv_timeout` instead of blocking the test
+/// harness forever.
+struct McpChild {
+    child: Child,
+    stdin: ChildStdin,
+    lines: mpsc::Receiver<std::io::Result<String>>,
+}
+
+impl McpChild {
+    fn spawn() -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_sysknife"))
+            .arg("mcp-server")
+            // Point at a socket that cannot exist. `tools/list` never touches
+            // the daemon, and this makes sure the test is not quietly relying
+            // on a real one being up on the developer's machine.
+            .env("SYSKNIFE_SOCKET", "/nonexistent/sysknife-mcp-test.sock")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sysknife mcp-server");
+
+        let stdin = child.stdin.take().expect("piped stdin");
+        let stdout: ChildStdout = child.stdout.take().expect("piped stdout");
+        let (tx, lines) = mpsc::channel();
+        std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            child,
+            stdin,
+            lines,
+        }
+    }
+
+    fn send(&mut self, message: &serde_json::Value) {
+        writeln!(self.stdin, "{message}").expect("write JSON-RPC frame");
+        self.stdin.flush().expect("flush JSON-RPC frame");
+    }
+
+    /// Next JSON-RPC response, skipping any notification the server emits on
+    /// its own initiative (those carry no `id`).
+    fn recv_response(&mut self) -> serde_json::Value {
+        loop {
+            let line = self
+                .lines
+                .recv_timeout(FRAME_TIMEOUT)
+                .expect("server produced a frame before the timeout")
+                .expect("stdout line is readable");
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: serde_json::Value = serde_json::from_str(&line).unwrap_or_else(|e| {
+                panic!("server wrote a non-JSON line to stdout: {line:?} ({e})")
+            });
+            if value.get("id").is_some() {
+                return value;
+            }
+        }
+    }
+}
+
+impl Drop for McpChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn the_mcp_server_completes_a_real_initialize_and_tools_list_over_stdio() {
+    let mut server = McpChild::spawn();
+
+    server.send(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "sysknife-stdio-test", "version": "0" }
+        }
+    }));
+
+    let init = server.recv_response();
+    assert!(
+        init.get("error").is_none(),
+        "initialize returned an error: {init}"
+    );
+    let server_info = &init["result"]["serverInfo"];
+    assert_eq!(
+        server_info["name"], "sysknife",
+        "server identified itself as {server_info} over the wire"
+    );
+
+    server.send(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    }));
+
+    server.send(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {}
+    }));
+
+    let listed = server.recv_response();
+    assert!(
+        listed.get("error").is_none(),
+        "tools/list returned an error: {listed}"
+    );
+    let tools = listed["result"]["tools"]
+        .as_array()
+        .unwrap_or_else(|| panic!("tools/list has no tools array: {listed}"));
+    let names: Vec<&str> = tools
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect();
+
+    // The full advertised surface. Asserting the exact set, not "at least one",
+    // is what makes this fail if a tool silently stops being registered.
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        sorted,
+        vec![
+            "sysknife_audit_verify",
+            "sysknife_doctor",
+            "sysknife_execute",
+            "sysknife_history",
+            "sysknife_plan",
+        ],
+        "advertised tools changed"
+    );
+
+    // Every tool must carry a schema: an agent cannot call a tool whose input
+    // shape it does not know, and an empty schema is a silent way to break that.
+    for tool in tools {
+        let name = tool["name"].as_str().unwrap_or("<unnamed>");
+        assert!(
+            tool["inputSchema"].is_object(),
+            "{name} has no object inputSchema: {tool}"
+        );
+    }
+}

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-shell/src-tauri/src/commands.rs
+++ b/apps/sysknife-shell/src-tauri/src/commands.rs
@@ -434,14 +434,17 @@ fn map_planning_error(err: sysknife_brain::planner::PlanningError) -> ShellError
         }
         PlanningError::RateLimitExceeded { .. } => ("rate_limit_exceeded", err.to_string()),
         PlanningError::StateUnavailable(_) => ("daemon_not_running", err.to_string()),
-        PlanningError::Provider(s) => {
-            if s.contains("429") {
-                ("llm_rate_limit", err.to_string())
-            } else if s.starts_with("http") || s.contains("HTTP") {
-                ("llm_http_error", err.to_string())
-            } else {
-                ("llm_parse_error", err.to_string())
-            }
+        // Matched on the variant, not on the rendered text. The previous
+        // substring search for "429"/"http" depended on the wording of
+        // `ProviderError`'s `#[error(...)]` strings.
+        PlanningError::Provider(provider_err) => {
+            use sysknife_brain::provider::ProviderError;
+            let code = match provider_err {
+                ProviderError::RateLimit(_) => "llm_rate_limit",
+                ProviderError::Http { .. } | ProviderError::Auth(_) => "llm_http_error",
+                ProviderError::Parse(_) | ProviderError::Request(_) => "llm_parse_error",
+            };
+            (code, err.to_string())
         }
         PlanningError::InvalidPlanOutput(_) => ("llm_parse_error", err.to_string()),
         _ => ("unknown", err.to_string()),

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-brain/src/planner.rs
+++ b/crates/sysknife-brain/src/planner.rs
@@ -490,17 +490,19 @@ pub enum PlanningError {
     #[error("planner ended without proposing a plan")]
     NoPlanProposed,
 
+    /// Carries the provider failure structurally.
+    ///
+    /// This used to be a `String` built from `ProviderError::to_string()`,
+    /// which threw away a classification the provider layer had already made.
+    /// Callers that needed it back — the shell's error mapper — recovered it by
+    /// searching the rendered message for `"429"` and `"http"`, so an edit to a
+    /// `#[error(...)]` format string in `provider.rs` could silently reclassify
+    /// a rate limit as a parse error.
     #[error("provider error: {0}")]
-    Provider(String),
+    Provider(#[from] ProviderError),
 
     #[error("invalid plan output: {0}")]
     InvalidPlanOutput(String),
-}
-
-impl From<ProviderError> for PlanningError {
-    fn from(e: ProviderError) -> Self {
-        Self::Provider(e.to_string())
-    }
 }
 
 impl From<PlanValidationError> for PlanningError {

--- a/crates/sysknife-brain/tests/planner.rs
+++ b/crates/sysknife-brain/tests/planner.rs
@@ -421,7 +421,7 @@ async fn provider_error_propagates() {
 
     assert!(matches!(
         planner.plan_intent("do something").await.unwrap_err(),
-        PlanningError::Provider(_)
+        PlanningError::Provider(ProviderError::Http { status: 500, .. })
     ));
 }
 
@@ -432,7 +432,7 @@ async fn auth_error_propagates() {
     ))]));
     assert!(matches!(
         planner.plan_intent("do something").await.unwrap_err(),
-        PlanningError::Provider(_)
+        PlanningError::Provider(ProviderError::Auth(_))
     ));
 }
 
@@ -1787,9 +1787,13 @@ async fn provider_parse_error_propagates() {
         "model returned unparseable JSON".into(),
     ))]));
 
+    // Asserting the variant, not just "some provider error": before
+    // `PlanningError::Provider` carried a `ProviderError`, these three tests
+    // made the identical assertion and could not tell a parse failure from a
+    // rate limit.
     assert!(matches!(
         planner.plan_intent("do something").await.unwrap_err(),
-        PlanningError::Provider(_)
+        PlanningError::Provider(ProviderError::Parse(_))
     ));
 }
 
@@ -1801,7 +1805,7 @@ async fn rate_limit_error_propagates() {
 
     assert!(matches!(
         planner.plan_intent("do something").await.unwrap_err(),
-        PlanningError::Provider(_)
+        PlanningError::Provider(ProviderError::RateLimit(_))
     ));
 }
 
@@ -1813,6 +1817,6 @@ async fn transport_request_error_propagates() {
 
     assert!(matches!(
         planner.plan_intent("do something").await.unwrap_err(),
-        PlanningError::Provider(_)
+        PlanningError::Provider(ProviderError::Request(_))
     ));
 }

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.12"
+version = "0.2.13"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon/src/audit_chain.rs
+++ b/crates/sysknife-daemon/src/audit_chain.rs
@@ -86,6 +86,13 @@ pub const HASH_HEX_LEN: usize = 128;
 const ROW_DOMAIN: &[u8] = b"sysknife-audit-row-v1\x1f";
 const CHECKPOINT_DOMAIN: &[u8] = b"sysknife-checkpoint-v1\x1f";
 const APPROVAL_DOMAIN: &[u8] = b"sysknife-approval-receipt-v1\x1f";
+const EVENT_DOMAIN: &[u8] = b"sysknife-audit-event-v1\x1f";
+
+/// Row encoding written before the caller-identity migration: no
+/// `caller_role`, no `event_tip`. Still verifiable — see [`ChainIdentity`].
+pub const CHAIN_VERSION_LEGACY: u32 = 1;
+/// Row encoding written by this binary: adds `caller_role` and `event_tip`.
+pub const CHAIN_VERSION_CURRENT: u32 = 2;
 
 /// Loaded Ed25519 signing key + its identifier. Construct via
 /// [`AuditKey::load_or_generate`].
@@ -393,6 +400,52 @@ fn fill_random(buf: &mut [u8]) -> std::io::Result<()> {
 /// respectively. The escape table is **prefix-free** (every escape starts
 /// with `\\`), so any value can be injected without ambiguity. See
 /// `push_field` for the implementation and tests for the round-trip.
+/// Which generation of the canonical row encoding a row was signed under.
+///
+/// # Why this is an enum and not two `Option` fields
+///
+/// Adding a field to [`ChainContent`] changes the signed message, so every row
+/// written before the change would re-encode differently and report as
+/// `Broken`. Chains already exist in the field, and "delete your audit log to
+/// upgrade" is not an acceptable migration for an audit log. The stored
+/// `chain_version` column therefore selects the encoding **per row**: legacy
+/// rows keep the exact bytes they were signed over, new rows carry the
+/// identity fields.
+///
+/// A downgrade is not a hiding place. Rewriting a `V2` row as `LegacyV1` (to
+/// erase `caller_role`) makes verification re-encode it without the identity
+/// fields, so the stored signature — made over the `V2` message — no longer
+/// verifies and the row reports as `Broken`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainIdentity<'a> {
+    /// `chain_version = 1`. Written before the identity migration.
+    LegacyV1,
+    /// `chain_version = 2`. Binds the row to the authenticated caller and to
+    /// the approval-event chain tip at insert time.
+    V2 {
+        /// Role the daemon resolved for the connection that requested this
+        /// action (`SO_PEERCRED` for Unix sockets, token for vsock). Signing
+        /// it is what lets an auditor answer "who asked for this".
+        caller_role: &'a str,
+        /// `chain_hash` of the last [`EventRow`] at insert time, or `""` when
+        /// the event chain is empty. This is the cross-chain binding: because
+        /// checkpoints anchor the *transaction* chain tip, a committed
+        /// `event_tip` transitively anchors the event chain, so deleting
+        /// approval events below it becomes detectable.
+        event_tip: &'a str,
+    },
+}
+
+impl ChainIdentity<'_> {
+    /// `chain_version` column value for this encoding.
+    pub fn version(&self) -> u32 {
+        match self {
+            Self::LegacyV1 => CHAIN_VERSION_LEGACY,
+            Self::V2 { .. } => CHAIN_VERSION_CURRENT,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChainContent<'a> {
     pub seq: u64,
@@ -417,6 +470,8 @@ pub struct ChainContent<'a> {
     /// JSON-canonical (sorted keys) array of warning strings.
     pub warnings_json: &'a str,
     pub created_at: &'a str,
+    /// Encoding generation. See [`ChainIdentity`] for why this is per-row.
+    pub identity: ChainIdentity<'a>,
 }
 
 impl<'a> ChainContent<'a> {
@@ -445,6 +500,23 @@ impl<'a> ChainContent<'a> {
         push_field(&mut buf, "approval_id", approval);
         push_field(&mut buf, "warnings_json", self.warnings_json);
         push_field(&mut buf, "created_at", self.created_at);
+        // v2 fields are *appended*, so a legacy row's bytes are unchanged and
+        // its signature still verifies. The `chain_version` tag leads the
+        // suffix so a future v3 can never alias a v2 message: the two differ
+        // in a signed field, not merely in field count.
+        if let ChainIdentity::V2 {
+            caller_role,
+            event_tip,
+        } = self.identity
+        {
+            push_field(
+                &mut buf,
+                "chain_version",
+                &CHAIN_VERSION_CURRENT.to_string(),
+            );
+            push_field(&mut buf, "caller_role", caller_role);
+            push_field(&mut buf, "event_tip", event_tip);
+        }
         buf
     }
 }
@@ -529,6 +601,47 @@ pub struct ChainRow {
     pub created_at: String,
     pub prev_chain_hash: String,
     pub chain_hash: String,
+    /// Which encoding this row was signed under. See [`ChainIdentity`].
+    pub chain_version: u32,
+    /// `NULL` for legacy rows; required for `chain_version = 2`.
+    pub caller_role: Option<String>,
+    /// `NULL` for legacy rows; required for `chain_version = 2`. May be the
+    /// empty string when the event chain was empty at insert time.
+    pub event_tip: Option<String>,
+}
+
+/// Why a stored row's columns do not describe a verifiable encoding.
+#[derive(Debug)]
+pub(crate) enum RowIdentityError {
+    /// The row claims an encoding this binary does not know how to reproduce.
+    /// Genuinely unverifiable, not evidence of tampering — an older binary
+    /// reading a newer chain lands here.
+    UnknownVersion(u32),
+    /// The row claims `chain_version = 2` but is missing an identity column.
+    /// No message can be reconstructed, and the shape is self-contradictory,
+    /// so this counts as a detected break rather than an inability to check.
+    MissingField(&'static str),
+}
+
+impl ChainRow {
+    /// Recover the encoding this row was signed under, so a caller can rebuild
+    /// the exact message that produced `chain_hash`.
+    pub(crate) fn identity(&self) -> Result<ChainIdentity<'_>, RowIdentityError> {
+        match self.chain_version {
+            CHAIN_VERSION_LEGACY => Ok(ChainIdentity::LegacyV1),
+            CHAIN_VERSION_CURRENT => Ok(ChainIdentity::V2 {
+                caller_role: self
+                    .caller_role
+                    .as_deref()
+                    .ok_or(RowIdentityError::MissingField("caller_role"))?,
+                event_tip: self
+                    .event_tip
+                    .as_deref()
+                    .ok_or(RowIdentityError::MissingField("event_tip"))?,
+            }),
+            other => Err(RowIdentityError::UnknownVersion(other)),
+        }
+    }
 }
 
 /// Verify a chain using the daemon's key. Verification uses the **public** key
@@ -600,6 +713,28 @@ fn verify_rows(vk: &VerifyingKey, expect_key_id: Option<&str>, rows: &[ChainRow]
                 actual: format!("prev_chain_hash={}", row.prev_chain_hash),
             };
         }
+        let identity = match row.identity() {
+            Ok(identity) => identity,
+            Err(RowIdentityError::UnknownVersion(v)) => {
+                return VerifyOutcome::CannotVerify {
+                    reason: format!(
+                        "row seq={} declares chain_version={v}, which this binary cannot \
+                         reproduce (it understands {CHAIN_VERSION_LEGACY}..={CHAIN_VERSION_CURRENT}); \
+                         verify with a build at least as new as the one that wrote the chain",
+                        row.seq
+                    ),
+                };
+            }
+            Err(RowIdentityError::MissingField(field)) => {
+                return VerifyOutcome::Broken {
+                    rows_checked,
+                    first_broken_seq: row.seq,
+                    first_broken_transaction_id: row.transaction_id.clone(),
+                    expected: format!("chain_version={CHAIN_VERSION_CURRENT} row carrying {field}"),
+                    actual: format!("{field}=NULL"),
+                };
+            }
+        };
         let content = ChainContent {
             seq: row.seq,
             key_id: &row.key_id,
@@ -612,6 +747,7 @@ fn verify_rows(vk: &VerifyingKey, expect_key_id: Option<&str>, rows: &[ChainRow]
             approval_id: row.approval_id.as_deref(),
             warnings_json: &row.warnings_json,
             created_at: &row.created_at,
+            identity,
         };
         let msg = chain_message(&content, &row.prev_chain_hash);
         if !signature_ok(vk, &msg, &row.chain_hash) {
@@ -627,6 +763,320 @@ fn verify_rows(vk: &VerifyingKey, expect_key_id: Option<&str>, rows: &[ChainRow]
         rows_checked += 1;
     }
     VerifyOutcome::Intact { rows_checked }
+}
+
+// ── Approval-event chain ─────────────────────────────────────────────────────
+
+/// A lifecycle event on an approval receipt.
+///
+/// The `transactions` chain commits to the *authorisation decision* at preview
+/// time. It says nothing about whether a human ever approved, whether that
+/// approval was spent, or whether it was retracted — those live in
+/// `transaction_approvals`, a plain mutable table. Deleting a row from it used
+/// to leave `sysknife audit verify` reporting `Intact`, so the record that an
+/// approval happened was the one part of the trail an attacker could erase
+/// without leaving a mark. These events are chained so that erasure breaks a
+/// signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditEventKind {
+    /// A receipt was minted for a queued transaction.
+    ApprovalGranted,
+    /// A receipt was spent to move a transaction into `Running`.
+    ApprovalConsumed,
+    /// An undelivered receipt was retracted before it could be spent.
+    ApprovalRevoked,
+}
+
+impl AuditEventKind {
+    /// Stored and signed spelling. Stable on the wire — changing one of these
+    /// strings invalidates every event signature already written.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ApprovalGranted => "approval_granted",
+            Self::ApprovalConsumed => "approval_consumed",
+            Self::ApprovalRevoked => "approval_revoked",
+        }
+    }
+}
+
+/// Immutable content of one approval event, signed into the event chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventContent<'a> {
+    pub seq: u64,
+    pub key_id: &'a str,
+    pub kind: AuditEventKind,
+    pub transaction_id: &'a str,
+    /// The receipt digest the event concerns. Binds the event to the specific
+    /// receipt, so swapping in a different approval's digest breaks the
+    /// signature.
+    pub receipt_digest: &'a str,
+    pub created_at: &'a str,
+}
+
+impl EventContent<'_> {
+    /// Canonical encoding, using the same prefix-free field framing as
+    /// [`ChainContent::canonical_bytes`].
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(256);
+        push_field(&mut buf, "seq", &self.seq.to_string());
+        push_field(&mut buf, "key_id", self.key_id);
+        push_field(&mut buf, "kind", self.kind.as_str());
+        push_field(&mut buf, "transaction_id", self.transaction_id);
+        push_field(&mut buf, "receipt_digest", self.receipt_digest);
+        push_field(&mut buf, "created_at", self.created_at);
+        buf
+    }
+}
+
+fn event_message(content: &EventContent, prev_chain_hash: &str) -> Vec<u8> {
+    let mut msg = EVENT_DOMAIN.to_vec();
+    msg.extend_from_slice(&content.canonical_bytes());
+    msg.extend_from_slice(prev_chain_hash.as_bytes());
+    msg
+}
+
+impl AuditKey {
+    /// Compute the event-chain signature for `content` linked to
+    /// `prev_chain_hash`. Separate domain tag from rows and checkpoints, so an
+    /// event signature can never be replayed as a transaction row.
+    pub fn event_hash(&self, content: &EventContent, prev_chain_hash: &str) -> String {
+        hex::encode(
+            self.signing
+                .sign(&event_message(content, prev_chain_hash))
+                .to_bytes(),
+        )
+    }
+}
+
+/// One approval event as fetched from the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventRow {
+    pub seq: u64,
+    pub key_id: String,
+    /// Stored spelling of an [`AuditEventKind`]. Kept as a string so an
+    /// unrecognised value read from the database is a verification failure
+    /// rather than a deserialisation panic.
+    pub kind: String,
+    pub transaction_id: String,
+    pub receipt_digest: String,
+    pub created_at: String,
+    pub prev_chain_hash: String,
+    pub chain_hash: String,
+}
+
+/// Verify the approval-event chain with the daemon's key.
+pub fn verify_event_chain(key: &AuditKey, rows: &[EventRow]) -> VerifyOutcome {
+    verify_event_rows(&key.verifying_key(), Some(key.key_id()), rows)
+}
+
+/// Verify the approval-event chain with only the exported public key.
+pub fn verify_event_chain_with_pubkey(verifying_key_hex: &str, rows: &[EventRow]) -> VerifyOutcome {
+    match parse_verifying_key(verifying_key_hex) {
+        Some(vk) => verify_event_rows(&vk, None, rows),
+        None => VerifyOutcome::CannotVerify {
+            reason: format!(
+                "invalid public key hex ({} chars); expected 64 hex chars of a \
+                 32-byte Ed25519 public key",
+                verifying_key_hex.len()
+            ),
+        },
+    }
+}
+
+fn verify_event_rows(
+    vk: &VerifyingKey,
+    expect_key_id: Option<&str>,
+    rows: &[EventRow],
+) -> VerifyOutcome {
+    let mut last_hash = String::new();
+    let mut rows_checked = 0u64;
+    for row in rows {
+        if let Some(kid) = expect_key_id {
+            if row.key_id != kid {
+                return VerifyOutcome::CannotVerify {
+                    reason: format!(
+                        "event seq={} uses key_id={:?} but only {:?} is loaded; \
+                         epoch keys not yet supported",
+                        row.seq, row.key_id, kid
+                    ),
+                };
+            }
+        }
+        if row.prev_chain_hash != last_hash {
+            return VerifyOutcome::Broken {
+                rows_checked,
+                first_broken_seq: row.seq,
+                first_broken_transaction_id: row.transaction_id.clone(),
+                expected: format!("prev_chain_hash={last_hash}"),
+                actual: format!("prev_chain_hash={}", row.prev_chain_hash),
+            };
+        }
+        // An unknown `kind` cannot be re-encoded, so it can never reproduce a
+        // valid signature. Report it as the break it is instead of guessing.
+        let Some(kind) = parse_event_kind(&row.kind) else {
+            return VerifyOutcome::Broken {
+                rows_checked,
+                first_broken_seq: row.seq,
+                first_broken_transaction_id: row.transaction_id.clone(),
+                expected: "a known event kind".to_string(),
+                actual: format!("kind={:?}", row.kind),
+            };
+        };
+        let content = EventContent {
+            seq: row.seq,
+            key_id: &row.key_id,
+            kind,
+            transaction_id: &row.transaction_id,
+            receipt_digest: &row.receipt_digest,
+            created_at: &row.created_at,
+        };
+        if !signature_ok(
+            vk,
+            &event_message(&content, &row.prev_chain_hash),
+            &row.chain_hash,
+        ) {
+            return VerifyOutcome::Broken {
+                rows_checked,
+                first_broken_seq: row.seq,
+                first_broken_transaction_id: row.transaction_id.clone(),
+                expected: "valid ed25519 signature".to_string(),
+                actual: row.chain_hash.clone(),
+            };
+        }
+        last_hash = row.chain_hash.clone();
+        rows_checked += 1;
+    }
+    VerifyOutcome::Intact { rows_checked }
+}
+
+fn parse_event_kind(raw: &str) -> Option<AuditEventKind> {
+    // Exhaustive by construction: the match below fails to compile if a
+    // variant is added without a spelling here.
+    [
+        AuditEventKind::ApprovalGranted,
+        AuditEventKind::ApprovalConsumed,
+        AuditEventKind::ApprovalRevoked,
+    ]
+    .into_iter()
+    .find(|kind| kind.as_str() == raw)
+}
+
+/// Result of checking that the transaction chain's committed `event_tip`
+/// values are still reproducible from the event chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindingOutcome {
+    /// Every committed tip is present in the event chain.
+    Consistent { bindings_checked: u64 },
+    /// A transaction row committed to an event tip that no longer exists —
+    /// approval events were deleted from the end of the event chain, which the
+    /// event chain walk alone cannot see.
+    MissingEvent {
+        transaction_seq: u64,
+        event_tip: String,
+    },
+}
+
+/// Check the cross-chain binding: each `chain_version = 2` transaction row
+/// signs the event-chain tip as of its insert, so a later deletion of trailing
+/// approval events leaves a tip that can no longer be found.
+///
+/// This is what extends checkpoint anchoring to the event chain for free: the
+/// checkpoints commit to the transaction tip, the transaction rows commit to
+/// event tips. Events appended *after* the last transaction row are still
+/// unanchored until the next row is written — the same bounded tail exposure
+/// the transaction chain has between checkpoints.
+pub fn verify_event_binding(tx_rows: &[ChainRow], event_rows: &[EventRow]) -> BindingOutcome {
+    let known: std::collections::HashSet<&str> = event_rows
+        .iter()
+        .map(|row| row.chain_hash.as_str())
+        .collect();
+    let mut bindings_checked = 0u64;
+    for row in tx_rows {
+        let Some(tip) = row.event_tip.as_deref() else {
+            continue;
+        };
+        if tip.is_empty() {
+            continue;
+        }
+        if !known.contains(tip) {
+            return BindingOutcome::MissingEvent {
+                transaction_seq: row.seq,
+                event_tip: tip.to_string(),
+            };
+        }
+        bindings_checked += 1;
+    }
+    BindingOutcome::Consistent { bindings_checked }
+}
+
+/// Everything `sysknife audit verify` checks, in one value.
+///
+/// Three independent questions, deliberately not collapsed into one enum:
+/// is the authorisation record intact, is the approval record intact, and do
+/// the two still agree. Collapsing them would let a clean transaction chain
+/// mask a tampered approval trail in the summary line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditVerification {
+    pub chain: VerifyOutcome,
+    pub events: VerifyOutcome,
+    pub binding: BindingOutcome,
+}
+
+impl AuditVerification {
+    /// Worst result across all three checks.
+    ///
+    /// A detected tamper (`1`) outranks an inability to check (`2`): if the
+    /// chain is provably broken, reporting "could not verify" because some
+    /// *other* check was inconclusive would understate what is known.
+    pub fn exit_code(&self) -> i32 {
+        let codes = [
+            outcome_to_exit_code(&self.chain),
+            outcome_to_exit_code(&self.events),
+            binding_outcome_to_exit_code(&self.binding),
+        ];
+        if codes.contains(&1) {
+            1
+        } else if codes.contains(&2) {
+            2
+        } else {
+            0
+        }
+    }
+}
+
+/// Run all three checks with the daemon's key.
+pub fn verify_all(
+    key: &AuditKey,
+    tx_rows: &[ChainRow],
+    event_rows: &[EventRow],
+) -> AuditVerification {
+    AuditVerification {
+        chain: verify_chain(key, tx_rows),
+        events: verify_event_chain(key, event_rows),
+        binding: verify_event_binding(tx_rows, event_rows),
+    }
+}
+
+/// Run all three checks with only the exported public key (the auditor path).
+pub fn verify_all_with_pubkey(
+    verifying_key_hex: &str,
+    tx_rows: &[ChainRow],
+    event_rows: &[EventRow],
+) -> AuditVerification {
+    AuditVerification {
+        chain: verify_chain_with_pubkey(verifying_key_hex, tx_rows),
+        events: verify_event_chain_with_pubkey(verifying_key_hex, event_rows),
+        binding: verify_event_binding(tx_rows, event_rows),
+    }
+}
+
+/// Exit code for the binding check, on the same scale as
+/// [`outcome_to_exit_code`]: a missing event is a detected tamper (`1`).
+pub fn binding_outcome_to_exit_code(outcome: &BindingOutcome) -> i32 {
+    match outcome {
+        BindingOutcome::Consistent { .. } => 0,
+        BindingOutcome::MissingEvent { .. } => 1,
+    }
 }
 
 // ── Signed checkpoints (external anchoring / tail-truncation detection) ──────
@@ -794,6 +1244,10 @@ mod tests {
             approval_id: None,
             warnings_json: "[]",
             created_at: "2026-04-24T12:00:00Z",
+            identity: ChainIdentity::V2 {
+                caller_role: "Dev",
+                event_tip: "",
+            },
         }
     }
 
@@ -911,6 +1365,41 @@ mod tests {
 
     // ── verify_chain ──────────────────────────────────────────────────────
 
+    /// Materialise the stored row that `content` would produce, so a test
+    /// never hand-copies field-by-field and accidentally signs one thing while
+    /// storing another.
+    fn row_for(content: &ChainContent<'_>, prev: &str, chain_hash: String) -> ChainRow {
+        let (chain_version, caller_role, event_tip) = match content.identity {
+            ChainIdentity::LegacyV1 => (CHAIN_VERSION_LEGACY, None, None),
+            ChainIdentity::V2 {
+                caller_role,
+                event_tip,
+            } => (
+                CHAIN_VERSION_CURRENT,
+                Some(caller_role.to_string()),
+                Some(event_tip.to_string()),
+            ),
+        };
+        ChainRow {
+            seq: content.seq,
+            key_id: content.key_id.to_string(),
+            transaction_id: content.transaction_id.to_string(),
+            request_id: content.request_id.to_string(),
+            request_hash: content.request_hash.to_string(),
+            action_name: content.action_name.to_string(),
+            risk_level: content.risk_level,
+            summary: content.summary.to_string(),
+            approval_id: content.approval_id.map(str::to_string),
+            warnings_json: content.warnings_json.to_string(),
+            created_at: content.created_at.to_string(),
+            prev_chain_hash: prev.to_string(),
+            chain_hash,
+            chain_version,
+            caller_role,
+            event_tip,
+        }
+    }
+
     fn build_chain(key: &AuditKey, count: usize) -> Vec<ChainRow> {
         let mut rows = Vec::with_capacity(count);
         let mut prev = String::new();
@@ -919,17 +1408,175 @@ mod tests {
             let txid = format!("tx{i}");
             let content = sample_content(seq, &txid);
             let hash = key.chain_hash(&content, &prev);
-            rows.push(ChainRow {
+            rows.push(row_for(&content, &prev, hash.clone()));
+            prev = hash;
+        }
+        rows
+    }
+
+    // ── caller identity in the signed content ─────────────────────────────
+
+    #[test]
+    fn caller_role_is_covered_by_the_row_signature() {
+        // The whole point of the v2 encoding: two rows identical except for
+        // who asked must not share a signature, or the chain cannot answer
+        // "which role requested this".
+        let key = fixed_key();
+        let mut dev = sample_content(1, "txa");
+        dev.identity = ChainIdentity::V2 {
+            caller_role: "Dev",
+            event_tip: "",
+        };
+        let mut boot = sample_content(1, "txa");
+        boot.identity = ChainIdentity::V2 {
+            caller_role: "Boot",
+            event_tip: "",
+        };
+        assert_ne!(key.chain_hash(&dev, ""), key.chain_hash(&boot, ""));
+    }
+
+    #[test]
+    fn event_tip_is_covered_by_the_row_signature() {
+        let key = fixed_key();
+        let mut empty = sample_content(1, "txa");
+        empty.identity = ChainIdentity::V2 {
+            caller_role: "Dev",
+            event_tip: "",
+        };
+        let mut bound = sample_content(1, "txa");
+        bound.identity = ChainIdentity::V2 {
+            caller_role: "Dev",
+            event_tip: "abc123",
+        };
+        assert_ne!(key.chain_hash(&empty, ""), key.chain_hash(&bound, ""));
+    }
+
+    #[test]
+    fn a_legacy_row_written_before_the_migration_still_verifies() {
+        // The migration contract. A chain written by v0.2.12 or earlier has no
+        // caller_role column; re-encoding those rows with an empty identity
+        // would report every historical row as Broken, i.e. an upgrade would
+        // look exactly like a compromise.
+        let key = fixed_key();
+        let mut content = sample_content(1, "tx-legacy");
+        content.identity = ChainIdentity::LegacyV1;
+        let hash = key.chain_hash(&content, "");
+        let row = row_for(&content, "", hash);
+        assert_eq!(row.chain_version, CHAIN_VERSION_LEGACY);
+        assert_eq!(row.caller_role, None);
+        assert_eq!(
+            verify_chain(&key, &[row]),
+            VerifyOutcome::Intact { rows_checked: 1 }
+        );
+    }
+
+    #[test]
+    fn a_chain_that_spans_the_migration_verifies_end_to_end() {
+        // The realistic upgrade shape: old rows, then new rows appended by the
+        // upgraded daemon, in one chain.
+        let key = fixed_key();
+        let mut rows = Vec::new();
+        let mut prev = String::new();
+        for (i, identity) in [
+            ChainIdentity::LegacyV1,
+            ChainIdentity::LegacyV1,
+            ChainIdentity::V2 {
+                caller_role: "Dev",
+                event_tip: "",
+            },
+            ChainIdentity::V2 {
+                caller_role: "Boot",
+                event_tip: "",
+            },
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let txid = format!("tx{i}");
+            let mut content = sample_content((i + 1) as u64, &txid);
+            content.identity = identity;
+            let hash = key.chain_hash(&content, &prev);
+            rows.push(row_for(&content, &prev, hash.clone()));
+            prev = hash;
+        }
+        assert_eq!(
+            verify_chain(&key, &rows),
+            VerifyOutcome::Intact { rows_checked: 4 }
+        );
+    }
+
+    #[test]
+    fn downgrading_a_v2_row_to_hide_the_caller_role_breaks_it() {
+        // The attack the version column might invite: relabel a v2 row as
+        // legacy and drop the identity columns, so verification re-encodes it
+        // without caller_role. The stored signature was made over the v2
+        // message, so it cannot verify against the shorter one.
+        let key = fixed_key();
+        let mut rows = build_chain(&key, 2);
+        rows[1].chain_version = CHAIN_VERSION_LEGACY;
+        rows[1].caller_role = None;
+        rows[1].event_tip = None;
+        match verify_chain(&key, &rows) {
+            VerifyOutcome::Broken {
+                first_broken_seq, ..
+            } => assert_eq!(first_broken_seq, 2),
+            other => panic!("expected Broken, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_v2_row_with_a_nulled_caller_role_is_broken_not_merely_unverifiable() {
+        // Nulling the column while leaving chain_version=2 is a
+        // self-contradictory row, not an infrastructure problem. It must map
+        // to exit code 1 (tamper detected), never 2 (could not check) — a CI
+        // gate that treats 2 as "skip" would otherwise wave it through.
+        let key = fixed_key();
+        let mut rows = build_chain(&key, 1);
+        rows[0].caller_role = None;
+        let outcome = verify_chain(&key, &rows);
+        assert!(matches!(outcome, VerifyOutcome::Broken { .. }));
+        assert_eq!(outcome_to_exit_code(&outcome), 1);
+    }
+
+    #[test]
+    fn a_chain_version_this_binary_does_not_know_is_cannot_verify() {
+        // An older binary reading a newer chain genuinely cannot reproduce the
+        // message. That is exit 2, distinct from a detected break.
+        let key = fixed_key();
+        let mut rows = build_chain(&key, 1);
+        rows[0].chain_version = CHAIN_VERSION_CURRENT + 1;
+        let outcome = verify_chain(&key, &rows);
+        assert!(matches!(outcome, VerifyOutcome::CannotVerify { .. }));
+        assert_eq!(outcome_to_exit_code(&outcome), 2);
+    }
+
+    // ── approval-event chain ──────────────────────────────────────────────
+
+    fn event_content<'a>(seq: u64, kind: AuditEventKind, txid: &'a str) -> EventContent<'a> {
+        EventContent {
+            seq,
+            key_id: CURRENT_KEY_ID,
+            kind,
+            transaction_id: txid,
+            receipt_digest: "digest-abc",
+            created_at: "2026-04-24T12:00:00Z",
+        }
+    }
+
+    fn build_event_chain(key: &AuditKey, kinds: &[AuditEventKind]) -> Vec<EventRow> {
+        let mut rows = Vec::with_capacity(kinds.len());
+        let mut prev = String::new();
+        for (i, kind) in kinds.iter().enumerate() {
+            let seq = (i + 1) as u64;
+            let txid = format!("tx{i}");
+            let content = event_content(seq, *kind, &txid);
+            let hash = key.event_hash(&content, &prev);
+            rows.push(EventRow {
                 seq,
                 key_id: content.key_id.to_string(),
+                kind: content.kind.as_str().to_string(),
                 transaction_id: content.transaction_id.to_string(),
-                request_id: content.request_id.to_string(),
-                request_hash: content.request_hash.to_string(),
-                action_name: content.action_name.to_string(),
-                risk_level: content.risk_level,
-                summary: content.summary.to_string(),
-                approval_id: content.approval_id.map(str::to_string),
-                warnings_json: content.warnings_json.to_string(),
+                receipt_digest: content.receipt_digest.to_string(),
                 created_at: content.created_at.to_string(),
                 prev_chain_hash: prev.clone(),
                 chain_hash: hash.clone(),
@@ -937,6 +1584,225 @@ mod tests {
             prev = hash;
         }
         rows
+    }
+
+    #[test]
+    fn event_kind_spellings_are_stable() {
+        // These strings are inside the signed message. Renaming one silently
+        // invalidates every event already written.
+        assert_eq!(AuditEventKind::ApprovalGranted.as_str(), "approval_granted");
+        assert_eq!(
+            AuditEventKind::ApprovalConsumed.as_str(),
+            "approval_consumed"
+        );
+        assert_eq!(AuditEventKind::ApprovalRevoked.as_str(), "approval_revoked");
+    }
+
+    #[test]
+    fn intact_event_chain_verifies() {
+        let key = fixed_key();
+        let rows = build_event_chain(
+            &key,
+            &[
+                AuditEventKind::ApprovalGranted,
+                AuditEventKind::ApprovalConsumed,
+            ],
+        );
+        assert_eq!(
+            verify_event_chain(&key, &rows),
+            VerifyOutcome::Intact { rows_checked: 2 }
+        );
+    }
+
+    #[test]
+    fn deleting_an_approval_event_from_the_middle_breaks_the_event_chain() {
+        // The finding this chain exists for: before it, deleting the record
+        // that an approval happened left `audit verify` reporting Intact.
+        let key = fixed_key();
+        let mut rows = build_event_chain(
+            &key,
+            &[
+                AuditEventKind::ApprovalGranted,
+                AuditEventKind::ApprovalConsumed,
+                AuditEventKind::ApprovalRevoked,
+            ],
+        );
+        rows.remove(1);
+        match verify_event_chain(&key, &rows) {
+            VerifyOutcome::Broken {
+                first_broken_seq, ..
+            } => assert_eq!(first_broken_seq, 3),
+            other => panic!("expected Broken, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn relabelling_a_revocation_as_a_grant_breaks_the_event_chain() {
+        let key = fixed_key();
+        let mut rows = build_event_chain(&key, &[AuditEventKind::ApprovalRevoked]);
+        rows[0].kind = AuditEventKind::ApprovalGranted.as_str().to_string();
+        assert!(matches!(
+            verify_event_chain(&key, &rows),
+            VerifyOutcome::Broken { .. }
+        ));
+    }
+
+    #[test]
+    fn an_unrecognised_event_kind_is_a_break_not_a_panic() {
+        let key = fixed_key();
+        let mut rows = build_event_chain(&key, &[AuditEventKind::ApprovalGranted]);
+        rows[0].kind = "approval_unicorned".to_string();
+        assert!(matches!(
+            verify_event_chain(&key, &rows),
+            VerifyOutcome::Broken { .. }
+        ));
+    }
+
+    #[test]
+    fn a_row_signature_cannot_be_replayed_as_an_event_signature() {
+        // Domain separation, checked functionally rather than by comparing the
+        // tag constants: the tags test proves the bytes differ, this proves the
+        // difference actually reaches the verifier.
+        let key = fixed_key();
+        let content = event_content(1, AuditEventKind::ApprovalGranted, "tx0");
+        let event_sig = key.event_hash(&content, "");
+        let row_sig = key.chain_hash(&sample_content(1, "tx0"), "");
+        assert_ne!(event_sig, row_sig);
+
+        let mut rows = build_event_chain(&key, &[AuditEventKind::ApprovalGranted]);
+        rows[0].chain_hash = row_sig;
+        assert!(matches!(
+            verify_event_chain(&key, &rows),
+            VerifyOutcome::Broken { .. }
+        ));
+    }
+
+    // ── cross-chain binding ───────────────────────────────────────────────
+
+    #[test]
+    fn deleting_the_last_approval_event_is_caught_by_the_transaction_binding() {
+        // Truncating the *tail* of the event chain leaves a self-consistent
+        // event chain — the walk alone cannot see it. It is caught because a
+        // later transaction row signed the tip that no longer exists, and the
+        // transaction chain is what checkpoints anchor.
+        let key = fixed_key();
+        let events = build_event_chain(
+            &key,
+            &[
+                AuditEventKind::ApprovalGranted,
+                AuditEventKind::ApprovalConsumed,
+            ],
+        );
+        let mut content = sample_content(1, "tx-after");
+        content.identity = ChainIdentity::V2 {
+            caller_role: "Dev",
+            event_tip: &events[1].chain_hash,
+        };
+        let hash = key.chain_hash(&content, "");
+        let tx_rows = vec![row_for(&content, "", hash)];
+
+        assert_eq!(
+            verify_event_binding(&tx_rows, &events),
+            BindingOutcome::Consistent {
+                bindings_checked: 1
+            }
+        );
+
+        let truncated = &events[..1];
+        assert_eq!(
+            verify_event_chain(&key, truncated),
+            VerifyOutcome::Intact { rows_checked: 1 },
+            "a truncated event chain still walks clean; the binding is the detector"
+        );
+        match verify_event_binding(&tx_rows, truncated) {
+            BindingOutcome::MissingEvent {
+                transaction_seq, ..
+            } => assert_eq!(transaction_seq, 1),
+            other => panic!("expected MissingEvent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_rows_carry_no_binding_to_check() {
+        // Rows written before the migration never committed to an event tip.
+        // They must not be counted as bindings, and must not fail the check.
+        let key = fixed_key();
+        let mut content = sample_content(1, "tx-legacy");
+        content.identity = ChainIdentity::LegacyV1;
+        let hash = key.chain_hash(&content, "");
+        let rows = vec![row_for(&content, "", hash)];
+        assert_eq!(
+            verify_event_binding(&rows, &[]),
+            BindingOutcome::Consistent {
+                bindings_checked: 0
+            }
+        );
+    }
+
+    #[test]
+    fn a_detected_break_outranks_an_inconclusive_check_in_the_exit_code() {
+        // If one check proves tampering and another merely cannot run, the
+        // command must report the tamper. Reporting 2 ("could not verify")
+        // would let a CI gate that treats 2 as a skip wave a broken chain
+        // through.
+        let verification = AuditVerification {
+            chain: VerifyOutcome::Broken {
+                rows_checked: 1,
+                first_broken_seq: 2,
+                first_broken_transaction_id: "tx".to_string(),
+                expected: "e".to_string(),
+                actual: "a".to_string(),
+            },
+            events: VerifyOutcome::CannotVerify {
+                reason: "no key".to_string(),
+            },
+            binding: BindingOutcome::Consistent {
+                bindings_checked: 0,
+            },
+        };
+        assert_eq!(verification.exit_code(), 1);
+    }
+
+    #[test]
+    fn a_clean_transaction_chain_does_not_mask_a_broken_event_chain() {
+        let verification = AuditVerification {
+            chain: VerifyOutcome::Intact { rows_checked: 3 },
+            events: VerifyOutcome::Intact { rows_checked: 1 },
+            binding: BindingOutcome::MissingEvent {
+                transaction_seq: 3,
+                event_tip: "abc".to_string(),
+            },
+        };
+        assert_eq!(verification.exit_code(), 1);
+    }
+
+    #[test]
+    fn all_three_clean_is_exit_zero() {
+        let verification = AuditVerification {
+            chain: VerifyOutcome::Intact { rows_checked: 3 },
+            events: VerifyOutcome::Intact { rows_checked: 2 },
+            binding: BindingOutcome::Consistent {
+                bindings_checked: 1,
+            },
+        };
+        assert_eq!(verification.exit_code(), 0);
+    }
+
+    #[test]
+    fn binding_exit_codes_split_clean_from_tampered() {
+        assert_eq!(
+            binding_outcome_to_exit_code(&BindingOutcome::Consistent {
+                bindings_checked: 0
+            }),
+            0
+        );
+        assert_eq!(
+            binding_outcome_to_exit_code(&BindingOutcome::MissingEvent {
+                transaction_seq: 7,
+                event_tip: "abc".to_string()
+            }),
+            1
+        );
     }
 
     #[test]
@@ -1016,6 +1882,9 @@ mod tests {
             prev_chain_hash: rows[0].chain_hash.clone(),
             // Not a valid signature; verification must reject this.
             chain_hash: "0".repeat(HASH_HEX_LEN),
+            chain_version: CHAIN_VERSION_CURRENT,
+            caller_role: Some("Dev".to_string()),
+            event_tip: Some(String::new()),
         };
 
         // Renumber the genuine seq=2/3 rows so seq is still 1..=4.
@@ -1434,15 +2303,22 @@ mod tests {
         // Security invariant: row and checkpoint signatures can never
         // cross-verify because their signed messages start with distinct,
         // prefix-free domain tags.
-        assert_ne!(ROW_DOMAIN, CHECKPOINT_DOMAIN);
-        assert_ne!(ROW_DOMAIN, APPROVAL_DOMAIN);
-        assert_ne!(CHECKPOINT_DOMAIN, APPROVAL_DOMAIN);
-        assert!(!ROW_DOMAIN.starts_with(CHECKPOINT_DOMAIN));
-        assert!(!CHECKPOINT_DOMAIN.starts_with(ROW_DOMAIN));
-        assert!(!ROW_DOMAIN.starts_with(APPROVAL_DOMAIN));
-        assert!(!APPROVAL_DOMAIN.starts_with(ROW_DOMAIN));
-        assert!(!CHECKPOINT_DOMAIN.starts_with(APPROVAL_DOMAIN));
-        assert!(!APPROVAL_DOMAIN.starts_with(CHECKPOINT_DOMAIN));
+        // Checked pairwise over the whole set rather than as a hand-written
+        // list: adding a fourth tag to a hand-written list silently leaves the
+        // new tag unchecked against the old ones.
+        let tags: [(&str, &[u8]); 4] = [
+            ("row", ROW_DOMAIN),
+            ("checkpoint", CHECKPOINT_DOMAIN),
+            ("approval", APPROVAL_DOMAIN),
+            ("event", EVENT_DOMAIN),
+        ];
+        for (i, (name_a, a)) in tags.iter().enumerate() {
+            for (name_b, b) in tags.iter().skip(i + 1) {
+                assert_ne!(a, b, "{name_a} and {name_b} share a domain tag");
+                assert!(!a.starts_with(b), "{name_a} is prefixed by {name_b}");
+                assert!(!b.starts_with(a), "{name_b} is prefixed by {name_a}");
+            }
+        }
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/checkpoint_sink.rs
+++ b/crates/sysknife-daemon/src/checkpoint_sink.rs
@@ -336,7 +336,8 @@ pub fn spawn_periodic_anchor(
 mod tests {
     use super::*;
     use crate::audit_chain::{
-        verify_checkpoints, AuditKey, ChainContent, ChainRow, CheckpointOutcome,
+        verify_checkpoints, AuditKey, ChainContent, ChainIdentity, ChainRow, CheckpointOutcome,
+        CHAIN_VERSION_CURRENT,
     };
     use sysknife_types::RiskLevel;
 
@@ -363,6 +364,10 @@ mod tests {
                 approval_id: None,
                 warnings_json: "[]",
                 created_at: "2026-04-24T12:00:00Z",
+                identity: ChainIdentity::V2 {
+                    caller_role: "dev",
+                    event_tip: "",
+                },
             };
             let hash = key.chain_hash(&content, &prev);
             rows.push(ChainRow {
@@ -379,6 +384,9 @@ mod tests {
                 created_at: "2026-04-24T12:00:00Z".to_string(),
                 prev_chain_hash: prev.clone(),
                 chain_hash: hash.clone(),
+                chain_version: CHAIN_VERSION_CURRENT,
+                caller_role: Some("dev".to_string()),
+                event_tip: Some(String::new()),
             });
             prev = hash;
         }
@@ -455,6 +463,7 @@ mod anchor_tests {
                 approval_id: row.approval_id.as_deref(),
                 warnings_json: &row.warnings_json,
                 created_at: &row.created_at,
+                identity: row.identity().expect("fixture rows are well-formed"),
             };
             let hash = key.chain_hash(&content, &prev);
             let mut cloned = row.clone();

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -682,9 +682,14 @@ fn validate_action_platform(state: &DaemonState, action_name: &str) -> Result<()
     } else {
         None
     };
-    let is_mutating = state
-        .policy
-        .min_role_for_action(action_name)
+    // Deliberately the compile-time baseline, not `state.policy`. Whether an
+    // action mutates the system is a property of the action; whether a given
+    // caller may run it is what `[policy.risk_overrides]` decides. Reading it
+    // from the override-adjusted role let an operator who tightened RBAC on a
+    // read-only action also make that read fail when the host distro could not
+    // be detected — a distro requirement appearing as a side effect of an
+    // access-control change.
+    let is_mutating = crate::policy::min_role_for_action(action_name)
         .is_some_and(|role| role > CallerRole::Observer);
     if required_family.is_none() && !is_mutating {
         return Ok(());
@@ -1099,7 +1104,17 @@ async fn dispatch_loop<S>(
                 request_id,
                 action_name,
                 params,
-            } => handle_describe(framed, action_name, params, request_id).await,
+            } => {
+                handle_describe(
+                    framed,
+                    &state,
+                    &caller_role,
+                    action_name,
+                    params,
+                    request_id,
+                )
+                .await
+            }
             DaemonRequest::Cancel {
                 request_id,
                 transaction_id,
@@ -1463,6 +1478,15 @@ async fn handle_query_action(
         .await;
     }
 
+    // Same fence preview and execute apply. Without it a Fedora-only read-only
+    // action reached the executor on a Debian host and failed as "rpm-ostree:
+    // No such file or directory" — an execution error where the other paths
+    // give a clean refusal. Read-only actions with no family requirement short
+    // out inside `validate_action_platform`, so this costs them nothing.
+    if let Err(message) = validate_action_platform(state, action_name) {
+        return send_error(framed, request_id, "unsupported_platform", message).await;
+    }
+
     // Special case: ListJobHistory queries the daemon's own transaction
     // store rather than executing a system command. Handle it here to
     // avoid routing through the ActionSpec/executor path.
@@ -1627,12 +1651,47 @@ async fn handle_query_action(
 /// exactly what will run.
 async fn handle_describe(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
+    state: &DaemonState,
+    caller_role: &CallerRole,
     action_name: &str,
     params: &Value,
     request_id: &str,
 ) -> Result<(), HandlerError> {
     use crate::actions::ActionMechanism;
     use crate::executor::build_action_spec;
+
+    // Describe renders the exact command an action would run. It used to apply
+    // neither the authorization gate nor the platform fence, so any caller
+    // could enumerate the argv of every privileged action on the host and get
+    // a rendered command for actions this distro cannot run. Both gates match
+    // `handle_preview` so the three read paths agree on who may ask what.
+    //
+    // Unknown actions are rejected first: an unrecognised name is a client
+    // error, and reporting it as an authorization failure would both mislead
+    // the caller and make "does this action exist" indistinguishable from
+    // "am I allowed to see it" — which is the wrong trade for a name the
+    // catalogue is public about anyway.
+    if state.policy.min_role_for_action(action_name).is_none() {
+        return send_error(
+            framed,
+            request_id,
+            "validation_failure",
+            format!("unknown action: {action_name}"),
+        )
+        .await;
+    }
+    if !authorize_action(&state.policy, caller_role, action_name) {
+        return send_error(
+            framed,
+            request_id,
+            "authorization_failure",
+            format!("action '{action_name}' is not allowed for {caller_role:?} role"),
+        )
+        .await;
+    }
+    if let Err(message) = validate_action_platform(state, action_name) {
+        return send_error(framed, request_id, "unsupported_platform", message).await;
+    }
 
     // ListJobHistory is handled directly in the dispatcher (SQLite query) and
     // has no ActionSpec.  Return a synthetic describe response so callers get a
@@ -3544,6 +3603,31 @@ mod tests {
     }
 
     #[test]
+    fn raising_a_read_only_action_via_risk_overrides_does_not_arm_the_platform_fence() {
+        // `[policy.risk_overrides]` answers "who may run this", not "is this a
+        // mutation". Deriving `is_mutating` from the override-adjusted role let
+        // an operator who tightened RBAC on a harmless read also make that read
+        // fail whenever the host distro could not be detected — a restriction
+        // they never asked for, appearing in an unrelated subsystem.
+        let dir = tempdir().unwrap();
+        let mut state = test_state(&dir);
+        state.host_distro = None;
+        let overrides =
+            std::collections::HashMap::from([("GetDiskUsage".to_string(), "high".to_string())]);
+        state.policy = crate::policy::PolicyTable::from_overrides(&overrides).unwrap();
+
+        assert_eq!(
+            state.policy.min_role_for_action("GetDiskUsage"),
+            Some(CallerRole::Admin),
+            "the override still governs authorization"
+        );
+        assert!(
+            validate_action_platform(&state, "GetDiskUsage").is_ok(),
+            "a read-only action stays exempt from the distro fence"
+        );
+    }
+
+    #[test]
     fn supported_hosts_still_enforce_action_family() {
         let dir = tempdir().unwrap();
         let mut state = test_state(&dir);
@@ -3553,6 +3637,115 @@ mod tests {
         });
         assert!(validate_action_platform(&state, "AptInstall").is_ok());
         assert!(validate_action_platform(&state, "AddLayeredPackage").is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // query_action / describe — the same fences as preview and execute
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn query_action_refuses_an_action_the_host_family_cannot_run() {
+        // `preview` and `execute` both call `validate_action_platform`;
+        // `query_action` reached `build_action_spec` and ran the command. On a
+        // Debian host that meant shelling out to `rpm-ostree`, so the caller
+        // got a "No such file or directory" execution error instead of the
+        // clean refusal the other two paths give.
+        let dir = tempdir().unwrap();
+        let mut state = test_state(&dir);
+        state.host_distro = Some(sysknife_core::distro::DistroId::Ubuntu {
+            major: 24,
+            minor: 4,
+        });
+
+        let resps = exchange(
+            state,
+            CallerRole::Observer,
+            vec![json!({
+                "type": "query_action",
+                "request_id": "r1",
+                "action_name": "GetLayeredPackages",
+                "params": {}
+            })],
+            1,
+        )
+        .await;
+
+        assert_eq!(resps[0]["type"], "error_response");
+        assert_eq!(resps[0]["category"], "unsupported_platform");
+    }
+
+    #[tokio::test]
+    async fn describe_refuses_an_action_the_caller_is_not_allowed_to_run() {
+        // Describe renders the exact command an action would run. It had no
+        // authorization check at all, so an Observer could enumerate the argv
+        // of every privileged action on the box.
+        let dir = tempdir().unwrap();
+        let state = test_state(&dir);
+
+        let resps = exchange(
+            state,
+            CallerRole::Observer,
+            vec![json!({
+                "type": "describe",
+                "request_id": "r1",
+                "action_name": "GrantSudoAccess",
+                "params": {"username": "alice", "commands": "/usr/bin/ls", "nopasswd": false}
+            })],
+            1,
+        )
+        .await;
+
+        assert_eq!(resps[0]["type"], "error_response");
+        assert_eq!(resps[0]["category"], "authorization_failure");
+    }
+
+    #[tokio::test]
+    async fn describe_refuses_an_action_the_host_family_cannot_run() {
+        let dir = tempdir().unwrap();
+        let mut state = test_state(&dir);
+        state.host_distro = Some(sysknife_core::distro::DistroId::Ubuntu {
+            major: 24,
+            minor: 4,
+        });
+
+        let resps = exchange(
+            state,
+            CallerRole::Admin,
+            vec![json!({
+                "type": "describe",
+                "request_id": "r1",
+                "action_name": "AddLayeredPackage",
+                "params": {"package": "vim"}
+            })],
+            1,
+        )
+        .await;
+
+        assert_eq!(resps[0]["type"], "error_response");
+        assert_eq!(resps[0]["category"], "unsupported_platform");
+    }
+
+    #[tokio::test]
+    async fn describe_still_answers_for_an_allowed_action() {
+        // The fences must not turn describe into a privileged-only call: a
+        // read-only action stays describable by an Observer.
+        let dir = tempdir().unwrap();
+        let state = test_state(&dir);
+
+        let resps = exchange(
+            state,
+            CallerRole::Observer,
+            vec![json!({
+                "type": "describe",
+                "request_id": "r1",
+                "action_name": "GetDiskUsage",
+                "params": {}
+            })],
+            1,
+        )
+        .await;
+
+        assert_eq!(resps[0]["type"], "describe_response");
     }
 
     // ------------------------------------------------------------------

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -1797,6 +1797,9 @@ async fn handle_preview(
         risk_level: spec.risk_level,
         summary: preview.summary.clone(),
         warnings: preview.warnings.clone(),
+        // The role the daemon resolved for this connection, not anything the
+        // request carried. Signing it is what lets the audit answer "who".
+        caller_role: *caller_role,
     };
 
     let recorded = match state.audit.record_previewed(new_tx, preview.clone()).await {
@@ -3921,6 +3924,11 @@ mod tests {
             }
             async fn fetch_chain_rows(&self) -> Result<Vec<ChainRow>, TransactionStoreError> {
                 self.0.fetch_chain_rows().await
+            }
+            async fn fetch_event_rows(
+                &self,
+            ) -> Result<Vec<crate::audit_chain::EventRow>, TransactionStoreError> {
+                self.0.fetch_event_rows().await
             }
             async fn verify_audit_chain(
                 &self,

--- a/crates/sysknife-daemon/src/store.rs
+++ b/crates/sysknife-daemon/src/store.rs
@@ -33,7 +33,7 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use sysknife_types::{JobState, PreviewEnvelope, TransactionRecord};
 
-use crate::audit_chain::{AuditKey, ChainRow, VerifyOutcome};
+use crate::audit_chain::{AuditKey, ChainRow, EventRow, VerifyOutcome};
 use crate::transactions::{
     NewTransaction, RecordedPreviewedTransaction, TransactionStore, TransactionStoreError,
 };
@@ -163,10 +163,41 @@ pub trait AuditStore: Send + Sync + std::fmt::Debug {
 
     async fn fetch_chain_rows(&self) -> Result<Vec<ChainRow>, TransactionStoreError>;
 
+    /// Every approval event, in seq order. Backs the second chain that records
+    /// grant/consume/revoke — see `audit_chain::AuditEventKind`.
+    async fn fetch_event_rows(&self) -> Result<Vec<EventRow>, TransactionStoreError>;
+
     async fn verify_audit_chain(
         &self,
         key: &AuditKey,
     ) -> Result<VerifyOutcome, TransactionStoreError>;
+
+    /// Walk the approval-event chain.
+    ///
+    /// Provided rather than required: it is the same signature walk over rows
+    /// the backend has already fetched, so a backend that implements
+    /// `fetch_event_rows` correctly cannot get this wrong, and an override
+    /// would be a second place for the two chains' verification to drift.
+    async fn verify_event_chain(
+        &self,
+        key: &AuditKey,
+    ) -> Result<VerifyOutcome, TransactionStoreError> {
+        let rows = self.fetch_event_rows().await?;
+        Ok(crate::audit_chain::verify_event_chain(key, &rows))
+    }
+
+    /// Check that every event tip committed by a transaction row still exists
+    /// in the event chain. See `audit_chain::verify_event_binding`.
+    async fn verify_event_binding(
+        &self,
+    ) -> Result<crate::audit_chain::BindingOutcome, TransactionStoreError> {
+        let tx_rows = self.fetch_chain_rows().await?;
+        let event_rows = self.fetch_event_rows().await?;
+        Ok(crate::audit_chain::verify_event_binding(
+            &tx_rows,
+            &event_rows,
+        ))
+    }
 }
 
 /// Adapter that exposes the existing rusqlite-backed [`TransactionStore`]
@@ -342,6 +373,11 @@ impl AuditStore for SqliteStore {
         blocking(move || inner.fetch_chain_rows()).await
     }
 
+    async fn fetch_event_rows(&self) -> Result<Vec<EventRow>, TransactionStoreError> {
+        let inner = Arc::clone(&self.inner);
+        blocking(move || inner.fetch_event_rows()).await
+    }
+
     async fn verify_audit_chain(
         &self,
         key: &AuditKey,
@@ -363,7 +399,7 @@ mod tests {
     use super::*;
     use crate::audit_chain::AuditKey;
     use crate::transactions::NewTransaction;
-    use sysknife_types::RiskLevel;
+    use sysknife_types::{CallerRole, RiskLevel};
     use tempfile::tempdir;
 
     fn sqlite_store(path: std::path::PathBuf) -> SqliteStore {
@@ -379,6 +415,7 @@ mod tests {
             risk_level: RiskLevel::High,
             summary: "Upgrade the system".to_string(),
             warnings: vec![],
+            caller_role: CallerRole::Dev,
         }
     }
 

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -35,7 +35,10 @@ use subtle::ConstantTimeEq;
 use sysknife_types::{JobState, PreviewEnvelope, TransactionRecord};
 use uuid::Uuid;
 
-use crate::audit_chain::{AuditKey, ChainContent, ChainRow, VerifyOutcome, CURRENT_KEY_ID};
+use crate::audit_chain::{
+    AuditEventKind, AuditKey, AuditVerification, ChainContent, ChainIdentity, ChainRow,
+    EventContent, EventRow, VerifyOutcome, CHAIN_VERSION_CURRENT, CURRENT_KEY_ID,
+};
 use crate::audit_watermark::emit_chain_tip_watermark;
 use crate::store::AuditStore;
 use crate::transactions::{
@@ -89,7 +92,33 @@ const MIGRATIONS: &[Migration] = &[Migration {
         "#,
         "CREATE INDEX IF NOT EXISTS transactions_seq_idx ON transactions(seq)",
     ],
-}];
+},
+    // Mirrors SQLITE_MIGRATIONS v2 in `transactions.rs`. The columns are
+    // nullable with a legacy default because rows written by an earlier binary
+    // were signed over an encoding without them — see `ChainIdentity`.
+    Migration {
+        version: 2,
+        name: "caller_identity_and_approval_events",
+        statements: &[
+            "ALTER TABLE transactions ADD COLUMN IF NOT EXISTS chain_version BIGINT NOT NULL DEFAULT 1",
+            "ALTER TABLE transactions ADD COLUMN IF NOT EXISTS caller_role TEXT",
+            "ALTER TABLE transactions ADD COLUMN IF NOT EXISTS event_tip TEXT",
+            r#"
+            CREATE TABLE IF NOT EXISTS audit_events (
+                seq BIGINT PRIMARY KEY,
+                key_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                transaction_id TEXT NOT NULL,
+                receipt_digest TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                chain_hash TEXT NOT NULL,
+                prev_chain_hash TEXT NOT NULL DEFAULT ''
+            )
+            "#,
+            "CREATE INDEX IF NOT EXISTS audit_events_transaction_idx ON audit_events(transaction_id)",
+        ],
+    },
+];
 
 /// Configuration for the Postgres backend. Built by `main.rs` from
 /// `[storage]` in `config.toml`.
@@ -163,18 +192,34 @@ impl PostgresStore {
         Ok(store)
     }
 
-    /// Verify an existing Postgres chain with only the exported public key.
-    /// This path performs no migrations and never loads the signing key.
-    pub async fn verify_with_pubkey(
+    /// Verify an existing Postgres chain — transaction chain, approval-event
+    /// chain, and the binding between them — with only the exported public
+    /// key. This path performs no migrations and never loads the signing key.
+    pub async fn verify_all_with_pubkey(
         config: &PostgresConfig,
         verifying_key_hex: &str,
-    ) -> Result<VerifyOutcome, TransactionStoreError> {
+    ) -> Result<AuditVerification, TransactionStoreError> {
         let pool = Self::connect_pool(config).await?;
-        let rows = fetch_chain_rows_from_pool(&pool).await?;
-        Ok(crate::audit_chain::verify_chain_with_pubkey(
+        let tx_rows = fetch_chain_rows_from_pool(&pool).await?;
+        // A chain written before the migration has no `audit_events` table.
+        // That is an absent feature, not a missing verification: report zero
+        // events rather than failing the whole verify.
+        let event_rows = fetch_event_rows_from_pool(&pool).await.unwrap_or_default();
+        Ok(crate::audit_chain::verify_all_with_pubkey(
             verifying_key_hex,
-            &rows,
+            &tx_rows,
+            &event_rows,
         ))
+    }
+
+    /// All three checks with the daemon's key.
+    pub async fn verify_all(
+        &self,
+        key: &AuditKey,
+    ) -> Result<AuditVerification, TransactionStoreError> {
+        let tx_rows = fetch_chain_rows_from_pool(&self.pool).await?;
+        let event_rows = fetch_event_rows_from_pool(&self.pool).await?;
+        Ok(crate::audit_chain::verify_all(key, &tx_rows, &event_rows))
     }
 
     /// Apply pending schema migrations atomically. The advisory transaction
@@ -435,6 +480,9 @@ impl AuditStore for PostgresStore {
             )));
         }
         let queued = serialize(&JobState::Queued)?;
+        // Approval row and chained event commit together — an approval absent
+        // from the event chain is exactly what that chain exists to prevent.
+        let mut tx = self.pool.begin().await.map_err(map_sqlx_err)?;
         let result = sqlx_core::query::query(
             sqlx_core::sql_str::AssertSqlSafe(format!(
                 "INSERT INTO transaction_approvals \
@@ -446,13 +494,24 @@ impl AuditStore for PostgresStore {
                  ON CONFLICT (transaction_id) DO NOTHING"
             )),
         )
-        .bind(receipt_digest)
+        .bind(&receipt_digest)
         .bind(now_iso())
         .bind(transaction_id)
         .bind(&queued)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(map_sqlx_err)?;
+        if result.rows_affected() > 0 {
+            append_event(
+                &mut tx,
+                &self.audit_key,
+                AuditEventKind::ApprovalGranted,
+                transaction_id,
+                &receipt_digest,
+            )
+            .await?;
+        }
+        tx.commit().await.map_err(map_sqlx_err)?;
         Ok((result.rows_affected() > 0).then_some(receipt))
     }
 
@@ -460,14 +519,41 @@ impl AuditStore for PostgresStore {
         &self,
         transaction_id: &str,
     ) -> Result<bool, TransactionStoreError> {
+        let mut tx = self.pool.begin().await.map_err(map_sqlx_err)?;
+        // Read the digest before the DELETE: the event names which receipt was
+        // retracted, and after the delete there is nothing left to name.
+        let digest: Option<String> = sqlx_core::query_scalar::query_scalar(
+            "SELECT receipt_digest FROM transaction_approvals \
+             WHERE transaction_id = $1 AND consumed_at IS NULL",
+        )
+        .bind(transaction_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_sqlx_err)?;
         let result = sqlx_core::query::query(
             "DELETE FROM transaction_approvals \
              WHERE transaction_id = $1 AND consumed_at IS NULL",
         )
         .bind(transaction_id)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(map_sqlx_err)?;
+        if result.rows_affected() > 0 {
+            let digest = digest.ok_or_else(|| {
+                TransactionStoreError::DatabaseInvariant(format!(
+                    "revoked an approval for {transaction_id} that had no receipt digest"
+                ))
+            })?;
+            append_event(
+                &mut tx,
+                &self.audit_key,
+                AuditEventKind::ApprovalRevoked,
+                transaction_id,
+                &digest,
+            )
+            .await?;
+        }
+        tx.commit().await.map_err(map_sqlx_err)?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -510,6 +596,14 @@ impl AuditStore for PostgresStore {
             .execute(&mut *tx)
             .await
             .map_err(map_sqlx_err)?;
+            append_event(
+                &mut tx,
+                &self.audit_key,
+                AuditEventKind::ApprovalConsumed,
+                transaction_id,
+                receipt_digest,
+            )
+            .await?;
         }
         tx.commit().await.map_err(map_sqlx_err)?;
         Ok(result.rows_affected() > 0)
@@ -678,6 +772,10 @@ impl AuditStore for PostgresStore {
         row.map(row_to_chain_row).transpose()
     }
 
+    async fn fetch_event_rows(&self) -> Result<Vec<EventRow>, TransactionStoreError> {
+        fetch_event_rows_from_pool(&self.pool).await
+    }
+
     async fn fetch_chain_rows(&self) -> Result<Vec<ChainRow>, TransactionStoreError> {
         fetch_chain_rows_from_pool(&self.pool).await
     }
@@ -702,6 +800,74 @@ async fn fetch_chain_rows_from_pool(pool: &PgPool) -> Result<Vec<ChainRow>, Tran
     .await
     .map_err(map_sqlx_err)?;
     rows.into_iter().map(row_to_chain_row).collect()
+}
+
+/// Fetch every approval event in seq order.
+async fn fetch_event_rows_from_pool(pool: &PgPool) -> Result<Vec<EventRow>, TransactionStoreError> {
+    let rows = sqlx_core::query::query(
+        "SELECT seq, key_id, kind, transaction_id, receipt_digest, \
+                created_at, prev_chain_hash, chain_hash \
+         FROM audit_events ORDER BY seq ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_err)?;
+    rows.into_iter().map(row_to_event_row).collect()
+}
+
+/// Append one signed approval event inside the caller's transaction.
+///
+/// `FOR UPDATE` on the current tip serialises concurrent appends the same way
+/// `insert_transaction` serialises on the transaction chain tip; without it two
+/// approvals could compute the same `seq` and collide on the primary key.
+async fn append_event(
+    tx: &mut sqlx_core::transaction::Transaction<'_, sqlx_postgres::Postgres>,
+    key: &AuditKey,
+    kind: AuditEventKind,
+    transaction_id: &str,
+    receipt_digest: &str,
+) -> Result<(), TransactionStoreError> {
+    let prev: Option<(i64, String)> = sqlx_core::query_as::query_as(
+        "SELECT seq, chain_hash FROM audit_events ORDER BY seq DESC LIMIT 1 FOR UPDATE",
+    )
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(map_sqlx_err)?;
+    let (seq, prev_chain_hash) = match prev {
+        Some((s, h)) => ((s as u64) + 1, h),
+        None => (1, String::new()),
+    };
+    let created_at = now_iso();
+    let key_id = CURRENT_KEY_ID.to_string();
+    let chain_hash = key.event_hash(
+        &EventContent {
+            seq,
+            key_id: &key_id,
+            kind,
+            transaction_id,
+            receipt_digest,
+            created_at: &created_at,
+        },
+        &prev_chain_hash,
+    );
+    sqlx_core::query::query(
+        "INSERT INTO audit_events ( \
+            seq, key_id, kind, transaction_id, receipt_digest, \
+            created_at, chain_hash, prev_chain_hash \
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+    )
+    .bind(seq as i64)
+    .bind(&key_id)
+    .bind(kind.as_str())
+    .bind(transaction_id)
+    .bind(receipt_digest)
+    .bind(&created_at)
+    .bind(&chain_hash)
+    .bind(&prev_chain_hash)
+    .execute(&mut **tx)
+    .await
+    .map_err(map_sqlx_err)?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -738,6 +904,16 @@ async fn insert_transaction(
         None => (1, String::new()),
     };
 
+    // Bind the row to the approval-event chain tip as of this insert. Read
+    // inside the same DB transaction as the seq allocation above.
+    let event_tip: String = sqlx_core::query_scalar::query_scalar(
+        "SELECT COALESCE((SELECT chain_hash FROM audit_events ORDER BY seq DESC LIMIT 1), '')",
+    )
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(map_sqlx_err)?;
+    let caller_role = transaction.caller_role.as_str();
+
     let chain_hash = key.chain_hash(
         &ChainContent {
             seq,
@@ -751,6 +927,10 @@ async fn insert_transaction(
             approval_id: approval_id.as_deref(),
             warnings_json: &warnings_json,
             created_at: &created_at,
+            identity: ChainIdentity::V2 {
+                caller_role,
+                event_tip: &event_tip,
+            },
         },
         &prev_chain_hash,
     );
@@ -759,8 +939,9 @@ async fn insert_transaction(
         "INSERT INTO transactions ( \
             transaction_id, request_id, request_hash, action_name, risk_level, \
             status, approval_id, summary, warnings_json, created_at, \
-            seq, key_id, chain_hash, prev_chain_hash \
-         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
+            seq, key_id, chain_hash, prev_chain_hash, \
+            chain_version, caller_role, event_tip \
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)",
     )
     .bind(transaction_id)
     .bind(&transaction.request_id)
@@ -776,6 +957,9 @@ async fn insert_transaction(
     .bind(&key_id)
     .bind(&chain_hash)
     .bind(&prev_chain_hash)
+    .bind(i64::from(CHAIN_VERSION_CURRENT))
+    .bind(caller_role)
+    .bind(&event_tip)
     .execute(&mut **tx)
     .await
     .map_err(map_sqlx_err)?;
@@ -852,6 +1036,24 @@ fn row_to_chain_row(row: sqlx_postgres::PgRow) -> Result<ChainRow, TransactionSt
         summary: row.try_get("summary").map_err(map_sqlx_err)?,
         approval_id: row.try_get("approval_id").map_err(map_sqlx_err)?,
         warnings_json: row.try_get("warnings_json").map_err(map_sqlx_err)?,
+        created_at: row.try_get("created_at").map_err(map_sqlx_err)?,
+        prev_chain_hash: row.try_get("prev_chain_hash").map_err(map_sqlx_err)?,
+        chain_hash: row.try_get("chain_hash").map_err(map_sqlx_err)?,
+        chain_version: row
+            .try_get::<i64, _>("chain_version")
+            .map_err(map_sqlx_err)? as u32,
+        caller_role: row.try_get("caller_role").map_err(map_sqlx_err)?,
+        event_tip: row.try_get("event_tip").map_err(map_sqlx_err)?,
+    })
+}
+
+fn row_to_event_row(row: sqlx_postgres::PgRow) -> Result<EventRow, TransactionStoreError> {
+    Ok(EventRow {
+        seq: row.try_get::<i64, _>("seq").map_err(map_sqlx_err)? as u64,
+        key_id: row.try_get("key_id").map_err(map_sqlx_err)?,
+        kind: row.try_get("kind").map_err(map_sqlx_err)?,
+        transaction_id: row.try_get("transaction_id").map_err(map_sqlx_err)?,
+        receipt_digest: row.try_get("receipt_digest").map_err(map_sqlx_err)?,
         created_at: row.try_get("created_at").map_err(map_sqlx_err)?,
         prev_chain_hash: row.try_get("prev_chain_hash").map_err(map_sqlx_err)?,
         chain_hash: row.try_get("chain_hash").map_err(map_sqlx_err)?,

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -48,6 +48,17 @@ use crate::transactions::{
 
 const MIGRATION_LOCK_ID: i64 = 0x5359_534b_4e49_4645;
 
+/// Column list every `ChainRow` read shares, kept next to `row_to_chain_row`.
+///
+/// The two read paths each spelled the list out. Adding the caller-identity
+/// columns updated the mapper and one of the two queries, and the miss showed
+/// up only as a runtime "no column found for name: chain_version" from the
+/// live-Postgres test — the unit tests, which never touch this SQL, stayed
+/// green. Mirrors `CHAIN_ROW_COLUMNS` in `transactions.rs`.
+const CHAIN_ROW_COLUMNS: &str = "seq, key_id, transaction_id, request_id, request_hash, \
+     action_name, risk_level, summary, approval_id, warnings_json, \
+     created_at, prev_chain_hash, chain_hash, chain_version, caller_role, event_tip";
+
 struct Migration {
     version: i64,
     name: &'static str,
@@ -759,12 +770,9 @@ impl AuditStore for PostgresStore {
         &self,
         transaction_id: &str,
     ) -> Result<Option<ChainRow>, TransactionStoreError> {
-        let row = sqlx_core::query::query(
-            "SELECT seq, key_id, transaction_id, request_id, request_hash, \
-                    action_name, risk_level, summary, approval_id, warnings_json, \
-                    created_at, prev_chain_hash, chain_hash \
-             FROM transactions WHERE transaction_id = $1",
-        )
+        let row = sqlx_core::query::query(sqlx_core::sql_str::AssertSqlSafe(format!(
+            "SELECT {CHAIN_ROW_COLUMNS} FROM transactions WHERE transaction_id = $1"
+        )))
         .bind(transaction_id)
         .fetch_optional(&self.pool)
         .await
@@ -790,12 +798,9 @@ impl AuditStore for PostgresStore {
 }
 
 async fn fetch_chain_rows_from_pool(pool: &PgPool) -> Result<Vec<ChainRow>, TransactionStoreError> {
-    let rows = sqlx_core::query::query(
-        "SELECT seq, key_id, transaction_id, request_id, request_hash, \
-                    action_name, risk_level, summary, approval_id, warnings_json, \
-                    created_at, prev_chain_hash, chain_hash \
-             FROM transactions ORDER BY seq ASC",
-    )
+    let rows = sqlx_core::query::query(sqlx_core::sql_str::AssertSqlSafe(format!(
+        "SELECT {CHAIN_ROW_COLUMNS} FROM transactions ORDER BY seq ASC"
+    )))
     .fetch_all(pool)
     .await
     .map_err(map_sqlx_err)?;

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -1,11 +1,14 @@
-use crate::audit_chain::{self, AuditKey, ChainContent, ChainRow, VerifyOutcome, CURRENT_KEY_ID};
+use crate::audit_chain::{
+    self, AuditEventKind, AuditKey, ChainContent, ChainIdentity, ChainRow, EventContent, EventRow,
+    VerifyOutcome, CHAIN_VERSION_CURRENT, CURRENT_KEY_ID,
+};
 use crate::audit_watermark::emit_chain_tip_watermark;
 use rusqlite::{params, Connection, TransactionBehavior};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
-use sysknife_types::{JobState, PreviewEnvelope, RiskLevel, TransactionRecord};
+use sysknife_types::{CallerRole, JobState, PreviewEnvelope, RiskLevel, TransactionRecord};
 use uuid::Uuid;
 
 /// Lifetime of an approval receipt / preview, in minutes.
@@ -69,6 +72,162 @@ pub struct NewTransaction {
     /// 2. Extend the chain protocol with a dedicated amendment record type.
     pub summary: String,
     pub warnings: Vec<String>,
+    /// Role the daemon resolved for the connection that asked for this action.
+    ///
+    /// Chain-hashed at INSERT alongside `summary`. Before this field existed
+    /// the signed record could say what was authorised but not *who asked*,
+    /// which is the first question any audit of a privileged action starts
+    /// with. Not caller-supplied over the wire: the dispatcher passes the role
+    /// it resolved from `SO_PEERCRED` (or the vsock token), never a value from
+    /// the request body.
+    pub caller_role: CallerRole,
+}
+
+/// One forward-only SQLite schema step, applied in `version` order and
+/// recorded in `schema_migrations`.
+///
+/// This mirrors the Postgres `MIGRATIONS` list deliberately. The SQLite path
+/// used to be a single `CREATE TABLE IF NOT EXISTS` batch plus a hardcoded
+/// `version > 1` guard, which had no way to express "add a column to an
+/// existing database" — `IF NOT EXISTS` skips a table that is already there,
+/// columns and all. Adding the caller-identity columns needed a real step.
+struct SqliteMigration {
+    version: i64,
+    name: &'static str,
+    sql: &'static str,
+}
+
+/// Schema history for the SQLite backend.
+///
+/// Migration 1 covers the append-tamper-evident hash chain (see
+/// `audit_chain.rs` for the full threat model — note that truncation of the
+/// tail is NOT detected by this chain alone; that requires the signed
+/// checkpoints anchored to an append-only sink (`checkpoint_sink`), with the
+/// journald watermark as a lighter best-effort complement):
+///   seq             — monotonic ordering, 1-indexed
+///   key_id          — identifies the key generation (forward-compatible with
+///                     epoch rotation in a follow-up issue)
+///   chain_hash      — ed25519_sign(ROW_DOMAIN || canonical(immutable_fields)
+///                     || prev_chain_hash, key)
+///   prev_chain_hash — chain_hash of the previous row, "" for the first row
+///
+/// `status` is intentionally absent from the chain content — it is mutable.
+/// The chain protects the *authorisation decision* captured at insert time,
+/// not the live execution state.
+const SQLITE_MIGRATIONS: &[SqliteMigration] = &[
+    SqliteMigration {
+        version: 1,
+        name: "initial_audit_schema",
+        sql: r#"
+            CREATE TABLE IF NOT EXISTS transactions (
+                transaction_id TEXT PRIMARY KEY,
+                request_id TEXT NOT NULL,
+                request_hash TEXT NOT NULL,
+                action_name TEXT NOT NULL,
+                risk_level TEXT NOT NULL,
+                status TEXT NOT NULL,
+                approval_id TEXT,
+                summary TEXT NOT NULL,
+                warnings_json TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                seq INTEGER NOT NULL UNIQUE,
+                key_id TEXT NOT NULL,
+                chain_hash TEXT NOT NULL,
+                prev_chain_hash TEXT NOT NULL DEFAULT ''
+            );
+
+            CREATE TABLE IF NOT EXISTS transaction_previews (
+                transaction_id TEXT PRIMARY KEY,
+                preview_json TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS transaction_approvals (
+                transaction_id TEXT PRIMARY KEY,
+                receipt_digest TEXT NOT NULL,
+                approved_at TEXT NOT NULL DEFAULT (datetime('now')),
+                consumed_at TEXT
+            );
+
+            CREATE INDEX IF NOT EXISTS transactions_seq_idx ON transactions(seq);
+        "#,
+    },
+    // Caller identity in the signed content, and the approval-event chain.
+    //
+    // The three new `transactions` columns are nullable with a legacy default
+    // on purpose: rows written by an earlier binary were signed over an
+    // encoding that has no such fields, and backfilling them with empty
+    // strings would change every historical message and report the whole chain
+    // as Broken. `chain_version` selects the encoding per row — see
+    // `audit_chain::ChainIdentity`.
+    SqliteMigration {
+        version: 2,
+        name: "caller_identity_and_approval_events",
+        sql: r#"
+            ALTER TABLE transactions ADD COLUMN chain_version INTEGER NOT NULL DEFAULT 1;
+            ALTER TABLE transactions ADD COLUMN caller_role TEXT;
+            ALTER TABLE transactions ADD COLUMN event_tip TEXT;
+
+            CREATE TABLE IF NOT EXISTS audit_events (
+                seq INTEGER PRIMARY KEY,
+                key_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                transaction_id TEXT NOT NULL,
+                receipt_digest TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                chain_hash TEXT NOT NULL,
+                prev_chain_hash TEXT NOT NULL DEFAULT ''
+            );
+
+            CREATE INDEX IF NOT EXISTS audit_events_transaction_idx
+                ON audit_events(transaction_id);
+        "#,
+    },
+];
+
+/// Column list for every `ChainRow` read, kept next to the mapper below.
+///
+/// The two read paths (`fetch_chain_rows`, `fetch_chain_row`) used to repeat
+/// both the SELECT and a positional `row.get(n)` block. Adding a column meant
+/// editing four places in step, and a mismatch between the two would surface
+/// as a verification failure rather than a compile error.
+const CHAIN_ROW_COLUMNS: &str = "seq, key_id, transaction_id, request_id, request_hash, \
+     action_name, risk_level, summary, approval_id, warnings_json, \
+     created_at, prev_chain_hash, chain_hash, chain_version, caller_role, event_tip";
+
+fn chain_row_from_sqlite(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChainRow> {
+    Ok(ChainRow {
+        seq: row.get::<_, i64>(0)? as u64,
+        key_id: row.get(1)?,
+        transaction_id: row.get(2)?,
+        request_id: row.get(3)?,
+        request_hash: row.get(4)?,
+        action_name: row.get(5)?,
+        risk_level: deserialize_field(&row.get::<_, String>(6)?).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, Box::new(e))
+        })?,
+        summary: row.get(7)?,
+        approval_id: row.get(8)?,
+        warnings_json: row.get(9)?,
+        created_at: row.get(10)?,
+        prev_chain_hash: row.get(11)?,
+        chain_hash: row.get(12)?,
+        chain_version: row.get::<_, i64>(13)? as u32,
+        caller_role: row.get(14)?,
+        event_tip: row.get(15)?,
+    })
+}
+
+fn event_row_from_sqlite(row: &rusqlite::Row<'_>) -> rusqlite::Result<EventRow> {
+    Ok(EventRow {
+        seq: row.get::<_, i64>(0)? as u64,
+        key_id: row.get(1)?,
+        kind: row.get(2)?,
+        transaction_id: row.get(3)?,
+        receipt_digest: row.get(4)?,
+        created_at: row.get(5)?,
+        prev_chain_hash: row.get(6)?,
+        chain_hash: row.get(7)?,
+    })
 }
 
 #[derive(Clone, Debug)]
@@ -368,9 +527,12 @@ impl TransactionStore {
             )));
         }
 
-        let conn = self.connection()?;
+        // The approval row and its chained event commit together: an approval
+        // that is not in the event chain is exactly the gap this chain closes.
+        let mut conn = self.connection()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let queued_json = serialize_field(&JobState::Queued)?;
-        let rows_affected = conn.execute(
+        let rows_affected = tx.execute(
             &format!(
                 "INSERT INTO transaction_approvals (transaction_id, receipt_digest) \
                  SELECT transaction_id, ?1 FROM transactions \
@@ -383,6 +545,16 @@ impl TransactionStore {
             ),
             params![receipt_digest, transaction_id, queued_json],
         )?;
+        if rows_affected > 0 {
+            Self::append_event(
+                &tx,
+                key,
+                AuditEventKind::ApprovalGranted,
+                transaction_id,
+                &receipt_digest,
+            )?;
+        }
+        tx.commit()?;
         Ok((rows_affected > 0).then_some(receipt))
     }
 
@@ -392,12 +564,48 @@ impl TransactionStore {
         &self,
         transaction_id: &str,
     ) -> Result<bool, TransactionStoreError> {
-        let conn = self.connection()?;
-        let rows_affected = conn.execute(
+        let key = self
+            .audit_key
+            .as_ref()
+            .ok_or(TransactionStoreError::AuditChainMissing(
+                "this TransactionStore was opened read-only; cannot revoke",
+            ))?;
+        let mut conn = self.connection()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        // Capture the digest before the DELETE: the event has to name which
+        // receipt was retracted, and after the delete there is nothing to name.
+        let digest: Option<String> = tx
+            .query_row(
+                "SELECT receipt_digest FROM transaction_approvals \
+                 WHERE transaction_id = ?1 AND consumed_at IS NULL",
+                params![transaction_id],
+                |row| row.get(0),
+            )
+            .map(Some)
+            .or_else(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                other => Err(other),
+            })?;
+        let rows_affected = tx.execute(
             "DELETE FROM transaction_approvals \
              WHERE transaction_id = ?1 AND consumed_at IS NULL",
             params![transaction_id],
         )?;
+        if rows_affected > 0 {
+            let digest = digest.ok_or_else(|| {
+                TransactionStoreError::DatabaseInvariant(format!(
+                    "revoked an approval for {transaction_id} that had no receipt digest"
+                ))
+            })?;
+            Self::append_event(
+                &tx,
+                key,
+                AuditEventKind::ApprovalRevoked,
+                transaction_id,
+                &digest,
+            )?;
+        }
+        tx.commit()?;
         Ok(rows_affected > 0)
     }
 
@@ -407,6 +615,12 @@ impl TransactionStore {
         transaction_id: &str,
         receipt_digest: &str,
     ) -> Result<bool, TransactionStoreError> {
+        let key = self
+            .audit_key
+            .as_ref()
+            .ok_or(TransactionStoreError::AuditChainMissing(
+                "this TransactionStore was opened read-only; cannot claim",
+            ))?;
         let mut conn = self.connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let queued_json = serialize_field(&JobState::Queued)?;
@@ -432,6 +646,13 @@ impl TransactionStore {
                  SET consumed_at = datetime('now') \
                  WHERE transaction_id = ?1 AND consumed_at IS NULL",
                 params![transaction_id],
+            )?;
+            Self::append_event(
+                &tx,
+                key,
+                AuditEventKind::ApprovalConsumed,
+                transaction_id,
+                receipt_digest,
             )?;
         }
         tx.commit()?;
@@ -638,64 +859,19 @@ impl TransactionStore {
             [],
             |row| row.get(0),
         )?;
-        if current > 1 {
+        let latest = SQLITE_MIGRATIONS.last().map_or(0, |m| m.version);
+        if current > latest {
             return Err(TransactionStoreError::DatabaseInvariant(format!(
-                "sqlite schema version {current} is newer than this binary supports (1)"
+                "sqlite schema version {current} is newer than this binary supports ({latest})"
             )));
         }
-        // Schema additions for the append-tamper-evident hash chain (see
-        // `audit_chain.rs` for the full threat model — note that truncation of
-        // the tail is NOT detected by this chain alone; that requires the
-        // signed checkpoints anchored to an append-only sink (`checkpoint_sink`),
-        // with the journald watermark as a lighter best-effort complement):
-        //   seq             — monotonic ordering, 1-indexed
-        //   key_id          — identifies the key generation (forward-compatible
-        //                     with epoch rotation in a follow-up issue)
-        //   chain_hash      — ed25519_sign(ROW_DOMAIN || canonical(immutable_fields)
-        //                     || prev_chain_hash, key)
-        //   prev_chain_hash — chain_hash of the previous row, "" for the first row
-        //
-        // status is intentionally absent from the chain content — it is mutable.
-        // The chain protects the *authorisation decision* captured at insert
-        // time, not the live execution state.
-        tx.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS transactions (
-                transaction_id TEXT PRIMARY KEY,
-                request_id TEXT NOT NULL,
-                request_hash TEXT NOT NULL,
-                action_name TEXT NOT NULL,
-                risk_level TEXT NOT NULL,
-                status TEXT NOT NULL,
-                approval_id TEXT,
-                summary TEXT NOT NULL,
-                warnings_json TEXT NOT NULL,
-                created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                seq INTEGER NOT NULL UNIQUE,
-                key_id TEXT NOT NULL,
-                chain_hash TEXT NOT NULL,
-                prev_chain_hash TEXT NOT NULL DEFAULT ''
-            );
-
-            CREATE TABLE IF NOT EXISTS transaction_previews (
-                transaction_id TEXT PRIMARY KEY,
-                preview_json TEXT NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS transaction_approvals (
-                transaction_id TEXT PRIMARY KEY,
-                receipt_digest TEXT NOT NULL,
-                approved_at TEXT NOT NULL DEFAULT (datetime('now')),
-                consumed_at TEXT
-            );
-
-            CREATE INDEX IF NOT EXISTS transactions_seq_idx ON transactions(seq);
-            "#,
-        )?;
-        tx.execute(
-            "INSERT OR IGNORE INTO schema_migrations (version, name) VALUES (1, ?1)",
-            params!["initial_audit_schema"],
-        )?;
+        for migration in SQLITE_MIGRATIONS.iter().filter(|m| m.version > current) {
+            tx.execute_batch(migration.sql)?;
+            tx.execute(
+                "INSERT INTO schema_migrations (version, name) VALUES (?1, ?2)",
+                params![migration.version, migration.name],
+            )?;
+        }
         tx.commit()?;
         Ok(())
     }
@@ -703,35 +879,26 @@ impl TransactionStore {
     /// Return all rows in seq order with the chain fields needed for verify.
     pub fn fetch_chain_rows(&self) -> Result<Vec<ChainRow>, TransactionStoreError> {
         let conn = self.connection()?;
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {CHAIN_ROW_COLUMNS} FROM transactions ORDER BY seq ASC"
+        ))?;
+        let rows = stmt.query_map([], chain_row_from_sqlite)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Return every approval event in seq order.
+    pub fn fetch_event_rows(&self) -> Result<Vec<EventRow>, TransactionStoreError> {
+        let conn = self.connection()?;
         let mut stmt = conn.prepare(
-            "SELECT seq, key_id, transaction_id, request_id, request_hash, \
-                    action_name, risk_level, summary, approval_id, warnings_json, \
+            "SELECT seq, key_id, kind, transaction_id, receipt_digest, \
                     created_at, prev_chain_hash, chain_hash \
-             FROM transactions ORDER BY seq ASC",
+             FROM audit_events ORDER BY seq ASC",
         )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(ChainRow {
-                seq: row.get::<_, i64>(0)? as u64,
-                key_id: row.get(1)?,
-                transaction_id: row.get(2)?,
-                request_id: row.get(3)?,
-                request_hash: row.get(4)?,
-                action_name: row.get(5)?,
-                risk_level: deserialize_field(&row.get::<_, String>(6)?).map_err(|e| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        6,
-                        rusqlite::types::Type::Text,
-                        Box::new(e),
-                    )
-                })?,
-                summary: row.get(7)?,
-                approval_id: row.get(8)?,
-                warnings_json: row.get(9)?,
-                created_at: row.get(10)?,
-                prev_chain_hash: row.get(11)?,
-                chain_hash: row.get(12)?,
-            })
-        })?;
+        let rows = stmt.query_map([], event_row_from_sqlite)?;
         let mut out = Vec::new();
         for row in rows {
             out.push(row?);
@@ -746,6 +913,25 @@ impl TransactionStore {
     ) -> Result<VerifyOutcome, TransactionStoreError> {
         let rows = self.fetch_chain_rows()?;
         Ok(audit_chain::verify_chain(key, &rows))
+    }
+
+    /// Walk the approval-event chain with `key`.
+    pub fn verify_event_chain(
+        &self,
+        key: &AuditKey,
+    ) -> Result<VerifyOutcome, TransactionStoreError> {
+        let rows = self.fetch_event_rows()?;
+        Ok(audit_chain::verify_event_chain(key, &rows))
+    }
+
+    /// Check that every event tip committed by a transaction row is still
+    /// present in the event chain. See [`audit_chain::verify_event_binding`].
+    pub fn verify_event_binding(
+        &self,
+    ) -> Result<audit_chain::BindingOutcome, TransactionStoreError> {
+        let tx_rows = self.fetch_chain_rows()?;
+        let event_rows = self.fetch_event_rows()?;
+        Ok(audit_chain::verify_event_binding(&tx_rows, &event_rows))
     }
 
     /// Verify the chain with only the hex-encoded Ed25519 **public** key. The
@@ -768,35 +954,12 @@ impl TransactionStore {
         transaction_id: &str,
     ) -> Result<Option<ChainRow>, TransactionStoreError> {
         let conn = self.connection()?;
-        let mut stmt = conn.prepare(
-            "SELECT seq, key_id, transaction_id, request_id, request_hash, \
-                    action_name, risk_level, summary, approval_id, warnings_json, \
-                    created_at, prev_chain_hash, chain_hash \
-             FROM transactions WHERE transaction_id = ?1",
-        )?;
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {CHAIN_ROW_COLUMNS} FROM transactions WHERE transaction_id = ?1"
+        ))?;
         let mut rows = stmt.query(params![transaction_id])?;
         if let Some(row) = rows.next()? {
-            Ok(Some(ChainRow {
-                seq: row.get::<_, i64>(0)? as u64,
-                key_id: row.get(1)?,
-                transaction_id: row.get(2)?,
-                request_id: row.get(3)?,
-                request_hash: row.get(4)?,
-                action_name: row.get(5)?,
-                risk_level: deserialize_field(&row.get::<_, String>(6)?).map_err(|e| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        6,
-                        rusqlite::types::Type::Text,
-                        Box::new(e),
-                    )
-                })?,
-                summary: row.get(7)?,
-                approval_id: row.get(8)?,
-                warnings_json: row.get(9)?,
-                created_at: row.get(10)?,
-                prev_chain_hash: row.get(11)?,
-                chain_hash: row.get(12)?,
-            }))
+            Ok(Some(chain_row_from_sqlite(row)?))
         } else {
             Ok(None)
         }
@@ -821,6 +984,73 @@ impl TransactionStore {
             Some((seq, hash)) => ((seq as u64) + 1, hash),
             None => (1, String::new()),
         })
+    }
+
+    /// `chain_hash` of the last approval event, or `None` when no event has
+    /// ever been recorded.
+    fn event_chain_tip(conn: &Connection) -> Result<Option<String>, TransactionStoreError> {
+        conn.query_row(
+            "SELECT chain_hash FROM audit_events ORDER BY seq DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .map(Some)
+        .or_else(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other.into()),
+        })
+    }
+
+    /// Append one signed approval event. Must be called inside a DB
+    /// transaction that also performs the state change being recorded: an
+    /// event committed without its state change (or the reverse) would be a
+    /// trail that disagrees with reality.
+    fn append_event(
+        conn: &Connection,
+        key: &AuditKey,
+        kind: AuditEventKind,
+        transaction_id: &str,
+        receipt_digest: &str,
+    ) -> Result<(), TransactionStoreError> {
+        let prev_chain_hash = Self::event_chain_tip(conn)?.unwrap_or_default();
+        let seq: i64 = conn.query_row(
+            "SELECT COALESCE(MAX(seq), 0) + 1 FROM audit_events",
+            [],
+            |row| row.get(0),
+        )?;
+        let created_at: String =
+            conn.query_row("SELECT strftime('%Y-%m-%dT%H:%M:%fZ', 'now')", [], |row| {
+                row.get(0)
+            })?;
+        let key_id = CURRENT_KEY_ID.to_string();
+        let chain_hash = key.event_hash(
+            &EventContent {
+                seq: seq as u64,
+                key_id: &key_id,
+                kind,
+                transaction_id,
+                receipt_digest,
+                created_at: &created_at,
+            },
+            &prev_chain_hash,
+        );
+        conn.execute(
+            "INSERT INTO audit_events (
+                seq, key_id, kind, transaction_id, receipt_digest,
+                created_at, chain_hash, prev_chain_hash
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                seq,
+                key_id,
+                kind.as_str(),
+                transaction_id,
+                receipt_digest,
+                created_at,
+                chain_hash,
+                prev_chain_hash,
+            ],
+        )?;
+        Ok(())
     }
 
     fn insert_transaction(
@@ -859,6 +1089,11 @@ impl TransactionStore {
             })?;
 
         let key_id = CURRENT_KEY_ID.to_string();
+        // Bind this row to the approval-event chain as it stands right now.
+        // Read inside the caller's DB transaction so a concurrent event append
+        // cannot land between the read and the insert.
+        let event_tip = Self::event_chain_tip(conn)?.unwrap_or_default();
+        let caller_role = transaction.caller_role.as_str();
         let chain_hash = key.chain_hash(
             &ChainContent {
                 seq,
@@ -872,6 +1107,10 @@ impl TransactionStore {
                 approval_id: approval_id.as_deref(),
                 warnings_json: &warnings_json,
                 created_at: &created_at,
+                identity: ChainIdentity::V2 {
+                    caller_role,
+                    event_tip: &event_tip,
+                },
             },
             &prev_chain_hash,
         );
@@ -903,8 +1142,11 @@ impl TransactionStore {
                 seq,
                 key_id,
                 chain_hash,
-                prev_chain_hash
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                prev_chain_hash,
+                chain_version,
+                caller_role,
+                event_tip
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
             params![
                 transaction_id,
                 request_id,
@@ -920,6 +1162,9 @@ impl TransactionStore {
                 key_id,
                 chain_hash,
                 prev_chain_hash,
+                CHAIN_VERSION_CURRENT as i64,
+                caller_role,
+                event_tip,
             ],
         )?;
 
@@ -986,6 +1231,7 @@ fn deserialize_field<T: DeserializeOwned>(value: &str) -> Result<T, serde_json::
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audit_chain::CHAIN_VERSION_LEGACY;
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
 
@@ -995,6 +1241,278 @@ mod tests {
     fn test_store(path: impl AsRef<Path>) -> TransactionStore {
         let key = Arc::new(AuditKey::from_bytes(vec![0x42; 32]));
         TransactionStore::open_with_key(path, key).unwrap()
+    }
+
+    // ── Schema migration ─────────────────────────────────────────────────
+
+    /// Create a database at exactly schema version 1 — the shape a v0.2.12
+    /// daemon left behind — and write one row using the encoding that binary
+    /// signed. Building the fixture from `SQLITE_MIGRATIONS[0]` rather than a
+    /// copied DDL string means it stays honest if migration 1 is ever edited.
+    fn legacy_v1_database(path: &Path, key: &AuditKey) -> String {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_migrations (
+                 version INTEGER PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+             );",
+        )
+        .unwrap();
+        conn.execute_batch(SQLITE_MIGRATIONS[0].sql).unwrap();
+        conn.execute(
+            "INSERT INTO schema_migrations (version, name) VALUES (1, ?1)",
+            params![SQLITE_MIGRATIONS[0].name],
+        )
+        .unwrap();
+
+        let transaction_id = "tx-legacy";
+        let created_at = "2026-04-24T12:00:00.000Z";
+        let chain_hash = key.chain_hash(
+            &ChainContent {
+                seq: 1,
+                key_id: CURRENT_KEY_ID,
+                transaction_id,
+                request_id: "req-legacy",
+                request_hash: "hash-legacy",
+                action_name: "UpdateSystem",
+                risk_level: RiskLevel::High,
+                summary: "Upgrade the system",
+                approval_id: None,
+                warnings_json: "[]",
+                created_at,
+                identity: ChainIdentity::LegacyV1,
+            },
+            "",
+        );
+        conn.execute(
+            "INSERT INTO transactions (
+                transaction_id, request_id, request_hash, action_name, risk_level,
+                status, approval_id, summary, warnings_json, created_at,
+                seq, key_id, chain_hash, prev_chain_hash
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?8, ?9, 1, ?10, ?11, '')",
+            params![
+                transaction_id,
+                "req-legacy",
+                "hash-legacy",
+                "UpdateSystem",
+                serialize_field(&RiskLevel::High).unwrap(),
+                serialize_field(&JobState::Queued).unwrap(),
+                "Upgrade the system",
+                "[]",
+                created_at,
+                CURRENT_KEY_ID,
+                chain_hash,
+            ],
+        )
+        .unwrap();
+        transaction_id.to_string()
+    }
+
+    #[test]
+    fn a_database_written_before_the_migration_still_verifies_after_upgrading() {
+        // The migration contract, end to end through the store. An operator
+        // upgrading the daemon must not see their existing audit log start
+        // reporting as tampered — that would make a real compromise
+        // indistinguishable from a routine upgrade.
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("tx.db");
+        let key = AuditKey::from_bytes(vec![0x42; 32]);
+        legacy_v1_database(&db_path, &key);
+
+        let store = test_store(&db_path);
+        assert_eq!(
+            store.verify_audit_chain(&key).unwrap(),
+            VerifyOutcome::Intact { rows_checked: 1 }
+        );
+        let rows = store.fetch_chain_rows().unwrap();
+        assert_eq!(rows[0].chain_version, CHAIN_VERSION_LEGACY);
+        assert_eq!(rows[0].caller_role, None);
+    }
+
+    #[test]
+    fn rows_appended_after_the_migration_chain_onto_legacy_rows() {
+        // Mixed-generation chain written through the real store, not a
+        // hand-built fixture: the new row's prev_chain_hash must link to the
+        // legacy row, and both encodings must verify in one walk.
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("tx.db");
+        let key = AuditKey::from_bytes(vec![0x42; 32]);
+        legacy_v1_database(&db_path, &key);
+
+        let store = test_store(&db_path);
+        store.record(queued_transaction()).unwrap();
+
+        let rows = store.fetch_chain_rows().unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[1].prev_chain_hash, rows[0].chain_hash);
+        assert_eq!(rows[1].chain_version, CHAIN_VERSION_CURRENT);
+        assert_eq!(
+            store.verify_audit_chain(&key).unwrap(),
+            VerifyOutcome::Intact { rows_checked: 2 }
+        );
+    }
+
+    #[test]
+    fn a_schema_newer_than_this_binary_is_refused() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("tx.db");
+        let key = AuditKey::from_bytes(vec![0x42; 32]);
+        legacy_v1_database(&db_path, &key);
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO schema_migrations (version, name) VALUES (99, 'from the future')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let err = TransactionStore::open_with_key(&db_path, Arc::new(key)).unwrap_err();
+        assert!(
+            matches!(err, TransactionStoreError::DatabaseInvariant(ref m) if m.contains("99")),
+            "expected a refusal naming the unsupported version, got {err:?}"
+        );
+    }
+
+    // ── caller identity + approval events ────────────────────────────────
+
+    #[test]
+    fn the_signed_row_records_which_role_asked() {
+        let dir = tempdir().unwrap();
+        let store = test_store(dir.path().join("tx.db"));
+        let mut tx = queued_transaction();
+        tx.caller_role = CallerRole::Admin;
+        store.record(tx).unwrap();
+
+        let rows = store.fetch_chain_rows().unwrap();
+        assert_eq!(rows[0].caller_role.as_deref(), Some("admin"));
+    }
+
+    #[test]
+    fn approving_consuming_and_revoking_each_append_a_chained_event() {
+        let dir = tempdir().unwrap();
+        let key = AuditKey::from_bytes(vec![0x42; 32]);
+        let store = test_store(dir.path().join("tx.db"));
+
+        // Approve then consume.
+        let a = store.record(queued_transaction()).unwrap();
+        let receipt = store
+            .approve_transaction(&a.transaction_id)
+            .unwrap()
+            .expect("queued transaction approves");
+        let digest = audit_chain::approval_receipt_digest(&receipt);
+        assert!(store
+            .claim_approved_for_execution(&a.transaction_id, &digest)
+            .unwrap());
+
+        // Approve then revoke.
+        let b = store.record(queued_transaction()).unwrap();
+        store.approve_transaction(&b.transaction_id).unwrap();
+        assert!(store.revoke_unconsumed_approval(&b.transaction_id).unwrap());
+
+        let events = store.fetch_event_rows().unwrap();
+        let kinds: Vec<&str> = events.iter().map(|e| e.kind.as_str()).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                "approval_granted",
+                "approval_consumed",
+                "approval_granted",
+                "approval_revoked",
+            ]
+        );
+        assert_eq!(
+            store.verify_event_chain(&key).unwrap(),
+            VerifyOutcome::Intact { rows_checked: 4 }
+        );
+    }
+
+    #[test]
+    fn a_failed_approval_appends_no_event() {
+        // Only real state changes get chained. A no-op approve (already
+        // approved) writing an event would make the trail claim something that
+        // did not happen.
+        let dir = tempdir().unwrap();
+        let store = test_store(dir.path().join("tx.db"));
+        let tx = store.record(queued_transaction()).unwrap();
+        store.approve_transaction(&tx.transaction_id).unwrap();
+        store.approve_transaction(&tx.transaction_id).unwrap();
+        assert_eq!(store.fetch_event_rows().unwrap().len(), 1);
+
+        // Same for a revoke with nothing to revoke.
+        assert!(!store.revoke_unconsumed_approval("no-such-tx").unwrap());
+        assert_eq!(store.fetch_event_rows().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn deleting_the_record_that_an_approval_happened_no_longer_goes_unnoticed() {
+        // The finding. Before the event chain, `transaction_approvals` was a
+        // plain table: DELETE the row and `audit verify` still said Intact, so
+        // the fact that a privileged action had been approved could be erased
+        // without a trace. Now the deletion has to survive two independent
+        // checks.
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("tx.db");
+        let key = AuditKey::from_bytes(vec![0x42; 32]);
+        let store = test_store(&db_path);
+
+        let a = store.record(queued_transaction()).unwrap();
+        store.approve_transaction(&a.transaction_id).unwrap();
+        // A later transaction commits to the event tip, which is what carries
+        // the binding into the checkpoint-anchored transaction chain.
+        store.record(queued_transaction()).unwrap();
+
+        assert_eq!(
+            store.verify_event_chain(&key).unwrap(),
+            VerifyOutcome::Intact { rows_checked: 1 }
+        );
+        assert_eq!(
+            store.verify_event_binding().unwrap(),
+            audit_chain::BindingOutcome::Consistent {
+                bindings_checked: 1
+            }
+        );
+
+        // Erase the approval and its event.
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute("DELETE FROM transaction_approvals", [])
+            .unwrap();
+        conn.execute("DELETE FROM audit_events", []).unwrap();
+        drop(conn);
+
+        // The event chain alone is now empty and walks clean — deleting the
+        // only event leaves nothing to contradict. The transaction row's
+        // committed tip is what catches it.
+        assert_eq!(
+            store.verify_event_chain(&key).unwrap(),
+            VerifyOutcome::Intact { rows_checked: 0 }
+        );
+        match store.verify_event_binding().unwrap() {
+            audit_chain::BindingOutcome::MissingEvent {
+                transaction_seq, ..
+            } => assert_eq!(transaction_seq, 2),
+            other => panic!("expected MissingEvent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_read_only_store_cannot_revoke_or_claim() {
+        // Both paths now append to the event chain, so both need the signing
+        // key. Refusing loudly beats silently skipping the event.
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("tx.db");
+        let store = test_store(&db_path);
+        store.record(queued_transaction()).unwrap();
+
+        let read_only = TransactionStore::open_read_only(&db_path).unwrap();
+        assert!(matches!(
+            read_only.revoke_unconsumed_approval("tx"),
+            Err(TransactionStoreError::AuditChainMissing(_))
+        ));
+        assert!(matches!(
+            read_only.claim_approved_for_execution("tx", "digest"),
+            Err(TransactionStoreError::AuditChainMissing(_))
+        ));
     }
 
     // ── Audit chain integration tests ────────────────────────────────────
@@ -1073,6 +1591,7 @@ mod tests {
                         risk_level: RiskLevel::Low,
                         summary: format!("worker {w} record {r}"),
                         warnings: vec![],
+                        caller_role: CallerRole::Dev,
                     };
                     store
                         .record(tx)
@@ -1253,6 +1772,7 @@ mod tests {
             risk_level: RiskLevel::High,
             summary: "Upgrade the system".to_string(),
             warnings: vec![],
+            caller_role: CallerRole::Dev,
         }
     }
 

--- a/crates/sysknife-daemon/tests/bootstrap.rs
+++ b/crates/sysknife-daemon/tests/bootstrap.rs
@@ -84,6 +84,7 @@ fn transaction_records_are_persisted() {
         risk_level: RiskLevel::High,
         summary: "Stage system update".into(),
         warnings: vec!["reboot required".into()],
+        caller_role: CallerRole::Dev,
     };
 
     let record = store.record(transaction).expect("record tx");

--- a/crates/sysknife-daemon/tests/coverage_gaps.rs
+++ b/crates/sysknife-daemon/tests/coverage_gaps.rs
@@ -96,6 +96,7 @@ fn make_transaction(action: &str) -> NewTransaction {
         risk_level: RiskLevel::High,
         summary: format!("Test {action}"),
         warnings: vec![],
+        caller_role: CallerRole::Dev,
     }
 }
 
@@ -118,6 +119,7 @@ fn list_transactions_limit_is_capped_at_100() {
                 risk_level: RiskLevel::High,
                 summary: format!("tx {i}"),
                 warnings: vec![],
+                caller_role: CallerRole::Dev,
             })
             .expect("record tx");
     }
@@ -189,6 +191,7 @@ async fn list_job_history_returns_recorded_transactions() {
             risk_level: RiskLevel::High,
             summary: "Stage system update".into(),
             warnings: vec![],
+            caller_role: CallerRole::Dev,
         })
         .await
         .expect("record tx");

--- a/crates/sysknife-daemon/tests/postgres_store.rs
+++ b/crates/sysknife-daemon/tests/postgres_store.rs
@@ -7,7 +7,7 @@ use sysknife_daemon::audit_chain::{AuditKey, VerifyOutcome};
 use sysknife_daemon::store::postgres::{PostgresConfig, PostgresStore};
 use sysknife_daemon::store::AuditStore;
 use sysknife_daemon::transactions::NewTransaction;
-use sysknife_types::{JobState, PreviewEnvelope, RequestHash, RiskLevel};
+use sysknife_types::{CallerRole, JobState, PreviewEnvelope, RequestHash, RiskLevel};
 
 fn test_url() -> Option<String> {
     std::env::var("SYSKNIFE_TEST_POSTGRES_URL").ok()
@@ -21,6 +21,7 @@ fn new_transaction() -> NewTransaction {
         risk_level: RiskLevel::Medium,
         summary: "Restart sshd".to_string(),
         warnings: vec!["brief connection interruption".to_string()],
+        caller_role: CallerRole::Dev,
     }
 }
 
@@ -229,12 +230,17 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
         store.verify_audit_chain(&key).await.expect("verify chain"),
         VerifyOutcome::Intact { rows_checked: 1 }
     );
+    let pubkey_only = PostgresStore::verify_all_with_pubkey(&config, &key.verifying_key_hex())
+        .await
+        .expect("verify Postgres chain with public key only");
+    assert_eq!(pubkey_only.chain, VerifyOutcome::Intact { rows_checked: 1 });
+    // No approval has been granted yet, so the event chain is empty and the
+    // transaction row committed to an empty tip — both must still be clean.
     assert_eq!(
-        PostgresStore::verify_with_pubkey(&config, &key.verifying_key_hex())
-            .await
-            .expect("verify Postgres chain with public key only"),
-        VerifyOutcome::Intact { rows_checked: 1 }
+        pubkey_only.events,
+        VerifyOutcome::Intact { rows_checked: 0 }
     );
+    assert_eq!(pubkey_only.exit_code(), 0);
 
     // cancel_queued success path on Postgres: a fresh, never-claimed Queued
     // transaction must cancel (return true) and flip to Canceled. Placed after

--- a/crates/sysknife-daemon/tests/postgres_store.rs
+++ b/crates/sysknife-daemon/tests/postgres_store.rs
@@ -58,6 +58,7 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
         .expect("connect to test database");
 
     for table in [
+        "audit_events",
         "transaction_approvals",
         "transaction_previews",
         "transactions",
@@ -125,17 +126,45 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
     .fetch_one(&admin)
     .await
     .expect("read schema migration version");
-    assert_eq!(migration, 1);
+    assert_eq!(
+        migration, 2,
+        "every migration in MIGRATIONS must have applied"
+    );
     assert!(store
         .get("legacy-row")
         .await
         .expect("load legacy row")
         .is_some());
 
-    sqlx_core::query::query("TRUNCATE transaction_approvals, transaction_previews, transactions")
-        .execute(&admin)
+    // Migration 2 must have added the caller-identity columns to a table that
+    // already existed — `CREATE TABLE IF NOT EXISTS` would have skipped it
+    // entirely — and left the pre-existing row on the legacy encoding rather
+    // than backfilling it into a shape its signature was never made over.
+    let legacy_chain_row = store
+        .fetch_chain_row("legacy-row")
         .await
-        .expect("clear legacy fixture before chain checks");
+        .expect("fetch legacy chain row")
+        .expect("legacy row survives the migration");
+    assert_eq!(legacy_chain_row.chain_version, 1);
+    assert_eq!(legacy_chain_row.caller_role, None);
+    assert_eq!(legacy_chain_row.event_tip, None);
+
+    let events_table_exists: bool =
+        sqlx_core::query_scalar::query_scalar("SELECT to_regclass('audit_events') IS NOT NULL")
+            .fetch_one(&admin)
+            .await
+            .expect("probe audit_events");
+    assert!(events_table_exists, "migration 2 creates audit_events");
+
+    // `audit_events` is truncated with the rest: its rows are signed with the
+    // audit key, and this test generates a fresh key per run, so events left
+    // behind by a previous run cannot verify under the new one.
+    sqlx_core::query::query(
+        "TRUNCATE audit_events, transaction_approvals, transaction_previews, transactions",
+    )
+    .execute(&admin)
+    .await
+    .expect("clear legacy fixture before chain checks");
 
     let recorded = store
         .record_previewed(new_transaction(), preview())
@@ -234,11 +263,17 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
         .await
         .expect("verify Postgres chain with public key only");
     assert_eq!(pubkey_only.chain, VerifyOutcome::Intact { rows_checked: 1 });
-    // No approval has been granted yet, so the event chain is empty and the
-    // transaction row committed to an empty tip — both must still be clean.
+    // The flow above approved and then claimed this transaction, so the event
+    // chain holds exactly those two events — and the auditor path, holding only
+    // the public key, can verify them.
     assert_eq!(
         pubkey_only.events,
-        VerifyOutcome::Intact { rows_checked: 0 }
+        VerifyOutcome::Intact { rows_checked: 2 }
+    );
+    let events = store.fetch_event_rows().await.expect("fetch events");
+    assert_eq!(
+        events.iter().map(|e| e.kind.as_str()).collect::<Vec<_>>(),
+        vec!["approval_granted", "approval_consumed"]
     );
     assert_eq!(pubkey_only.exit_code(), 0);
 
@@ -271,16 +306,131 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
             .fetch_one(&admin)
             .await
             .expect("count migrations");
-    assert_eq!(migration_count, 1);
+    // Idempotence: reconnecting re-runs `initialize`, which must not record a
+    // migration a second time.
+    assert_eq!(migration_count, 2);
 
-    let migration_row =
-        sqlx_core::query::query("SELECT version, name FROM schema_migrations WHERE version = 1")
-            .fetch_one(&admin)
-            .await
-            .expect("load migration metadata");
-    assert_eq!(migration_row.try_get::<i64, _>("version").unwrap(), 1);
-    assert_eq!(
-        migration_row.try_get::<String, _>("name").unwrap(),
-        "initial_audit_schema"
+    for (version, name) in [
+        (1_i64, "initial_audit_schema"),
+        (2, "caller_identity_and_approval_events"),
+    ] {
+        let migration_row = sqlx_core::query::query(
+            "SELECT version, name FROM schema_migrations WHERE version = $1",
+        )
+        .bind(version)
+        .fetch_one(&admin)
+        .await
+        .expect("load migration metadata");
+        assert_eq!(migration_row.try_get::<i64, _>("version").unwrap(), version);
+        assert_eq!(migration_row.try_get::<String, _>("name").unwrap(), name);
+    }
+}
+
+/// The `PostgresCheckpointSink` round-trip, against a live database.
+///
+/// Every other checkpoint test runs against `InMemoryCheckpointSink`, which
+/// shares no code with the Postgres implementation: not the `to_regclass`
+/// bootstrap probe, not the `i64`/`u64` seq casts, not the column mapping. The
+/// external anchor is the control that makes tail truncation detectable at
+/// all, so "it works in memory" is the wrong thing to be confident about.
+///
+/// Runs in its own schema. `nextest` executes each test in a separate process
+/// and in parallel, so two destructive tests sharing `public` would race — the
+/// first version of this test tore down the other test's tables mid-run.
+#[tokio::test]
+async fn postgres_checkpoint_sink_round_trips_and_detects_truncation() {
+    use sysknife_daemon::checkpoint_sink::{
+        anchor_once, AnchorOutcome, CheckpointSink, PostgresCheckpointSink,
+    };
+
+    const SCHEMA: &str = "checkpoint_sink_test";
+
+    let Some(url) = test_url() else {
+        eprintln!("SYSKNIFE_TEST_POSTGRES_URL is unset; live Postgres contract not requested");
+        return;
+    };
+    assert!(
+        url.contains("sysknife_test"),
+        "refusing destructive integration test against a non-test database"
     );
+
+    let admin = PgPoolOptions::new()
+        .max_connections(1)
+        .connect_with(PgConnectOptions::from_str(&url).expect("valid test URL"))
+        .await
+        .expect("connect for schema setup");
+    for statement in [
+        format!("DROP SCHEMA IF EXISTS {SCHEMA} CASCADE"),
+        format!("CREATE SCHEMA {SCHEMA}"),
+    ] {
+        sqlx_core::query::query(sqlx_core::sql_str::AssertSqlSafe(statement))
+            .execute(&admin)
+            .await
+            .expect("prepare isolated schema");
+    }
+
+    let separator = if url.contains('?') { '&' } else { '?' };
+    let scoped_url = format!("{url}{separator}options=-csearch_path%3D{SCHEMA}");
+
+    let key_dir = tempfile::tempdir().expect("create audit-key directory");
+    let key = AuditKey::load_or_generate(&key_dir.path().join("audit-key"))
+        .expect("generate test audit key");
+    let config = PostgresConfig {
+        url: scoped_url.clone(),
+        ..PostgresConfig::default()
+    };
+
+    let store = PostgresStore::connect(&config, Arc::new(key.clone()))
+        .await
+        .expect("connect store");
+    store.record(new_transaction()).await.expect("record row");
+    let rows = store.fetch_chain_rows().await.expect("fetch chain rows");
+    assert_eq!(rows.len(), 1, "isolated schema should hold exactly our row");
+
+    let sink = PostgresCheckpointSink::connect(&scoped_url)
+        .await
+        .expect("connect checkpoint sink");
+
+    // A second connect must be a no-op, not a failure: the daemon reconnects,
+    // and the bootstrap probe is what keeps a least-privilege role working
+    // against an already-provisioned table.
+    PostgresCheckpointSink::connect(&scoped_url)
+        .await
+        .expect("reconnecting to an existing table succeeds");
+
+    let outcome = anchor_once(&key, &rows, &sink, "2026-07-27T12:00:00Z")
+        .await
+        .expect("anchor");
+    assert_eq!(
+        outcome,
+        AnchorOutcome::Anchored {
+            seq: 1,
+            checkpoints_checked: 1
+        }
+    );
+
+    // Read back through the real column mapping, not the value we wrote.
+    let loaded = sink.load_all().await.expect("load checkpoints");
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].seq, 1);
+    assert_eq!(loaded[0].chain_tip, rows[0].chain_hash);
+
+    // An anchor that cannot be justified must not advance the tip. Treating a
+    // refused anchor as routine is how this defence quietly stops working.
+    let outcome = anchor_once(&key, &[], &sink, "2026-07-27T12:05:00Z")
+        .await
+        .expect("anchor against an empty chain");
+    assert_eq!(outcome, AnchorOutcome::ChainEmpty);
+    assert_eq!(
+        sink.load_all().await.expect("reload checkpoints").len(),
+        1,
+        "a refused anchor must not append a checkpoint"
+    );
+
+    sqlx_core::query::query(sqlx_core::sql_str::AssertSqlSafe(format!(
+        "DROP SCHEMA {SCHEMA} CASCADE"
+    )))
+    .execute(&admin)
+    .await
+    .expect("drop isolated schema");
 }

--- a/crates/sysknife-daemon/tests/preview_approval.rs
+++ b/crates/sysknife-daemon/tests/preview_approval.rs
@@ -2,7 +2,7 @@ use serde_json::json;
 use sysknife_daemon::jobs::{allowed_transition, is_terminal};
 use sysknife_daemon::preview::preview_action;
 use sysknife_daemon::transactions::{NewTransaction, TransactionStore};
-use sysknife_types::{JobState, PreviewEnvelope, RequestEnvelope, RiskLevel};
+use sysknife_types::{CallerRole, JobState, PreviewEnvelope, RequestEnvelope, RiskLevel};
 use tempfile::tempdir;
 
 fn request(action_name: &str, request_id: &str, request_hash: &str) -> RequestEnvelope {
@@ -213,6 +213,7 @@ fn previewed_transactions_persist_preview_state() {
         risk_level: RiskLevel::High,
         summary: "Stage system update".to_string(),
         warnings: vec!["system reboot required".to_string()],
+        caller_role: CallerRole::Dev,
     };
 
     let recorded = store

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -379,6 +379,79 @@ impl From<String> for RequestHash {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Approval-flow newtypes
+// ---------------------------------------------------------------------------
+
+/// Identifier for one preview/approve/execute round-trip.
+///
+/// Distinct from [`ApprovalReceipt`] at the type level because the two are
+/// indistinguishable at the value level: both are opaque strings passed side by
+/// side into the same calls. `execute(transaction_id, action_name, params,
+/// approval_receipt, …)` took three bare `&str` in a row, so transposing any
+/// two of them compiled and failed at runtime as a stale-approval error, which
+/// reads like an expiry rather than a call-site bug.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TransactionId(String);
+
+/// A one-time bearer receipt minted by `sysknife approve`.
+///
+/// This is a **credential**: whoever holds it can execute the approved step
+/// once. `Debug` is redacted so a `tracing::debug!("{req:?}")` on any struct
+/// carrying one cannot spill it into a log. Use [`ApprovalReceipt::as_str`]
+/// where the real value is genuinely needed.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ApprovalReceipt(String);
+
+impl std::fmt::Debug for ApprovalReceipt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ApprovalReceipt(<redacted>)")
+    }
+}
+
+macro_rules! opaque_string_newtype {
+    ($name:ident) => {
+        impl $name {
+            pub fn new(s: impl Into<String>) -> Self {
+                Self(s.into())
+            }
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+            pub fn into_inner(self) -> String {
+                self.0
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(s)
+            }
+        }
+    };
+}
+
+opaque_string_newtype!(TransactionId);
+opaque_string_newtype!(ApprovalReceipt);
+
+// `Display` only for the identifier. `ApprovalReceipt` deliberately has none:
+// a credential that formats itself into any `{}` is one interpolation away
+// from a log line, and the explicit `as_str()` marks the places that really
+// need the secret.
+impl std::fmt::Display for TransactionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Caller privilege tier, ordered least to most privileged.
 ///
 /// **Variant order is the privilege order** and `Ord` is derived from it, so

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -398,6 +398,24 @@ pub enum CallerRole {
     Boot,
 }
 
+impl CallerRole {
+    /// Stable lowercase spelling, identical to the serde representation.
+    ///
+    /// The audit chain signs this string, so it is a wire format: renaming a
+    /// variant must not silently change what past signatures were made over.
+    /// `format!("{role:?}")` cannot be used for that — `Debug` carries no
+    /// stability promise and tracks the identifier. `caller_role_as_str_matches_serde`
+    /// pins the two encodings together.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Observer => "observer",
+            Self::Dev => "dev",
+            Self::Admin => "admin",
+            Self::Boot => "boot",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RiskLevel {

--- a/crates/sysknife-types/tests/schema_roundtrip.rs
+++ b/crates/sysknife-types/tests/schema_roundtrip.rs
@@ -1,6 +1,6 @@
 use sysknife_types::{
-    CallerRole, FailureCategory, JobState, PreviewEnvelope, RequestEnvelope, ResultEnvelope,
-    RiskLevel, TransactionRecord,
+    ApprovalReceipt, CallerRole, FailureCategory, JobState, PreviewEnvelope, RequestEnvelope,
+    ResultEnvelope, RiskLevel, TransactionId, TransactionRecord,
 };
 
 #[test]
@@ -101,4 +101,32 @@ fn caller_role_as_str_matches_serde() {
         let json = serde_json::to_string(&role).unwrap();
         assert_eq!(json, format!("\"{}\"", role.as_str()));
     }
+}
+
+#[test]
+fn an_approval_receipt_never_renders_itself_in_debug_output() {
+    // The receipt is a one-time bearer credential: whoever holds it can run the
+    // approved step. Any struct carrying one inherits its `Debug`, so a single
+    // `tracing::debug!("{req:?}")` would put a live credential in a log file.
+    let receipt = ApprovalReceipt::new("sk-receipt-deadbeef");
+    let rendered = format!("{receipt:?}");
+    assert!(
+        !rendered.contains("deadbeef"),
+        "Debug leaked the receipt: {rendered}"
+    );
+    // Still reachable where it is genuinely needed.
+    assert_eq!(receipt.as_str(), "sk-receipt-deadbeef");
+}
+
+#[test]
+fn approval_flow_newtypes_stay_bare_strings_on_the_wire() {
+    // `serde(transparent)`: the daemon's JSON IPC frames are unchanged by the
+    // newtypes, so an older peer still parses them.
+    let id = TransactionId::new("tx-abc123");
+    assert_eq!(serde_json::to_string(&id).unwrap(), "\"tx-abc123\"");
+    let back: TransactionId = serde_json::from_str("\"tx-abc123\"").unwrap();
+    assert_eq!(back, id);
+
+    let receipt = ApprovalReceipt::new("receipt-1");
+    assert_eq!(serde_json::to_string(&receipt).unwrap(), "\"receipt-1\"");
 }

--- a/crates/sysknife-types/tests/schema_roundtrip.rs
+++ b/crates/sysknife-types/tests/schema_roundtrip.rs
@@ -85,3 +85,20 @@ fn failure_category_serializes_stably() {
 
     assert_eq!(value, decoded);
 }
+
+#[test]
+fn caller_role_as_str_matches_serde() {
+    // `as_str` is signed into the audit chain and serde crosses the daemon
+    // wire. Two spellings of the same enum drifting apart would mean a role
+    // recorded in the chain no longer matches the one in a transported
+    // record, so they are pinned to each other rather than to a literal list.
+    for role in [
+        CallerRole::Observer,
+        CallerRole::Dev,
+        CallerRole::Admin,
+        CallerRole::Boot,
+    ] {
+        let json = serde_json::to_string(&role).unwrap();
+        assert_eq!(json, format!("\"{}\"", role.as_str()));
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -147,9 +147,16 @@ writes for every executed action.
 
 #### `sysknife audit verify`
 
-Verify the audit chain. Exits `0` if intact, `1` if any row is broken
-(tampered), `2` if the chain cannot be verified (missing key, unreadable
-database).
+Verify the audit trail: the transaction chain, the approval-event chain, and
+the binding between them. All three are reported and any one can fail the
+command. Exits `0` if everything is intact, `1` if any check finds tampering,
+`2` if a check cannot run at all (missing key, unreadable database). When the
+checks disagree the worst wins, and `1` outranks `2` — if something is provably
+broken, "could not verify" would understate it.
+
+With `--json` the report is an object with a top-level `status` plus a `chain`,
+`approval_events` and `binding` section, so a pipeline can act on which part
+failed.
 
 ```sh
 sysknife audit verify

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -24,8 +24,10 @@ the daemon made about one action, at the moment it made it:
 | `approval_id` | Which signed approval receipt authorized execution, if any |
 | `warnings_json` | Warnings surfaced to the user before approval |
 | `created_at` | When the row was written |
+| `caller_role` | Which privilege tier the daemon resolved for the connection that asked |
+| `event_tip` | The approval-event chain tip at insert time (see below) |
 
-These eleven fields are serialized into a stable, self-describing byte
+These thirteen fields are serialized into a stable, self-describing byte
 string (tag + value pairs, with a prefix-free escape scheme so no field's
 content can be crafted to alias another field's boundary), then signed. The
 resulting signature *is* the row's `chain_hash` — there is no separate hash
@@ -36,6 +38,19 @@ The mutable `status` column (queued → running → succeeded/failed/rolled
 back) is **not** part of the signed content. The chain protects the
 *authorization decision* captured at insert time, not the live execution
 state — a scope decision, not an oversight (see [Limits](#limits-and-honest-scope)).
+```
+
+```admonish info title="Rows written before v0.2.13"
+`caller_role` and `event_tip` were added in v0.2.13. Rows written by an
+earlier daemon were signed over an encoding that has no such fields, so each
+row carries a `chain_version` column and verification reproduces the exact
+encoding that row was signed under. An upgraded daemon appends v2 rows onto
+an existing v1 chain and the whole chain still verifies in one walk — an
+upgrade never makes a healthy audit log look tampered.
+
+The version is not a hiding place: relabelling a v2 row as v1 to erase its
+`caller_role` makes verification re-encode it without the identity fields, so
+the stored signature no longer verifies and the row reports as broken.
 ```
 
 ## The hash chain: each entry links to the one before it
@@ -94,6 +109,42 @@ Two more properties fall out of the implementation:
   always produce the identical signature. This makes chain verification
   reproducible without any randomness or nonce bookkeeping on the verifier's
   side.
+
+## The approval-event chain
+
+The transaction chain records what the daemon *authorized*. It says nothing
+about whether a human then approved it, whether that approval was spent, or
+whether it was retracted — those lifecycle facts used to live only in
+`transaction_approvals`, a plain mutable table. Deleting a row from it left
+`sysknife audit verify` reporting `Intact`, which made the record that a
+privileged action had been approved the one part of the trail an attacker
+could erase without leaving a mark.
+
+Approval events are now their own forward Ed25519 chain, under their own
+domain tag (`sysknife-audit-event-v1`), with one row per state change:
+
+| `kind` | When it is written |
+|---|---|
+| `approval_granted` | A receipt was minted for a queued transaction |
+| `approval_consumed` | A receipt was spent to move a transaction to `Running` |
+| `approval_revoked` | An undelivered receipt was retracted before it could be spent |
+
+Each event and the state change it records commit in the same database
+transaction, so a state change without its event (or the reverse) is not a
+reachable state. Deleting an event from the middle of the chain breaks the
+next event's `prev_chain_hash`, exactly as it does for transaction rows.
+
+**Cross-chain binding.** Deleting events from the *end* of the event chain
+would leave a self-consistent remainder, the same tail-truncation blind spot
+the transaction chain has. That is what `event_tip` is for: every transaction
+row signs the event-chain tip as of its insert. Because signed checkpoints
+anchor the *transaction* chain, and transaction rows commit to event tips,
+anchoring transitively covers the event chain. `sysknife audit verify`
+reports the binding check alongside the two chain walks.
+
+The residual exposure is the same bounded tail every append-only log has:
+events appended after the most recent transaction row are not yet bound by
+anything, until the next row is written.
 
 ## Signed checkpoints: closing the truncation gap
 
@@ -204,7 +255,9 @@ it does and does not prove:
   does not mean "the action's final status is trustworthy."
 - **Truncation needs an external sink to be detectable at all.** Without a
   checkpoint anchored off-host, deleting the tail of the chain is invisible
-  to `sysknife audit verify` by construction.
+  to `sysknife audit verify` by construction. The same applies to approval
+  events appended after the last transaction row: nothing has committed to
+  them yet.
 - **Key rotation is manual today.** Every row carries a `key_id` (currently
   always `"v1"`); rotation means regenerating the chain from scratch until
   a planned epoch-aware rotation flow lands.

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -214,10 +214,16 @@ Anchor and check signed checkpoints against an external database:
 SYSKNIFE_CHECKPOINT_DB="postgres://user@host/checkpoints" sysknife audit checkpoint
 ```
 
+Three checks run: the transaction chain, the approval-event chain, and the
+binding between them. All three are reported, and any one of them can fail the
+command — a clean transaction chain must never mask a tampered approval trail.
+
 **A clean run looks like:**
 
 ```text
 OK: 4128 row(s) verified in sqlite
+OK: 512 approval event(s) verified
+OK: 4128 row(s) still match the approval event they committed to
 ```
 
 **A detected tamper looks like:**
@@ -234,11 +240,26 @@ signature mismatch — same report shape, different `expected`/`actual`
 pair. Either failure is reported at the *first* broken row; rows before it
 are still proven intact.
 
+**Deleted approval events look like:**
+
+```text
+OK: 4128 row(s) verified in sqlite
+OK: 300 approval event(s) verified
+BROKEN: transaction seq=4128 committed to approval event 71ac…9d2f, which is
+no longer in the event chain — approval events were deleted from the end of
+the chain
+```
+
+Note that the event chain itself still walks clean there: truncating its tail
+leaves a self-consistent remainder. The binding is what catches it.
+
 Exit codes matter for automation: `0` intact, `1` broken (a real tamper was
 detected), `2` cannot verify (missing key file, unreadable database, wrong
 key generation loaded). The 1-vs-2 split is deliberate — a CI job that only
 checks for a nonzero exit code must not silently treat "I couldn't check"
-the same as "I checked and it's fine."
+the same as "I checked and it's fine." When the three checks disagree, the
+worst wins, and `1` outranks `2`: if anything is provably broken, saying
+"could not verify" would understate what is known.
 
 ## Limits and honest scope {#limits-and-honest-scope}
 

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {


### PR DESCRIPTION
## Summary

The rest of the backlog, headed by the item v0.2.12 deferred: the chain could
say **what** was authorised but not **who** asked, and nothing signed recorded
that an approval ever happened.

**`caller_role` is now signed into every row** — the tier the daemon resolved
from `SO_PEERCRED` or the vsock token, never a value from the request body.

**Approval grant/consume/revoke are a second forward Ed25519 chain**, under
their own domain tag, each event committing in the same database transaction as
the state change it records. Before this, `transaction_approvals` was a plain
mutable table: `DELETE` a row and `sysknife audit verify` still reported
`Intact`, so the record that a privileged action had been approved was the one
part of the trail that could be erased without leaving a mark.

**Cross-chain binding.** Deleting events from the *end* of that chain would
still leave a self-consistent remainder — the same tail-truncation blind spot
the transaction chain has. So each transaction row signs the event-chain tip as
of its insert. Checkpoints anchor the transaction chain; transaction rows commit
to event tips; off-host anchoring therefore covers both, with no second sink.

Full detail in `CHANGELOG.md`.

## Related Issue

Follow-up to #111.

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`cargo nextest run --workspace --locked`: **1479 passed, 0 failed** (1473 on
`main`). `cargo clippy --workspace --all-features -- -D warnings`: clean.
`scripts/ci-local.sh`: PASS on every non-skipped check, including
`postgres-contract` against a live `postgres:16`.

## Notes for Reviewers

**The migration is the part to scrutinise.** Adding fields to the signed
content changes the message, so every row written by v0.2.12 or earlier would
re-encode differently and report as `Broken` — an upgrade that looks exactly
like a compromise. Rows therefore carry a `chain_version` and verification
reproduces the encoding each row was signed under. `a_chain_that_spans_the_migration_verifies_end_to_end`
and the store-level `a_database_written_before_the_migration_still_verifies_after_upgrading`
(which builds a real v1 database from `SQLITE_MIGRATIONS[0]`) pin this.

The version column is not a hiding place: relabelling a v2 row as v1 to erase
its `caller_role` makes verification re-encode it without the identity fields,
so the signature fails. A `chain_version=2` row with a nulled `caller_role` is
reported as **broken** (exit 1), not unverifiable (exit 2) — a CI gate treating
2 as "skip" must not wave it through. An unknown *future* version is exit 2,
which is the honest answer for an older binary reading a newer chain.

**A real bug, found by running the new Postgres test against a real database.**
`fetch_chain_rows_from_pool` still selected the pre-migration column list, so
every Postgres chain read would have failed with `no column found for name:
chain_version`. No unit test touches that SQL. Both backends now build the
column list from one constant, which is what would have prevented it.

**Three unfenced read paths.** `describe` renders the exact command an action
would run and had neither an authorization check nor a platform fence — any
caller could enumerate the argv of every privileged action on the host.
`query_action` checked the role but not the host family. And
`validate_action_platform` derived "is this a mutation" from the
override-adjusted role, so tightening RBAC on a read-only action via
`[policy.risk_overrides]` also made that read fail when the distro could not be
detected.

**Behaviour changes worth confirming:**
- `sysknife audit verify` prints three results instead of one and fails on any
  of them. Exit codes are unchanged for a clean chain; a detected tamper (1)
  outranks an inconclusive check (2).
- The MCP `sysknife_audit_verify` report gains three fields, and its top-level
  `status` is now the worst of the three rather than the transaction chain
  alone.
- `revoke_unconsumed_approval` and `claim_approved_for_execution` now refuse on
  a read-only store, since both append to the event chain.

**One finding needed no change.** The audit-forward drop warning from the same
batch was already implemented: `Forwarder::submit` counts consecutive `try_send`
drops and warns at `DROP_WARN_THRESHOLD`.

**Deliberately not done:** `StepToExecute.action_name` → `ActionName`. It would
mean adding a `schemars` dependency to `sysknife-types` (a crate published as a
lightweight types library) or a feature flag, to move a rejection that the
daemon already performs authoritatively via `build_action_spec`. The earlier
check would be nicer; it is not worth a dependency on the published crate for a
gate that already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f
