### PR TITLE
Ship server.json for the official MCP Registry listing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Test setup package contracts
         run: npm test --prefix packages/setup
 
+      - name: Check MCP Registry manifest coherence
+        run: bash tests/release/registry-manifest.test.sh
+
       - name: Check release rehearsal contract
         run: bash tests/release/release-rehearsal.test.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Check registry state for resumable publishing
         run: bash scripts/check_registry_versions.sh "${{ github.ref_name }}"
 
+      # The MCP Registry listing is published from server.json against the crate
+      # this release uploads, so an incoherent manifest is a release-time defect.
+      - name: Check MCP Registry manifest coherence
+        run: bash tests/release/registry-manifest.test.sh
+
       - name: Require publication credentials
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [Unreleased]
+
+### Added
+
+- **`server.json`** at the repository root: the manifest published to the
+  official [MCP Registry](https://registry.modelcontextprotocol.io) under
+  `io.github.lacs-project/sysknife`. It lists the `cargo` package
+  `sysknife-cli` with `mcp-server` as a positional argument, which is what the
+  registry's cargo validator and `mcp-publisher validate` accept. No new
+  package and no version bump: the ownership marker has shipped in the crate
+  README since 0.2.6, so the already-published 0.2.14 crate is what gets
+  listed.
+- `tests/release/registry-manifest.test.sh` guards the listing. The failure it
+  exists for is quiet: the validator proves ownership by searching the crate's
+  **rendered** crates.io README for a plain-text `mcp-name:` token, and
+  crates.io strips HTML comments when rendering, so moving the marker into a
+  comment or dropping it during a README rewrite breaks the next publish with
+  nothing in the repository looking wrong. The test also pins the registry type,
+  base URL, transport, crate identity, and the `mcp-server` argument. It runs in
+  CI and in the release preflight.
+
+### Changed
+
+- `scripts/check_release_versions.sh` covers both `server.json` version fields,
+  so a release cannot bump the crates and leave the registry listing pointing at
+  a version whose README the validator will not fetch.
+- `docs/mcp-registry.md` records the two-call crates.io check that proves the
+  marker is live in a given published version, rather than only present in the
+  repository.
+
 ## [0.2.14] — 2026-07-28
 
 ### Added

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -23,8 +23,13 @@ crate directly:
 
 This supersedes the earlier npm-launcher plan: the npm package `sysknife-setup`
 is an installer/wizard, not a stdio server, and `npx sysknife-setup` would launch
-the wizard rather than the server. The `cargo` type avoids that entirely — no
+the wizard rather than the server. Worse than merely wrong, the wizard reads
+answers from stdin when stdin is not a TTY, so it would consume a client's
+`initialize` frame as a prompt answer. The `cargo` type avoids that entirely: no
 dedicated launcher package is needed.
+
+The root `server.json` is accepted by `mcp-publisher validate`, which checks
+against the live registry rather than only the local schema.
 
 Namespace: `io.github.lacs-project/sysknife` (verified by GitHub identity — the
 authenticating account must belong to the `lacs-project` org; no DNS needed).
@@ -46,45 +51,39 @@ crate version whose README carries it (see the release step below).
 
 ## `server.json`
 
-Not shipped as a root file: the `version` is coupled to a published crate
-version that carries the marker, so it is finalized at release time. Template:
+Shipped at the repository root. The `version` is coupled to a published crate
+version that carries the marker, and two checks keep that coupling honest:
 
-```json
-{
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.lacs-project/sysknife",
-  "description": "Let AI operate your Linux box through typed, approval-gated, Ed25519-audited actions instead of shell strings.",
-  "repository": {
-    "url": "https://github.com/lacs-project/sysknife",
-    "source": "github"
-  },
-  "version": "0.2.6",
-  "packages": [
-    {
-      "registryType": "cargo",
-      "registryBaseUrl": "https://crates.io",
-      "identifier": "sysknife-cli",
-      "version": "0.2.6",
-      "transport": { "type": "stdio" },
-      "packageArguments": [
-        { "type": "positional", "valueHint": "subcommand", "value": "mcp-server" }
-      ]
-    }
-  ]
-}
-```
+- `scripts/check_release_versions.sh` includes both `server.json` version fields
+  in the release-wide version comparison, so a release cannot bump the crates
+  and leave the listing pointing at the previous version.
+- `tests/release/registry-manifest.test.sh` asserts the rest of the manifest:
+  `registryType`/`registryBaseUrl`/`transport`, that the identifier is the CLI
+  crate, that the `mcp-server` positional argument is present, and that the
+  ownership marker is in the crate README **outside** an HTML comment. It runs
+  in CI and in the release preflight.
+
+Both mean a stale or incoherent listing fails a check rather than a publish.
 
 ## Publish steps
 
-The crate README marker (`apps/sysknife-cli/README.md`) is already in the repo,
-so the next crate release is registry-ready. To publish the listing:
+The crate README marker (`apps/sysknife-cli/README.md`) is in the repo and has
+shipped in every published crate since 0.2.6, so any current version is
+registry-ready. To publish the listing:
 
-1. **Release a crate version that carries the marker.** The marker landed after
-   0.2.5, so cut the next version (e.g. 0.2.6) via the normal tag-driven
-   release; that publishes `sysknife-cli` with the marker in its README. Confirm
-   the README ships in the packaged crate first
-   (`cargo package -p sysknife-cli --list | grep README.md`), then set the
-   `version` fields in `server.json` to that version.
+1. **Confirm the marker is live in the version `server.json` names.** The
+   validator reads the *rendered* README from crates.io, in two calls:
+   ```sh
+   version=0.2.14
+   ua='sysknife-release/1.0 (https://github.com/lacs-project/sysknife)'
+   url="$(curl -sS -H 'Accept: application/json' -H "User-Agent: $ua" \
+     "https://crates.io/api/v1/crates/sysknife-cli/${version}/readme" \
+     | node -p 'JSON.parse(require("fs").readFileSync(0,"utf8")).url')"
+   curl -sS -H "User-Agent: $ua" "$url" \
+     | grep -c 'mcp-name: io.github.lacs-project/sysknife'
+   ```
+   A count of `1` means the marker is visible to the validator. A `0` means the
+   listing cannot be published for that version, whatever the repo says.
 2. **Install the publisher CLI:**
    ```sh
    brew install mcp-publisher   # or download from the registry's GitHub Releases
@@ -100,15 +99,18 @@ so the next crate release is registry-ready. To publish the listing:
      ```sh
      ./mcp-publisher login github-oidc
      ```
-4. **Validate and publish** (from the repo root, with `server.json` present):
+4. **Validate and publish** (from the repo root):
    ```sh
-   mcp-publisher validate
+   mcp-publisher validate   # checks server.json against the live registry
    mcp-publisher publish
    ```
+   `validate` needs no authentication, so it is worth running before the login
+   step. Only `publish` requires the token.
 5. **Verify:**
    ```sh
-   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.lacs-project/sysknife"
+   curl "https://registry.modelcontextprotocol.io/v0/servers?search=sysknife"
    ```
+   The `count` in the response metadata goes from `0` to `1`.
 
 ## Downstream propagation
 

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -33,6 +33,11 @@ versions+=("$(node -p "require('$repo_root/packages/setup/package.json').version
 # The Codex plugin manifest reports the version to plugin directories, so a
 # release that forgets it publishes a listing that misstates what is shipped.
 versions+=("$(node -p "require('$repo_root/.codex-plugin/plugin.json').version")")
+# server.json is the manifest published to the official MCP Registry. Its
+# version names the crate version whose rendered README carries the ownership
+# marker, so a stale value here fails authorization at publish time.
+versions+=("$(node -p "require('$repo_root/server.json').version")")
+versions+=("$(node -p "require('$repo_root/server.json').packages[0].version")")
 
 baseline="${versions[0]}"
 for version in "${versions[@]}"; do

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -269,6 +269,7 @@ run_hygiene_group() {
     run_step 'hygiene: check_release_versions.sh' bash "$repo_root/scripts/check_release_versions.sh"
     run_step 'hygiene: public-claims.test.sh' bash "$repo_root/tests/release/public-claims.test.sh"
     run_step 'hygiene: npm test --prefix packages/setup' npm test --prefix "$repo_root/packages/setup"
+    run_step 'hygiene: registry-manifest.test.sh' bash "$repo_root/tests/release/registry-manifest.test.sh"
     run_step 'hygiene: release-rehearsal.test.sh' bash "$repo_root/tests/release/release-rehearsal.test.sh"
     run_step 'hygiene: ubuntu-vm-bootstrap.test.sh' bash "$repo_root/tests/e2e/ubuntu-vm-bootstrap.test.sh"
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.lacs-project/sysknife",
+  "title": "SysKnife",
+  "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
+  "version": "0.2.14",
+  "websiteUrl": "https://lacs-project.github.io/sysknife/",
+  "repository": {
+    "url": "https://github.com/lacs-project/sysknife",
+    "source": "github"
+  },
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/lacs-project/sysknife/main/assets/raster/sysknife-256.png",
+      "mimeType": "image/png",
+      "sizes": ["256x256"]
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "cargo",
+      "registryBaseUrl": "https://crates.io",
+      "identifier": "sysknife-cli",
+      "version": "0.2.14",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "valueHint": "subcommand",
+          "value": "mcp-server"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "SYSKNIFE_SOCKET",
+          "description": "Where the privileged daemon listens: a unix:// path, a vsock:// target, or a bare path. Defaults to wherever the daemon bound, so it is only needed for a non-default install or a remote VM.",
+          "isRequired": false,
+          "isSecret": false,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/release/registry-manifest.test.sh
+++ b/tests/release/registry-manifest.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Guards server.json -- the manifest published to the official MCP Registry --
+# against the two ways it can silently stop working.
+#
+# 1. Ownership. The cargo validator proves ownership by fetching the crate's
+#    RENDERED README from crates.io and searching for a plain-text
+#    `mcp-name: <server name>` token. crates.io strips HTML comments when
+#    rendering, so a well-meaning edit that tucks the marker into a comment, or
+#    a README rewrite that drops it, makes the next publish fail authorization.
+# 2. Coupling. The marker only exists in a *published* crate version, so
+#    server.json's version must name the crate version that carries it, and the
+#    packaged crate must actually ship the README.
+#
+# Neither failure is visible to the Rust test suite, so it is asserted here.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+server_json="$repo_root/server.json"
+crate_readme="$repo_root/apps/sysknife-cli/README.md"
+
+fail() {
+    printf 'registry-manifest: %s\n' "$1" >&2
+    exit 1
+}
+
+[[ -f "$server_json" ]] || fail 'server.json is missing from the repository root'
+
+field() { node -p "JSON.parse(require('fs').readFileSync('$server_json','utf8'))$1"; }
+
+name="$(field ".name")"
+version="$(field ".version")"
+pkg_count="$(field ".packages.length")"
+registry_type="$(field ".packages[0].registryType")"
+registry_base="$(field ".packages[0].registryBaseUrl")"
+identifier="$(field ".packages[0].identifier")"
+pkg_version="$(field ".packages[0].version")"
+transport="$(field ".packages[0].transport.type")"
+
+[[ "$pkg_count" == "1" ]] \
+    || fail "expected exactly one package entry, found $pkg_count"
+[[ "$registry_type" == "cargo" ]] \
+    || fail "packages[0].registryType is '$registry_type', expected cargo"
+# The validator rejects any other base URL for a cargo package outright.
+[[ "$registry_base" == "https://crates.io" ]] \
+    || fail "packages[0].registryBaseUrl is '$registry_base', expected https://crates.io"
+[[ "$transport" == "stdio" ]] \
+    || fail "packages[0].transport.type is '$transport', expected stdio"
+[[ "$pkg_version" == "$version" ]] \
+    || fail "packages[0].version $pkg_version does not match server version $version"
+
+# The listed crate has to be the one that installs the `sysknife` binary, and
+# its version has to be this release's version -- the crate release is what
+# publishes the README the validator reads.
+crate_manifest="$repo_root/apps/sysknife-cli/Cargo.toml"
+crate_name="$(sed -n 's/^name = "\([^"]*\)"/\1/p' "$crate_manifest" | head -n 1)"
+crate_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$crate_manifest" | head -n 1)"
+[[ "$identifier" == "$crate_name" ]] \
+    || fail "packages[0].identifier is '$identifier', expected the CLI crate '$crate_name'"
+[[ "$version" == "$crate_version" ]] \
+    || fail "server.json version $version does not match $crate_name $crate_version"
+
+# `sysknife`'s MCP server is a subcommand, so the listing has to carry it as a
+# positional argument. Without it a client runs the bare CLI, which prints help
+# and exits instead of speaking JSON-RPC.
+subcommand="$(field ".packages[0].packageArguments?.filter(a => a.type === 'positional').map(a => a.value).join(',') ?? ''")"
+[[ "$subcommand" == "mcp-server" ]] \
+    || fail "packages[0].packageArguments positional values are '$subcommand', expected exactly mcp-server"
+
+# ---------------------------------------------------------------------------
+# The crates.io ownership marker
+# ---------------------------------------------------------------------------
+
+marker="mcp-name: $name"
+
+grep -Fq "$marker" "$crate_readme" \
+    || fail "apps/sysknife-cli/README.md does not contain '$marker'; the registry could not verify ownership"
+
+# crates.io renders the README as Markdown, so anything inside an HTML comment
+# disappears before the validator ever sees it.
+if node -e "
+const fs = require('fs');
+const src = fs.readFileSync('$crate_readme', 'utf8');
+const visible = src.replace(/<!--[\s\S]*?-->/g, '');
+process.exit(visible.includes('$marker') ? 1 : 0);
+"; then
+    fail "'$marker' in apps/sysknife-cli/README.md survives only inside an HTML comment; crates.io strips those when rendering"
+fi
+
+# A marker in a README that the packaged crate does not ship is a marker the
+# validator cannot fetch.
+grep -Eq '^readme = ' "$crate_manifest" || grep -Fq 'README.md' "$crate_manifest" \
+    || fail "apps/sysknife-cli/Cargo.toml does not reference README.md, so the packaged crate may omit it"
+
+printf 'registry-manifest: server.json -> cargo %s@%s (%s) with a rendered ownership marker.\n' \
+    "$identifier" "$version" "$subcommand"


### PR DESCRIPTION
## Summary

Ships `server.json`, the manifest published to the official
[MCP Registry](https://registry.modelcontextprotocol.io) under
`io.github.lacs-project/sysknife`, plus the two checks that keep it honest.

**No new package and no version bump.** The registry's cargo validator proves
ownership by fetching the crate's *rendered* README from crates.io and searching
for a plain-text `mcp-name:` token. That marker has shipped in every published
`sysknife-cli` since 0.2.6, so the already-published 0.2.14 crate is what gets
listed. Verified live rather than assumed:

```
https://static.crates.io/readmes/sysknife-cli/sysknife-cli-0.2.14.html
  → mcp-name: io.github.lacs-project/sysknife   (found)
```

`mcp-publisher validate` accepts the manifest against the live registry, not
just the local schema:

```
Validating against https://registry.modelcontextprotocol.io...
✅ server.json is valid
```

## Related Issue

Implements the publish path documented in `docs/mcp-registry.md`.

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`cargo nextest run --workspace --locked`: **1479 passed, 0 failed** (unchanged;
no Rust code is touched). `shellcheck --severity=warning` clean across every
maintained script, `yamllint` clean on both edited workflows.

## Notes for Reviewers

**The guard exists for a failure that leaves no trace in the repository.**
crates.io strips HTML comments when rendering Markdown, so moving the
`mcp-name:` marker into a comment, or dropping it during a README rewrite,
breaks the next registry publish while every file still *looks* correct.
`tests/release/registry-manifest.test.sh` re-strips comments the way crates.io
does and asserts the marker survives. It also pins the registry type, the
`https://crates.io` base URL (the validator rejects any other), the stdio
transport, the crate identity, and the `mcp-server` positional argument, because
without that argument a client runs the bare CLI, which prints help instead of
speaking JSON-RPC.

Each assertion was mutation-tested rather than assumed to work:

| Mutation | Result |
|---|---|
| marker wrapped in `<!-- -->` | fails: "survives only inside an HTML comment" |
| `packageArguments` deleted | fails: "positional values are '', expected exactly mcp-server" |
| version set to 0.2.13 | fails: "does not match sysknife-cli 0.2.14" |

**`check_release_versions.sh` now covers both `server.json` version fields**, so
a release cannot bump the crates and leave the listing naming a version whose
README the validator will not fetch. Both checks run in CI and in the release
preflight.

**One correction to the record.** An earlier note claimed `cargo` was not a
supported `registryType` and that a dedicated npm launcher package was needed.
That was wrong: the registry ships `internal/validators/registries/cargo.go`,
and `docs/mcp-registry.md` in this repository already had the cargo path right.
The npm path would also have been actively harmful, which the doc now records:
`npx sysknife-setup` runs the wizard, and the wizard reads answers from stdin
when stdin is not a TTY, so it would consume a client's `initialize` frame as a
prompt answer.

**Not done here:** actually publishing the listing. `mcp-publisher publish`
needs a one-time `mcp-publisher login github` device-code login, which is a
human step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f
