### PR TITLE
chore(release): v0.2.14

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [0.2.14] — 2026-07-28
+
+### Added
+
+- **`.codex-plugin/plugin.json`** — the manifest Codex plugin directories read
+  to list SysKnife. `hashgraph-online/awesome-codex-plugins` fetches this
+  repository's default branch and fails a listing PR when the manifest is
+  absent, which is exactly what was blocking
+  [their #327](https://github.com/hashgraph-online/awesome-codex-plugins/pull/327).
+  It carries the required identity, licence and interface fields, and a
+  `composerIcon` pointing at the committed 16KB `assets/raster/sysknife-256.png`.
+- `.codex-plugin/mcp.json` declares how to launch the server, with **no `env`
+  block**: credentials come from the environment, and a tracked manifest holding
+  a placeholder API key is an easy way to commit a real one by accident (the
+  root `.mcp.json` is gitignored for that reason). `command` is the bare
+  `sysknife` so it resolves from `PATH` after any supported install.
+
+### Changed
+
+- `scripts/check_release_versions.sh` covers the plugin manifest, so a release
+  that bumps the crates but forgets it fails CI instead of leaving a plugin
+  directory advertising a version that was never shipped.
+
+No behaviour change to any binary; this release exists so the published version
+and the manifest a directory reads agree.
+
 ## [0.2.13] — 2026-07-27
 
 The last item v0.2.12 deferred: the audit chain could say what was authorised,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "prost",
  "prost-build",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.13"
+version = "0.2.14"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.13",
+  "version": "0.2.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.13"
+version = "0.2.14"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.13"
+version = "0.2.14"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.13"
+version = "0.2.14"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.13"
+version = "0.2.14"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.13"
+version = "0.2.14"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.13"
+version = "0.2.14"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts v0.2.14 so the `.codex-plugin/plugin.json` added in #113 ships, and so the
version it reports to plugin directories matches a release that actually exists.

No behaviour change to any binary. The only code touched is the version fields
plus the CHANGELOG entry.

## Related Issue

Follows #113, which unblocks
[hashgraph-online/awesome-codex-plugins#327](https://github.com/hashgraph-online/awesome-codex-plugins/pull/327).

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`scripts/ci-local.sh --fast`: PASS. `cargo nextest run --workspace --locked`:
**1479 passed, 0 failed**. `check_release_versions.sh 0.2.14`: all manifests
match, including the plugin manifest now that it is in the checked set.

## Notes for Reviewers

The plugin manifest is in `check_release_versions.sh`, so this bump had to
include it. That is the point of adding it to the check: a directory listing
that advertises a version which was never released is worse than no listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f