### PR TITLE
Fedora Atomic is deprioritized, not legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <strong>Distros</strong>&nbsp;
   <img src="https://img.shields.io/badge/Ubuntu%2020.04%2B-supported-2f855a?style=flat-square&logo=ubuntu&logoColor=white" alt="Ubuntu 20.04 and later supported">
   <img src="https://img.shields.io/badge/Ubuntu%2024.04-VM%20validated-2f855a?style=flat-square&logo=ubuntu&logoColor=white" alt="Ubuntu 24.04 VM validated">
-  <img src="https://img.shields.io/badge/Fedora%20Atomic-legacy%2C%20unsupported-6b7280?style=flat-square&logo=fedora&logoColor=white" alt="Fedora Atomic legacy and unsupported">
+  <img src="https://img.shields.io/badge/Fedora%20Atomic%2041%2B-eligible%2C%20unvalidated-b7791f?style=flat-square&logo=fedora&logoColor=white" alt="Fedora Atomic 41 and later eligible but not VM validated">
 </p>
 
 <p align="center">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,12 +10,14 @@ artefacts.
 
 ## Phase 8: Multi-distro
 
-Tracked in the v0.4.0 milestone. Ubuntu is the supported target today
-(20.04 and later, see [docs/distro-support.md](docs/distro-support.md)); the
-items below widen that.
+Tracked in the v0.4.0 milestone. Ubuntu is the primary target today (20.04 and
+later) because that is where the users are; Fedora Atomic 41+ is eligible and its
+rpm-ostree action families work, it just needs a fresh validation run. See
+[docs/distro-support.md](docs/distro-support.md).
 
 - Ubuntu 22.04 full action parity (65/65 stories)
 - Ubuntu 26.04 full action parity (65/65 stories)
+- record a current Fedora Silverblue 44 full VM run
 - dnf action family (Fedora Workstation non-atomic)
 - pacman action family (Arch/Manjaro)
 

--- a/crates/sysknife-core/src/distro.rs
+++ b/crates/sysknife-core/src/distro.rs
@@ -21,8 +21,12 @@
 /// [`ParseError::FileTooLarge`].
 pub const MAX_OS_RELEASE_BYTES: usize = 10 * 1024;
 
-/// Oldest Fedora Atomic release still eligible. Legacy: Fedora is no longer a
-/// supported target, but existing installs keep working.
+/// Oldest Fedora Atomic release SysKnife acts on.
+///
+/// Fedora Atomic is a real target: the rpm-ostree, Flatpak and toolbox action
+/// families are implemented and mutations are allowed from 41 onward. It is
+/// simply not where the effort goes, because Ubuntu has far more users, so it
+/// carries no current live-VM validation run. See `docs/distro-support.md`.
 pub const OLDEST_ELIGIBLE_FEDORA_ATOMIC: u32 = 41;
 
 /// Oldest Ubuntu major version SysKnife acts on (20 → 20.04).
