### PR TITLE
chore(release): v0.2.15

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
-## [Unreleased]
+## [0.2.15] — 2026-07-28
+
+The install path was broken for every new user: `npx sysknife-setup`, the command
+the README leads with, could not fetch release metadata at all. This release
+exists to ship that fix, so it is worth taking even though no feature changed.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "prost",
  "prost-build",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.2.12",
+      "version": "0.2.15",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "@vitest/coverage-v8": "^4.1.4",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.14",
+  "version": "0.2.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",
@@ -22,7 +22,10 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["appimage", "rpm"],
+    "targets": [
+      "appimage",
+      "rpm"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -30,14 +33,16 @@
       "icons/icon.ico"
     ],
     "category": "Utility",
-    "shortDescription": "AI agent for Linux — preview, approve, execute.",
+    "shortDescription": "AI agent for Linux \u2014 preview, approve, execute.",
     "longDescription": "SysKnife (Linux Agent Control Standard) is an AI agent for Linux system administration. Every action is shown to you as a typed plan before execution. No command runs without your explicit approval. Full audit trail included.",
     "linux": {
       "deb": {
         "depends": []
       },
       "rpm": {
-        "depends": ["polkit"]
+        "depends": [
+          "polkit"
+        ]
       },
       "appimage": {
         "bundleMediaFramework": false

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.14"
+version = "0.2.15"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -13,7 +13,9 @@
     {
       "src": "https://raw.githubusercontent.com/lacs-project/sysknife/main/assets/raster/sysknife-256.png",
       "mimeType": "image/png",
-      "sizes": ["256x256"]
+      "sizes": [
+        "256x256"
+      ]
     }
   ],
   "packages": [
@@ -21,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Version bump only, so the merged install fixes actually reach users.

**Why this cannot wait.** In the published 0.2.14, `npx sysknife-setup` (the command the README leads with) cannot install anything on any platform: it sends the asset-download `Accept: application/octet-stream` on the release-metadata request, and GitHub answers HTTP 415. The fix landed in #116 but is unreleased, so every new user still hits a dead end.

Ships #116 (Ubuntu install and first-run experience) and #117 (socket reported as a URI over MCP, Glama badge).

## Related Issue

Follows #116 and #117.

## Validation

- [x] Tests added or updated (none needed; version bump only)
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`cargo nextest run --workspace --locked`: **1505 passed, 0 failed**. `clippy --all-features -- -D warnings`: clean. `RUSTDOCFLAGS=-D warnings cargo doc`: clean. `cargo fmt --all --check`: clean. `markdownlint-cli2`: 0 issues. `npm test --prefix packages/setup`: 58 passed.

Release-specific checks:

```
bash scripts/check_release_versions.sh v0.2.15   -> All release versions match 0.2.15.
bash scripts/check_registry_versions.sh v0.2.15  -> all 7 packages: 0.2.15 available
bash scripts/release_rehearsal.sh --check        -> Rehearsal preflight passed for v0.2.15
bash tests/release/registry-manifest.test.sh     -> server.json -> cargo sysknife-cli@0.2.15
```

## Notes for Reviewers

**14 manifests bumped**, covering everything `check_release_versions.sh` compares: eight `Cargo.toml` files, `Cargo.lock`, the shell's `package.json` / `package-lock.json` / `tauri.conf.json`, `packages/setup/package.json`, `.codex-plugin/plugin.json`, and both `server.json` version fields.

**One ordering constraint worth stating.** `server.json` now names `sysknife-cli@0.2.15`, and the MCP Registry validator reads the *published* crate's rendered README for the ownership marker. So the registry listing must be re-published only after the release workflow uploads the crate, not before. `registry-manifest.test.sh` passes now because it checks the in-repo README; it cannot check crates.io for an unpublished version.

**After merge:** a signed `v0.2.15` tag triggers `release.yml`, which publishes `sysknife-setup` to npm via OIDC, the six crates to crates.io in dependency order, and creates the GitHub Release with binaries, SBOMs, and checksums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f