### PR TITLE
Add the Smithery manifest, in the only shape that can work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check MCP Registry manifest coherence
         run: bash tests/release/registry-manifest.test.sh
 
+      - name: Check Smithery manifest coherence
+        run: bash tests/release/smithery-manifest.test.sh
+
       - name: Check release rehearsal contract
         run: bash tests/release/release-rehearsal.test.sh
 

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -131,7 +131,7 @@ separate submission. Verified by walking each flow on 2026-07-29:
 | **PulseMCP** | No submission form exists for servers. Choosing "MCP Server" on `pulsemcp.com/submit` returns instructions only: they ingest the official registry daily and process weekly. The URL field on that page belongs to the *MCP Client* branch. Email `hello@pulsemcp.com` only if a week has passed since the registry publish without a listing. |
 | **mcpservers.org** | Web form: server name, one-sentence description, link, category, contact email. Free tier with a review pass; a paid tier only buys queue position. |
 | **Glama** | Browser-only build spec at `glama.ai/mcp/servers/lacs-project/sysknife/admin/dockerfile`. Keep the `mcp-proxy --` prefix in the CMD arguments: that wrapper is how Glama exposes a stdio server. |
-| **Smithery** | Needs a `smithery.yaml` in the repository declaring a stdio `commandFunction`, alongside the existing `glama.json`. |
+| **Smithery** | `smithery.yaml` is in the repository root, declaring the **stdio** form: their CLI spawns `sysknife mcp-server` on the user's own machine, where a daemon can actually exist. Their two *hosted* runtimes (`typescript`, `container`) require Streamable HTTP and would run a daemonless sandbox, so they are the wrong shape here, and `tests/release/smithery-manifest.test.sh` fails the build if someone switches to one. The user still needs the `sysknife` binary installed first; Smithery spawns it, it does not install it. |
 | **mcp.so, LobeHub** | Separate submissions; both reject automated fetches, so use a real browser. |
 
 ## Sandboxed directories and the empty tool list

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -270,6 +270,7 @@ run_hygiene_group() {
     run_step 'hygiene: public-claims.test.sh' bash "$repo_root/tests/release/public-claims.test.sh"
     run_step 'hygiene: npm test --prefix packages/setup' npm test --prefix "$repo_root/packages/setup"
     run_step 'hygiene: registry-manifest.test.sh' bash "$repo_root/tests/release/registry-manifest.test.sh"
+    run_step 'hygiene: smithery-manifest.test.sh' bash "$repo_root/tests/release/smithery-manifest.test.sh"
     run_step 'hygiene: release-rehearsal.test.sh' bash "$repo_root/tests/release/release-rehearsal.test.sh"
     run_step 'hygiene: ubuntu-vm-bootstrap.test.sh' bash "$repo_root/tests/e2e/ubuntu-vm-bootstrap.test.sh"
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,37 @@
+# Smithery manifest: https://smithery.ai/docs
+#
+# stdio on purpose, not one of Smithery's hosted runtimes.
+#
+# `sysknife mcp-server` is the unprivileged half of SysKnife. It plans, previews
+# and forwards; it cannot change anything. Every mutation travels over a local
+# unix socket to sysknife-daemon, which holds the privileged policy. A hosted
+# container has no daemon and no host worth administering, so it would boot and
+# report zero tools. Spawning the server on the user's own machine is the only
+# shape that yields a working server.
+#
+# Prerequisite for the user: the `sysknife` binary must already be installed and
+# on PATH (`npx sysknife-setup` is the shortest route, `cargo install
+# sysknife-cli` the other). Smithery spawns the binary; it does not install it.
+#
+# See docs/mcp-registry.md for why directory listings show an empty tool list,
+# and tests/release/smithery-manifest.test.sh for the guard that keeps the
+# command below in step with the CLI.
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      socket:
+        type: string
+        description: >-
+          Where the privileged daemon listens: a unix:// path, a vsock:// target,
+          or a bare path. Leave empty to use wherever the daemon bound, which is
+          correct for a default install.
+    required: []
+  commandFunction: |-
+    (config) => ({
+      command: 'sysknife',
+      args: ['mcp-server'],
+      env: config.socket ? { SYSKNIFE_SOCKET: config.socket } : {}
+    })
+  exampleConfig: {}

--- a/tests/release/smithery-manifest.test.sh
+++ b/tests/release/smithery-manifest.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Guards smithery.yaml -- the manifest Smithery reads to run SysKnife's MCP
+# server on a user's own machine -- against the ways it can silently rot.
+#
+# Smithery has two deployment runtimes, and only one of them can work here:
+#
+#   runtime: typescript / container  ->  Smithery HOSTS the server in its cloud
+#                                        and requires Streamable HTTP.
+#   startCommand.type: stdio         ->  Smithery's CLI SPAWNS the server on the
+#                                        user's machine over stdio.
+#
+# SysKnife must use the stdio form. The MCP server is the unprivileged half of
+# the system; it has nothing to offer until it can reach sysknife-daemon over a
+# local unix socket, which a hosted container cannot provide. Running locally is
+# not a limitation of the listing, it is the only shape that produces a working
+# server. See docs/mcp-registry.md.
+#
+# Three failure modes are asserted:
+#
+# 1. Wrong runtime. Someone "modernises" the file to runtime: container, and the
+#    listing starts booting a daemonless sandbox that reports zero tools.
+# 2. Command drift. The CLI subcommand is renamed and the manifest keeps naming
+#    the old one, so every install fails at spawn.
+# 3. A placeholder credential in configSchema. A tracked manifest carrying a
+#    fake API key is how a real one eventually gets committed; SysKnife reads
+#    provider credentials from the environment instead.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+manifest="$repo_root/smithery.yaml"
+cli_source="$repo_root/apps/sysknife-cli/src/cli.rs"
+
+fail() {
+    printf 'smithery-manifest: %s\n' "$1" >&2
+    exit 1
+}
+
+[[ -f "$manifest" ]] || fail 'smithery.yaml is missing from the repository root'
+[[ -f "$cli_source" ]] || fail "cannot read $cli_source to cross-check the subcommand"
+
+# yq is not a repo dependency, so read the two scalars with grep rather than a
+# YAML parser. Both live at a known depth and the guard below rejects anything
+# that would make the shape ambiguous.
+if grep -qE '^[[:space:]]*runtime:' "$manifest"; then
+    fail 'smithery.yaml declares a runtime; hosted runtimes need Streamable HTTP and a daemonless container cannot serve SysKnife'
+fi
+
+start_type="$(grep -A2 '^startCommand:' "$manifest" | grep -oP '^\s*type:\s*"?\K[a-z]+' | head -1)"
+[[ "$start_type" == "stdio" ]] \
+    || fail "startCommand.type is '${start_type:-<missing>}', expected stdio"
+
+grep -q 'commandFunction:' "$manifest" \
+    || fail 'startCommand.commandFunction is missing; Smithery has no way to spawn the server'
+
+# The spawned command must be the real binary and the real subcommand.
+grep -q "command: *'sysknife'" "$manifest" \
+    || fail "commandFunction does not spawn the 'sysknife' binary"
+
+subcommand="$(grep -oP "args: *\[ *'\K[a-z-]+" "$manifest" | head -1)"
+[[ -n "$subcommand" ]] || fail 'commandFunction passes no subcommand'
+
+# Cross-check against the CLI itself: #[command(name = "mcp-server")] is the
+# single source of truth for what the binary answers to.
+grep -q "#\[command(name = \"${subcommand}\")\]" "$cli_source" \
+    || fail "commandFunction runs 'sysknife ${subcommand}', which is not a subcommand declared in apps/sysknife-cli/src/cli.rs"
+
+# No placeholder credentials. Provider keys come from the environment.
+if grep -qiE '(api_?key|token|secret|password)' "$manifest"; then
+    fail 'smithery.yaml mentions a credential field; SysKnife reads provider keys from the environment, and a placeholder key in a tracked file is how a real one gets committed'
+fi
+
+printf 'smithery-manifest: OK\n'


### PR DESCRIPTION
## What

Smithery can carry SysKnife two ways, and only one of them produces a working
server:

| Form | What Smithery does | Fit |
|---|---|---|
| `runtime: typescript` / `runtime: container` | hosts the server in Smithery's cloud, requires Streamable HTTP | **wrong**: a hosted container has no `sysknife-daemon` and no host worth administering, so it boots and reports zero tools |
| `startCommand.type: stdio` | their CLI spawns the binary on the user's own machine | **right**: that is where a privileged daemon can exist |

So `smithery.yaml` declares the stdio form, spawning `sysknife mcp-server` with
an optional `socket` config value mapped to `SYSKNIFE_SOCKET`. It carries no
credential fields: provider keys come from the environment, and a placeholder key
in a tracked manifest is how a real one eventually gets committed.

## Guard, written first

`tests/release/smithery-manifest.test.sh` covers the three ways this file rots.
Each assertion was proven to fail before the manifest existed:

| Mutation | Caught |
|---|---|
| `runtime: container` added | yes |
| `startCommand.type: http` | yes |
| subcommand renamed to `mcp-serve` | yes (cross-checked against `#[command(name = "mcp-server")]` in `apps/sysknife-cli/src/cli.rs`) |
| `apiKey` added to `configSchema` | yes |

Wired into `ci.yml` and `scripts/ci-local.sh`, but deliberately **not** into
`release.yml`: unlike `server.json`, nothing publishes this file during a release,
so it is a hygiene check rather than a release gate.

## Verification

- `bash tests/release/smithery-manifest.test.sh` → `OK`; all four mutations rejected
- `cargo nextest run --workspace --locked` — 1534 passed, 0 failed
- `yamllint .github/workflows/ci.yml` clean; `smithery.yaml` parses under `yaml.safe_load`

## Follow-up, not automatable

Claiming the listing at smithery.ai is a GitHub sign-in in a browser. Their deploy
view will show few or no tools for the reason documented in #129.

## Out of scope

`apps/sysknife-shell` (frozen GUI).