### PR TITLE
chore(release): v0.2.16

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
-## [Unreleased]
+## [0.2.16] — 2026-07-28
 
 A whole-repository review pass (four independent read-only reviewers, one per
 lens: UX, security, dead code, and drift between code and docs) followed by the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "prost",
  "prost-build",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.15"
+version = "0.2.16"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "@vitest/coverage-v8": "^4.1.4",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.15",
+  "version": "0.2.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.15"
+version = "0.2.16"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.15"
+version = "0.2.16"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.15"
+version = "0.2.16"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.15"
+version = "0.2.16"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.15"
+version = "0.2.16"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.15"
+version = "0.2.16"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Ships the review sweep from #123.

All fifteen version sites bumped together (`scripts/check_release_versions.sh v0.2.16`
passes), and the CHANGELOG's `Unreleased` section promoted to `0.2.16`.

Highlights of what this release carries:

- Ubuntu eligibility widened to every release from 20.04 — the daemon previously
  refused **all mutating actions** on 20.04 and every interim release
- Approval now follows the daemon's authoritative preview instead of preceding it
- The nine privileged helpers that were packaged and granted but never installed
- `--daemon-mode=system` reports honestly instead of claiming success
- `audit verify` resolves the system audit store, and states the truncation caveat
- Wi-Fi passwords no longer persisted to the audit database
- 30s pre-first-request IPC deadline, closing a cheap local denial of service

Gates: 1534 tests, clippy `-D warnings`, rustdoc, markdownlint, and the four repo
contract scripts all clean.

Merge, then the signed tag follows.