### PR TITLE
Quote the test baseline the documented command actually prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,519 Rust tests and 72 frontend tests** form the current deterministic
+**1,534 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -51,7 +51,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (legacy, unsupported target) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,519 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,534 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -138,7 +138,7 @@ flow.
 
 ## Status
 
-189 typed actions · 1,519 Rust tests + 72 frontend tests · MIT
+189 typed actions · 1,534 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/scripts/check_public_claims.sh
+++ b/scripts/check_public_claims.sh
@@ -29,11 +29,17 @@ reject_pattern() {
     fi
 }
 
-# Any count below the current baseline is stale. The previous range stopped at
-# 1,347 while reality had already moved to 1,490, so the guard sat green through
-# 85 tests of drift — the range has to be widened whenever the baseline moves.
-reject_pattern '1,(2[0-9][0-9]|3[0-9][0-9]|4[0-9][0-9]|50[0-9]|51[0-8])( Rust)? tests' \
-    'test count is stale; the release baseline is 1,519 Rust tests' \
+# Any count below the current baseline is stale. The range must be widened
+# whenever the baseline moves: it once stopped at 1,347 while reality was at
+# 1,490, so the guard sat green through 85 tests of drift.
+#
+# The baseline counts the WHOLE workspace — exactly what
+# `cargo nextest run --workspace --locked` prints — so a reader can verify it
+# with one command. Quoting a subset (e.g. excluding the GUI crate) makes the
+# number unverifiable from the documented command, which is how it silently
+# came to mean two different things.
+reject_pattern '1,(2[0-9][0-9]|3[0-9][0-9]|4[0-9][0-9]|5[0-2][0-9]|53[0-3])( Rust)? tests' \
+    'test count is stale; the release baseline is 1,534 Rust tests' \
     "${claim_files[@]}"
 reject_pattern 'until npm publish lands|publish[- ]pending' \
     'setup package is documented as unpublished' "${claim_files[@]}"
@@ -63,8 +69,8 @@ required_test_count_docs=(
     "$repo_root/docs/distro-support.md"
 )
 for path in "${required_test_count_docs[@]}"; do
-    if ! grep -Fq '1,519 Rust tests' "$path"; then
-        printf 'Verified test baseline missing from %s: expected 1,519 Rust tests\n' \
+    if ! grep -Fq '1,534 Rust tests' "$path"; then
+        printf 'Verified test baseline missing from %s: expected 1,534 Rust tests\n' \
             "$path" >&2
         exit 1
     fi


### PR DESCRIPTION
Follow-up to #123, which moved the published baseline from `1,405` to `1,519`.

Those two numbers count different things:

| number | what it counts | how you get it |
|---|---|---|
| `1,405` (old) | whole workspace | `cargo nextest run --workspace --locked` |
| `1,519` (#123) | workspace **minus the GUI crate** | `-E 'not package(sysknife-shell)'` |
| `1,534` (this PR) | whole workspace | `cargo nextest run --workspace --locked` |

`docs/distro-support.md` calls it "the deterministic **workspace** baseline" while
the documented command prints 1,534 — so the number and its own verification
instruction disagreed. That is the same class of defect #123 existed to fix, and I
introduced it there by quoting the subset I happened to measure while checking how
many tests the sweep added.

Fixed by quoting the whole-workspace figure in all three docs. A subset is not
verifiable from the command a reader is told to run, and the guard's comment now
says so, so the next person to move the baseline keeps it comparable.

The stale-count reject range widens to `1,200`–`1,533` accordingly. The
meta-test needs no change: #123 made it derive the baseline from the checker
rather than repeating the literal, so it followed automatically.

Docs and one shell script only; 1534 tests pass.