### PR TITLE
Fix the Ubuntu install and first-run experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   (`build-essential`) are required, and that **`cmake` is not**. `.github/`
   installs cmake before building this workspace, so the natural inference was
   that it was needed; clean-container runs disprove it — `aws-lc-sys` builds
-  from `gcc` alone, and the only hard failure is `error: linker \`cc\` not found`
+  from `gcc` alone, and the only hard failure is `error: linker cc not found`
   with no compiler at all. Build time is stated too: 6m56s on Ubuntu 24.04,
   11m43s on 22.04, about 400 crates.
 - `docs/quickstart.md` is now the canonical install page, and README and
@@ -90,6 +90,12 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   leads with this machine, since the documented headline case is a local install.
   Its socket-unreachable hint now matches the socket's kind rather than always
   naming the system unit.
+- `scripts/check_release_versions.sh` covers both `server.json` version fields,
+  so a release cannot bump the crates and leave the registry listing pointing at
+  a version whose README the validator will not fetch.
+- `docs/mcp-registry.md` records the two-call crates.io check that proves the
+  marker is live in a given published version, rather than only present in the
+  repository.
 
 ### Added
 
@@ -109,15 +115,6 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   nothing in the repository looking wrong. The test also pins the registry type,
   base URL, transport, crate identity, and the `mcp-server` argument. It runs in
   CI and in the release preflight.
-
-### Changed
-
-- `scripts/check_release_versions.sh` covers both `server.json` version fields,
-  so a release cannot bump the crates and leave the registry listing pointing at
-  a version whose README the validator will not fetch.
-- `docs/mcp-registry.md` records the two-call crates.io check that proves the
-  marker is live in a given published version, rather than only present in the
-  repository.
 
 ## [0.2.14] — 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,87 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+### Fixed
+
+- **`npx sysknife-setup` could not install anything, on any platform.** The
+  release-metadata request reused the asset-download `Accept:
+  application/octet-stream`, and GitHub answers that with **HTTP 415** on the
+  metadata endpoint, so the advertised primary install path died at
+  `✗ Failed to fetch release metadata` before downloading a byte. Metadata now
+  asks for `application/vnd.github+json`. Verified end to end in a clean
+  `ubuntu:24.04` container: both binaries download, SHA-256 verify, and install.
+- **The wizard crashed with a raw `SyntaxError` on Ubuntu 22.04**, whose
+  `apt install nodejs` gives Node 12. `engines` is only a warning to npx, and a
+  version check inside `index.js` could never run, because a parse error is
+  raised for the whole module before any statement in it executes. The bin
+  entrypoint is now a Node-12-parseable guard that explains the requirement and
+  offers three ways to get a current Node, or to skip Node entirely.
+- **`--no-prompts` silently installed the daemon that cannot do the job.** It
+  always answered "user service", which runs as the invoking user, while the
+  NOPASSWD grants live in `packaging/sysknife-sudoers` scoped to the `sysknife`
+  system user. Since the daemon reaches privileged work through `sudo`, an
+  automated install produced something that answered read-only queries and
+  failed everything else with `sudo: a password is required`. Unattended runs now
+  require `--daemon-mode=system|user|skip`, and choosing user mode prints what
+  will not work and how to get a daemon that can.
+- **A second daemon silently evicted the first.** The bind path removed any
+  existing socket after checking only that it *was* a socket, never that anything
+  was behind it, so starting the daemon twice unlinked the live socket and left
+  the first process's clients dark with no error, warning, or log line. The path
+  is now probe-connected first: a live daemon means refusal, a stale socket is
+  still reclaimed.
+- **Daemon startup dumped Rust `Debug` at operators.** Binding without
+  permission produced `Error: Io("Permission denied (os error 13)")` with no
+  path and no hint, the most likely first-run failure and the worst message in
+  the codebase. `main` now reports through `Display`, the bind failure names the
+  directory and the uid and both ways out, and `listening on …` is printed only
+  after the bind actually succeeds rather than before it.
+- **`sysknife doctor` was the worst-informed command about the thing it exists to
+  diagnose.** It printed neither the socket it dialled (the caller had the label
+  in hand) nor any next step, rendered sockets as `Unix("/run/…")`, and `main`
+  re-printed the whole sentence underneath. It now reports once, names the socket
+  as a URI, and suggests the systemd unit matching the socket's kind — user-mode
+  first for a `/run/user/…` socket, and no local unit at all for vsock.
+- **`sysknife approve` blamed a flag that does not exist.** Without a TTY it
+  returned "plan requires interactive approval but `--non-interactive` was set",
+  which cannot be true: `approve` has no such flag. Piping or scripting it now
+  says stdin is not a terminal.
+- **Planning printed nothing for minutes without a TTY.** `indicatif` hides the
+  spinner when stderr is not a terminal, so an ssh or logged run was
+  indistinguishable from a hang (173s measured). One stderr line now names the
+  provider and model before the request.
+- **A keyless environment chose Ollama without saying so**, then failed against a
+  port the user had never heard of. The fallback now announces itself and lists
+  the keys that would override it.
+- Provider errors no longer name an internal dependency (`Rig completion error:`),
+  and OpenAI auth failures name `OPENAI_API_KEY` instead of "your API key".
+- Authorization refusals name the group that grants the required role and the
+  `usermod` command, including that it only applies to a new login. Previously
+  they ended at "is not allowed for Observer role" — accurate and a dead end.
+
+### Changed
+
+- **Documented the real build prerequisite, which is not the one CI implied.**
+  Every from-source path now states that a C compiler and linker
+  (`build-essential`) are required, and that **`cmake` is not**. `.github/`
+  installs cmake before building this workspace, so the natural inference was
+  that it was needed; clean-container runs disprove it — `aws-lc-sys` builds
+  from `gcc` alone, and the only hard failure is `error: linker \`cc\` not found`
+  with no compiler at all. Build time is stated too: 6m56s on Ubuntu 24.04,
+  11m43s on 22.04, about 400 crates.
+- `docs/quickstart.md` is now the canonical install page, and README and
+  `docs/mcp.md` link to it instead of carrying their own slightly different
+  sequences. `docs/mcp.md`'s "Build the binary" is relabelled as the alternative
+  it always was, not step 4 of 5.
+- `apps/sysknife-cli/README.md` — the page crates.io renders, and therefore what
+  someone arriving from the MCP Registry reads — now leads with the fact that the
+  crate is half of SysKnife: it plans and dry-runs, and executing needs the
+  privileged daemon.
+- The setup wizard's target prompt says "Target" rather than "VM Target" and
+  leads with this machine, since the documented headline case is a local install.
+  Its socket-unreachable hint now matches the socket's kind rather than always
+  naming the system unit.
+
 ### Added
 
 - **`server.json`** at the repository root: the manifest published to the

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ the prompt, enforces the receipt boundary.
 
 Needs Rust stable **and a C compiler** (`build-essential`): the TLS and SQLite
 dependencies build native code, so a rustup-only machine stops at
-`error: linker \`cc\` not found`. `cmake` is not required. Budget 7 to 12
+`error: linker cc not found`. `cmake` is not required. Budget 7 to 12
 minutes for the ~400-crate build (6m56s on Ubuntu 24.04, 11m43s on 22.04).
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ plan and execute from chat.
 npx sysknife-setup
 ```
 
+Needs **Node 18 or newer**. On Ubuntu 22.04 `apt install nodejs` gives Node 12,
+which is too old; the installer says so and how to get a current Node. No Rust
+toolchain and no compile: it downloads verified prebuilt binaries.
+
 [![npm version](https://img.shields.io/npm/v/sysknife-setup?style=flat-square&logo=npm)](https://www.npmjs.com/package/sysknife-setup)
 
 What this does:
@@ -96,7 +100,11 @@ What this does:
    `sysknife_audit_verify` — as first-class tools.
 5. **Installs and starts the daemon as a service** (last step) — a systemd
    *user* service by default (no sudo; kept alive across logout via linger).
-   Pick the system-level service for a production, multi-user host.
+   That service runs as you, so read-only actions work but **mutating ones do
+   not**: installing packages or restarting services needs the system-level
+   service, whose sudoers grants belong to the `sysknife` system user. Pick the
+   system service on any host where you intend to change something, and pass
+   `--daemon-mode=system|user|skip` to choose without a prompt.
 
 | Client          | Files written                                        |
 |-----------------|------------------------------------------------------|
@@ -116,7 +124,13 @@ the prompt, enforces the receipt boundary.
 <details>
 <summary><strong>Manual install — Ubuntu LTS · Fedora Atomic</strong></summary>
 
+Needs Rust stable **and a C compiler** (`build-essential`): the TLS and SQLite
+dependencies build native code, so a rustup-only machine stops at
+`error: linker \`cc\` not found`. `cmake` is not required. Budget 7 to 12
+minutes for the ~400-crate build (6m56s on Ubuntu 24.04, 11m43s on 22.04).
+
 ```sh
+sudo apt-get install -y build-essential
 git clone https://github.com/lacs-project/sysknife
 cd sysknife
 make build                            # builds sysknife (CLI) + sysknife-daemon
@@ -124,8 +138,8 @@ sudo make install                     # installs both; daemon runs as a system s
 sudo systemctl enable --now sysknife-daemon
 
 # Then wire your IDE — --no-binary skips the download since you just built them
-# (choose "skip" at the daemon-service prompt; make install already set it up)
-npx sysknife-setup --no-binary
+# (--daemon-mode=skip: make install already set the service up)
+npx sysknife-setup --no-binary --daemon-mode=skip
 ```
 
 Ubuntu 24.04 is validated with 65/65 stories on a live VM. Ubuntu 22.04 and
@@ -325,8 +339,9 @@ are scoped with clear acceptance criteria.
 
 | Channel | Install | Notes |
 |---------|---------|-------|
