### PR TITLE
Make the two unautomatable post-release steps impossible to forget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,3 +285,98 @@ jobs:
             "dist/sha256sums-linux-aarch64.txt" \
             "dist/sysknife-${VERSION}-linux-x86_64.spdx.json" \
             "dist/sysknife-${VERSION}-linux-aarch64.spdx.json"
+
+  post-release-checklist:
+    name: File the manual post-release steps
+    # Only after publication actually succeeded: a checklist for a release that
+    # never shipped is worse than no checklist.
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # gh release download
+      issues: write  # gh issue create
+
+    steps:
+      - name: Fetch the published checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release download "$VERSION" --repo "$REPO" \
+            --pattern sha256sums-linux-x86_64.txt --dir .
+
+      - name: Open the checklist issue
+        # Two directory listings cannot be automated from CI: the MCP Registry
+        # requires a device-code login, and Glama's build spec is a browser-only
+        # admin form. Left implicit, both get forgotten, and the listings then
+        # advertise a version nobody can install. The issue carries the exact
+        # commands and the real checksum for this tag.
+        #
+        # Every interpolated value is server-controlled (the tag we pushed, the
+        # static repo path, the actor who pushed it); no user text is shelled.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          binary="sysknife-${VERSION}-linux-x86_64"
+          sha="$(awk -v f="$binary" '$2 == f { print $1 }' sha256sums-linux-x86_64.txt)"
+          if [ -z "$sha" ]; then
+            echo "::error::no checksum for $binary in sha256sums-linux-x86_64.txt"
+            exit 1
+          fi
+          version_no_v="${VERSION#v}"
+
+          cat > body.md <<EOF
+          \`${VERSION}\` is published to npm, crates.io, and GitHub Releases. Two
+          directory listings still point at the previous version, and neither can be
+          updated from CI.
+
+          ### 1. Official MCP Registry
+
+          \`server.json\` already names \`sysknife-cli@${version_no_v}\`. The validator reads
+          the **published** crate's rendered README for the \`mcp-name:\` marker, so this
+          step only works now that crates.io has the version.
+
+          \`\`\`sh
+          mcp-publisher login github   # device code, cannot run unattended
+          mcp-publisher publish        # from the repository root
+          \`\`\`
+
+          Verify:
+
+          \`\`\`sh
+          curl -sS "https://registry.modelcontextprotocol.io/v0/servers?search=sysknife" \\
+            | grep -o '"version":"${version_no_v}"'
+          \`\`\`
+
+          ### 2. Glama build spec
+
+          Browser-only: <https://glama.ai/mcp/servers/lacs-project/sysknife/admin/dockerfile>
+
+          Replace **Build steps** with the following, leave every other field alone
+          (in particular keep the \`mcp-proxy --\` prefix in CMD arguments, which is how
+          Glama exposes a stdio server), then click **Build & Release**:
+
+          \`\`\`json
+          [
+            "curl -fsSL -o /app/sysknife https://github.com/${REPO}/releases/download/${VERSION}/${binary}",
+            "echo \\"${sha}  /app/sysknife\\" | sha256sum -c -",
+            "chmod +x /app/sysknife"
+          ]
+          \`\`\`
+
+          ### Notes
+
+          - Checksum above is read from this release's \`sha256sums-linux-x86_64.txt\`, not hand-copied.
+          - Neither step blocks users installing \`${VERSION}\`; they affect discovery only.
+          - Close this issue once both are done.
+          EOF
+
+          gh issue create --repo "$REPO" \
+            --title "Post-release manual steps for ${VERSION}" \
+            --body-file body.md \
+            --assignee "$ACTOR"

--- a/docs/release.md
+++ b/docs/release.md
@@ -72,6 +72,40 @@ The tag pattern does not accept prerelease suffixes. Do not move or reuse a
 published tag. If publication partly fails, diagnose and rerun the workflow on
 the same commit; do not publish a different tree under the same version.
 
+Tags are signed. SSH signing is configured per repository so it cannot leak into
+unrelated work:
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/git-signing -C "sysknife git signing"
+gh ssh-key add ~/.ssh/git-signing.pub --type signing --title "git signing (sysknife)"
+git config gpg.format ssh
+git config user.signingkey ~/.ssh/git-signing.pub
+git config tag.gpgsign true
+```
+
+Verify before pushing: `git tag -v v0.2.15` must report a good signature. An
+unverifiable tag on a published release is worse than an unsigned one.
+
+## Manual steps after publication
+
+Two directory listings cannot be updated from CI, so the release workflow files
+a checklist issue titled `Post-release manual steps for <tag>` and assigns it to
+whoever pushed the tag. It carries the exact commands and the real checksum read
+from that release's `sha256sums-linux-x86_64.txt`.
+
+1. **Official MCP Registry.** `mcp-publisher login github` is a device-code flow
+   and cannot run unattended. The publish must also wait for crates.io to have
+   the version, because the validator reads the *published* crate's rendered
+   README for the `mcp-name:` marker.
+2. **Glama build spec.** The admin form is browser-only. Only the build steps
+   change per release, to the new binary URL and checksum. Leave the
+   `mcp-proxy --` prefix in the CMD arguments alone; that is how Glama exposes a
+   stdio server over HTTP.
+
+Neither step blocks anyone installing the release. They affect discovery only, so
+they are not release blockers, which is exactly why they need a ticket rather
+than a line in a log nobody reads.
+
 ## Registry details
 
 ### npm

