### PR TITLE
Explain why directory sandboxes list SysKnife with zero tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ are scoped with clear acceptance criteria.
 |---------|---------|-------|
 | **npm** | `npx sysknife-setup` | [npmjs.com/package/sysknife-setup](https://www.npmjs.com/package/sysknife-setup) — setup wizard; needs Node 18+, no compile |
 | **crates.io** | `cargo install sysknife-cli` / `cargo install sysknife-daemon` | Needs `build-essential`; ~7-12 min build. Published by reviewed version tags; see [docs/release.md](docs/release.md) |
-| **MCP Registry** | `io.github.lacs-project/sysknife` | [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) — resolves to the crates.io install above |
+| **MCP Registry** | `io.github.lacs-project/sysknife` | [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) — resolves to the crates.io install above. Directory pages that sandbox a server show SysKnife with an empty tool list; [docs/mcp-registry.md](docs/mcp-registry.md#sandboxed-directories-and-the-empty-tool-list) explains why that is expected |
 | **GitHub Releases** | Download from [Releases](https://github.com/lacs-project/sysknife/releases) | Prebuilt x86_64 + aarch64 binaries with SHA-256 checksums on every tag |
 
 ## License

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
 
 - [Quick Start](quickstart.md)
 - [MCP Server](mcp.md)
+- [Registry and Directory Listings](mcp-registry.md)
 - [CLI Reference](cli.md)
 - [Configure Your LLM](configuration.md)
 - [Distro Support](distro-support.md)

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -123,6 +123,55 @@ registry-ready. To publish the listing:
 ## Downstream propagation
 
 One publish to the official registry auto-propagates to the **GitHub MCP
-Registry** and **PulseMCP** (they ingest from it). Glama, mcp.so, Smithery,
-LobeHub, and mcpservers.org still take **separate manual submissions** for
-maximum reach.
+Registry** and **PulseMCP**, which ingest from it. Everything else takes a
+separate submission. Verified by walking each flow on 2026-07-29:
+
+| Directory | How it takes a server |
+|---|---|
+| **PulseMCP** | No submission form exists for servers. Choosing "MCP Server" on `pulsemcp.com/submit` returns instructions only: they ingest the official registry daily and process weekly. The URL field on that page belongs to the *MCP Client* branch. Email `hello@pulsemcp.com` only if a week has passed since the registry publish without a listing. |
+| **mcpservers.org** | Web form: server name, one-sentence description, link, category, contact email. Free tier with a review pass; a paid tier only buys queue position. |
+| **Glama** | Browser-only build spec at `glama.ai/mcp/servers/lacs-project/sysknife/admin/dockerfile`. Keep the `mcp-proxy --` prefix in the CMD arguments: that wrapper is how Glama exposes a stdio server. |
+| **Smithery** | Needs a `smithery.yaml` in the repository declaring a stdio `commandFunction`, alongside the existing `glama.json`. |
+| **mcp.so, LobeHub** | Separate submissions; both reject automated fetches, so use a real browser. |
+
+## Sandboxed directories and the empty tool list
+
+Most directories work the same way: build a container from the repository, boot
+the server inside it, introspect the tool list, and score what they find. That
+model assumes a self-contained server, one that reaches an API over the network
+or reads files inside its own sandbox. SysKnife is not that, by design, and the
+consequence shows up on those pages as an empty tool list.
+
+`sysknife mcp-server` is the **unprivileged** half of the system. It plans,
+previews, renders, and forwards. It cannot change anything. Every mutation
+travels over a unix socket to `sysknife-daemon`, which holds the sudoers, polkit
+and helper policy that `sudo make install` owns, and the socket itself is
+`0750 sysknife:sysknife` at `/run/sysknife/daemon.sock`. That split is the
+product: it is why an agent cannot hand a shell string to root, and why every
+executed action lands in the signed chain. See
+[Architecture & Trust Boundaries](architecture.md).
+
+Three things follow, and all three are expected rather than broken:
+
+1. **No daemon in the sandbox, so no tools.** With nothing listening on the
+   socket, `sysknife doctor` correctly reports it absent and the tool list comes
+   back empty. A directory showing `"tools": []` for SysKnife is reporting the
+   truth about its own container, not a fault in the server.
+2. **stdio needs a wrapper.** Container-based hosts front the binary with a
+   proxy (Glama uses `mcp-proxy --`). Strip that prefix while editing a build
+   spec and the listing stops working.
+3. **A green sandbox run would prove nothing anyway.** The host under
+   administration would be a throwaway container, so "it booted and listed five
+   tools" carries no information about whether SysKnife administers a real
+   Ubuntu machine correctly.
+
+The practical guidance: treat these listings as **discovery surface**, not as
+validation. They are cheap inbound links from where people look for MCP servers.
+The evidence that actually bears on correctness lives elsewhere: the VM runs
+recorded in [Distro Support](distro-support.md), the story suite, and an audit
+chain a third party can verify with only the public key.
+
+And the inverse, which matters more: **do not relax the daemon boundary to score
+better in a sandbox.** A version of SysKnife that enumerated tools and mutated
+state from inside an unprivileged container would score higher on those pages and
+would no longer be worth installing.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -16,6 +16,12 @@ audit-logged path.
 > Run `npx sysknife-setup` — it detects which AI clients you have installed and
 > writes the correct config files for each one automatically.
 
+> **Found SysKnife on a directory page listing zero tools?** That is expected,
+> not a fault. The MCP server is the unprivileged half of SysKnife and needs a
+> privileged daemon on a real host to have any tools to offer, which a directory's
+> build sandbox cannot provide. See
+> [Registry and Directory Listings](mcp-registry.md#sandboxed-directories-and-the-empty-tool-list).
+
 ---
 
 ## Tools


### PR DESCRIPTION
## What

Glama reports `"tools": []` for SysKnife, and container-based directories always
will. That is structural, not a defect: `sysknife mcp-server` is the unprivileged
half of the system and has nothing to offer until a privileged `sysknife-daemon`
is listening on `/run/sysknife/daemon.sock`, which a build sandbox cannot provide.
Nothing in the docs said so, which left the empty listing looking like a bug.

`docs/mcp-registry.md` gains two sections:

- **Downstream propagation**, rewritten as a table of what each directory
  actually accepts, verified by walking each flow on 2026-07-29. Notably PulseMCP
  has **no** submission form for servers: the "MCP Server" branch of their submit
  page only points at the official registry, and the URL field belongs to the MCP
  *Client* branch.
- **Sandboxed directories and the empty tool list**, which explains the three
  consequences (no daemon means no tools, stdio needs the `mcp-proxy --` wrapper,
  and a green sandbox run would prove nothing about a real host), and states the
  inverse rule plainly: do not relax the daemon boundary to score better.

`docs/mcp.md` and the README distribution table now point at that section, so the
reader who arrived from a zero-tool listing lands on the explanation.

## Also fixed

`docs/mcp-registry.md` was an orphan: not in `docs/SUMMARY.md`, so none of it was
reaching the published book. It is now listed under Getting Started.

Eight other public docs are still orphaned from `SUMMARY.md`
(`ubuntu-action-gap-analysis.md`, `user-stories.md`, `testing/user-stories.md`,
`demo/demo-script.md`, `research/prompt-composition-patterns.md`,
`security/red-team-2026-04-26.md`, `contributing/ubuntu-vm-testing.md`). Left
alone here to keep this PR to one concern.

## Verification

- `mdbook build` clean; `book/mcp-registry.html` renders and carries the
  `#sandboxed-directories-and-the-empty-tool-list` anchor the other two pages link to
- `cargo nextest run --workspace --locked` — 1534 passed, 0 failed
- Docs-only: no code, config, or workflow touched

## Out of scope

`apps/sysknife-shell` (frozen GUI).