-| **npm** | `npx sysknife-setup` | [npmjs.com/package/sysknife-setup](https://www.npmjs.com/package/sysknife-setup) — zero-install setup wizard |
-| **crates.io** | `cargo install sysknife-cli` / `cargo install sysknife-daemon` | Published by reviewed version tags; see [docs/release.md](docs/release.md) |
+| **npm** | `npx sysknife-setup` | [npmjs.com/package/sysknife-setup](https://www.npmjs.com/package/sysknife-setup) — setup wizard; needs Node 18+, no compile |
+| **crates.io** | `cargo install sysknife-cli` / `cargo install sysknife-daemon` | Needs `build-essential`; ~7-12 min build. Published by reviewed version tags; see [docs/release.md](docs/release.md) |
+| **MCP Registry** | `io.github.lacs-project/sysknife` | [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) — resolves to the crates.io install above |
 | **GitHub Releases** | Download from [Releases](https://github.com/lacs-project/sysknife/releases) | Prebuilt x86_64 + aarch64 binaries with SHA-256 checksums on every tag |
 
 ## License

--- a/apps/sysknife-cli/README.md
+++ b/apps/sysknife-cli/README.md
@@ -13,9 +13,36 @@ implementation of the LACS (Linux Agent Control Standard) protocol.
 
 ## Install
 
+**This crate is half of SysKnife.** It installs the `sysknife` binary: the CLI,
+the planner, and the stdio MCP server. Executing anything also needs
+`sysknife-daemon`, a privileged systemd service, because the CLI never performs
+privileged work itself. Planning and `--dry-run` work without it.
+
+### From source
+
+A C compiler and linker are required (the TLS and SQLite dependencies build
+native code). On a machine with only `rustup`, the build fails at
+`error: linker \`cc\` not found`.
+
 ```sh
+sudo apt-get install -y build-essential   # Debian/Ubuntu
 cargo install sysknife-cli
 ```
+
+Expect 7 to 12 minutes: it compiles around 400 crates. Measured on stock Ubuntu
+containers, 6m56s on 24.04 and 11m43s on 22.04. `cmake` is **not** required.
+
+### Prebuilt, and the daemon too
+
+Faster, and it installs both halves plus your MCP client config:
+
+```sh
+npx sysknife-setup            # needs Node 18+
+```
+
+The wizard downloads SHA-256-verified binaries from the release page, so there
+is no compile and no toolchain. On Ubuntu 22.04 note that `apt install nodejs`
+gives Node 12, which is too old.
 
 ## Use
 

--- a/apps/sysknife-cli/README.md
+++ b/apps/sysknife-cli/README.md
@@ -22,7 +22,7 @@ privileged work itself. Planning and `--dry-run` work without it.
 
 A C compiler and linker are required (the TLS and SQLite dependencies build
 native code). On a machine with only `rustup`, the build fails at
-`error: linker \`cc\` not found`.
+`error: linker cc not found`.
 
 ```sh
 sudo apt-get install -y build-essential   # Debian/Ubuntu

--- a/apps/sysknife-cli/src/client.rs
+++ b/apps/sysknife-cli/src/client.rs
@@ -102,6 +102,20 @@ impl SocketTarget {
         }
         Ok(Self::Unix(PathBuf::from(s)))
     }
+
+    /// The target as a user-facing URI, in the same form [`Self::try_from_str`]
+    /// accepts.
+    ///
+    /// Every message that mentions the socket uses this. `{:?}` would print
+    /// `Unix("/run/sysknife/daemon.sock")`, which is Rust's internals rather
+    /// than something a reader can paste back into `SYSKNIFE_SOCKET`.
+    pub fn label(&self) -> String {
+        match self {
+            Self::Unix(path) => format!("unix://{}", path.display()),
+            #[cfg(target_os = "linux")]
+            Self::Vsock { cid, port } => format!("vsock://{cid}:{port}"),
+        }
+    }
 }
 
 impl From<PathBuf> for SocketTarget {
@@ -299,8 +313,12 @@ impl DaemonClient {
     fn connect_sync(&self) -> Result<SyncStream, PlanningError> {
         match &self.target {
             SocketTarget::Unix(path) => {
-                let stream = UnixStream::connect(path)
-                    .map_err(|e| PlanningError::StateUnavailable(format!("connect: {e}")))?;
+                let stream = UnixStream::connect(path).map_err(|e| {
+                    PlanningError::StateUnavailable(format!(
+                        "cannot reach the SysKnife daemon at unix://{}: {e}",
+                        path.display()
+                    ))
+                })?;
                 stream
                     .set_read_timeout(Some(SOCKET_TIMEOUT))
                     .map_err(|e| PlanningError::StateUnavailable(format!("set timeout: {e}")))?;
@@ -311,8 +329,12 @@ impl DaemonClient {
             }
             #[cfg(target_os = "linux")]
             SocketTarget::Vsock { cid, port } => {
-                let mut stream = vsock::VsockStream::connect_with_cid_port(*cid, *port)
-                    .map_err(|e| PlanningError::StateUnavailable(format!("connect: {e}")))?;
+                let mut stream =
+                    vsock::VsockStream::connect_with_cid_port(*cid, *port).map_err(|e| {
+                        PlanningError::StateUnavailable(format!(
+                            "cannot reach the SysKnife daemon at vsock://{cid}:{port}: {e}"
+                        ))
+                    })?;
                 stream
                     .set_read_timeout(Some(SOCKET_TIMEOUT))
                     .map_err(|e| PlanningError::StateUnavailable(format!("set timeout: {e}")))?;
@@ -1231,9 +1253,16 @@ mod tests {
         let err = client.curated_state().unwrap_err();
         match err {
             PlanningError::StateUnavailable(msg) => {
+                // Names the target and keeps the OS cause. Asserting on the
+                // socket path rather than the word "connect" is the stronger
+                // contract: a message without the path is useless to a reader.
                 assert!(
-                    msg.contains("connect"),
-                    "error should mention 'connect', got: {msg}"
+                    msg.contains("/tmp/sysknife-no-such-socket-xyzzy.sock"),
+                    "error should name the socket, got: {msg}"
+                );
+                assert!(
+                    msg.contains("No such file or directory"),
+                    "error should keep the OS cause, got: {msg}"
                 );
             }
             other => panic!("expected StateUnavailable, got {other:?}"),
@@ -1676,6 +1705,58 @@ mod tests {
         assert!(SocketTarget::try_from_str("vsock://3:notaport").is_err());
     }
 
+    // -----------------------------------------------------------------
+    // Naming the target in connect failures
+    //
+    // "connect: No such file or directory (os error 2)" was the entire
+    // message a user got when the daemon was not running — it never said
+    // which socket was dialled, so there was nothing to check, fix, or
+    // even paste into a bug report. `label()` also exists because the
+    // socket was previously rendered with `{:?}`, printing
+    // `Unix("/run/…")` at users.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn socket_label_is_a_uri_a_user_can_act_on_not_a_debug_dump() {
+        let unix = SocketTarget::Unix(PathBuf::from("/run/sysknife/daemon.sock"));
+        assert_eq!(unix.label(), "unix:///run/sysknife/daemon.sock");
+        assert!(!unix.label().contains("Unix("), "no Rust Debug formatting");
+        // Round-trips through the parser it is meant to mirror.
+        assert_eq!(SocketTarget::try_from_str(&unix.label()).unwrap(), unix);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn vsock_label_is_the_uri_form_the_parser_accepts() {
+        let target = SocketTarget::Vsock { cid: 3, port: 7777 };
+        assert_eq!(target.label(), "vsock://3:7777");
+        assert_eq!(SocketTarget::try_from_str(&target.label()).unwrap(), target);
+    }
+
+    #[test]
+    fn a_failed_unix_connect_names_the_socket_it_tried() {
+        let missing = std::env::temp_dir().join("sysknife-does-not-exist-4f2a.sock");
+        let client = DaemonClient::new(SocketTarget::Unix(missing.clone()));
+        let err = client.curated_state().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains(missing.to_str().unwrap()),
+            "the socket path must appear in the error, got: {msg}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn a_failed_vsock_connect_names_the_cid_and_port() {
+        let client = DaemonClient::new(SocketTarget::Vsock {
+            cid: 99,
+            port: 7777,
+        });
+        let msg = client.curated_state().unwrap_err().to_string();
+        assert!(msg.contains("99"), "cid must appear in: {msg}");
+        assert!(msg.contains("7777"), "port must appear in: {msg}");
+    }
+
     #[test]
     #[cfg(target_os = "linux")]
     fn vsock_connection_failure_maps_to_state_unavailable() {
@@ -1687,7 +1768,10 @@ mod tests {
         let err = client.curated_state().unwrap_err();
         match err {
             PlanningError::StateUnavailable(msg) => {
-                assert!(msg.contains("connect"), "expected 'connect' in: {msg}");
+                assert!(
+                    msg.contains("vsock://99:7777"),
+                    "error should name the vsock target, got: {msg}"
+                );
             }
             other => panic!("expected StateUnavailable, got {other:?}"),
         }

--- a/apps/sysknife-cli/src/error.rs
+++ b/apps/sysknife-cli/src/error.rs
@@ -33,6 +33,21 @@ pub enum CliError {
     #[error("plan requires interactive approval but --non-interactive was set")]
     NonInteractive,
 
+    /// Produced when `sysknife approve` is run without a terminal on stdin.
+    ///
+    /// Distinct from [`Self::NonInteractive`] because the cause is different and
+    /// the old shared message was simply wrong here: `approve` has no
+    /// `--non-interactive` flag, so telling the user it "was set" sent anyone
+    /// who piped or scripted the command looking for a flag that does not exist.
+    ///
+    /// Exit code 1 — a human decision is still required before this can run.
+    #[error(
+        "sysknife approve needs a terminal to confirm on, and stdin is not one \
+         (it is a pipe, a redirect, or a non-interactive ssh command). \
+         Run it directly in a shell."
+    )]
+    ApprovalNeedsTerminal,
+
     /// Produced by subcommands that have their own exit-code semantics (e.g.
     /// `sysknife audit verify` uses 0/1/2). The wrapped value is the literal
     /// exit code the process should return.
@@ -43,7 +58,10 @@ pub enum CliError {
 impl CliError {
     pub fn exit_code(&self) -> i32 {
         match self {
-            Self::Rejected | Self::RiskCeilingExceeded { .. } | Self::NonInteractive => 1,
+            Self::Rejected
+            | Self::RiskCeilingExceeded { .. }
+            | Self::NonInteractive
+            | Self::ApprovalNeedsTerminal => 1,
             Self::ExecutionFailed(_) => 2,
             Self::PlanningFailed(_) => 3,
             Self::ConfigOrDaemon(_) => 4,
@@ -76,6 +94,31 @@ mod tests {
     #[test]
     fn exit_code_non_interactive_is_1() {
         assert_eq!(CliError::NonInteractive.exit_code(), 1);
+    }
+
+    #[test]
+    fn exit_code_approval_needs_terminal_is_1() {
+        assert_eq!(CliError::ApprovalNeedsTerminal.exit_code(), 1);
+    }
+
+    #[test]
+    fn a_missing_terminal_is_not_reported_as_a_flag_the_user_never_passed() {
+        // `sysknife approve` has no --non-interactive flag, so the shared
+        // message used to state a cause that could not be true.
+        let msg = CliError::ApprovalNeedsTerminal.to_string();
+        assert!(
+            !msg.contains("--non-interactive"),
+            "must not blame a flag that does not exist for this subcommand: {msg}"
+        );
+        assert!(msg.contains("terminal"), "names the real cause: {msg}");
+        assert!(
+            msg.contains("Run it directly in a shell"),
+            "tells the user what to do instead: {msg}"
+        );
+        // The genuine flag case keeps its own, accurate wording.
+        assert!(CliError::NonInteractive
+            .to_string()
+            .contains("--non-interactive"));
     }
 
     #[test]

--- a/apps/sysknife-cli/src/main.rs
+++ b/apps/sysknife-cli/src/main.rs
@@ -49,7 +49,12 @@ async fn main() {
     .await;
 
     if let Err(e) = result {
-        eprintln!("sysknife: {e}");
+        // `Exit` means the subcommand owns its own output and has already
+        // printed a report (e.g. `doctor`, `audit verify`). Printing here too
+        // showed the user the same failure twice.
+        if !matches!(e, crate::error::CliError::Exit(_)) {
+            eprintln!("sysknife: {e}");
+        }
         std::process::exit(e.exit_code());
     }
 }

--- a/apps/sysknife-cli/src/render.rs
+++ b/apps/sysknife-cli/src/render.rs
@@ -241,12 +241,70 @@ pub fn print_doctor_ok(
     log.println(&format!("  distro    {distro}"));
 }
 
+/// Announce a planning request on a terminal-less stderr.
+///
+/// The spinner is the only thing that tells a user planning is under way, and
+/// `indicatif` hides it when stderr is not a TTY. A slow provider then produced
+/// no output at all for minutes (173s measured against a local Ollama), which
+/// over ssh or in a log file is indistinguishable from a hung process. One line
+/// is enough to tell the two apart, and it goes to stderr so `--json` consumers
+/// reading stdout are unaffected.
+pub fn print_planning_notice(provider: &str, model: &str, intent: &str) {
+    eprintln!("→ planning \"{intent}\" with {provider}/{model}, this can take a minute…");
+}
+
+/// The lines a `sysknife doctor` failure prints, without colour.
+///
+/// Split out from [`print_doctor_fail`] so the wording and the ordering of the
+/// remediation hints are testable. The hint order is not cosmetic: pointing
+/// someone with a user-mode daemon at `sudo systemctl` sends them to a unit that
+/// does not exist on their machine, and a vsock target has no local unit at all.
+fn doctor_fail_lines(socket: &str, error: &str) -> Vec<String> {
+    // Connect failures already name their target, so re-prefixing would print
+    // the socket twice in one sentence.
+    let headline = if error.contains(socket) {
+        format!("daemon unreachable: {error}")
+    } else {
+        format!("daemon unreachable at {socket}: {error}")
+    };
+    let mut lines = vec![headline];
+
+    // A remote daemon is not managed by systemd on this host, so naming local
+    // units would be actively misleading.
+    if socket.starts_with("vsock://") {
+        lines.push("check the daemon on the target VM, and that SYSKNIFE_TOKEN matches".into());
+        return lines;
+    }
+
+    // $XDG_RUNTIME_DIR is /run/user/<uid> on Ubuntu; that is where the setup
+    // wizard's default (user-mode) daemon binds.
+    let user_mode = socket.contains("/run/user/");
+    let system_hint = "system service:  sudo systemctl status sysknife-daemon";
+    let user_hint = "user service:    systemctl --user status sysknife-daemon";
+    if user_mode {
+        lines.push(user_hint.into());
+        lines.push(system_hint.into());
+    } else {
+        lines.push(system_hint.into());
+        lines.push(user_hint.into());
+    }
+    lines
+}
+
 /// Print a `sysknife doctor` failure to stderr.
-pub fn print_doctor_fail(error: &str) {
+pub fn print_doctor_fail(socket: &str, error: &str) {
+    let mut lines = doctor_fail_lines(socket, error).into_iter();
+    let headline = lines.next().expect("always at least one line");
     eprintln!(
-        "{}  daemon unreachable: {error}",
+        "{}  {headline}",
         "✗".if_supports_color(Stream::Stderr, |t| t.red()),
     );
+    for hint in lines {
+        eprintln!(
+            "   {} {hint}",
+            "→".if_supports_color(Stream::Stderr, |t| t.dimmed())
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +357,69 @@ mod tests {
         assert!(
             !s.contains("high "),
             "high-risk badge must NOT use lowercase 'high'; got {s:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // `sysknife doctor` failure text
+    //
+    // The whole point of `doctor` is answering "why can't I reach the
+    // daemon". It used to print only:
+    //
+    //   ✗  daemon unreachable: state unavailable: connect: No such file …
+    //
+    // No socket, no next step, even though the caller had the socket
+    // label in hand. These tests pin both, and pin that the remediation
+    // matches the kind of install the socket path implies — telling
+    // someone with a user-mode daemon to run `sudo systemctl` sends them
+    // to a unit that does not exist.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn doctor_failure_names_the_socket_and_a_next_step() {
+        let out = doctor_fail_lines("unix:///run/sysknife/daemon.sock", "connect: No such file");
+        let joined = out.join("\n");
+        assert!(joined.contains("unix:///run/sysknife/daemon.sock"));
+        assert!(joined.contains("connect: No such file"), "keeps the cause");
+        assert!(
+            joined.contains("systemctl"),
+            "must offer a command to run, got: {joined}"
+        );
+    }
+
+    #[test]
+    fn a_system_socket_suggests_the_system_unit_first() {
+        let out = doctor_fail_lines("unix:///run/sysknife/daemon.sock", "boom").join("\n");
+        let system_at = out.find("sudo systemctl").expect("system hint present");
+        let user_at = out.find("systemctl --user").expect("user hint present");
+        assert!(
+            system_at < user_at,
+            "system hint first for /run, got: {out}"
+        );
+    }
+
+    #[test]
+    fn a_per_user_runtime_socket_suggests_the_user_unit_first() {
+        // $XDG_RUNTIME_DIR is /run/user/<uid> on Ubuntu, which is where the
+        // wizard's default (user-mode) daemon binds.
+        let out =
+            doctor_fail_lines("unix:///run/user/1000/sysknife/daemon.sock", "boom").join("\n");
+        let user_at = out.find("systemctl --user").expect("user hint present");
+        let system_at = out.find("sudo systemctl").expect("system hint present");
+        assert!(
+            user_at < system_at,
+            "user hint first for /run/user, got: {out}"
+        );
+    }
+
+    #[test]
+    fn a_vsock_target_does_not_suggest_local_systemd_at_all() {
+        // The daemon is on another host; `systemctl` here would be wrong.
+        let out = doctor_fail_lines("vsock://3:7777", "boom").join("\n");
+        assert!(out.contains("vsock://3:7777"));
+        assert!(
+            !out.contains("systemctl"),
+            "local unit commands are misleading for a remote target, got: {out}"
         );
     }
 

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -227,7 +227,7 @@ pub async fn run_approve(
     log: &Logger,
 ) -> Result<(), CliError> {
     if !std::io::stdin().is_terminal() {
-        return Err(CliError::NonInteractive);
+        return Err(CliError::ApprovalNeedsTerminal);
     }
     let client = DaemonClient::new(socket);
     let details = client.approval_details(transaction_id).await?;
@@ -368,7 +368,9 @@ pub async fn run_doctor(
 ) -> Result<(), CliError> {
     let config = BrainConfig::from_env().map_err(|e| CliError::ConfigOrDaemon(e.to_string()))?;
 
-    let socket_label = format!("{socket:?}");
+    // `{:?}` printed `Unix("/run/…")` at users; `label()` gives the URI form
+    // they can put back into SYSKNIFE_SOCKET.
+    let socket_label = socket.label();
     let client = DaemonClient::new(socket);
 
     // Detect the running distro once; failure is non-fatal for doctor.
@@ -409,12 +411,16 @@ pub async fn run_doctor(
         }
         Err(e) => {
             if json_out {
-                let out = json!({ "ok": false, "error": e.to_string() });
+                // Scripts need to know which socket failed, not just that one did.
+                let out = json!({ "ok": false, "socket": socket_label, "error": e.to_string() });
                 log.println(&serde_json::to_string(&out).expect("static JSON"));
             } else {
-                crate::render::print_doctor_fail(&e.to_string());
+                crate::render::print_doctor_fail(&socket_label, &e.to_string());
             }
-            Err(CliError::ConfigOrDaemon(e.to_string()))
+            // The report above is the user-facing output; `Exit` carries the
+            // code (4, as for any config/daemon failure) without main
+            // re-printing the same sentence underneath it.
+            Err(CliError::Exit(4))
         }
     }
 }
@@ -987,6 +993,16 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
     // (the daemon will produce its own error at execution time).
     let distro = sysknife_core::distro::detect().ok();
 
+    // Captured before `config` is moved into the planner below.
+    let provider_label = config.provider_name().to_string();
+    let model_label = config.model_name().to_string();
+
+    // Nothing used to say a provider had been picked by elimination, so a
+    // keyless first run failed against a port the user had never heard of.
+    if let Some(notice) = config.provider_guess_notice() {
+        eprintln!("! {notice}");
+    }
+
     let plan_client = DaemonClient::new(opts.socket.clone());
 
     // Layer 3: planning event channel — planner emits PlanEvent as it works;
@@ -1004,6 +1020,12 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
     // Layer 1: spinner — auto-hidden by indicatif when stderr is not a TTY.
     let spinner =
         (!opts.json).then(|| crate::render::make_spinner(format!("Planning \"{intent}\"…")));
+
+    // …and because it is hidden there, a piped or ssh'd run would otherwise
+    // print nothing at all while the provider thinks. Say it once instead.
+    if !io::stderr().is_terminal() {
+        crate::render::print_planning_notice(&provider_label, &model_label, &intent);
+    }
 
     // Spawn event updater: receives PlanEvent and updates the spinner message.
     // The task exits naturally when the channel closes (i.e. when the planner

--- a/apps/sysknife-cli/tests/doctor_output.rs
+++ b/apps/sysknife-cli/tests/doctor_output.rs
@@ -1,0 +1,76 @@
+//! What `sysknife doctor` actually prints when the daemon is not there.
+//!
+//! `doctor` exists to answer "why can't I reach the daemon", and it is the
+//! command every install guide points at first, so its output is a contract.
+//! Three things were wrong and are pinned here:
+//!
+//!   1. it never named the socket it dialled, even though the caller had the
+//!      label in hand;
+//!   2. it offered no next step, while the setup wizard's own probe did;
+//!   3. `main` re-printed the same sentence underneath the report, so the user
+//!      read the failure twice.
+//!
+//! Driven through the real binary because the duplication in (3) only exists in
+//! the seam between `run_doctor` and `main`.
+
+use std::process::Command;
+
+/// A socket path that cannot exist, so the connect always fails.
+const MISSING_SOCKET: &str = "/tmp/sysknife-doctor-output-test-a41c/daemon.sock";
+
+fn run_doctor(socket: &str) -> (String, Option<i32>) {
+    let out = Command::new(env!("CARGO_BIN_EXE_sysknife"))
+        .arg("doctor")
+        .env("SYSKNIFE_SOCKET", socket)
+        // Any provider works: doctor fails at the socket before planning.
+        .env("ANTHROPIC_API_KEY", "sk-ant-test-not-used")
+        .output()
+        .expect("the sysknife binary runs");
+    (
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code(),
+    )
+}
+
+#[test]
+fn names_the_socket_it_tried() {
+    let (stderr, code) = run_doctor(MISSING_SOCKET);
+    assert!(
+        stderr.contains(MISSING_SOCKET),
+        "the socket must appear, got:\n{stderr}"
+    );
+    assert_eq!(code, Some(4), "daemon/config failures exit 4");
+}
+
+#[test]
+fn offers_a_command_to_run_next() {
+    let (stderr, _) = run_doctor(MISSING_SOCKET);
+    assert!(
+        stderr.contains("systemctl"),
+        "a next step must be offered, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn reports_the_failure_once_not_twice() {
+    let (stderr, _) = run_doctor(MISSING_SOCKET);
+    let mentions = stderr.matches(MISSING_SOCKET).count();
+    assert_eq!(
+        mentions, 1,
+        "the socket should be named exactly once; a second copy means the \
+         report and the top-level handler both printed it:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("subcommand exit code"),
+        "internal plumbing must not leak into user output:\n{stderr}"
+    );
+}
+
+#[test]
+fn does_not_print_rust_debug_formatting_at_the_user() {
+    let (stderr, _) = run_doctor(MISSING_SOCKET);
+    assert!(
+        !stderr.contains("Unix("),
+        "sockets must render as URIs, not Debug:\n{stderr}"
+    );
+}

--- a/crates/sysknife-brain/src/config.rs
+++ b/crates/sysknife-brain/src/config.rs
@@ -46,6 +46,10 @@ pub const DEFAULT_MAX_TURNS: usize = 10;
 pub struct BrainConfig {
     pub(crate) provider: ProviderConfig,
     pub max_turns: usize,
+    /// True when no provider was named and no key was found, so Ollama was
+    /// picked by elimination rather than by anyone's intent. Drives the notice
+    /// in [`Self::provider_guess_notice`]; see there for why it matters.
+    provider_guessed: bool,
 }
 
 /// Per-provider client configuration.  See [`BrainConfig`] for why this is
@@ -208,6 +212,10 @@ impl BrainConfig {
             }
         };
 
+        let provider_explicit = std::env::var("SYSKNIFE_LLM_PROVIDER").is_ok();
+        let anthropic_key_present = std::env::var("ANTHROPIC_API_KEY")
+            .map(|v| !v.trim().is_empty())
+            .unwrap_or(false);
         let provider_name = std::env::var("SYSKNIFE_LLM_PROVIDER").unwrap_or_else(|_| {
             // Auto-detect: use anthropic only when a non-whitespace key is present.
             // A whitespace-only key would pass is_ok() but fail validation below,
@@ -292,7 +300,48 @@ impl BrainConfig {
         Ok(Self {
             provider,
             max_turns,
+            // Only a keyless, unnamed fallback counts as a guess: an explicit
+            // SYSKNIFE_LLM_PROVIDER is intent, and a key in the environment is
+            // intent too.
+            provider_guessed: !provider_explicit && !anthropic_key_present,
         })
+    }
+
+    /// True when Ollama was selected by elimination rather than by intent.
+    pub fn provider_was_guessed(&self) -> bool {
+        self.provider_guessed
+    }
+
+    /// A line worth printing before the first request, or `None` when the
+    /// provider was chosen deliberately.
+    ///
+    /// Without this, a fresh install with no keys set produced only a bare
+    /// transport error against `http://localhost:11434` — a port the user had
+    /// never heard of, for a provider nothing told them had been picked.
+    pub fn provider_guess_notice(&self) -> Option<String> {
+        if !self.provider_guessed {
+            return None;
+        }
+        Some(format!(
+            "no LLM provider configured, so falling back to {} at {}. \
+             Install Ollama (https://ollama.com) and `ollama pull {}`, or set one of \
+             ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY, or pick one \
+             explicitly with SYSKNIFE_LLM_PROVIDER.",
+            self.provider_name(),
+            self.base_url_label(),
+            self.model_name(),
+        ))
+    }
+
+    /// The endpoint the provider will be dialled on, for messages that need to
+    /// name it. Cloud providers report their own name rather than a URL, since
+    /// the URL is not the actionable part there.
+    fn base_url_label(&self) -> String {
+        match &self.provider {
+            ProviderConfig::Ollama { base_url, .. } => base_url.clone(),
+            ProviderConfig::Anthropic { base_url, .. } => base_url.clone(),
+            _ => format!("the {} API", self.provider_name()),
+        }
     }
 
     /// Returns the provider name string (e.g. `"anthropic"`, `"ollama"`, `"openai"`).
@@ -331,6 +380,9 @@ impl BrainConfig {
                 model: DEFAULT_OLLAMA_MODEL.into(),
             },
             max_turns: DEFAULT_MAX_TURNS,
+            // Constructed explicitly by a caller that wants Ollama, so this is
+            // intent, not the keyless fallback `from_env` performs.
+            provider_guessed: false,
         }
     }
 }
