### PR TITLE
audit verify must say which machine's chain it read

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,534 Rust tests and 72 frontend tests** form the current deterministic
+**1,539 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -316,6 +316,10 @@ pub struct AuditVerifyReport {
     /// Backend label: a filesystem path for SQLite, the literal `"postgres"`
     /// for Postgres deployments.
     pub backend: String,
+    /// Set when `SYSKNIFE_SOCKET` names a daemon that may not live on this
+    /// machine, because verification reads a local store while every other tool
+    /// travels over that socket. `None` for the local-daemon case.
+    pub daemon_socket_caveat: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -901,6 +905,20 @@ async fn audit_chain_quick_check(
 // ---------------------------------------------------------------------------
 
 async fn audit_verify_inner() -> AuditVerifyReport {
+    // Every path through the verifier, including the early cannot_verify
+    // returns, has to carry the caveat, so it is attached once here rather than
+    // at each return site.
+    with_socket_caveat(
+        audit_verify_local_store().await,
+        crate::runner::remote_daemon_caveat_from_env(),
+    )
+}
+
+/// Verify the chain in the store on **this** machine.
+///
+/// Named for what it actually does: this is a filesystem operation, not a daemon
+/// request, so it says nothing about the host `SYSKNIFE_SOCKET` points at.
+async fn audit_verify_local_store() -> AuditVerifyReport {
     use sysknife_daemon::audit_chain::AuditKey;
 
     let lacs_config = sysknife_core::config::LacsConfig::load();
@@ -994,6 +1012,7 @@ fn outcome_to_report(
             events_checked,
             approval_events_status,
             binding_status,
+            daemon_socket_caveat: None,
         },
         VerifyOutcome::Broken {
             rows_checked,
@@ -1013,6 +1032,7 @@ fn outcome_to_report(
             events_checked,
             approval_events_status,
             binding_status,
+            daemon_socket_caveat: None,
         },
         VerifyOutcome::CannotVerify { reason } => {
             let mut r = cannot_verify_report(backend, reason);
@@ -1036,6 +1056,16 @@ fn outcome_to_report(
     report
 }
 
+/// Attach the "which machine did this verify" caveat to a finished report.
+///
+/// Kept separate from report construction so the three construction sites stay
+/// free of environment reads and the composition is unit-testable without
+/// mutating process env, which parallel tests share.
+fn with_socket_caveat(mut report: AuditVerifyReport, caveat: Option<String>) -> AuditVerifyReport {
+    report.daemon_socket_caveat = caveat;
+    report
+}
+
 fn cannot_verify_report(backend: String, reason: String) -> AuditVerifyReport {
     AuditVerifyReport {
         status: "cannot_verify".to_string(),
@@ -1049,6 +1079,7 @@ fn cannot_verify_report(backend: String, reason: String) -> AuditVerifyReport {
         events_checked: 0,
         approval_events_status: "cannot_verify".to_string(),
         binding_status: "consistent".to_string(),
+        daemon_socket_caveat: None,
     }
 }
 
@@ -1077,6 +1108,47 @@ pub async fn run_mcp_server() -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // An agent must be told when the verdict is about a different machine
+    // -----------------------------------------------------------------------
+
+    /// The agent calling `sysknife_audit_verify` has less context than a human
+    /// at a terminal: it cannot see that `SYSKNIFE_SOCKET` points into a VM or
+    /// down an SSH tunnel. If the report says `intact` and carries nothing else,
+    /// the agent will tell the operator their audit trail is fine, having read a
+    /// chain on the wrong host. The caveat has to travel in the structured
+    /// output, not only in the CLI's human text.
+    #[test]
+    fn the_report_carries_the_which_machine_caveat() {
+        let report = with_socket_caveat(
+            cannot_verify_report("/tmp/store.sqlite".into(), "no key".into()),
+            Some("NOTE: SYSKNIFE_SOCKET is /tmp/sysknife-web01.sock".into()),
+        );
+
+        let caveat = report
+            .daemon_socket_caveat
+            .as_deref()
+            .expect("the caveat must survive onto the report");
+        assert!(caveat.contains("/tmp/sysknife-web01.sock"));
+
+        let json = serde_json::to_value(&report).expect("report serializes");
+        assert!(
+            json.get("daemon_socket_caveat").is_some(),
+            "and must be visible in the tool's JSON output, got: {json}"
+        );
+    }
+
+    /// The local case stays clean: no socket override, no field content, so the
+    /// common path does not train agents to skip the note.
+    #[test]
+    fn a_local_daemon_leaves_the_caveat_empty() {
+        let report = with_socket_caveat(
+            cannot_verify_report("/tmp/store.sqlite".into(), "no key".into()),
+            None,
+        );
+        assert!(report.daemon_socket_caveat.is_none());
+    }
 
     // -----------------------------------------------------------------------
     // The plan an agent sees carries the daemon's authoritative preview

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -92,6 +92,60 @@ fn anchor_configured() -> bool {
     std::env::var("SYSKNIFE_CHECKPOINT_DB").is_ok_and(|v| !v.trim().is_empty())
 }
 
+/// `remote_daemon_caveat` applied to the process environment.
+///
+/// Mirrors how [`anchor_configured`] reads its own variable rather than taking it
+/// as an argument, so the caveat cannot drift from the socket the client actually
+/// used. An unparseable value yields no caveat: `resolve_socket_target` already
+/// exits with a clear message before verification runs.
+pub(crate) fn remote_daemon_caveat_from_env() -> Option<String> {
+    let raw = std::env::var("SYSKNIFE_SOCKET").ok()?;
+    let target = crate::client::SocketTarget::try_from_str(&raw).ok()?;
+    remote_daemon_caveat(Some(&raw), &target)
+}
+
+/// The caveat that belongs next to a verification verdict when the daemon being
+/// administered may not be the machine whose chain was just read.
+///
+/// SysKnife has two data paths and they do not go to the same place. `plan`,
+/// `execute`, `history` and `doctor` travel over `SYSKNIFE_SOCKET`, which the
+/// documented topologies point at another host: an SSH-forwarded Unix socket, or
+/// a vsock target in a VM. Verification is not a daemon request at all; it opens
+/// a store on the local filesystem (see [`sysknife_core::resolve_audit_store`]).
+///
+/// So an operator who tunnels to `web01`, executes there, then runs `audit
+/// verify` reads their **own** machine's store. If that store exists, which it
+/// does on any laptop that ever ran a user-mode daemon, the verdict is `Intact`
+/// for a chain that has nothing to do with the actions just taken. Silence there
+/// would turn the product's central claim into a false reassurance.
+///
+/// `socket_env` is the raw `SYSKNIFE_SOCKET` value, or `None` when unset. Unset
+/// means the local default, which is the common case and stays quiet: a caveat
+/// printed on every run is a caveat nobody reads.
+fn remote_daemon_caveat(
+    socket_env: Option<&str>,
+    target: &crate::client::SocketTarget,
+) -> Option<String> {
+    let raw = socket_env?;
+
+    #[cfg(target_os = "linux")]
+    if matches!(target, crate::client::SocketTarget::Vsock { .. }) {
+        return Some(format!(
+            "NOTE: SYSKNIFE_SOCKET is {raw}, so the daemon runs in a VM while this \
+             verification read a store on this machine. The chain lives where the daemon \
+             wrote it. Verify inside the VM, or copy its database and exported public key \
+             out and re-run with --pubkey <FILE>."
+        ));
+    }
+
+    Some(format!(
+        "NOTE: SYSKNIFE_SOCKET is {raw}. If that socket is forwarded from another host \
+         (for example `ssh -L`), the actions you took ran there while this verification \
+         read a store on this machine. Verify on the host that owns the daemon, or copy \
+         its database and exported public key out and re-run with --pubkey <FILE>."
+    ))
+}
+
 /// The caveat that belongs next to a verification verdict when no independent
 /// checkpoint anchor is configured.
 ///
@@ -900,6 +954,7 @@ fn emit_verification(
             } else {
                 json!({"configured": false, "caveat": anchor_caveat(false)})
             },
+            "daemon_socket_caveat": remote_daemon_caveat_from_env(),
             "binding": match &verification.binding {
                 BindingOutcome::Consistent { bindings_checked } => json!({
                     "status": "consistent",
@@ -943,8 +998,13 @@ fn emit_verification(
         }
     }
 
-    // Sits directly under the chain verdict, because that verdict is what an
-    // operator reads as "the audit log is fine".
+    // Both caveats sit directly under the chain verdict, because that verdict is
+    // what an operator reads as "the audit log is fine". Which machine was read
+    // comes first: an Intact verdict for the wrong host misleads more than an
+    // unanchored one does.
+    if let Some(caveat) = remote_daemon_caveat_from_env() {
+        log.println(&caveat);
+    }
     if let Some(caveat) = anchor_caveat(anchor_configured()) {
         log.println(caveat);
     }
@@ -1511,6 +1571,71 @@ async fn prompt_exact(msg: &str, expected: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // Which machine's chain was verified
+    // -----------------------------------------------------------------------
+
+    /// The control plane and the verifier read different things: `plan`,
+    /// `execute`, `history` and `doctor` all travel to `SYSKNIFE_SOCKET`, while
+    /// verification opens a store on the local filesystem. In the SSH-tunnel
+    /// and vsock topologies the docs recommend, those are two different
+    /// machines, and a laptop that ever ran a user-mode daemon has a local
+    /// chain that verifies happily. "Intact" for the wrong host is the one
+    /// failure this command must never produce silently.
+    #[test]
+    fn a_forwarded_socket_makes_the_verifier_name_the_machine_it_read() {
+        let caveat = remote_daemon_caveat(
+            Some("/tmp/sysknife-web01.sock"),
+            &crate::client::SocketTarget::Unix("/tmp/sysknife-web01.sock".into()),
+        )
+        .expect("an explicitly configured socket must produce a caveat");
+
+        assert!(
+            caveat.contains("/tmp/sysknife-web01.sock"),
+            "the caveat must name the daemon socket in play, got: {caveat}"
+        );
+        assert!(
+            caveat.to_lowercase().contains("this machine"),
+            "and say the store just read is local, got: {caveat}"
+        );
+    }
+
+    /// vsock is unambiguous: the daemon is in another kernel, so the chain
+    /// cannot be on this filesystem. The wording should not hedge.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_vsock_daemon_caveat_says_the_chain_lives_in_the_vm() {
+        let caveat = remote_daemon_caveat(
+            Some("vsock://3:9734"),
+            &crate::client::SocketTarget::Vsock { cid: 3, port: 9734 },
+        )
+        .expect("a vsock target is always another host");
+
+        let lower = caveat.to_lowercase();
+        assert!(
+            lower.contains("vm") || lower.contains("another host"),
+            "name where the chain actually is, got: {caveat}"
+        );
+        assert!(
+            caveat.contains("--pubkey"),
+            "and point at the auditor path that works across machines, got: {caveat}"
+        );
+    }
+
+    /// No env var means the daemon is this machine's own, which is the common
+    /// case. Emitting the caveat there would train operators to ignore it.
+    #[test]
+    fn the_default_socket_produces_no_caveat() {
+        assert!(
+            remote_daemon_caveat(
+                None,
+                &crate::client::SocketTarget::Unix("/run/sysknife/daemon.sock".into())
+            )
+            .is_none(),
+            "an unset SYSKNIFE_SOCKET is the local daemon; stay quiet"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // Audit-integrity caveat

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,534 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,539 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -138,7 +138,7 @@ flow.
 
 ## Status
 
-189 typed actions · 1,534 Rust tests + 72 frontend tests · MIT
+189 typed actions · 1,539 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -211,6 +211,56 @@ Full chain, third-party path:
 sysknife audit verify --pubkey audit-key.pub
 ```
 
+### Verification is host-local, and that matters over a tunnel
+
+`plan`, `execute`, `history` and `doctor` are daemon requests: they travel over
+`SYSKNIFE_SOCKET`, which in the [VM and remote topologies](vm-daemon-setup.md)
+points at another machine. **Verification is not a daemon request.** It opens the
+transaction store on the filesystem of the machine you run it on.
+
+So this sequence does not do what it looks like:
+
+```sh
+ssh -fN -L /tmp/sysknife-web01.sock:/run/sysknife/daemon.sock admin@web01
+SYSKNIFE_SOCKET=/tmp/sysknife-web01.sock sysknife "install ripgrep"   # runs on web01
+sysknife audit verify                                                 # reads THIS machine
+```
+
+The verdict describes your own laptop's chain. If a local store exists, which it
+does on any machine that has ever run a user-mode daemon, the answer is a
+confident `OK` about actions that happened somewhere else.
+
+The command now says so whenever `SYSKNIFE_SOCKET` is set:
+
+```text
+OK: 128 row(s) verified in /home/you/.local/state/sysknife/daemon.sqlite
+NOTE: SYSKNIFE_SOCKET is /tmp/sysknife-web01.sock. If that socket is forwarded
+from another host (for example `ssh -L`), the actions you took ran there while
+this verification read a store on this machine. Verify on the host that owns the
+daemon, or copy its database and exported public key out and re-run with
+--pubkey <FILE>.
+```
+
+The same string travels in `--json` output as `daemon_socket_caveat`, and on the
+`sysknife_audit_verify` MCP tool's report under the same name, so an agent cannot
+report a clean trail for the wrong host either.
+
+Two correct ways to verify a remote host:
+
+```sh
+# On the host that owns the daemon
+ssh admin@web01 'sudo sysknife audit verify'
+
+# Or pull the evidence to an auditor's machine: the store plus the public key,
+# never the private key
+scp admin@web01:/var/lib/sysknife/daemon.sqlite  ./web01.sqlite
+scp admin@web01:/var/lib/sysknife/audit-key.pub ./web01.pub
+SYSKNIFE_DATABASE_PATH=./web01.sqlite sysknife audit verify --pubkey ./web01.pub
+```
+
+The second form is the auditor path the public key exists for: it proves the
+chain without granting daemon access or signing ability.
+
 Machine-readable output for CI or a SIEM pipeline:
 
 ```sh

--- a/docs/vm-daemon-setup.md
+++ b/docs/vm-daemon-setup.md
@@ -75,6 +75,85 @@ ssh -fN \
 > remote command. The local socket `/tmp/sysknife-vm.sock` is created on the
 > host and forwards transparently to the daemon inside the guest.
 
+Three flags worth adding once you rely on this:
+
+```sh
+ssh -fN \
+  -o ExitOnForwardFailure=yes \
+  -o StreamLocalBindUnlink=yes \
+  -o ServerAliveInterval=30 \
+  -L /tmp/sysknife-vm.sock:/run/sysknife/daemon.sock <user>@<host>
+```
+
+- `ExitOnForwardFailure=yes` makes SSH fail loudly instead of forking a session
+  whose forward never came up, which otherwise looks like a dead daemon.
+- `StreamLocalBindUnlink=yes` removes a stale local socket file. Without it, a
+  second tunnel after an unclean exit fails with "cannot bind".
+- `ServerAliveInterval=30` keeps a long planning session from being dropped by an
+  idle NAT or firewall.
+
+### Who you are over a tunnel
+
+Authorization is **not** carried by the tunnel. The daemon reads the connecting
+peer's credentials with `SO_PEERCRED` and resolves that peer's group membership
+(`resolve_caller_role` in `crates/sysknife-daemon/src/dispatcher.rs`). Over a
+forwarded socket the connecting peer is the `sshd` process on the remote side,
+running as the SSH user, so:
+
+- The role comes from the **remote** user's groups: `sysknife-observer`,
+  `sysknife-dev`, `sysknife-admin`, or `wheel`.
+- That user must also be in the `sysknife` group, because `/run/sysknife` is
+  `0750 sysknife:sysknife`. Without it every request is refused before any role
+  check runs.
+- Your local groups are irrelevant. Being `wheel` on your laptop grants nothing
+  on the remote host.
+
+```sh
+# On the remote host, for the account you SSH in as
+sudo usermod -aG sysknife,sysknife-admin <user>
+# then log out and back in: group membership only applies to a new session
+```
+
+This is why SysKnife tunnels a Unix socket rather than exposing an HTTP
+listener. SSH supplies authentication, the socket supplies authorization, and
+peer credentials cannot be spoofed by whoever reaches the port. See
+[Registry and Directory Listings](mcp-registry.md#sandboxed-directories-and-the-empty-tool-list) for the
+matching decision about network-exposed listings.
+
+### More than one host
+
+Give each host its own local socket and its own MCP server entry. Nothing is
+shared between them, so there is no state to switch:
+
+```sh
+ssh -fN -o ExitOnForwardFailure=yes -o StreamLocalBindUnlink=yes \
+  -L /tmp/sysknife-web01.sock:/run/sysknife/daemon.sock admin@web01
+ssh -fN -o ExitOnForwardFailure=yes -o StreamLocalBindUnlink=yes \
+  -L /tmp/sysknife-db01.sock:/run/sysknife/daemon.sock  admin@db01
+```
+
+```json
+{
+  "mcpServers": {
+    "sysknife-web01": {
+      "command": "sysknife",
+      "args": ["mcp-server"],
+      "env": { "SYSKNIFE_SOCKET": "/tmp/sysknife-web01.sock" }
+    },
+    "sysknife-db01": {
+      "command": "sysknife",
+      "args": ["mcp-server"],
+      "env": { "SYSKNIFE_SOCKET": "/tmp/sysknife-db01.sock" }
+    }
+  }
+}
+```
+
+Each host keeps its own audit chain, on that host. `sysknife audit verify` reads
+the store on the machine you run it on, never through the socket, so verify on
+the host itself or pull its database and public key to an auditor's machine. See
+[Verification is host-local](the-audit-chain.md#verification-is-host-local-and-that-matters-over-a-tunnel).
+
 ### Configure and connect (SSH tunnel)
 
 Run the setup wizard on the host and choose the integration you want:

--- a/scripts/check_public_claims.sh
+++ b/scripts/check_public_claims.sh
@@ -38,8 +38,8 @@ reject_pattern() {
 # with one command. Quoting a subset (e.g. excluding the GUI crate) makes the
 # number unverifiable from the documented command, which is how it silently
 # came to mean two different things.
-reject_pattern '1,(2[0-9][0-9]|3[0-9][0-9]|4[0-9][0-9]|5[0-2][0-9]|53[0-3])( Rust)? tests' \
-    'test count is stale; the release baseline is 1,534 Rust tests' \
+reject_pattern '1,(2[0-9][0-9]|3[0-9][0-9]|4[0-9][0-9]|5[0-2][0-9]|53[0-8])( Rust)? tests' \
+    'test count is stale; the release baseline is 1,539 Rust tests' \
     "${claim_files[@]}"
 reject_pattern 'until npm publish lands|publish[- ]pending' \
     'setup package is documented as unpublished' "${claim_files[@]}"
@@ -69,8 +69,8 @@ required_test_count_docs=(
     "$repo_root/docs/distro-support.md"
 )
 for path in "${required_test_count_docs[@]}"; do
-    if ! grep -Fq '1,534 Rust tests' "$path"; then
-        printf 'Verified test baseline missing from %s: expected 1,534 Rust tests\n' \
+    if ! grep -Fq '1,539 Rust tests' "$path"; then
+        printf 'Verified test baseline missing from %s: expected 1,539 Rust tests\n' \
             "$path" >&2
         exit 1
     fi


### PR DESCRIPTION
## The defect

SysKnife has two data paths and they do not lead to the same machine:

| Surface | Where it goes |
|---|---|
| `sysknife_plan`, `sysknife_execute`, `sysknife_history`, `sysknife_doctor` | over `SYSKNIFE_SOCKET`, i.e. possibly a remote host |
| `sysknife audit verify`, `sysknife_audit_verify` | `default_database_path()` / `resolve_audit_store()` on the **local** filesystem |

Nothing said so, and the docs themselves recommend topologies where those differ
(`docs/vm-daemon-setup.md` SSH tunnel, vsock). The resulting sequence looks right
and is not:

```sh
ssh -fN -L /tmp/sysknife-web01.sock:/run/sysknife/daemon.sock admin@web01
SYSKNIFE_SOCKET=/tmp/sysknife-web01.sock sysknife "install ripgrep"   # runs on web01
sysknife audit verify                                                 # reads THIS machine
```

Any laptop that has ever run a user-mode daemon has a local store, so the answer
is a confident `OK` about a chain unrelated to the actions just taken. For a
project whose headline is "every action signed, anyone can verify", a clean
verdict for the wrong host is the worst available failure mode.

To be precise about what was *not* wrong: both verify paths pre-check the key
file, so neither mints a key, and `--pubkey` behaves correctly. The defect is
solely that the machine identity was never surfaced.

## The fix

`remote_daemon_caveat` (pure, unit-tested) produces the note; it fires only when
`SYSKNIFE_SOCKET` is explicitly set, because a caveat on every run is a caveat
nobody reads. vsock gets stronger wording since another kernel is unambiguous.

- CLI prints it directly under the chain verdict, above the anchor caveat, and
  emits it in `--json` as `daemon_socket_caveat`
- `AuditVerifyReport` gains the same field, attached once via `with_socket_caveat`
  so all early `cannot_verify` returns carry it too. An agent gets the caveat in
  structured output, since it cannot see the operator's env.

## Docs: what was actually missing

I assumed the SSH tunnel was undocumented. It was not, `docs/vm-daemon-setup.md`
§2a has covered it all along. The real gaps, now filled:

- **Who you are over a tunnel.** Authorization comes from `SO_PEERCRED` on the
  connecting peer, which over a forwarded socket is the remote `sshd` process, so
  the role derives from the **remote** user's groups and that user must also be in
  `sysknife` to open a `0750` socket at all. Local group membership is irrelevant.
- **Verification is host-local**, with the two correct ways to verify a remote
  host (run it there, or pull the DB plus public key and use `--pubkey`).
- **More than one host**: a socket and an MCP entry per host.
- Tunnel flags that prevent silent failure: `ExitOnForwardFailure`,
  `StreamLocalBindUnlink`, `ServerAliveInterval`.

## Verification

- New tests written first and observed failing (`cannot find function
  remote_daemon_caveat`): forwarded socket names the machine, vsock names the VM
  and points at `--pubkey`, default socket stays silent, report carries the field,
  local case leaves it empty
- Behavioural proof against a real on-disk chain: with `SYSKNIFE_SOCKET` unset the
  output has no caveat; with `SYSKNIFE_SOCKET=/tmp/sysknife-web01.sock` the caveat
  appears immediately under the `OK` line
- `cargo nextest run --workspace --locked` — 1539 passed, 0 failed
- `mdbook build` clean; both new cross-links verified against the built HTML
  anchors (one was wrong on first write and fixed)
- Published test baseline moved 1,534 → 1,539 in `README.md`,
  `docs/introduction.md`, `docs/distro-support.md` and
  `scripts/check_public_claims.sh` (reject range extended to `53[0-8]`), so the
  documented command still matches the documented number.
  `check_public_claims.sh` and `public-claims.test.sh` both pass.

## Out of scope

`apps/sysknife-shell` (frozen GUI). Routing verification through the daemon so it
can verify the host it runs on would be a protocol change; the caveat is the
honest fix until then.