--- a/tests/release/release-rehearsal.test.sh
+++ b/tests/release/release-rehearsal.test.sh
@@ -38,6 +38,19 @@ fi
 release_workflow="${repo_root}/.github/workflows/release.yml"
 grep -Fq 'check_registry_versions.sh' "$release_workflow"
 grep -Fq 'already exists; skipping' "$release_workflow"
+
+# Two directory listings cannot be automated: the MCP Registry needs a
+# device-code login and Glama's build spec is browser-only. Both were therefore
+# forgotten after releases. The workflow now files a checklist issue naming
+# them, with the freshly published checksum filled in, so the work is visible
+# without anyone reading a build log. Assert the job and both venues survive.
+grep -Fq 'Post-release manual steps' "$release_workflow"
+grep -Fq 'mcp-publisher publish' "$release_workflow"
+grep -Fq 'glama.ai' "$release_workflow"
+# The checklist is only useful if it carries the real checksum for this tag,
+# and only honest if it appears after publication actually succeeded.
+grep -Fq 'sha256sums-linux-x86_64.txt' "$release_workflow"
+grep -Eq 'needs: \[release\]' "$release_workflow"
 # Positive invariant: EVERY `uses:` in EVERY workflow MUST pin a full 40-hex
 # commit SHA. This catches every mutable form (semver tags like @v6.1.0,
 # @stable, @main, per-tool tags like @cargo-nextest, and short SHAs), across


### PR DESCRIPTION
## Summary

Two directory listings cannot be updated from CI, and both were skipped after v0.2.14: the **MCP Registry** needs a device-code login, and **Glama**'s build spec is a browser-only admin form. Left implicit, the listings keep advertising a binary URL and checksum that no longer exist.

`release.yml` now files an issue titled `Post-release manual steps for <tag>`, assigned to whoever pushed the tag, carrying the exact commands and the **real checksum read from that release's own `sha256sums-linux-x86_64.txt`** rather than copied by hand.

## Related Issue

Arose from cutting v0.2.15, where both steps had to be done by hand.

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`cargo nextest run --workspace --locked`: **1505 passed**. `yamllint` clean on the workflow. `shellcheck --severity=warning` clean across every maintained script. The contract test fails without the new job and passes with it.

**The heredoc was verified by execution, not by reading.** I extracted the step's `run` script from the *parsed* YAML and ran it with a fixture checksums file:

- the `EOF` terminator lands at column 0 only because YAML strips the block scalar's indentation, which is the failure mode that would have produced `warning: here-document delimited by end-of-file` at release time and nowhere earlier;
- code fences and `\"` escaping survive into the rendered Markdown;
- the checksum substitutes from the file rather than being interpolated from anywhere untrusted.

## Notes for Reviewers

**`needs: [release]`** is deliberate: a checklist for a release that never shipped is worse than no checklist. Permissions are the minimum for the job, `contents: read` to download the checksums asset and `issues: write` to file the ticket.

**No untrusted input is shelled.** Every interpolated value is server-controlled: `github.ref_name` is the tag we pushed, `github.repository` is static, `github.actor` is the pusher. All are passed via `env:` rather than inlined, per the repository's existing convention in this workflow.

**`docs/release.md` also gains the SSH tag-signing setup** its own `git tag -s` instruction always assumed. That instruction was never followed: `v0.2.13` and `v0.2.14` are unsigned (`git tag -v` reports "no signature found"). `v0.2.15` is the first signed tag, and signing is configured **per repository** so it cannot leak into unrelated work on another account.

**Already exercised end to end for v0.2.15**, by hand, because the job did not exist at tag time: the registry now lists `sysknife-cli@0.2.15` as `isLatest`, and the Glama spec needs `03120de95be4fce15870295fbadcc4f92de20f74426b5db311d52107e469f9be`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f