### PR TITLE
Add the .codex-plugin manifest plugin directories require

### DIFF
--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -1,0 +1,29 @@
+# Codex plugin manifest
+
+`plugin.json` is the manifest Codex plugin directories read to list SysKnife —
+notably [`hashgraph-online/awesome-codex-plugins`](https://github.com/hashgraph-online/awesome-codex-plugins),
+whose `scripts/validate-plugin-pr.py` fetches this repository and fails the
+listing PR if `.codex-plugin/plugin.json` is absent or incomplete.
+
+`mcp.json` declares how to launch the server. It deliberately carries **no
+`env` block**: SysKnife reads its LLM credentials from the environment
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …), and a manifest with a placeholder
+key invites someone to paste a real one into a tracked file. The root
+`.mcp.json.example` shows the fuller shape for local development, and root
+`.mcp.json` is gitignored for the same reason.
+
+`command` is the bare `sysknife` name, so it resolves from `PATH` after any of
+the supported installs (`npx sysknife-setup`, `cargo install sysknife-cli`, or a
+release binary). Nothing here needs the daemon: `tools/list` answers from the
+statically registered tool router, so a directory can introspect the server
+without a privileged process running.
+
+## Keeping it current
+
+`version` must match the released version. `scripts/check_release_versions.sh`
+includes this file, so a release that forgets to bump it fails CI rather than
+publishing a manifest that misreports which version a directory is listing.
+
+`interface.composerIcon` must resolve to a file in this repository under 50KB —
+`assets/raster/sysknife-256.png` is ~16KB. See `assets/raster/README.md` for how
+the PNGs are regenerated from the SVG sources.

--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sysknife": {
+      "command": "sysknife",
+      "args": ["mcp-server"]
+    }
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "sysknife",
+  "version": "0.2.13",
+  "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
+  "repository": "https://github.com/lacs-project/sysknife",
+  "author": {
+    "name": "LACS Project",
+    "url": "https://github.com/lacs-project"
+  },
+  "license": "MIT",
+  "keywords": [
+    "linux",
+    "sysadmin",
+    "mcp",
+    "codex",
+    "audit",
+    "approval",
+    "devops"
+  ],
+  "interface": {
+    "displayName": "SysKnife",
+    "shortDescription": "Run Linux admin tasks from Codex behind a typed approval gate",
+    "longDescription": "SysKnife turns a plain-language request into a plan of typed, risk-classified actions. Nothing executes on the model's word: the privileged daemon is the only component that runs anything, it refuses any action outside its catalogue, and medium- and high-risk steps require a single-use approval receipt minted out-of-band by a human running `sysknife approve` in a terminal. Every authorisation decision, and every approval grant, consumption and revocation, is recorded in Ed25519-signed forward hash chains that a third party can verify with only the exported public key. Failed system updates roll back automatically on atomic-host distros.",
+    "developerName": "LACS Project",
+    "category": "DevOps",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "What is using disk space on this machine?",
+      "Install ripgrep",
+      "Show me what SysKnife has run recently",
+      "Verify the audit chain"
+    ],
+    "brandColor": "#FF6B1A",
+    "composerIcon": "./assets/raster/sysknife-256.png",
+    "logo": "./assets/logo/sysknife.svg"
+  },
+  "mcpServers": "./.codex-plugin/mcp.json"
+}

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -30,6 +30,9 @@ versions+=("$(node -p "require('$repo_root/apps/sysknife-shell/package.json').ve
 versions+=("$(node -p "require('$repo_root/apps/sysknife-shell/package-lock.json').version")")
 versions+=("$(node -p "require('$repo_root/apps/sysknife-shell/src-tauri/tauri.conf.json').version")")
 versions+=("$(node -p "require('$repo_root/packages/setup/package.json').version")")
+# The Codex plugin manifest reports the version to plugin directories, so a
+# release that forgets it publishes a listing that misstates what is shipped.
+versions+=("$(node -p "require('$repo_root/.codex-plugin/plugin.json').version")")
 
 baseline="${versions[0]}"
 for version in "${versions[@]}"; do


### PR DESCRIPTION
## Summary

Unblocks the awesome-codex-plugins listing PR
([hashgraph-online/awesome-codex-plugins#327](https://github.com/hashgraph-online/awesome-codex-plugins/pull/327)),
whose `Validate plugin bundles` check fails with:

```text
Source repo https://github.com/lacs-project/sysknife does not contain .codex-plugin/plugin.json
```

Their `scripts/validate-plugin-pr.py` fetches this repository's `HEAD.zip` and
requires a manifest with `name`, `version`, `description`, `repository` and
`license`, plus an `interface` object carrying `displayName`,
`shortDescription` and a `composerIcon` that resolves to a real file under
50KB. The check reads the **default branch**, so the manifest has to land here
before that PR can go green.

`assets/raster/sysknife-256.png` (~16KB) is the icon. `name` is the lowercase
slug their validator demands, and `version` is semver.

## Related Issue

External: hashgraph-online/awesome-codex-plugins#327.

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

Manifest checked against a local re-implementation of every rule in their
validator (required fields, semver, lowercase slug, icon resolves and is under
50KB): no errors. `scripts/ci-local.sh --fast`: PASS.
`check_repo_completeness.sh`, `public-claims.test.sh`,
`check_release_versions.sh 0.2.13`: PASS.

## Notes for Reviewers

**`mcp.json` carries no `env` block, deliberately.** SysKnife reads LLM
credentials from the environment, and the root `.mcp.json` is gitignored
precisely because a real key was once committed there. A tracked manifest with
a `"OPENAI_API_KEY": "sk-proj-..."` placeholder invites the same mistake, so
the fuller shape stays in `.mcp.json.example` where it is clearly a sample.

`command` is the bare `sysknife` rather than an absolute path, so it resolves
from `PATH` after any supported install (`npx sysknife-setup`,
`cargo install sysknife-cli`, or a release binary).

**Version drift is now a CI failure, not a silent one.**
`check_release_versions.sh` includes the manifest, so a release that bumps the
crates but forgets this file fails rather than leaving a plugin directory
advertising the wrong version.

No behaviour change to any binary — this is metadata plus one line of shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f