### PR TITLE
Report the daemon socket as a URI over MCP too, and add the Glama badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ### Fixed
 
+- **`sysknife_doctor` over MCP reported the socket as Rust `Debug`.** The CLI was
+  fixed to print `unix:///run/…` but `mcp_server.rs` kept its own
+  `format!("{socket:?}")`, so the two disagreed about the same value and MCP
+  clients received `Unix("/run/sysknife/daemon.sock")` — not a string anything can
+  put back into `SYSKNIFE_SOCKET`. The field's schema description documented that
+  Debug form as its example, which is what an LLM reads. Caught by Glama's build
+  harness running a real MCP client against the server, not by this repository's
+  own tests. A test now asserts no source file in the crate formats a socket with
+  `Debug`, because the same defect was introduced and then half-fixed twice.
+
 - **`npx sysknife-setup` could not install anything, on any platform.** The
   release-metadata request reused the asset-download `Accept:
   application/octet-stream`, and GitHub answers that with **HTTP 415** on the
@@ -86,6 +96,9 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   someone arriving from the MCP Registry reads — now leads with the fact that the
   crate is half of SysKnife: it plans and dry-runs, and executing needs the
   privileged daemon.
+- README carries the Glama server-score badge (currently license A, quality A,
+  maintenance B). The badge stopped being a generic placeholder once the server
+  had a Glama release built from its own Dockerfile spec.
 - The setup wizard's target prompt says "Target" rather than "VM Target" and
   leads with this machine, since the documented headline case is a local install.
   Its socket-unreachable hint now matches the socket's kind rather than always

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   <a href="https://github.com/lacs-project/sysknife/issues"><img src="https://img.shields.io/github/issues/lacs-project/sysknife?style=flat-square" alt="Issues"></a>
   <a href="https://github.com/lacs-project/sysknife/discussions"><img src="https://img.shields.io/github/discussions/lacs-project/sysknife?style=flat-square&label=discuss" alt="Discussions"></a>
   <a href="https://www.npmjs.com/package/sysknife-setup"><img src="https://img.shields.io/npm/v/sysknife-setup?style=flat-square&logo=npm&label=npx%20setup" alt="npm version"></a>
+  <a href="https://glama.ai/mcp/servers/lacs-project/sysknife"><img src="https://glama.ai/mcp/servers/lacs-project/sysknife/badges/score.svg" alt="Glama MCP server quality score"></a>
 </p>
 
 <p align="center">