@@ -429,6 +481,82 @@ mod tests {
         assert!(
             matches!(result, Err(ConfigError::InvalidMaxTurns(_))),
             "expected InvalidMaxTurns, got: {result:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // The keyless Ollama fallback
+    //
+    // With no provider env vars at all, `from_env` quietly selects Ollama.
+    // Almost nobody on a fresh Ubuntu box is running Ollama, so the first
+    // command a new user typed failed with a bare transport error naming a
+    // port they had never heard of, and nothing said a provider had been
+    // guessed. The guess is fine; making it silently was not.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn a_keyless_environment_records_that_ollama_was_only_a_guess() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var("SYSKNIFE_LLM_PROVIDER");
+            std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("SYSKNIFE_LLM_MODEL");
+            std::env::remove_var("SYSKNIFE_BRAIN_MAX_TURNS");
+        }
+        let cfg = BrainConfig::from_env().expect("keyless env falls back to ollama");
+        assert_eq!(cfg.provider_name(), "ollama");
+        assert!(
+            cfg.provider_was_guessed(),
+            "a keyless fallback must be marked as a guess so the CLI can say so"
+        );
+        let notice = cfg.provider_guess_notice().expect("a notice is available");
+        assert!(notice.contains("ollama"), "names what was picked: {notice}");
+        assert!(
+            notice.contains("ANTHROPIC_API_KEY") || notice.contains("OPENAI_API_KEY"),
+            "names at least one key the user could set instead: {notice}"
+        );
+    }
+
+    #[test]
+    fn an_explicitly_chosen_provider_is_never_reported_as_a_guess() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("SYSKNIFE_LLM_PROVIDER", "ollama");
+            std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("SYSKNIFE_LLM_MODEL");
+            std::env::remove_var("SYSKNIFE_BRAIN_MAX_TURNS");
+        }
+        let result = BrainConfig::from_env();
+        unsafe {
+            std::env::remove_var("SYSKNIFE_LLM_PROVIDER");
+        }
+        let cfg = result.expect("explicit ollama is valid");
+        assert!(
+            !cfg.provider_was_guessed(),
+            "the user asked for ollama; do not lecture them about it"
+        );
+        assert!(cfg.provider_guess_notice().is_none());
+    }
+
+    #[test]
+    fn a_key_backed_autodetect_is_not_a_guess_worth_warning_about() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var("SYSKNIFE_LLM_PROVIDER");
+            std::env::set_var("ANTHROPIC_API_KEY", "sk-test-key");
+            std::env::remove_var("SYSKNIFE_LLM_MODEL");
+            std::env::remove_var("SYSKNIFE_ANTHROPIC_URL");
+            std::env::remove_var("SYSKNIFE_BRAIN_MAX_TURNS");
+        }
+        let result = BrainConfig::from_env();
+        unsafe {
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
+        let cfg = result.expect("key present selects anthropic");
+        assert_eq!(cfg.provider_name(), "anthropic");
+        assert!(
+            !cfg.provider_was_guessed(),
+            "a key in the environment is an intent, not a guess"
         );
     }
 