@@ -222,9 +226,10 @@ impl DistroId {
     ///   Ubuntu is the supported platform, so eligibility must not depend on
     ///   the LTS cadence — the apt, snap, ufw and netplan tooling every action
     ///   drives is present across those releases.
-    /// - Fedora Atomic variants 41+ (Silverblue, Kinoite, and siblings) remain
-    ///   eligible from earlier releases, but are no longer a supported target;
-    ///   see `docs/distro-support.md`.
+    /// - Fedora Atomic variants 41+ (Silverblue, Kinoite, and siblings) are
+    ///   eligible too. The rpm-ostree action families work; the difference from
+    ///   Ubuntu is validation effort, not support, because Ubuntu has far more
+    ///   users. See `docs/distro-support.md`.
     ///
     /// # Eligibility is not validation coverage
     ///

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -1,9 +1,11 @@
 # Distro support matrix
 
-**Ubuntu is the supported platform: every release from 20.04 onward, LTS and
-interim alike.** Fedora Atomic support predates that decision. Its code is still
-present and still works, but it is no longer a supported target and is not
-validated — treat it as legacy.
+**Ubuntu is the primary platform: every release from 20.04 onward, LTS and
+interim alike.** That is a focus decision, not a judgement about other families:
+Ubuntu simply has far more users. Fedora Atomic remains a real target. Its
+rpm-ostree, Flatpak and toolbox action families are implemented and mutations are
+allowed from Fedora Atomic 41 onward; what it lacks is a current live-VM
+validation run, which is why it sits at a lower evidence tier below.
 
 SysKnife reports operating-system support by evidence, not by family name
 alone. Recognition in `/etc/os-release` means the planner can select the right
@@ -18,7 +20,7 @@ the bug this section now documents:
 - **Eligibility** — will the daemon act on this host at all? That is
   `DistroId::is_supported()` in `crates/sysknife-core/src/distro.rs`, and the
   daemon refuses every *mutating* action when it is false. It is true for all
-  Ubuntu releases from 20.04 up.
+  Ubuntu releases from 20.04 up, and for Fedora Atomic 41 and later.
 - **Validation tier** — has the full story suite been run on that release?
   That is the table below, and it will always be narrower than eligibility.
 
@@ -47,8 +49,8 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Ubuntu 22.04 LTS** | Ubuntu/apt family | VM bootstrap and smoke tests | **Smoke-tested** |
 | **Ubuntu 26.04 LTS** | Ubuntu/apt family | VM bootstrap, smoke tests, and sudo-rs sudoers verification (26.04 ships sudo-rs 0.2.x; `visudo -cf` parses the SysKnife sudoers and every grant — including the trailing-`*` wildcard grants — is honoured) | **Smoke-tested** |
 | **Every other Ubuntu 20.04+ release** (20.04, 20.10, 21.x, 23.x, 25.x, 26.10, …) | Ubuntu/apt family | Eligible by release family; no per-release VM run | **Smoke-tested** |
-| **Fedora Silverblue 44** | rpm-ostree, Flatpak, toolbox, firewalld, systemd, containers | Harness and fixture coverage; no current live-VM run | **Experimental** (legacy, unsupported target) |
-| **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (legacy, unsupported target) |
+| **Fedora Silverblue 44** | rpm-ostree, Flatpak, toolbox, firewalld, systemd, containers | Harness and fixture coverage; no current live-VM run | **Experimental** (eligible, awaiting a fresh VM run) |
+| **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
 The deterministic workspace baseline is 1,534 Rust tests plus 72 frontend


### PR DESCRIPTION
## What

Ubuntu is the primary target because it has far more users. That is a decision
about where validation effort goes, not a demotion of other families, and the
docs overstated it: `is_supported()` returns true for Fedora Atomic 41 and later,
and the rpm-ostree, Flatpak and toolbox action families are implemented, so
"legacy, unsupported target" described something the code does not do.

Reworded in four places, plus one restoration:

- `crates/sysknife-core/src/distro.rs` — both doc comments on
  `OLDEST_ELIGIBLE_FEDORA_ATOMIC` and `is_supported()`
- `docs/distro-support.md` — header paragraph, the eligibility bullet (which
  listed only Ubuntu), and the two Fedora Atomic matrix rows
  (`Experimental (eligible, awaiting a fresh VM run)`)
- `README.md` — distro badge is now `Fedora Atomic 41+ / eligible, unvalidated`
  in amber, instead of grey `legacy, unsupported`
- `ROADMAP.md` — restores "record a current Fedora Silverblue 44 full VM run",
  which #127 dropped on the wrong premise

No behaviour change: `is_supported()` is untouched.

## Verification

- `cargo nextest run --workspace --locked` — 1534 passed, 0 failed
- `scripts/check_public_claims.sh` runs in `docs-and-hygiene`; the Fedora reject
  pattern targets "plain Fedora Workstation/Server fully supported", which this
  wording does not claim

## Out of scope

`apps/sysknife-shell` (frozen GUI).