--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -215,7 +215,8 @@ pub struct HistoryOutput {
 /// provider, and audit-chain health at the moment the tool was called.
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct DoctorReport {
-    /// Resolved daemon socket target, e.g. `"Unix(\"/run/sysknife/daemon.sock\")"`.
+    /// Resolved daemon socket target as a URI, e.g. `"unix:///run/sysknife/daemon.sock"`
+    /// or `"vsock://3:7777"`. Accepted verbatim by `SYSKNIFE_SOCKET`.
     pub daemon_socket: String,
     /// `true` iff the daemon answered `query_state` within the socket timeout.
     pub daemon_reachable: bool,
@@ -719,7 +720,10 @@ async fn doctor_inner() -> DoctorReport {
     let mut warnings: Vec<String> = Vec::new();
 
     let socket = resolve_socket_target();
-    let socket_label = format!("{socket:?}");
+    // `label()`, not `{:?}`: this string is published to MCP clients, and
+    // `Unix("/run/…")` is Rust internals rather than something a caller can put
+    // back into SYSKNIFE_SOCKET. Must match what `sysknife doctor` prints.
+    let socket_label = socket.label();
 
     // Detect the running distro — non-fatal if /etc/os-release is absent.
     let distro = match sysknife_core::distro::detect() {
@@ -1377,5 +1381,89 @@ mod tests {
 
         std::env::remove_var("SYSKNIFE_SOCKET");
         server.abort();
+    }
+
+    // -----------------------------------------------------------------------
+    // The socket label an MCP client reads
+    //
+    // `sysknife doctor` on the CLI was fixed to render sockets as
+    // `unix:///run/…` instead of Rust's `Unix("/run/…")`, but the MCP path
+    // kept its own `format!("{socket:?}")` and was missed. The two then
+    // disagreed about the same value, and the schema description shipped the
+    // Debug form as the documented example — which is what an LLM, and
+    // Glama's tool evaluator, actually read.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn doctor_reports_the_socket_as_a_uri_not_rust_debug() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("daemon.sock");
+        std::env::set_var("SYSKNIFE_SOCKET", sock.to_str().unwrap());
+
+        let report = doctor_inner().await;
+
+        std::env::remove_var("SYSKNIFE_SOCKET");
+
+        assert_eq!(
+            report.daemon_socket,
+            format!("unix://{}", sock.display()),
+            "the MCP report must use the same URI form as the CLI"
+        );
+        assert!(
+            !report.daemon_socket.contains("Unix("),
+            "no Rust Debug formatting in MCP output: {}",
+            report.daemon_socket
+        );
+        // The value must be something a caller can feed back to SYSKNIFE_SOCKET.
+        assert_eq!(
+            crate::client::SocketTarget::try_from_str(&report.daemon_socket).unwrap(),
+            crate::client::SocketTarget::Unix(sock.clone()),
+        );
+    }
+
+    #[test]
+    fn the_doctor_schema_documents_the_uri_form_not_the_debug_form() {
+        // This description is published to every MCP client as the field's
+        // documentation, so a stale example is a wrong instruction, not a typo.
+        let schema = serde_json::to_string(&schemars::schema_for!(DoctorReport)).unwrap();
+        assert!(
+            !schema.contains("Unix("),
+            "the schema still documents Rust Debug formatting: {schema}"
+        );
+        assert!(
+            schema.contains("unix://"),
+            "the schema should show the URI form as its example"
+        );
+    }
+
+    #[test]
+    fn no_source_file_formats_a_socket_target_with_debug() {
+        // The CLI fix landed and the MCP one was missed, so the same defect
+        // existed twice in one crate. Cheaper to assert the shape is gone than
+        // to rediscover it from a third party's build log.
+        //
+        // The needle is assembled from two halves so this file does not contain
+        // the pattern it forbids, which would make the test fail on itself.
+        let needle = concat!("{socket", ":?}");
+        for entry in std::fs::read_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/src")).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).unwrap();
+            for (n, line) in src.lines().enumerate() {
+                // Comments do not execute, and the comments explaining this
+                // very defect necessarily quote the pattern.
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
+                assert!(
+                    !line.contains(needle),
+                    "{}:{} formats a socket with Debug; use SocketTarget::label()",
+                    path.display(),
+                    n + 1
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

PR #116 fixed `sysknife doctor` to render sockets as `unix:///run/…` instead of Rust's `Unix("/run/…")`. It missed `mcp_server.rs`, which had its own `format!("{socket:?}")`. The CLI and the MCP tool then disagreed about the same value, and `DoctorReport`'s schema shipped the Debug form as the field's documented example, which is the text an LLM and a directory's evaluator read.

**Found by Glama's build harness**, which runs a real MCP client against the built image and logs `tools/list` plus tool output. Nothing in this repository's tests inspected that string.

Also adds the Glama server-score badge to the README badge row.

## Related Issue

Follow-up to #116.

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`cargo nextest run --workspace --locked`: **1505 passed, 0 failed** (1502 before, 3 new). `cargo clippy --workspace --all-features --locked -- -D warnings`: clean. `cargo fmt --all --check`: clean. `RUSTDOCFLAGS=-D warnings cargo doc`: clean. `markdownlint-cli2` over CI's exact file list: 0 issues. `markdown-link-check` on README: 54 links checked, both new Glama URLs pass. `npm test --prefix packages/setup`: 58 passed.

## Notes for Reviewers

**Three tests, one of which guards the class rather than the instance.** The same defect was introduced once and half-fixed once, so beyond asserting the value and the schema description, a test walks the crate's own sources and fails if any line formats a socket with `Debug`. Its needle is assembled as `concat!("{socket", ":?}")` so the file does not contain the pattern it forbids, and it skips comment lines because the comments explaining this defect necessarily quote it.

**Deliberately not fixed:** the same build log emits `unknown format "uint64" ignored in schema` three times, from `schemars` annotating `u64` fields. Unknown `format` values are explicitly ignorable per JSON Schema, so this is spec-legal and harmless; writing custom `schema_with` overrides to silence a warning in a third party's validator would add code that does nothing for users.

**On the badge:** it previously served a generic placeholder, byte-identical to another server's. It now reports real values (license A, quality A, maintenance B, 5 tools, Rust, MIT), because the server has a Glama release built from its own Dockerfile spec. Server Coherence and Tool Definition Quality remain pending on Glama's side; the badge will pick them up when their evaluation runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f