--- a/crates/sysknife-brain/src/providers/openai_adapter.rs
+++ b/crates/sysknife-brain/src/providers/openai_adapter.rs
@@ -379,7 +379,9 @@ fn map_openai_error(err: async_openai::error::OpenAIError) -> ProviderError {
                     "OpenAI authentication error: {}",
                     msg
                 );
-                ProviderError::Auth("OpenAI authentication failed — check your API key".to_string())
+                ProviderError::Auth(
+                    "OpenAI authentication failed — check OPENAI_API_KEY".to_string(),
+                )
             }
             super::StatusClass::RateLimit => {
                 tracing::warn!(
@@ -412,7 +414,7 @@ fn map_openai_error(err: async_openai::error::OpenAIError) -> ProviderError {
             "OpenAI authentication error: {}",
             msg
         );
-        ProviderError::Auth("OpenAI authentication failed — check your API key".to_string())
+        ProviderError::Auth("OpenAI authentication failed — check OPENAI_API_KEY".to_string())
     } else if msg.contains("429") || msg.to_lowercase().contains("rate limit") {
         tracing::warn!(
             target: "sysknife_brain::openai_adapter",
@@ -931,7 +933,7 @@ mod tests {
         );
         if let ProviderError::Auth(msg) = mapped {
             assert_eq!(
-                msg, "OpenAI authentication failed — check your API key",
+                msg, "OpenAI authentication failed — check OPENAI_API_KEY",
                 "auth message must be the fixed key-safe string, not the raw SDK text"
             );
         }
@@ -1013,7 +1015,7 @@ mod tests {
         // ProviderError::Auth — it returns a fixed, safe message instead.
         // We can't construct OpenAIError directly, so we test the rule by
         // confirming the fixed string is what the production code returns.
-        let fixed_msg = "OpenAI authentication failed — check your API key";
+        let fixed_msg = "OpenAI authentication failed — check OPENAI_API_KEY";
         // Verify the string constant in production code matches what callers expect.
         assert!(
             fixed_msg.contains("authentication failed"),

--- a/crates/sysknife-brain/src/providers/rig_adapter.rs
+++ b/crates/sysknife-brain/src/providers/rig_adapter.rs
@@ -387,7 +387,9 @@ const AUTH_FAILURE_MSG: &str = "provider authentication failed — check your AP
 
 fn map_rig_error(err: rig::completion::CompletionError) -> ProviderError {
     let msg = sanitize_error_msg(&err.to_string());
-    eprintln!("[sysknife-brain] Rig completion error: {msg}");
+    // "Rig" is the name of a dependency, which means nothing to a user
+    // reading their terminal; say whose request failed instead.
+    eprintln!("[sysknife-brain] LLM request failed: {msg}");
 
     // Prefer the structured HTTP status Rig preserves via
     // `provider_response_status()` (see `impl_provider_response_helpers!` in

--- a/crates/sysknife-daemon/src/auth.rs
+++ b/crates/sysknife-daemon/src/auth.rs
@@ -31,7 +31,8 @@ fn higher_role(current: CallerRole, candidate: CallerRole) -> CallerRole {
     current.max(candidate)
 }
 
-/// The group that grants `role`, i.e. the inverse of [`role_for_group`].
+/// The group that grants `role`, i.e. the inverse of the private
+/// `role_for_group` mapping above.
 ///
 /// Exists so a refusal can name the group to join. `wheel` also grants Admin,
 /// but the SysKnife group is the one to recommend: it is what `make install`

--- a/crates/sysknife-daemon/src/auth.rs
+++ b/crates/sysknife-daemon/src/auth.rs
@@ -31,6 +31,34 @@ fn higher_role(current: CallerRole, candidate: CallerRole) -> CallerRole {
     current.max(candidate)
 }
 
+/// The group that grants `role`, i.e. the inverse of [`role_for_group`].
+///
+/// Exists so a refusal can name the group to join. `wheel` also grants Admin,
+/// but the SysKnife group is the one to recommend: it is what `make install`
+/// creates, and it scopes access to this daemon rather than to sudo at large.
+pub fn group_for_role(role: CallerRole) -> &'static str {
+    match role {
+        CallerRole::Boot => BOOT_GROUP,
+        CallerRole::Admin => ADMIN_GROUP,
+        CallerRole::Dev => DEV_GROUP,
+        CallerRole::Observer => OBSERVER_GROUP,
+    }
+}
+
+/// The message a caller sees when their role is too low for an action.
+///
+/// Names the action, both roles, the group that would grant the needed role,
+/// and the command to join it — including the part people lose an afternoon to,
+/// that a new group only takes effect in a new login session.
+pub fn denial_message(action: &str, caller: CallerRole, required: CallerRole) -> String {
+    format!(
+        "action '{action}' requires the {required:?} role, but you have {caller:?}. \
+         Join the group that grants it: sudo usermod -aG {group} $USER, \
+         then log out and back in (group membership only applies to a new login).",
+        group = group_for_role(required),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Token authentication (vsock connections)
 // ---------------------------------------------------------------------------
@@ -195,6 +223,57 @@ mod tests {
 
     fn role(groups: &[&str]) -> CallerRole {
         highest_role_from_groups(groups.iter().copied())
+    }
+
+    // -----------------------------------------------------------------
+    // Telling a denied caller how to stop being denied
+    //
+    // Denials named the action and the caller's role and stopped there:
+    // "action 'AptInstall' is not allowed for Observer role". Accurate,
+    // and a dead end — the group that grants the role is not discoverable
+    // from that sentence, and unlike every other well-written message in
+    // this codebase it offered no command to run.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn every_role_maps_back_to_the_group_that_grants_it() {
+        assert_eq!(group_for_role(CallerRole::Observer), OBSERVER_GROUP);
+        assert_eq!(group_for_role(CallerRole::Dev), DEV_GROUP);
+        assert_eq!(group_for_role(CallerRole::Admin), ADMIN_GROUP);
+        assert_eq!(group_for_role(CallerRole::Boot), BOOT_GROUP);
+    }
+
+    #[test]
+    fn the_group_a_role_maps_to_actually_grants_that_role() {
+        // Guards against the two mappings drifting apart: whatever group we
+        // tell the user to join must resolve back to the role they need.
+        for wanted in [
+            CallerRole::Observer,
+            CallerRole::Dev,
+            CallerRole::Admin,
+            CallerRole::Boot,
+        ] {
+            let group = group_for_role(wanted);
+            assert_eq!(
+                role(&[group]),
+                wanted,
+                "joining {group} must grant {wanted:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_denial_says_which_group_to_join_and_how() {
+        let msg = denial_message("AptInstall", CallerRole::Observer, CallerRole::Dev);
+        assert!(msg.contains("AptInstall"), "names the action: {msg}");
+        assert!(msg.contains("Observer"), "names the current role: {msg}");
+        assert!(msg.contains("Dev"), "names the required role: {msg}");
+        assert!(msg.contains(DEV_GROUP), "names the group: {msg}");
+        assert!(msg.contains("usermod"), "gives the command: {msg}");
+        assert!(
+            msg.contains("log out") || msg.contains("new login"),
+            "group membership needs a fresh session; say so: {msg}"
+        );
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -613,6 +613,26 @@ fn authorize_action(
     policy.action_allowed(caller, action_name)
 }
 
+/// The message for a refused action.
+///
+/// Refusals used to end at "is not allowed for Observer role", which is true and
+/// unactionable. When the required role is known, name the group that grants it
+/// and the command to join. The role ceiling can be raised per action via
+/// `[policy.risk_overrides]`, so the effective minimum is read from the live
+/// policy rather than the compile-time baseline.
+fn authorization_failure_message(
+    policy: &crate::policy::PolicyTable,
+    caller: &CallerRole,
+    action_name: &str,
+) -> String {
+    match policy.min_role_for_action(action_name) {
+        Some(required) => crate::auth::denial_message(action_name, *caller, required),
+        // No baseline entry means the action is not in the catalogue at all;
+        // there is no group to recommend.
+        None => format!("action '{action_name}' is not allowed for {caller:?} role"),
+    }
+}
+
 /// Authorize a caller to act on an existing transaction (approve / cancel /
 /// view details), keyed on the transaction's own action. Transaction IDs are
 /// enumerable by any Observer-tier caller via history, so without this a
@@ -641,9 +661,10 @@ async fn authorize_for_transaction(
                     framed,
                     request_id,
                     "authorization_failure",
-                    format!(
-                        "action '{}' is not allowed for {caller_role:?} role",
-                        transaction.action_name
+                    authorization_failure_message(
+                        &state.policy,
+                        caller_role,
+                        &transaction.action_name,
                     ),
                 )
                 .await?;
@@ -1250,10 +1271,7 @@ async fn handle_approval_details(
             framed,
             request_id,
             "authorization_failure",
-            format!(
-                "action '{}' is not allowed for {caller_role:?} role",
-                transaction.action_name
-            ),
+            authorization_failure_message(&state.policy, caller_role, &transaction.action_name),
         )
         .await;
     }
@@ -1685,7 +1703,7 @@ async fn handle_describe(
             framed,
             request_id,
             "authorization_failure",
-            format!("action '{action_name}' is not allowed for {caller_role:?} role"),
+            authorization_failure_message(&state.policy, caller_role, action_name),
         )
         .await;
     }
@@ -1775,7 +1793,7 @@ async fn handle_preview(
             framed,
             request_id,
             "authorization_failure",
-            format!("action '{action_name}' is not allowed for {caller_role:?} role"),
+            authorization_failure_message(&state.policy, caller_role, action_name),
         )
         .await;
     }
@@ -2087,7 +2105,7 @@ async fn handle_execute(
             framed,
             request_id,
             "authorization_failure",
-            format!("action '{action_name}' is not allowed for {caller_role:?} role"),
+            authorization_failure_message(&state.policy, caller_role, action_name),
         )
         .await;
     }

--- a/crates/sysknife-daemon/src/main.rs
+++ b/crates/sysknife-daemon/src/main.rs
@@ -7,7 +7,7 @@ use sysknife_daemon::dispatcher::{resolve_caller_role, unix_connection_handler};
 use sysknife_daemon::policy::PolicyTable;
 use sysknife_daemon::state::{DaemonConfig, DaemonState};
 use sysknife_daemon::state_collector::RealCommandRunner;
-use sysknife_daemon::transport::listen::{bind_unix_listener, ListenTarget};
+use sysknife_daemon::transport::listen::{bind_unix_listener, ListenTarget, ListenTargetError};
 use tokio::net::UnixListener;
 use tokio::sync::Semaphore;
 
@@ -24,7 +24,18 @@ const STALE_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs
 const MAX_CONNECTIONS: usize = 16;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() {
+    // Report through Display and exit. Returning `Result` from `main` makes Rust
+    // print `Error: Io("Permission denied (os error 13)")` — Debug formatting,
+    // no context — which was the worst message the daemon could produce, and it
+    // appeared underneath the hand-written FATAL lines below as a duplicate.
+    if let Err(e) = run().await {
+        eprintln!("[sysknife-daemon] FATAL: {e}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Apply config-file values as env var defaults before reading any config.
     // Must run before the tokio runtime starts worker threads.
     let lacs_config = LacsConfig::load();
@@ -41,9 +52,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .as_ref()
         .and_then(|p| p.risk_overrides.clone())
         .unwrap_or_default();
-    let policy = PolicyTable::from_overrides(&raw_overrides).map_err(|e| {
-        eprintln!("[sysknife-daemon] FATAL: policy validation failed: {e}");
-        e
+    let policy = PolicyTable::from_overrides(&raw_overrides).inspect_err(|_| {
+        // `main` prints the error itself; this adds the context it lacks.
+        eprintln!("[sysknife-daemon] policy validation failed");
     })?;
 
     if policy.override_count() > 0 {
@@ -61,7 +72,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let forwarder: Option<AuditForwarder> = match build_forwarder(lacs_config.audit.as_ref()) {
         Ok(f) => f,
         Err(e) => {
-            eprintln!("[sysknife-daemon] FATAL: audit forwarder config invalid: {e}");
+            eprintln!("[sysknife-daemon] audit forwarder config invalid");
             return Err(e.into());
         }
     };
@@ -90,15 +101,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             DaemonState::open_full(config, policy, forwarder)?
         }
         Err(e) => {
-            eprintln!("[sysknife-daemon] FATAL: postgres backend init failed: {e}");
+            eprintln!("[sysknife-daemon] postgres backend init failed");
             return Err(e.into());
         }
     };
 
     let runner = Arc::new(RealCommandRunner);
     let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
-
-    eprintln!("[sysknife-daemon] listening on {listen_uri}");
 
     // Reconcile transactions orphaned by a previous crash/restart before we
     // accept any connection: a row still marked Running belonged to an execution
@@ -149,15 +158,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match listen_target {
         ListenTarget::Unix(path) => {
-            let std_listener = bind_unix_listener(&ListenTarget::Unix(path))?;
+            // The most likely first-run mistake is installing the system unit
+            // and starting it without root. The error alone says only
+            // "Permission denied", so add which directory and which uid, and
+            // the two ways out.
+            // Reported here rather than by `main` so the remediation follows the
+            // error instead of preceding it.
+            let std_listener = match bind_unix_listener(&ListenTarget::Unix(path.clone())) {
+                Ok(listener) => listener,
+                Err(e) => {
+                    eprintln!("[sysknife-daemon] FATAL: {e}");
+                    if matches!(e, ListenTargetError::Io(ref m) if m.contains("Permission denied"))
+                    {
+                        eprintln!(
+                            "[sysknife-daemon] {} is not writable by uid {}. Either run the \
+                             system service as root (sudo systemctl start sysknife-daemon), or \
+                             point this daemon at a socket you own with \
+                             SYSKNIFE_LISTEN_URI=unix://$XDG_RUNTIME_DIR/sysknife/daemon.sock",
+                            path.parent().unwrap_or(&path).display(),
+                            unsafe { libc::geteuid() },
+                        );
+                    }
+                    std::process::exit(1);
+                }
+            };
             std_listener.set_nonblocking(true)?;
             let listener = UnixListener::from_std(std_listener)?;
+            // Only true once the bind has actually succeeded.
+            eprintln!("[sysknife-daemon] listening on {listen_uri}");
             unix_accept_loop(listener, state, runner, semaphore).await;
         }
         #[cfg(target_os = "linux")]
         ListenTarget::Vsock { port } => {
             use sysknife_daemon::transport::listen::bind_vsock_listener;
-            let listener = bind_vsock_listener(port)?;
+            let listener = bind_vsock_listener(port).inspect_err(|_| {
+                eprintln!("[sysknife-daemon] cannot bind vsock port {port}");
+            })?;
+            eprintln!("[sysknife-daemon] listening on {listen_uri}");
             vsock_accept_loop(listener, state, runner, semaphore).await;
         }
     }

--- a/crates/sysknife-daemon/src/transport/listen.rs
+++ b/crates/sysknife-daemon/src/transport/listen.rs
@@ -24,6 +24,13 @@ pub enum ListenTargetError {
     #[error("existing path is not a unix socket: {0}")]
     ExistingPathNotSocket(String),
 
+    #[error(
+        "refusing to bind {0}: a daemon is already listening there. Stop it first \
+         (sudo systemctl stop sysknife-daemon, or systemctl --user stop sysknife-daemon), \
+         or give this one its own socket with SYSKNIFE_LISTEN_URI."
+    )]
+    AlreadyBound(String),
+
     #[error("io error: {0}")]
     Io(String),
 }
@@ -86,12 +93,23 @@ pub fn bind_unix_listener(target: &ListenTarget) -> Result<UnixListener, ListenT
     match target {
         ListenTarget::Unix(path) => {
             if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).map_err(|err| ListenTargetError::Io(err.to_string()))?;
+                fs::create_dir_all(parent).map_err(|err| {
+                    // Name the socket as well as the directory: the socket is
+                    // what the operator configured, the directory is only how
+                    // it failed.
+                    ListenTargetError::Io(format!(
+                        "cannot create directory {} for socket {}: {err}",
+                        parent.display(),
+                        path.display()
+                    ))
+                })?;
             }
 
             if path.exists() {
                 let file_type = fs::symlink_metadata(path)
-                    .map_err(|err| ListenTargetError::Io(err.to_string()))?
+                    .map_err(|err| {
+                        ListenTargetError::Io(format!("stat {}: {err}", path.display()))
+                    })?
                     .file_type();
                 if !file_type.is_socket() {
                     return Err(ListenTargetError::ExistingPathNotSocket(
@@ -99,11 +117,22 @@ pub fn bind_unix_listener(target: &ListenTarget) -> Result<UnixListener, ListenT
                     ));
                 }
 
-                fs::remove_file(path).map_err(|err| ListenTargetError::Io(err.to_string()))?;
+                // Unlinking is only safe once we know nothing is behind it. A
+                // successful connect means a live daemon owns this path, and
+                // removing the file would take its clients down silently.
+                // ECONNREFUSED (or anything else) means the file is a leftover
+                // from a crash and reclaiming it is correct.
+                if std::os::unix::net::UnixStream::connect(path).is_ok() {
+                    return Err(ListenTargetError::AlreadyBound(path.display().to_string()));
+                }
+
+                fs::remove_file(path).map_err(|err| {
+                    ListenTargetError::Io(format!("remove stale socket {}: {err}", path.display()))
+                })?;
             }
 
-            let listener =
-                UnixListener::bind(path).map_err(|err| ListenTargetError::Io(err.to_string()))?;
+            let listener = UnixListener::bind(path)
+                .map_err(|err| ListenTargetError::Io(format!("bind {}: {err}", path.display())))?;
 
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o660)).map_err(
@@ -126,6 +155,78 @@ pub fn bind_unix_listener(target: &ListenTarget) -> Result<UnixListener, ListenT
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- binding over an existing socket ---
+    //
+    // The bind path used to `remove_file` any existing socket unconditionally,
+    // after checking only that it *was* a socket, never that it was dead. So
+    // starting a second daemon on the same path unlinked the first one's socket
+    // and bound a new one: both processes logged "listening on …" and every
+    // client of the first silently went dark, with no error, warning, or log
+    // line anywhere. Running the daemon twice is an easy mistake to make when
+    // following a "quick test" instruction and a systemd instruction in the
+    // same session.
+
+    #[test]
+    fn refuses_to_bind_over_a_daemon_that_is_still_listening() {
+        let dir = std::env::temp_dir().join(format!("sysknife-bind-live-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("daemon.sock");
+        let target = ListenTarget::Unix(path.clone());
+
+        let _first = bind_unix_listener(&target).expect("first bind succeeds");
+
+        let err = bind_unix_listener(&target).expect_err("second bind must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&path.display().to_string()),
+            "the refusal must name the socket, got: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("already"),
+            "the refusal must say something is already there, got: {msg}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn cleans_up_a_stale_socket_left_by_a_crashed_daemon() {
+        // A socket file with nothing behind it is exactly what a crash or an
+        // unclean shutdown leaves. Refusing here would make the daemon
+        // unstartable until someone deleted the file by hand.
+        let dir = std::env::temp_dir().join(format!("sysknife-bind-stale-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("daemon.sock");
+        let target = ListenTarget::Unix(path.clone());
+
+        {
+            let _listener = bind_unix_listener(&target).expect("bind to create the socket");
+        } // dropped: the file remains, but nothing is listening on it.
+        assert!(path.exists(), "the socket file outlives the listener");
+
+        let _second = bind_unix_listener(&target).expect("a stale socket must be reclaimed");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_bind_failure_names_the_path_it_failed_on() {
+        // Parent is a regular file, so directory creation fails with ENOTDIR
+        // regardless of the uid running the test.
+        let file = std::env::temp_dir().join(format!("sysknife-not-a-dir-{}", std::process::id()));
+        std::fs::write(&file, b"x").unwrap();
+        let path = file.join("daemon.sock");
+
+        let err = bind_unix_listener(&ListenTarget::Unix(path.clone()))
+            .expect_err("binding under a file must fail");
+        assert!(
+            err.to_string().contains(&path.display().to_string()),
+            "the error must name the socket path, got: {err}"
+        );
+
+        std::fs::remove_file(&file).ok();
+    }
 
     // --- vsock URI parsing ---
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -45,7 +45,7 @@ cd apps/sysknife-shell && pnpm install && cd ../..
 The workspace builds native code (TLS via aws-lc-sys/ring, SQLite via
 libsqlite3-sys), so a C compiler and linker are required on top of rustup:
 `sudo apt-get install -y build-essential` on Debian/Ubuntu. Without one the
-build stops at `error: linker \`cc\` not found`. `cmake` is not required.
+build stops at `error: linker cc not found`. `cmake` is not required.
 
 ```sh
 # Build all Rust crates (fast, no linking of the Tauri app)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -42,6 +42,11 @@ cd apps/sysknife-shell && pnpm install && cd ../..
 
 ## Building
 
+The workspace builds native code (TLS via aws-lc-sys/ring, SQLite via
+libsqlite3-sys), so a C compiler and linker are required on top of rustup:
+`sudo apt-get install -y build-essential` on Debian/Ubuntu. Without one the
+build stops at `error: linker \`cc\` not found`. `cmake` is not required.
+
 ```sh
 # Build all Rust crates (fast, no linking of the Tauri app)
 cargo build --workspace

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -111,11 +111,15 @@ SysKnife, not an afterthought.
 > See [Distro Support](distro-support.md) for the full matrix.
 
 ```sh
+sudo apt-get install -y build-essential          # Rust stable and a C compiler
 git clone https://github.com/lacs-project/sysknife
-cd sysknife && make build && sudo make install
+cd sysknife && make build && sudo make install   # ~7-12 min: about 400 crates
 sudo systemctl enable --now sysknife-daemon
 sysknife "show disk usage"
 ```
+
+For prebuilt binaries instead of a build, run `npx sysknife-setup` (Node 18+).
+See the canonical [Quick Start](quickstart.md).
 
 No API key needed if you have [Ollama](https://ollama.com) running locally —
 SysKnife auto-detects it. See [Quick Start](quickstart.md).

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -20,6 +20,12 @@ crate directly:
 - Because `sysknife`'s MCP server is a subcommand, the package entry passes
   `mcp-server` as a positional `packageArguments` value. A client resolves the
   listing to `cargo install sysknife-cli` then runs `sysknife mcp-server`.
+- Two things that install implies, and which the registry entry has no field for:
+  it needs a C compiler (`build-essential`; **not** cmake, verified in clean
+  Ubuntu containers) and takes 7 to 12 minutes; and the CLI alone can plan but
+  not execute, because execution belongs to the privileged `sysknife-daemon`.
+  Both are stated up front in `apps/sysknife-cli/README.md`, which is the page
+  crates.io renders and therefore what a registry visitor actually reads.
 
 This supersedes the earlier npm-launcher plan: the npm package `sysknife-setup`
 is an installer/wizard, not a stdio server, and `npx sysknife-setup` would launch

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -143,9 +143,11 @@ the security boundary.
 npx sysknife-setup
 ```
 
-The wizard detects your installed `sysknife` binary, asks for the daemon
-socket and LLM provider, and then asks which integration to configure.
-No manual file editing needed.
+Needs Node 18 or newer (Ubuntu 22.04's apt Node is 12, which is too old). The
+wizard detects your installed `sysknife` binary, asks for the daemon socket and
+LLM provider, and then asks which integration to configure. No manual file
+editing needed. For install options and prerequisites in full, see the
+canonical [Quick Start](quickstart.md).
 
 If you already know the target, skip the picker:
 
@@ -208,7 +210,11 @@ If you prefer to edit `.mcp.json` by hand:
 
 For vsock add `SYSKNIFE_TOKEN` alongside `SYSKNIFE_SOCKET`.
 
-### 4. Build the binary
+### 4. If you skipped the prebuilt download: build the binary
+
+Not a step in the sequence above — an alternative to the wizard's download, for
+building from source. Needs a C compiler (`sudo apt-get install -y
+build-essential` on Ubuntu); `cmake` is not required.
 
 ```sh
 cargo build -p sysknife-cli --release

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,7 +41,7 @@ does not, because the sudoers grants belong to the `sysknife` system user.
 **Prerequisites:** Rust stable (`rustup update stable`), **a C compiler and
 linker**, and an LLM provider (see Step 2). The TLS and SQLite dependencies
 build native code, so a machine with only `rustup` fails at
-`error: linker \`cc\` not found`. `cmake` is not required.
+`error: linker cc not found`. `cmake` is not required.
 
 ```sh
 sudo apt-get install -y build-essential   # Debian/Ubuntu

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,8 @@
 # Quick Start
 
+This is the canonical install page. Everywhere else links here rather than
+repeating a second, slightly different sequence.
+
 > **💡 Prefer your AI coding tool?**
 >
 > If you use Claude Code, Cursor, or Codex CLI — run `npx sysknife-setup` and
@@ -8,16 +11,49 @@
 
 ## Step 1 — Install
 
-**Prerequisites:** Rust stable (`rustup update stable`) and an LLM provider
-(see Step 2).
+Two paths. The wizard needs no toolchain and no compile; building from source
+needs both.
+
+### Fastest: prebuilt binaries
 
 ```sh
+npx sysknife-setup
+```
+
+**Prerequisites:** Node 18 or newer. On Ubuntu 22.04, `apt install nodejs`
+installs Node 12, which is too old — the installer will tell you so and how to
+get a current Node. It downloads SHA-256-verified binaries from the release
+page, installs the daemon service, and writes your MCP client config.
+
+Unattended runs must say which daemon to install, because the choice decides
+what will work:
+
+```sh
+npx sysknife-setup --claude --no-prompts --daemon-mode=system
+```
+
+`--daemon-mode=user` installs an unprivileged service that runs as you: read-only
+actions work, and anything mutating (installing packages, restarting services)
+does not, because the sudoers grants belong to the `sysknife` system user.
+
+### From source
+
+**Prerequisites:** Rust stable (`rustup update stable`), **a C compiler and
+linker**, and an LLM provider (see Step 2). The TLS and SQLite dependencies
+build native code, so a machine with only `rustup` fails at
+`error: linker \`cc\` not found`. `cmake` is not required.
+
+```sh
+sudo apt-get install -y build-essential   # Debian/Ubuntu
 git clone https://github.com/lacs-project/sysknife
 cd sysknife
 make build
 sudo make install
 sudo systemctl enable --now sysknife-daemon
 ```
+
+`make build` compiles around 400 crates: expect 7 to 12 minutes on a first
+build (measured 6m56s on Ubuntu 24.04, 11m43s on 22.04).
 
 > **ℹ️ Fedora / Silverblue**
 >
@@ -74,7 +110,7 @@ That's it. The planner proposes a typed plan, you approve, the daemon executes.
 
 ---
 
-## Try without installing anything
+## Try the planner without the daemon
 
 On any Linux machine with an API key:
 
@@ -83,8 +119,13 @@ export ANTHROPIC_API_KEY=sk-ant-...
 cargo run --bin sysknife -- --dry-run "show disk usage"
 ```
 
-Plans the intent and prints the result. No daemon, no root, no installation.
-Useful for evaluating the planner or running in CI.
+Plans the intent and prints the result. No daemon and no root: nothing
+privileged runs, so this is the way to evaluate the planner or run it in CI.
+
+It is not, however, free of installation — `cargo run` builds the workspace, so
+it needs Rust plus `build-essential` and the same 7 to 12 minutes as any other
+first build. If what you want is the quickest look at SysKnife, use
+`npx sysknife-setup` and the prebuilt binaries instead.
 
 ---
 

--- a/docs/vm-daemon-setup.md
+++ b/docs/vm-daemon-setup.md
@@ -24,7 +24,8 @@ SSH into the guest and run:
 git clone https://github.com/lacs-project/sysknife
 cd sysknife
 
-# Build and install (requires Rust stable)
+# Build and install (requires Rust stable and a C compiler:
+#   sudo apt-get install -y build-essential   — cmake is not needed)
 make build
 sudo make install
 

--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -39,7 +39,7 @@ const readline = require('readline');
 const crypto   = require('crypto');
 
 const { installBinaryIfMissing } = require('./install-binary.js');
-const { installDaemonService }   = require('./install-daemon.js');
+const { installDaemonService, parseDaemonMode } = require('./install-daemon.js');
 const { mergeMcpServers }        = require('./mcp-config.js');
 
 // ---------------------------------------------------------------------------
@@ -262,6 +262,28 @@ if (NO_PROMPTS && !HAVE_EXPLICIT_INTEGRATION_FLAGS) {
   process.exit(2);
 }
 
+// Which daemon to install is a capability decision, not a default: the
+// user-mode service cannot perform mutating actions (see
+// userModeCapabilityWarning). So an unattended run has to say which one it
+// wants rather than inherit a guess.
+let DAEMON_MODE;
+try {
+  DAEMON_MODE = parseDaemonMode(process.argv.slice(2));
+} catch (e) {
+  console.error(e.message);
+  process.exit(2);
+}
+if (NO_PROMPTS && DAEMON_MODE === null) {
+  console.error(
+    'sysknife-setup: --no-prompts requires --daemon-mode=system, --daemon-mode=user, '
+    + 'or --daemon-mode=skip.\n'
+    + '  system  the privileged service; needed for installing packages, restarting services\n'
+    + '  user    runs as you, no sudo; read-only actions only\n'
+    + '  skip    do not install a service',
+  );
+  process.exit(2);
+}
+
 // ---------------------------------------------------------------------------
 // Hookify rule content (Claude Code only)
 // ---------------------------------------------------------------------------
@@ -413,11 +435,12 @@ guest VM queries — local shell returns host data, not VM data.
 
 async function collectTarget(rl, lineQueue, idx) {
   console.log();
-  console.log(`  ${B}── VM Target ${idx} ${'─'.repeat(40 - String(idx).length)}${X}`);
+  console.log(`  ${B}── Target ${idx} ${'─'.repeat(43 - String(idx).length)}${X}`);
   console.log(`  ${D}Socket examples:${X}`);
-  console.log(`    ${D}/run/sysknife/daemon.sock${X}   ${D}local daemon (systemd default)${X}`);
-  console.log(`    ${D}/tmp/sysknife-vm.sock${X}        ${D}SSH tunnel to a VM${X}`);
-  console.log(`    ${D}vsock://10:9734${X}              ${D}virtio-vsock (CID:port)${X}`);
+  console.log(`    ${D}${runtimeSocketPath()}${X}  ${D}this machine, user service (default)${X}`);
+  console.log(`    ${D}/run/sysknife/daemon.sock${X}   ${D}this machine, system service${X}`);
+  console.log(`    ${D}/tmp/sysknife-vm.sock${X}        ${D}another host, over an SSH tunnel${X}`);
+  console.log(`    ${D}vsock://10:9734${X}              ${D}a VM, over virtio-vsock (CID:port)${X}`);
 
   const defaultSocket = runtimeSocketPath();
   const socket = await ask(rl, lineQueue, 'Daemon socket', defaultSocket);
@@ -430,7 +453,12 @@ async function collectTarget(rl, lineQueue, idx) {
       ok(`Daemon socket reachable: ${socket}`);
     } else if (reachable === false) {
       warn(`Daemon socket not reachable: ${socket}`);
-      step(`Start the daemon:  sudo systemctl start sysknife-daemon`);
+      // A socket under /run/user/<uid> belongs to the user service; telling
+      // someone to `sudo systemctl start` it sends them to a unit that does
+      // not exist on their machine.
+      step(socket.includes('/run/user/')
+        ? `Start the daemon:  systemctl --user start sysknife-daemon`
+        : `Start the daemon:  sudo systemctl start sysknife-daemon`);
       step(`       or build:   cargo run -p sysknife-daemon`);
     }
   }
@@ -832,8 +860,8 @@ async function main() {
   const daemonBinPath = binaryPath.replace(/\/sysknife$/, '/sysknife-daemon');
   await installDaemonService({
     ask: askWrapper,
-    noPrompts: NO_PROMPTS,
     daemonBinPath,
+    daemonMode: DAEMON_MODE,
   });
 
   // ── Socket validation ─────────────────────────────────────────────────────
@@ -917,6 +945,12 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   --all         Configure Claude Code, Cursor, and Codex CLI.
   --no-binary   Skip prebuilt binary download (build from source instead).
   --no-prompts  Accept all defaults non-interactively (useful for scripts/tests).
+                Requires --daemon-mode, since the daemon choice decides which
+                actions will work.
+  --daemon-mode=system|user|skip
+                system  privileged service; required for mutating actions
+                user    runs as you, no sudo; read-only actions only
+                skip    install no service
   --help, -h    Show this help message and exit.
 
 \x1b[1mDESCRIPTION\x1b[0m

--- a/packages/setup/install-binary.js
+++ b/packages/setup/install-binary.js
@@ -37,6 +37,16 @@ const RELEASES_API = 'https://api.github.com/repos/lacs-project/sysknife/release
 /** User-agent required by GitHub API. */
 const USER_AGENT = 'sysknife-setup/0.1 (node)';
 
+// Two endpoints, two media types, and they are not interchangeable.
+//
+// The releases *metadata* endpoint answers `Accept: application/octet-stream`
+// with **HTTP 415 Unsupported Media Type**, so asking for it there fails every
+// install before a single byte is downloaded. Asset downloads, in contrast,
+// require the octet-stream type to get the file rather than its JSON envelope.
+// Verified against the live API: json → 200, octet-stream → 415.
+const GITHUB_JSON_ACCEPT = 'application/vnd.github+json';
+const ASSET_ACCEPT = 'application/octet-stream';
+
 /**
  * Default install path when XDG_BIN_HOME is not set and ~/.local/bin is not
  * on PATH.  We prefer ~/.local/bin over /usr/local/bin so that the common
@@ -181,21 +191,25 @@ async function chooseInstallDir(ask, noPrompts) {
  * Follows up to 5 redirects.  Rejects on HTTP errors.
  *
  * @param {string} url
- * @param {number} [redirectsLeft=5]
+ * @param {{ accept?: string, redirectsLeft?: number }} [opts]
+ *        `accept` defaults to {@link ASSET_ACCEPT}; metadata requests must pass
+ *        {@link GITHUB_JSON_ACCEPT} or GitHub answers HTTP 415.
  * @returns {Promise<Buffer>}
  */
-function fetchBuffer(url, redirectsLeft = 5) {
+function fetchBuffer(url, opts = {}) {
+  const accept = opts.accept || ASSET_ACCEPT;
+  const redirectsLeft = opts.redirectsLeft === undefined ? 5 : opts.redirectsLeft;
   return new Promise((resolve, reject) => {
     const req = https.get(url, {
       headers: {
         'User-Agent': USER_AGENT,
-        Accept: 'application/octet-stream',
+        Accept: accept,
       },
     }, (res) => {
       if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307 || res.statusCode === 308) {
         if (redirectsLeft <= 0) { reject(new Error('Too many redirects')); return; }
         req.destroy();
-        resolve(fetchBuffer(res.headers.location, redirectsLeft - 1));
+        resolve(fetchBuffer(res.headers.location, { accept, redirectsLeft: redirectsLeft - 1 }));
         return;
       }
       if (res.statusCode !== 200) {
@@ -272,8 +286,11 @@ function fetchWithProgress(url, label, redirectsLeft = 5) {
  * @param {string} [url] override for testing
  * @returns {Promise<object>}
  */
-async function fetchLatestRelease(url = RELEASES_API) {
-  const buf = await fetchBuffer(url);
+// `fetch` is injectable so the Accept header this sends can be asserted
+// offline; see tests/release-metadata.test.mjs. Production always uses the
+// default.
+async function fetchLatestRelease(url = RELEASES_API, fetch = fetchBuffer) {
+  const buf = await fetch(url, { accept: GITHUB_JSON_ACCEPT });
   return JSON.parse(buf.toString('utf8'));
 }
 
@@ -550,4 +567,12 @@ async function installBinaryIfMissing(opts) {
   return { installed: true, path: cliDest };
 }
 
-module.exports = { installBinaryIfMissing, detectPlatform, verifySha256, isOnPath };
+module.exports = {
+  installBinaryIfMissing,
+  detectPlatform,
+  verifySha256,
+  isOnPath,
+  fetchLatestRelease,
+  GITHUB_JSON_ACCEPT,
+  ASSET_ACCEPT,
+};

--- a/packages/setup/install-daemon.js
+++ b/packages/setup/install-daemon.js
@@ -8,7 +8,7 @@
  *   installDaemonService(opts) → Promise<void>
  *
  *   opts.ask(question, defaultVal)  — async prompt helper from index.js
- *   opts.noPrompts                  — boolean; accept all defaults silently
+ *   opts.daemonMode                 — 'system' | 'user' | 'skip'; null asks
  *   opts.daemonBinPath              — absolute path to sysknife-daemon binary
  *
  * Two install modes:
@@ -148,6 +148,56 @@ function systemctl(args, userMode = false) {
 }
 
 // ---------------------------------------------------------------------------
+// Daemon mode selection
+// ---------------------------------------------------------------------------
+
+/** The three answers the daemon-mode question has. */
+const DAEMON_MODES = ['system', 'user', 'skip'];
+
+/**
+ * Read `--daemon-mode=<mode>` from argv.
+ *
+ * Returns null when the flag is absent, so callers can tell "not specified"
+ * from a value. Deliberately does not default: defaulting silently to the
+ * user-mode service is what left automated installs unable to perform any
+ * mutating action.
+ *
+ * @param {string[]} argv
+ * @returns {string|null}
+ * @throws when the flag is present with a value that is not a known mode
+ */
+function parseDaemonMode(argv) {
+  const flag = argv.find(a => a.startsWith('--daemon-mode'));
+  if (!flag) return null;
+  const value = flag.includes('=') ? flag.slice(flag.indexOf('=') + 1) : '';
+  if (!DAEMON_MODES.includes(value)) {
+    throw new Error(
+      `sysknife-setup: --daemon-mode must be one of: ${DAEMON_MODES.join(', ')} (got "${value}")`,
+    );
+  }
+  return value;
+}
+
+/**
+ * What a user-mode daemon cannot do, and how to get a daemon that can.
+ *
+ * The daemon runs privileged actions by shelling out through `sudo`, and the
+ * NOPASSWD grants that makes non-interactive live in packaging/sysknife-sudoers,
+ * installed only by `sudo make install` and scoped to the `sysknife` system
+ * user. A user-mode unit runs as the invoking human instead, so those grants do
+ * not apply to it.
+ */
+function userModeCapabilityWarning() {
+  return (
+    'This is a user-mode daemon running as you, so read-only actions work but '
+    + 'mutating ones (installing packages, restarting services, writing config) '
+    + 'will fail with "sudo: a password is required". Those need the system '
+    + 'service and its sudoers grants: clone the repo and run `sudo make install`, '
+    + 'then `sudo systemctl enable --now sysknife-daemon`.'
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -157,10 +207,10 @@ function systemctl(args, userMode = false) {
  *
  * Skips silently when systemd is not detected.
  *
- * @param {{ ask: Function, noPrompts: boolean, daemonBinPath: string }} opts
+ * @param {{ ask: Function, daemonBinPath: string, daemonMode: string|null }} opts
  */
 async function installDaemonService(opts) {
-  const { ask, noPrompts = false, daemonBinPath } = opts;
+  const { ask, daemonBinPath, daemonMode = null } = opts;
 
   if (!hasSystemd()) {
     warn('systemd not detected — skipping daemon service install.');
@@ -176,8 +226,11 @@ async function installDaemonService(opts) {
   console.log(`  3) Skip`);
   console.log();
 
-  const defaultChoice = noPrompts ? '1' : undefined;
-  const choice = (await ask('Install daemon service (1 / 2 / 3)', defaultChoice || '1')).trim();
+  // An explicit --daemon-mode answers the question outright. Without it there
+  // must be a human to ask: `noPrompts` used to silently mean "1" (user mode),
+  // which quietly produced a daemon that could not mutate anything.
+  const preset = { system: '2', user: '1', skip: '3' }[daemonMode];
+  const choice = preset || (await ask('Install daemon service (1 / 2 / 3)', '1')).trim();
 
   if (choice === '3' || choice.toLowerCase().startsWith('s')) {
     step('Skipping daemon service install.');
@@ -192,6 +245,7 @@ async function installDaemonService(opts) {
 
   // Default: choice === '1' or anything else → user service
   await _installUserService(daemonBinPath);
+  warn(userModeCapabilityWarning());
 }
 
 /** Install a user-level service under ~/.config/systemd/user/. */
@@ -265,4 +319,12 @@ async function _installSystemService(daemonBinPath) {
   step(`Daemon binary path that will be used:  ${daemonBinPath}`);
 }
 
-module.exports = { installDaemonService, userUnitContent, runtimeSocketPath, runtimeDir };
+module.exports = {
+  installDaemonService,
+  userUnitContent,
+  runtimeSocketPath,
+  runtimeDir,
+  parseDaemonMode,
+  userModeCapabilityWarning,
+  DAEMON_MODES,
+};

--- a/packages/setup/node-preflight.js
+++ b/packages/setup/node-preflight.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * node-preflight.js — "is this Node new enough to even parse the wizard?"
+ *
+ * IMPORTANT: this file must stay parseable by Node 12, because that is the Node
+ * that Ubuntu 22.04 installs from apt and therefore the version most likely to
+ * be running when the check matters. No optional chaining, no nullish
+ * coalescing, no logical assignment. tests/node-preflight.test.mjs enforces it.
+ *
+ * Why a separate file at all: `index.js` uses modern syntax, so on Node 12 it
+ * raises `SyntaxError` at parse time — before any statement in it could run. A
+ * guard written inside index.js could never execute. The guard has to live
+ * somewhere that parses, and index.js must not be required until it passes.
+ */
+
+/** Oldest Node the wizard's own syntax and APIs require. Keep in sync with `engines.node`. */
+var MIN_MAJOR = 18;
+
+/**
+ * Explain, actionably, why this Node cannot run the wizard.
+ *
+ * @param {string} version - `process.versions.node`, e.g. "12.22.9"
+ * @returns {string|null} a ready-to-print message, or null when the version is fine
+ */
+function unsupportedMessage(version) {
+  var major = parseInt(String(version).split('.')[0], 10);
+  var shown = version ? 'v' + version : 'an unknown version';
+
+  // An unrecognisable version is treated as unsupported on purpose: proceeding
+  // risks the SyntaxError this guard exists to replace, and the message below
+  // is useful either way.
+  if (!isNaN(major) && major >= MIN_MAJOR) return null;
+
+  return (
+    'sysknife-setup needs Node ' + MIN_MAJOR + ' or newer. You are running ' + shown + '.\n' +
+    '\n' +
+    "Ubuntu 22.04's `apt install nodejs` gives Node 12, which cannot run this\n" +
+    'installer. Pick whichever of these suits the machine:\n' +
+    '\n' +
+    '  system-wide (needs root):\n' +
+    '    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -\n' +
+    '    sudo apt-get install -y nodejs\n' +
+    '\n' +
+    '  just for you (no root):\n' +
+    '    curl -fsSL https://fnm.vercel.app/install | bash && fnm install 22\n' +
+    '\n' +
+    '  snap (no root prompt on most Ubuntu desktops):\n' +
+    '    sudo snap install node --classic --channel=22\n' +
+    '\n' +
+    'Or skip Node entirely: the release page ships prebuilt binaries, and\n' +
+    'docs/quickstart.md covers installing them by hand.\n' +
+    '  https://github.com/lacs-project/sysknife/releases/latest\n'
+  );
+}
+
+module.exports = { unsupportedMessage: unsupportedMessage, MIN_MAJOR: MIN_MAJOR };

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/lacs-project/sysknife#readme",
   "bugs": "https://github.com/lacs-project/sysknife/issues",
   "bin": {
-    "sysknife-setup": "index.js",
+    "sysknife-setup": "sysknife-setup.js",
     "sysknife-mcp": "mcp-launcher.js"
   },
   "engines": {
@@ -23,7 +23,9 @@
     "install-daemon.js",
     "mcp-config.js",
     "mcp-launcher.js",
-    "providers.js"
+    "node-preflight.js",
+    "providers.js",
+    "sysknife-setup.js"
   ],
   "keywords": [
     "sysknife",
@@ -38,6 +40,6 @@
   },
   "scripts": {
     "test": "node --test tests/*.test.mjs",
-    "prepublishOnly": "node index.js --help"
+    "prepublishOnly": "node sysknife-setup.js --help"
   }
 }

--- a/packages/setup/sysknife-setup.js
+++ b/packages/setup/sysknife-setup.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * sysknife-setup.js — the `npx sysknife-setup` entrypoint.
+ *
+ * This exists only to check the Node version before `index.js` is loaded.
+ * `index.js` uses syntax that Node 12 (Ubuntu 22.04's apt default) cannot
+ * parse, and a parse error is raised for the whole module before any statement
+ * in it runs — so the check cannot live there. It also cannot rely on
+ * `engines.node`, which npx reports as a warning and then ignores.
+ *
+ * Keep this file parseable by Node 12: no `?.`, no `??`, no logical assignment.
+ * tests/node-preflight.test.mjs enforces that, and enforces that the check
+ * happens before the require below.
+ */
+
+var preflight = require('./node-preflight.js');
+
+var problem = preflight.unsupportedMessage(process.versions.node);
+if (problem) {
+  process.stderr.write('\n' + problem + '\n');
+  process.exit(1);
+}
+
+require('./index.js');

--- a/packages/setup/tests/daemon-mode.test.mjs
+++ b/packages/setup/tests/daemon-mode.test.mjs
@@ -1,0 +1,92 @@
+/**
+ * daemon-mode.test.mjs
+ *
+ * `--no-prompts` used to answer the daemon-mode question for you, and it always
+ * answered "1", the user-mode service. That service runs as the invoking user,
+ * while the NOPASSWD grants in packaging/sysknife-sudoers are scoped to the
+ * `sysknife` system user and installed only by `sudo make install`. The daemon
+ * shells out through `sudo` for mutating actions (AptInstall and ~173 other call
+ * sites), so an automated install produced a daemon that answered read-only
+ * queries and failed everything else with a bare `sudo: a password is required`.
+ *
+ * Two fixes are pinned here: an explicit `--daemon-mode` flag, and a refusal to
+ * guess when `--no-prompts` is given without it — the same pattern index.js
+ * already uses for the integration flags.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const pkgDir = path.resolve(__dirname, '..');
+const entry = path.join(pkgDir, 'sysknife-setup.js');
+
+const { parseDaemonMode, DAEMON_MODES, userModeCapabilityWarning } = require('../install-daemon.js');
+
+test('--daemon-mode accepts exactly the three real choices', () => {
+  assert.deepEqual(DAEMON_MODES, ['system', 'user', 'skip']);
+  for (const mode of DAEMON_MODES) {
+    assert.equal(parseDaemonMode([`--daemon-mode=${mode}`]), mode);
+  }
+});
+
+test('an absent flag is reported as unset, not defaulted', () => {
+  // Defaulting is what caused the silent wrong choice; the caller must decide.
+  assert.equal(parseDaemonMode([]), null);
+  assert.equal(parseDaemonMode(['--claude', '--no-prompts']), null);
+});
+
+test('a misspelled mode is rejected rather than guessed at', () => {
+  assert.throws(() => parseDaemonMode(['--daemon-mode=sytsem']), /system, user, skip/);
+  assert.throws(() => parseDaemonMode(['--daemon-mode=']), /system, user, skip/);
+});
+
+test('the user-mode warning states what will not work, and the fix', () => {
+  const warning = userModeCapabilityWarning();
+  assert.match(warning, /read-only/i, 'says what still works');
+  assert.match(warning, /sudo make install|system service/i, 'names the fix');
+  assert.match(warning, /sudo/, 'explains the mechanism that fails');
+});
+
+// ---------------------------------------------------------------------------
+// The refusal, end to end through the real entrypoint
+// ---------------------------------------------------------------------------
+
+function runSetup(args) {
+  // The wizard writes .mcp.json and .claude/ into its working directory, so it
+  // gets a throwaway one: a test that leaves files in the repo is a test that
+  // has already done damage.
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sysknife-setup-run-'));
+  return spawnSync(process.execPath, [entry, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 30_000,
+    // And a HOME of its own, so nothing lands in the developer's dotfiles.
+    env: { ...process.env, HOME: cwd },
+  });
+}
+
+test('--no-prompts refuses to pick a daemon mode on the user\'s behalf', () => {
+  const res = runSetup(['--claude', '--no-prompts', '--no-binary']);
+  assert.equal(res.status, 2, `expected exit 2, got ${res.status}: ${res.stderr}`);
+  assert.match(
+    res.stderr,
+    /--no-prompts requires --daemon-mode/,
+    `must name the missing flag, got: ${res.stderr}`,
+  );
+  assert.match(res.stderr, /system/, 'must name the choices');
+});
+
+test('an interactive run still needs no flag', () => {
+  // The flag is only mandatory when nobody is there to answer the prompt.
+  const res = runSetup(['--help']);
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /--daemon-mode/, 'help documents the new flag');
+});

--- a/packages/setup/tests/node-preflight.test.mjs
+++ b/packages/setup/tests/node-preflight.test.mjs
@@ -1,0 +1,126 @@
+/**
+ * node-preflight.test.mjs
+ *
+ * Ubuntu 22.04's `apt install nodejs` gives Node 12, and `engines` in
+ * package.json is only a *warning* to npx. So `npx sysknife-setup` on a stock
+ * 22.04 box used to die like this, before a single line of the wizard ran:
+ *
+ *   npm WARN EBADENGINE Unsupported engine { required: { node: '>=18' } ... }
+ *   .../index.js:645
+ *         const count = seen.get(t.name) ?? 0;
+ *                                         ^
+ *   SyntaxError: Unexpected token '?'
+ *
+ * A version check at the top of index.js cannot fix that: `SyntaxError` is
+ * raised when Node *parses the whole module*, before any statement executes.
+ * The guard therefore lives in a separate entrypoint that contains no syntax
+ * newer than Node 12 can parse, and only `require`s the wizard once the version
+ * is known to be new enough.
+ *
+ * These tests pin both halves: the message, and the parseability that makes the
+ * message reachable at all.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const pkgDir = path.resolve(__dirname, '..');
+
+const { unsupportedMessage, MIN_MAJOR } = require('../node-preflight.js');
+const pkg = require('../package.json');
+
+// ---------------------------------------------------------------------------
+// The check itself
+// ---------------------------------------------------------------------------
+
+test('rejects the Node that Ubuntu 22.04 ships, and says how to fix it', () => {
+  const msg = unsupportedMessage('12.22.9');
+  assert.ok(msg, 'Node 12 must be rejected');
+  assert.match(msg, /12\.22\.9/, 'names the version actually in use');
+  assert.match(msg, /\b18\b/, 'names the minimum');
+  // Actionable: at least one runnable command, not just a complaint.
+  assert.match(msg, /nodesource|nvm|snap|fnm/i, 'suggests a way to get a newer Node');
+  assert.match(msg, /releases/, 'offers the no-Node escape hatch (prebuilt binaries)');
+});
+
+test('rejects every major below the minimum and accepts every one at or above', () => {
+  for (const v of ['0.10.48', '4.9.1', '8.17.0', '12.22.9', '14.21.3', '16.20.2']) {
+    assert.ok(unsupportedMessage(v), `${v} must be rejected`);
+  }
+  for (const v of ['18.0.0', '18.19.1', '20.11.0', '22.5.1', '24.0.0']) {
+    assert.equal(unsupportedMessage(v), null, `${v} must be accepted`);
+  }
+});
+
+test('an unparseable version is not silently treated as supported', () => {
+  // Better to explain the requirement than to proceed and crash on syntax.
+  assert.ok(unsupportedMessage(''));
+  assert.ok(unsupportedMessage('not-a-version'));
+});
+
+test('the minimum matches what package.json advertises', () => {
+  assert.equal(MIN_MAJOR, 18);
+  assert.match(pkg.engines.node, />=\s*18/);
+});
+
+// ---------------------------------------------------------------------------
+// Reachability: the guard is worthless if the file holding it cannot be parsed
+// by the very Node versions it exists to reject.
+// ---------------------------------------------------------------------------
+
+const GUARD_FILES = ['sysknife-setup.js', 'node-preflight.js'];
+
+// Syntax Node 12 cannot parse. Optional chaining and nullish coalescing landed
+// in Node 14; logical assignment and class fields in Node 15/12.4+.
+const TOO_NEW = [
+  [/\?\?/, 'nullish coalescing (??) needs Node 14'],
+  [/\?\./, 'optional chaining (?.) needs Node 14'],
+  [/\|\|=|&&=/, 'logical assignment needs Node 15'],
+  [/^\s*#[A-Za-z_]/m, 'private class fields need Node 12.4+'],
+];
+
+for (const file of GUARD_FILES) {
+  test(`${file} contains no syntax newer than Node 12 can parse`, () => {
+    const src = fs.readFileSync(path.join(pkgDir, file), 'utf8');
+    // Strip comments so prose about `??` in a comment does not fail the scan.
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    for (const [re, why] of TOO_NEW) {
+      assert.ok(!re.test(code), `${file} uses ${why}`);
+    }
+  });
+}
+
+test('the guard entrypoint does not require the wizard until the check passes', () => {
+  const src = fs.readFileSync(path.join(pkgDir, 'sysknife-setup.js'), 'utf8');
+  const guardAt = src.indexOf('unsupportedMessage');
+  const wizardAt = src.indexOf("require('./index.js')");
+  assert.ok(guardAt !== -1 && wizardAt !== -1, 'both the check and the delegation are present');
+  assert.ok(guardAt < wizardAt, 'the version check must run before index.js is loaded');
+});
+
+// ---------------------------------------------------------------------------
+// Packaging contract
+// ---------------------------------------------------------------------------
+
+test('npx runs the guard, not the wizard directly', () => {
+  assert.equal(pkg.bin['sysknife-setup'], 'sysknife-setup.js');
+  for (const f of [...GUARD_FILES, 'index.js']) {
+    assert.ok(pkg.files.includes(f), `${f} must ship in the tarball`);
+  }
+});
+
+test('the guard delegates to the wizard on a supported Node', () => {
+  const res = spawnSync(process.execPath, [path.join(pkgDir, 'sysknife-setup.js'), '--help'], {
+    encoding: 'utf8',
+    timeout: 20_000,
+  });
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /sysknife-setup/, 'the wizard help text is reached');
+});

--- a/packages/setup/tests/release-metadata.test.mjs
+++ b/packages/setup/tests/release-metadata.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * release-metadata.test.mjs
+ *
+ * The GitHub releases *metadata* endpoint rejects `Accept:
+ * application/octet-stream` with HTTP 415 — that media type is only correct for
+ * asset downloads. Sending it on the metadata request broke every
+ * `npx sysknife-setup` run:
+ *
+ *   ✗  Failed to fetch release metadata: HTTP 415 fetching
+ *      https://api.github.com/repos/lacs-project/sysknife/releases/latest
+ *
+ * Verified against the live API: `application/vnd.github+json` → 200,
+ * `application/octet-stream` → 415. These tests pin the two Accept values to
+ * the two kinds of request so the asset header can never leak back onto the
+ * metadata call.
+ *
+ * Offline — the fetcher is injected, no real network call is made.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fsp from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const {
+  fetchLatestRelease,
+  GITHUB_JSON_ACCEPT,
+  ASSET_ACCEPT,
+} = require('../install-binary.js');
+
+test('the metadata request asks for GitHub JSON, not octet-stream', async () => {
+  const seen = [];
+  const fixture = await fsp.readFile(
+    path.join(__dirname, 'fixtures', 'fake-release.json'),
+    'utf8',
+  );
+  const fakeFetch = (url, opts) => {
+    seen.push({ url, accept: opts && opts.accept });
+    return Promise.resolve(Buffer.from(fixture));
+  };
+
+  const release = await fetchLatestRelease('https://example.invalid/releases/latest', fakeFetch);
+
+  assert.equal(seen.length, 1);
+  assert.equal(
+    seen[0].accept,
+    'application/vnd.github+json',
+    'metadata must be requested as GitHub JSON; application/octet-stream returns HTTP 415',
+  );
+  assert.ok(Array.isArray(release.assets), 'the response is parsed as a release object');
+});
+
+test('the two Accept values stay distinct and correctly valued', () => {
+  assert.equal(GITHUB_JSON_ACCEPT, 'application/vnd.github+json');
+  assert.equal(ASSET_ACCEPT, 'application/octet-stream');
+  assert.notEqual(GITHUB_JSON_ACCEPT, ASSET_ACCEPT);
+});


### PR DESCRIPTION
## Summary

A UX pass over the Ubuntu install and first-run experience. Four independent
reviewers walked the project as users (fresh 24.04 desktop, headless 22.04
server, someone arriving from the MCP Registry listing, and a failure-mode
hunter), then every install path was run in clean `ubuntu:22.04`, `24.04` and
`26.04` containers.

**The containers found what code review could not.** All three reviewers who
read `packages/setup/` graded the wizard positively, because the code is good.
It nevertheless could not install anything on any platform:

```
✗  Failed to fetch release metadata: HTTP 415 fetching
   https://api.github.com/repos/lacs-project/sysknife/releases/latest
```

The metadata request reused the asset-download `Accept` header. Verified against
the live API: `application/octet-stream` → 415, `application/vnd.github+json` →
200.

## Related Issue

No tracking issue; findings came from the review pass described above.

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`cargo nextest run --workspace --locked`: **1502 passed, 0 failed** (1479 on
`main`, so 23 new tests and none broken). `npm test --prefix packages/setup`:
58 passed. `cargo clippy --workspace --all-features --locked -- -D warnings`:
clean. `cargo fmt --all --check`: clean. `shellcheck --severity=warning` across
every maintained script: clean. `postgres-contract` against a live
`postgres:16`: 2 passed. Every hygiene script passes.

Behaviour verified by running it, not by reading it:

| Check | Result |
|---|---|
| `npx sysknife-setup` on `ubuntu:24.04` | both binaries download, SHA-256 verify, install |
| same on `ubuntu:22.04` (Node 12) | clear message + exit 1, no `SyntaxError` |
| `--no-prompts` with no `--daemon-mode` | exit 2, names the three choices |
| daemon bind without permission | named directory, uid, and both ways out |
| second daemon on a live socket | refused, first one untouched |
| `cargo install sysknife-cli`, gcc only | succeeds, 11m43s (22.04) / 6m56s (24.04) |
| same with no C compiler | `error: linker cc not found`, ~30s |

## Notes for Reviewers

**Two install-blocking defects.** The 415 above, and a raw `SyntaxError` on
Ubuntu 22.04, whose `apt install nodejs` gives Node 12. The second one
constrains its own fix: `engines` is only a warning to npx, and a version check
inside `index.js` can never execute, because `SyntaxError` is raised when Node
parses the whole module. The guard therefore lives in a separate
Node-12-parseable entrypoint, and `tests/node-preflight.test.mjs` asserts both
the message and that the file holding it stays parseable by the versions it
exists to reject.

**One correctness bug, not cosmetic.** `bind_unix_listener` removed any existing
socket after checking only that it *was* a socket, never that anything was
listening. Starting the daemon twice therefore unlinked the live socket and
bound a new one: two "listening on …" lines, and every client of the first
process silently went dark. It now probe-connects before unlinking, so a live
daemon is refused and a socket left by a crash is still reclaimed.

**`--no-prompts` produced a daemon that could not do the job.** It always
answered "user service", which runs as the invoking user, while the NOPASSWD
grants in `packaging/sysknife-sudoers` are scoped to the `sysknife` system user
and installed only by `sudo make install`. With ~174 `sudo` call sites in the
action modules, an automated install answered read-only queries and failed
everything else with `sudo: a password is required`. Unattended runs now require
`--daemon-mode=system|user|skip`, mirroring the existing refusal for integration
flags, and choosing user mode says what will not work.

**A documented prerequisite that was wrong, and instructively so.** `.github/`
installs `cmake` before building this workspace, so all four reviewers
independently concluded cmake was a required prerequisite. Clean containers
disprove it: `aws-lc-sys 0.43` builds from `gcc` alone, and the only hard failure
is rustc's own `error: linker \`cc\` not found` with no compiler at all. The docs
now say `build-essential`, say explicitly that cmake is not needed, and state the
real cost. Writing "install cmake" would have propagated a plausible inference
the machine contradicts.

**Message fixes, each one previously verified as user-visible.** Connect errors
name their target; `doctor` reports once (it had printed the socket twice, once
as `Unix("/run/…")`) and suggests the systemd unit matching the socket's kind,
with no local unit suggested for vsock; daemon startup reports through `Display`
instead of `Error: Io("Permission denied (os error 13)")` and no longer claims
to be listening before the bind succeeds; `approve` stops citing a
`--non-interactive` flag it does not have; a keyless run announces the Ollama
fallback; planning prints one line when there is no TTY to spin on (a 173s
silence was measured); refusals name the group to join and that it needs a new
login; and no user-facing message names an internal dependency.

**One test hygiene fix worth flagging:** a new test ran the wizard with the
repository as its working directory and left `.claude/` behind. It now runs in a
temp cwd with its own `HOME`.

**Not addressed here:** the GUI (out of scope), and non-Ubuntu distributions —
this pass was deliberately Ubuntu-only, so Fedora Atomic wording is unchanged.
The container runs are rootless with no systemd, so they prove the
reach-a-working-binary path; the `systemctl enable --now` step still needs a real
VM to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f
