### PR TITLE
Sign which account acted, not just which role (chain_version = 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,11 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Clippy
-        run: cargo clippy --workspace --all-features --locked -- -D warnings
+        # --all-targets so #[cfg(test)] code is linted too. Without it a
+        # duplicated #[test] attribute (which silently drops the test it was
+        # meant for) and dead test helpers both pass CI: rustc emits warnings
+        # that this job never compiles.
+        run: cargo clippy --workspace --all-features --all-targets --locked -- -D warnings
 
       - name: Doc check (broken intra-doc links)
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [0.3.0] — unreleased
+
+The signed audit chain now records **which account** acted, not only which role.
+Schema version 3, with a real migration and no rewrite of existing rows.
+
+### Added
+
+- **`chain_version = 3` signs a caller principal.** A row bound to a
+  `CallerRole` could not separate two members of `sysknife-admin`, so the trail
+  answered "an Admin did this" and stopped one question short of where an
+  investigation starts. Rows now also sign `caller_principal`, resolved by the
+  daemon from the same `SO_PEERCRED` read that yields the role and never taken
+  from the request body. Three forms, with the scheme signed alongside the value
+  because the evidence differs in strength: `uid:<n>` attested by the kernel,
+  `token:vsock` for a pre-shared secret that proves possession of a file rather
+  than an account, and `none:unattributed` when the daemon could establish
+  neither.
+- **The principal reaches the SIEM.** Forwarded RFC 5424 events carry a
+  `principal` structured-data field, taken from the signed row rather than from
+  connection state, so an external monitor sees what the chain committed to.
+- **`sysknife audit verify` reports `unattributed_rows`.** A chain of rows that
+  name nobody verifies as intact, which is true and incomplete; the count is now
+  reported next to the verdict, in `--json`, and on the `sysknife_audit_verify`
+  MCP tool.
+- Golden on-disk vectors for all three encodings, plus one row exercising the
+  escape table, an absent approval id and a non-empty predecessor hash. These
+  are the only tests that can notice an encoding drifting, because every other
+  test signs and verifies in one process.
+
+### Changed
+
+- **Existing audit logs keep verifying.** v1, v2 and v3 rows coexist in one
+  chain and each is re-encoded exactly as it was signed. Migration 3 adds a
+  nullable column in both backends and backfills nothing: writing a principal
+  into a row signed without one would change its message and report the chain as
+  broken.
+- `CallerAttribution` replaces a bare `CallerRole` through the dispatcher, with
+  private fields and per-transport constructors, so an attribution failure can
+  no longer be paired with a privileged role.
+- CI lints test targets (`cargo clippy --all-targets`). Without it a duplicated
+  `#[test]` attribute, which silently drops the test it was meant for, passed
+  every check.
+
+### Fixed
+
+- **A version-aliasing hazard that would have broken every existing audit log.**
+  The v2 encoder signed `CHAIN_VERSION_CURRENT` and version dispatch compared
+  against the same constant, so the next encoding bump would have re-encoded
+  every stored v2 row and reported healthy chains as unverifiable — while the
+  unit suite stayed green, because in-memory tests sign and verify under one
+  constant. Each generation now signs and dispatches on its own stable literal,
+  and the stored `chain_version` is derived from the identity that was signed.
+- **A peer outside the daemon's namespaces was signed as a real account.** The
+  kernel substitutes the overflow uid (`nobody`) rather than failing when a
+  peer's uid is not mappable, and reports pid 0 when the pid is not
+  representable. Both were recorded as kernel-attested accounts; both now record
+  an attribution failure.
+- The missing-field break message named the newest encoding rather than the one
+  the row declares, and reported an empty column as `NULL`.
+
 ## [0.2.16] — 2026-07-28
 
 A whole-repository review pass (four independent read-only reviewers, one per

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,548 Rust tests and 72 frontend tests** form the current deterministic
+**1,561 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,539 Rust tests and 72 frontend tests** form the current deterministic
+**1,548 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -105,7 +105,7 @@ part of the signed value so an auditor can tell them apart:
 |---|---|
 | `uid:<n>` | Unix-socket peer, uid attested by the kernel at `connect()` |
 | `token:vsock` | vsock peer authenticated by the pre-shared token: possession of a file, not an account |
-| `unattributed` | `SO_PEERCRED` yielded no usable peer; the connection is handled at `Observer` and the row admits attribution failed rather than inventing a uid |
+| `none:unattributed` | The daemon could not establish an account: `SO_PEERCRED` failed, returned no usable pid, or reported the overflow uid because the peer is not representable in this daemon's namespaces. The connection is handled at `Observer` and the row admits attribution failed rather than naming `nobody` |
 
 ### Layer 4 — One-time approval receipt (sysknife-daemon)
 
@@ -337,3 +337,4 @@ security certification work.
 | Action param validation | — | Action params are typed per-handler but not validated at a shared schema boundary. A compromised LLM could propose valid action + malicious params (e.g. `AddAuthorizedKey` with an attacker-controlled key). |
 | UDP audit forwarding | — | External RFC 5424 forwarding is best effort and provides no delivery acknowledgement. Use the transaction database and tested backups as the durable record. |
 | Caller attribution strength | — | Rows written under `chain_version = 3` name the account (`uid:<n>`), but a uid is only as meaningful as account hygiene on the host: shared logins, `su` into a service account, or a uid reused after a user is deleted all weaken the claim. vsock callers are recorded as `token:vsock` because a pre-shared secret proves possession of a file, not a person. Rows written before the upgrade remain role-only by design, since backfilling them would rewrite what was signed. |
+| Unattributed callers verify as intact | — | A row whose principal is `none:unattributed` is authentic and verifiable, but names no account, and a chain composed entirely of such rows still reports `Intact`. That verdict is about tampering only. `sysknife audit verify` reports `unattributed_rows` alongside it, and the daemon logs a warning per occurrence, but an operator who reads only the verdict will overestimate what the trail can attribute. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,6 +94,19 @@ The per-action minimum role is a compile-time exhaustive match in
 are denied unconditionally. The caller's role is never supplied by the
 client — it is always derived server-side from kernel credentials.
 
+The same `SO_PEERCRED` read yields the peer's **uid**, which is recorded as the
+caller principal alongside the role and signed into the audit chain
+(`chain_version = 3`). Role answers "was this permitted"; principal answers
+"which account asked", and two members of `sysknife-admin` are no longer
+indistinguishable in the signed record. Three forms exist, and the scheme is
+part of the signed value so an auditor can tell them apart:
+
+| Principal | Meaning |
+|---|---|
+| `uid:<n>` | Unix-socket peer, uid attested by the kernel at `connect()` |
+| `token:vsock` | vsock peer authenticated by the pre-shared token: possession of a file, not an account |
+| `unattributed` | `SO_PEERCRED` yielded no usable peer; the connection is handled at `Observer` and the row admits attribution failed rather than inventing a uid |
+
 ### Layer 4 — One-time approval receipt (sysknife-daemon)
 
 Every mutating action requires a preview→approve→execute round-trip:
@@ -323,4 +336,4 @@ security certification work.
 | Tool output injection | [#98](https://github.com/lacs-project/sysknife/issues/98) | `query_*` results re-enter the LLM context unsanitized. A crafted service description or package name could attempt prompt injection. Impact is bounded by Layer 2–5. |
 | Action param validation | — | Action params are typed per-handler but not validated at a shared schema boundary. A compromised LLM could propose valid action + malicious params (e.g. `AddAuthorizedKey` with an attacker-controlled key). |
 | UDP audit forwarding | — | External RFC 5424 forwarding is best effort and provides no delivery acknowledgement. Use the transaction database and tested backups as the durable record. |
-| Caller attribution granularity | — | The signed chain binds each row to the caller's *role* (`chain_version = 2`), not to the individual account. Two members of `sysknife-admin` produce indistinguishable signed records, so the trail establishes "an Admin did this", not which Unix account. The uid is available at the `SO_PEERCRED` boundary where the role is already derived; recording it means a new signed row encoding (`chain_version = 3`) across both storage backends, and is tracked separately rather than bundled into an unrelated change. |
+| Caller attribution strength | — | Rows written under `chain_version = 3` name the account (`uid:<n>`), but a uid is only as meaningful as account hygiene on the host: shared logins, `su` into a service account, or a uid reused after a user is deleted all weaken the claim. vsock callers are recorded as `token:vsock` because a pre-shared secret proves possession of a file, not a person. Rows written before the upgrade remain role-only by design, since backfilling them would rewrite what was signed. |

--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -316,6 +316,11 @@ pub struct AuditVerifyReport {
     /// Backend label: a filesystem path for SQLite, the literal `"postgres"`
     /// for Postgres deployments.
     pub backend: String,
+    /// How many verified rows record that the daemon could not name the caller.
+    ///
+    /// `status: "intact"` with a non-zero count here means the chain is sound and
+    /// the attribution is not: report both, never the first alone.
+    pub unattributed_rows: u64,
     /// Set when `SYSKNIFE_SOCKET` names a daemon that may not live on this
     /// machine, because verification reads a local store while every other tool
     /// travels over that socket. `None` for the local-daemon case.
@@ -982,6 +987,7 @@ fn outcome_to_report(
 ) -> AuditVerifyReport {
     use sysknife_daemon::audit_chain::{BindingOutcome, VerifyOutcome};
 
+    let unattributed_rows = verification.unattributed_rows;
     let events_checked = match &verification.events {
         VerifyOutcome::Intact { rows_checked } | VerifyOutcome::Broken { rows_checked, .. } => {
             *rows_checked
@@ -1012,6 +1018,7 @@ fn outcome_to_report(
             events_checked,
             approval_events_status,
             binding_status,
+            unattributed_rows,
             daemon_socket_caveat: None,
         },
         VerifyOutcome::Broken {
@@ -1032,6 +1039,7 @@ fn outcome_to_report(
             events_checked,
             approval_events_status,
             binding_status,
+            unattributed_rows,
             daemon_socket_caveat: None,
         },
         VerifyOutcome::CannotVerify { reason } => {
@@ -1079,6 +1087,7 @@ fn cannot_verify_report(backend: String, reason: String) -> AuditVerifyReport {
         events_checked: 0,
         approval_events_status: "cannot_verify".to_string(),
         binding_status: "consistent".to_string(),
+        unattributed_rows: 0,
         daemon_socket_caveat: None,
     }
 }

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -838,6 +838,8 @@ fn cannot_verify_all(reason: String) -> AuditVerification {
         binding: BindingOutcome::Consistent {
             bindings_checked: 0,
         },
+        // Nothing was read, so nothing is known about attribution either.
+        unattributed_rows: 0,
     }
 }
 
@@ -955,6 +957,7 @@ fn emit_verification(
                 json!({"configured": false, "caveat": anchor_caveat(false)})
             },
             "daemon_socket_caveat": remote_daemon_caveat_from_env(),
+            "unattributed_rows": verification.unattributed_rows,
             "binding": match &verification.binding {
                 BindingOutcome::Consistent { bindings_checked } => json!({
                     "status": "consistent",
@@ -1002,6 +1005,17 @@ fn emit_verification(
     // what an operator reads as "the audit log is fine". Which machine was read
     // comes first: an Intact verdict for the wrong host misleads more than an
     // unanchored one does.
+    if verification.unattributed_rows > 0 {
+        log.println(&format!(
+            "NOTE: {} row(s) record that the daemon could not name the caller \
+             (principal `{}`). Those actions are authentic and verified, but the trail \
+             cannot say which account took them. This happens when SO_PEERCRED yields no \
+             usable peer, or when the peer is not representable in the daemon's \
+             namespaces; see the daemon log for the connections concerned.",
+            verification.unattributed_rows,
+            sysknife_daemon::auth::CallerPrincipal::Unattributed.as_signed_str(),
+        ));
+    }
     if let Some(caveat) = remote_daemon_caveat_from_env() {
         log.println(&caveat);
     }

--- a/crates/sysknife-brain/src/providers/mod.rs
+++ b/crates/sysknife-brain/src/providers/mod.rs
@@ -115,6 +115,12 @@ pub(super) fn sanitize_error_msg(msg: &str) -> String {
     result
 }
 
+/// How much of a provider response to echo into a diagnostic line.
+///
+/// Both adapters truncated previews at a bare `200`, in four places, so the
+/// same decision was spelled four times and could drift three ways.
+pub(crate) const LOG_PREVIEW_CHARS: usize = 200;
+
 #[cfg(test)]
 mod tests {
     use super::sanitize_error_msg;
@@ -208,9 +214,3 @@ mod tests {
         assert_eq!(result, input);
     }
 }
-
-/// How much of a provider response to echo into a diagnostic line.
-///
-/// Both adapters truncated previews at a bare `200`, in four places, so the
-/// same decision was spelled four times and could drift three ways.
-pub(crate) const LOG_PREVIEW_CHARS: usize = 200;

--- a/crates/sysknife-daemon/src/audit_chain.rs
+++ b/crates/sysknife-daemon/src/audit_chain.rs
@@ -91,8 +91,19 @@ const EVENT_DOMAIN: &[u8] = b"sysknife-audit-event-v1\x1f";
 /// Row encoding written before the caller-identity migration: no
 /// `caller_role`, no `event_tip`. Still verifiable — see [`ChainIdentity`].
 pub const CHAIN_VERSION_LEGACY: u32 = 1;
-/// Row encoding written by this binary: adds `caller_role` and `event_tip`.
-pub const CHAIN_VERSION_CURRENT: u32 = 2;
+/// Row encoding that added `caller_role` and `event_tip`.
+///
+/// This is a **stable literal, never an alias for the newest version**. The v2
+/// encoder signs this value, and `ChainRow::identity` dispatches stored rows
+/// against it. Point either at `CHAIN_VERSION_CURRENT` and the next encoding
+/// bump silently re-encodes every v2 row on disk, breaking audit logs while the
+/// unit suite stays green, because in-memory tests sign and verify under the
+/// same constant. `a_row_written_by_the_previous_release_still_verifies` is the
+/// golden vector that notices.
+pub const CHAIN_VERSION_V2: u32 = 2;
+/// Row encoding written by this binary: adds `caller_principal` on top of v2, so
+/// a row names the account that asked, not only its role class.
+pub const CHAIN_VERSION_CURRENT: u32 = 3;
 
 /// Loaded Ed25519 signing key + its identifier. Construct via
 /// [`AuditKey::load_or_generate`].
@@ -434,6 +445,28 @@ pub enum ChainIdentity<'a> {
         /// approval events below it becomes detectable.
         event_tip: &'a str,
     },
+    /// `chain_version = 3`. Everything v2 binds, plus the individual account.
+    ///
+    /// v2 answers "an Admin did this". On a host with two members of
+    /// `sysknife-admin` their signed records were indistinguishable, so the
+    /// trail could not answer the first question an investigation asks. v3
+    /// signs a principal as well.
+    V3 {
+        /// As v2.
+        caller_role: &'a str,
+        /// As v2.
+        event_tip: &'a str,
+        /// Scheme-prefixed identity of the caller, produced by
+        /// [`crate::auth::CallerPrincipal`]: `uid:1000` for a Unix-socket peer
+        /// whose credentials the kernel attested, `token:vsock` for a
+        /// vsock connection authenticated by the pre-shared token.
+        ///
+        /// The scheme is signed along with the value on purpose. An auditor must
+        /// be able to tell a kernel-attested account from a shared secret that
+        /// any holder could have presented, and a bare string would erase that
+        /// difference.
+        caller_principal: &'a str,
+    },
 }
 
 impl ChainIdentity<'_> {
@@ -441,7 +474,8 @@ impl ChainIdentity<'_> {
     pub fn version(&self) -> u32 {
         match self {
             Self::LegacyV1 => CHAIN_VERSION_LEGACY,
-            Self::V2 { .. } => CHAIN_VERSION_CURRENT,
+            Self::V2 { .. } => CHAIN_VERSION_V2,
+            Self::V3 { .. } => CHAIN_VERSION_CURRENT,
         }
     }
 }
@@ -509,6 +543,16 @@ impl<'a> ChainContent<'a> {
             event_tip,
         } = self.identity
         {
+            push_field(&mut buf, "chain_version", &CHAIN_VERSION_V2.to_string());
+            push_field(&mut buf, "caller_role", caller_role);
+            push_field(&mut buf, "event_tip", event_tip);
+        }
+        if let ChainIdentity::V3 {
+            caller_role,
+            event_tip,
+            caller_principal,
+        } = self.identity
+        {
             push_field(
                 &mut buf,
                 "chain_version",
@@ -516,6 +560,7 @@ impl<'a> ChainContent<'a> {
             );
             push_field(&mut buf, "caller_role", caller_role);
             push_field(&mut buf, "event_tip", event_tip);
+            push_field(&mut buf, "caller_principal", caller_principal);
         }
         buf
     }
@@ -608,6 +653,10 @@ pub struct ChainRow {
     /// `NULL` for legacy rows; required for `chain_version = 2`. May be the
     /// empty string when the event chain was empty at insert time.
     pub event_tip: Option<String>,
+    /// `NULL` for rows written before the principal migration (v1 and v2);
+    /// required for `chain_version = 3`. Scheme-prefixed, see
+    /// [`ChainIdentity::V3`].
+    pub caller_principal: Option<String>,
 }
 
 /// Why a stored row's columns do not describe a verifiable encoding.
@@ -629,7 +678,7 @@ impl ChainRow {
     pub(crate) fn identity(&self) -> Result<ChainIdentity<'_>, RowIdentityError> {
         match self.chain_version {
             CHAIN_VERSION_LEGACY => Ok(ChainIdentity::LegacyV1),
-            CHAIN_VERSION_CURRENT => Ok(ChainIdentity::V2 {
+            CHAIN_VERSION_V2 => Ok(ChainIdentity::V2 {
                 caller_role: self
                     .caller_role
                     .as_deref()
@@ -638,6 +687,24 @@ impl ChainRow {
                     .event_tip
                     .as_deref()
                     .ok_or(RowIdentityError::MissingField("event_tip"))?,
+            }),
+            CHAIN_VERSION_CURRENT => Ok(ChainIdentity::V3 {
+                caller_role: self
+                    .caller_role
+                    .as_deref()
+                    .ok_or(RowIdentityError::MissingField("caller_role"))?,
+                event_tip: self
+                    .event_tip
+                    .as_deref()
+                    .ok_or(RowIdentityError::MissingField("event_tip"))?,
+                // An empty principal is treated as absent: a v3 row must name
+                // who asked, and "" names nobody. Accepting it would let a
+                // blank pass for an identity.
+                caller_principal: self
+                    .caller_principal
+                    .as_deref()
+                    .filter(|p| !p.is_empty())
+                    .ok_or(RowIdentityError::MissingField("caller_principal"))?,
             }),
             other => Err(RowIdentityError::UnknownVersion(other)),
         }
@@ -1369,15 +1436,26 @@ mod tests {
     /// never hand-copies field-by-field and accidentally signs one thing while
     /// storing another.
     fn row_for(content: &ChainContent<'_>, prev: &str, chain_hash: String) -> ChainRow {
-        let (chain_version, caller_role, event_tip) = match content.identity {
-            ChainIdentity::LegacyV1 => (CHAIN_VERSION_LEGACY, None, None),
+        let (chain_version, caller_role, event_tip, caller_principal) = match content.identity {
+            ChainIdentity::LegacyV1 => (CHAIN_VERSION_LEGACY, None, None, None),
             ChainIdentity::V2 {
                 caller_role,
                 event_tip,
             } => (
+                CHAIN_VERSION_V2,
+                Some(caller_role.to_string()),
+                Some(event_tip.to_string()),
+                None,
+            ),
+            ChainIdentity::V3 {
+                caller_role,
+                event_tip,
+                caller_principal,
+            } => (
                 CHAIN_VERSION_CURRENT,
                 Some(caller_role.to_string()),
                 Some(event_tip.to_string()),
+                Some(caller_principal.to_string()),
             ),
         };
         ChainRow {
@@ -1397,6 +1475,7 @@ mod tests {
             chain_version,
             caller_role,
             event_tip,
+            caller_principal,
         }
     }
 
@@ -1467,6 +1546,219 @@ mod tests {
         assert_eq!(
             verify_chain(&key, &[row]),
             VerifyOutcome::Intact { rows_checked: 1 }
+        );
+    }
+
+    // ── v3: the row names the account, not just the role ──────────────────
+
+    /// The point of the encoding: two callers who share a role must produce
+    /// distinguishable signed records. If the principal were unsigned, or merely
+    /// stored, this would pass while proving nothing.
+    #[test]
+    fn two_admins_are_distinguishable_in_the_signed_record() {
+        let key = fixed_key();
+        let mut alice = sample_content(1, "tx-alice");
+        alice.identity = ChainIdentity::V3 {
+            caller_role: "admin",
+            event_tip: "",
+            caller_principal: "uid:1000",
+        };
+        let mut bob = sample_content(1, "tx-alice");
+        bob.identity = ChainIdentity::V3 {
+            caller_role: "admin",
+            event_tip: "",
+            caller_principal: "uid:1001",
+        };
+
+        assert_ne!(
+            key.chain_hash(&alice, ""),
+            key.chain_hash(&bob, ""),
+            "identical rows differing only in principal must sign differently, \
+             otherwise the chain still cannot answer which account acted"
+        );
+    }
+
+    /// Rewriting the stored principal must break verification. A field that can
+    /// be edited after the fact records nothing an auditor can rely on.
+    #[test]
+    fn editing_the_stored_principal_breaks_the_row() {
+        let key = fixed_key();
+        let mut content = sample_content(1, "tx1");
+        content.identity = ChainIdentity::V3 {
+            caller_role: "admin",
+            event_tip: "",
+            caller_principal: "uid:1000",
+        };
+        let hash = key.chain_hash(&content, "");
+        let mut row = row_for(&content, "", hash);
+        row.caller_principal = Some("uid:0".to_string());
+
+        assert!(
+            matches!(verify_chain(&key, &[row]), VerifyOutcome::Broken { .. }),
+            "a principal swapped to root must not verify"
+        );
+    }
+
+    /// Downgrade is the other direction of the same attack: strip the principal
+    /// and claim the row was written under v2, hiding which account acted. The
+    /// v3 message signed a different byte string, so it cannot verify as v2.
+    #[test]
+    fn downgrading_a_v3_row_to_v2_to_hide_the_account_breaks_it() {
+        let key = fixed_key();
+        let mut content = sample_content(1, "tx1");
+        content.identity = ChainIdentity::V3 {
+            caller_role: "admin",
+            event_tip: "",
+            caller_principal: "uid:1000",
+        };
+        let hash = key.chain_hash(&content, "");
+        let mut row = row_for(&content, "", hash);
+        row.chain_version = CHAIN_VERSION_V2;
+        row.caller_principal = None;
+
+        assert!(
+            matches!(verify_chain(&key, &[row]), VerifyOutcome::Broken { .. }),
+            "a v3 row relabelled as v2 must not verify"
+        );
+    }
+
+    /// A v3 row with no principal is self-contradictory, and so is one whose
+    /// principal is blank: both claim an encoding that names an account while
+    /// naming none. Treated as a break, not as "cannot verify", because the row
+    /// contradicts itself rather than being written by a newer binary.
+    #[test]
+    fn a_v3_row_without_a_usable_principal_is_broken() {
+        let key = fixed_key();
+        let mut content = sample_content(1, "tx1");
+        content.identity = ChainIdentity::V3 {
+            caller_role: "admin",
+            event_tip: "",
+            caller_principal: "uid:1000",
+        };
+        let hash = key.chain_hash(&content, "");
+
+        for absent in [None, Some(String::new())] {
+            let mut row = row_for(&content, "", hash.clone());
+            row.caller_principal = absent.clone();
+            assert!(
+                matches!(verify_chain(&key, &[row]), VerifyOutcome::Broken { .. }),
+                "a v3 row with principal {absent:?} must be reported as broken"
+            );
+        }
+    }
+
+    /// The realistic database after two upgrades: legacy rows, v2 rows, then v3
+    /// rows, all in one chain. Every generation has to keep verifying, which is
+    /// the whole reason the encoding is selected per row.
+    #[test]
+    fn a_chain_spanning_all_three_encodings_verifies() {
+        let key = fixed_key();
+        let mut rows = Vec::new();
+        let mut prev = String::new();
+        for (i, identity) in [
+            ChainIdentity::LegacyV1,
+            ChainIdentity::V2 {
+                caller_role: "dev",
+                event_tip: "",
+            },
+            ChainIdentity::V3 {
+                caller_role: "admin",
+                event_tip: "",
+                caller_principal: "uid:1000",
+            },
+            ChainIdentity::V3 {
+                caller_role: "admin",
+                event_tip: "",
+                caller_principal: "token:vsock",
+            },
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let txid = format!("tx{i}");
+            let mut content = sample_content((i + 1) as u64, &txid);
+            content.identity = identity;
+            let hash = key.chain_hash(&content, &prev);
+            rows.push(row_for(&content, &prev, hash.clone()));
+            prev = hash;
+        }
+
+        assert_eq!(
+            verify_chain(&key, &rows),
+            VerifyOutcome::Intact { rows_checked: 4 }
+        );
+    }
+
+    /// A row from a future encoding is "cannot verify", never "broken": an older
+    /// binary reading a newer chain has found no tampering, only work it cannot
+    /// reproduce. The message must say the supported range so the operator knows
+    /// the fix is a newer build.
+    #[test]
+    fn a_future_encoding_reports_cannot_verify_with_the_supported_range() {
+        let key = fixed_key();
+        let content = sample_content(1, "tx1");
+        let hash = key.chain_hash(&content, "");
+        let mut row = row_for(&content, "", hash);
+        row.chain_version = CHAIN_VERSION_CURRENT + 1;
+
+        match verify_chain(&key, &[row]) {
+            VerifyOutcome::CannotVerify { reason } => {
+                assert!(
+                    reason.contains(&format!("chain_version={}", CHAIN_VERSION_CURRENT + 1)),
+                    "name the version found, got: {reason}"
+                );
+                assert!(
+                    reason.contains(&CHAIN_VERSION_CURRENT.to_string()),
+                    "and the newest version understood, got: {reason}"
+                );
+            }
+            other => panic!("a future encoding must not be reported as tampering: {other:?}"),
+        }
+    }
+
+    /// A row exactly as the released binary wrote it must keep verifying, and
+    /// no in-memory test can prove that: every other test in this module signs
+    /// and verifies inside one process, so both halves move together whenever a
+    /// constant changes. The hash below was captured from the v2 encoder at
+    /// v0.2.16 over the content spelled out here, and it stands in for a real
+    /// database on a real host.
+    ///
+    /// Concretely, this catches the aliasing hazard the `ChainIdentity` docs warn
+    /// about: `identity()` dispatches stored `chain_version` values against
+    /// `CHAIN_VERSION_CURRENT`, and the v2 encoder used to *sign* that same
+    /// constant. Bump it for a new encoding and both the dispatch and the message
+    /// shift, so every v2 row on disk stops verifying while the whole unit suite
+    /// stays green. Only a golden vector notices.
+    #[test]
+    fn a_row_written_by_the_previous_release_still_verifies() {
+        const GOLDEN_V2_CHAIN_HASH: &str = "ba12cbe49a149387898bc30f1e8d409effa025ab8e440e6e72bedf060afc831e45d9be264d6b18b7e0ef2f2b3584dbc6953b535546cecbbdc3d7ac666cae4d0a";
+
+        let key = fixed_key();
+        let row = ChainRow {
+            seq: 7,
+            key_id: CURRENT_KEY_ID.to_string(),
+            transaction_id: "tx-golden".to_string(),
+            request_id: "req-golden".to_string(),
+            request_hash: "hash-golden".to_string(),
+            action_name: "AptInstall".to_string(),
+            risk_level: RiskLevel::Medium,
+            summary: "install ripgrep".to_string(),
+            approval_id: Some("appr-golden".to_string()),
+            warnings_json: "[]".to_string(),
+            created_at: "2026-07-29T00:00:00Z".to_string(),
+            prev_chain_hash: String::new(),
+            chain_hash: GOLDEN_V2_CHAIN_HASH.to_string(),
+            chain_version: 2,
+            caller_role: Some("admin".to_string()),
+            event_tip: Some("eventtip-golden".to_string()),
+            caller_principal: None,
+        };
+
+        assert_eq!(
+            verify_chain(&key, &[row]),
+            VerifyOutcome::Intact { rows_checked: 1 },
+            "a v2 row on disk must verify under this binary; if this fails, the v2 \
+             encoding or its version dispatch changed and existing audit logs are unreadable"
         );
     }
 
@@ -1885,6 +2177,7 @@ mod tests {
             chain_version: CHAIN_VERSION_CURRENT,
             caller_role: Some("Dev".to_string()),
             event_tip: Some(String::new()),
+            caller_principal: None,
         };
 
         // Renumber the genuine seq=2/3 rows so seq is still 1..=4.

--- a/crates/sysknife-daemon/src/audit_chain.rs
+++ b/crates/sysknife-daemon/src/audit_chain.rs
@@ -101,9 +101,21 @@ pub const CHAIN_VERSION_LEGACY: u32 = 1;
 /// same constant. `a_row_written_by_the_previous_release_still_verifies` is the
 /// golden vector that notices.
 pub const CHAIN_VERSION_V2: u32 = 2;
-/// Row encoding written by this binary: adds `caller_principal` on top of v2, so
-/// a row names the account that asked, not only its role class.
-pub const CHAIN_VERSION_CURRENT: u32 = 3;
+/// Row encoding that added `caller_principal` on top of v2, so a row names the
+/// account that asked, not only its role class.
+///
+/// A stable literal for the same reason [`CHAIN_VERSION_V2`] is one: the v3
+/// encoder signs this value and `ChainRow::identity` dispatches stored v3 rows
+/// against it, so it must not move when a v4 encoding arrives.
+/// `a_v3_row_on_disk_still_verifies` is the golden vector that notices if it does.
+pub const CHAIN_VERSION_V3: u32 = 3;
+/// The encoding this binary *writes*. Always an alias for the newest versioned
+/// constant, never used to encode or dispatch a specific generation.
+///
+/// Kept distinct from the per-version literals because those two jobs pull in
+/// opposite directions: the writer must move with each new encoding, while every
+/// stored generation must keep being reproduced byte for byte forever.
+pub const CHAIN_VERSION_CURRENT: u32 = CHAIN_VERSION_V3;
 
 /// Loaded Ed25519 signing key + its identifier. Construct via
 /// [`AuditKey::load_or_generate`].
@@ -435,8 +447,9 @@ pub enum ChainIdentity<'a> {
     /// the approval-event chain tip at insert time.
     V2 {
         /// Role the daemon resolved for the connection that requested this
-        /// action (`SO_PEERCRED` for Unix sockets, token for vsock). Signing
-        /// it is what lets an auditor answer "who asked for this".
+        /// action (`SO_PEERCRED` for Unix sockets, token for vsock). Signing it
+        /// lets an auditor answer which privilege tier asked; naming the account
+        /// is v3's `caller_principal`.
         caller_role: &'a str,
         /// `chain_hash` of the last [`EventRow`] at insert time, or `""` when
         /// the event chain is empty. This is the cross-chain binding: because
@@ -458,8 +471,9 @@ pub enum ChainIdentity<'a> {
         event_tip: &'a str,
         /// Scheme-prefixed identity of the caller, produced by
         /// [`crate::auth::CallerPrincipal`]: `uid:1000` for a Unix-socket peer
-        /// whose credentials the kernel attested, `token:vsock` for a
-        /// vsock connection authenticated by the pre-shared token.
+        /// whose credentials the kernel attested, `token:vsock` for a vsock
+        /// connection authenticated by the pre-shared token, and
+        /// `none:unattributed` when the daemon could establish neither.
         ///
         /// The scheme is signed along with the value on purpose. An auditor must
         /// be able to tell a kernel-attested account from a shared secret that
@@ -475,7 +489,7 @@ impl ChainIdentity<'_> {
         match self {
             Self::LegacyV1 => CHAIN_VERSION_LEGACY,
             Self::V2 { .. } => CHAIN_VERSION_V2,
-            Self::V3 { .. } => CHAIN_VERSION_CURRENT,
+            Self::V3 { .. } => CHAIN_VERSION_V3,
         }
     }
 }
@@ -534,33 +548,41 @@ impl<'a> ChainContent<'a> {
         push_field(&mut buf, "approval_id", approval);
         push_field(&mut buf, "warnings_json", self.warnings_json);
         push_field(&mut buf, "created_at", self.created_at);
-        // v2 fields are *appended*, so a legacy row's bytes are unchanged and
-        // its signature still verifies. The `chain_version` tag leads the
-        // suffix so a future v3 can never alias a v2 message: the two differ
-        // in a signed field, not merely in field count.
-        if let ChainIdentity::V2 {
-            caller_role,
-            event_tip,
-        } = self.identity
-        {
-            push_field(&mut buf, "chain_version", &CHAIN_VERSION_V2.to_string());
-            push_field(&mut buf, "caller_role", caller_role);
-            push_field(&mut buf, "event_tip", event_tip);
-        }
-        if let ChainIdentity::V3 {
-            caller_role,
-            event_tip,
-            caller_principal,
-        } = self.identity
-        {
-            push_field(
-                &mut buf,
-                "chain_version",
-                &CHAIN_VERSION_CURRENT.to_string(),
-            );
-            push_field(&mut buf, "caller_role", caller_role);
-            push_field(&mut buf, "event_tip", event_tip);
-            push_field(&mut buf, "caller_principal", caller_principal);
+        // Per-generation suffixes are *appended*, so a legacy row's bytes are
+        // unchanged and its signature still verifies. The `chain_version` tag
+        // leads each suffix, so no generation can alias another: two encodings
+        // differ in a signed field, not merely in field count.
+        //
+        // This is an exhaustive `match`, not a sequence of `if let`s, and that
+        // matters more than it looks. With `if let` chains, adding a variant and
+        // forgetting its arm compiles fine and silently encodes the new
+        // generation byte-identically to `LegacyV1` — signing an aliased message,
+        // which is exactly what the tag is supposed to prevent. As a `match`,
+        // the same omission is a compile error.
+        //
+        // Each arm spells its own fields out rather than sharing a helper. The
+        // duplication is deliberate: a frozen encoding must be able to stay
+        // frozen while a newer one changes.
+        match self.identity {
+            ChainIdentity::LegacyV1 => {}
+            ChainIdentity::V2 {
+                caller_role,
+                event_tip,
+            } => {
+                push_field(&mut buf, "chain_version", &CHAIN_VERSION_V2.to_string());
+                push_field(&mut buf, "caller_role", caller_role);
+                push_field(&mut buf, "event_tip", event_tip);
+            }
+            ChainIdentity::V3 {
+                caller_role,
+                event_tip,
+                caller_principal,
+            } => {
+                push_field(&mut buf, "chain_version", &CHAIN_VERSION_V3.to_string());
+                push_field(&mut buf, "caller_role", caller_role);
+                push_field(&mut buf, "event_tip", event_tip);
+                push_field(&mut buf, "caller_principal", caller_principal);
+            }
         }
         buf
     }
@@ -648,9 +670,9 @@ pub struct ChainRow {
     pub chain_hash: String,
     /// Which encoding this row was signed under. See [`ChainIdentity`].
     pub chain_version: u32,
-    /// `NULL` for legacy rows; required for `chain_version = 2`.
+    /// `NULL` for legacy rows; required for `chain_version` 2 and 3.
     pub caller_role: Option<String>,
-    /// `NULL` for legacy rows; required for `chain_version = 2`. May be the
+    /// `NULL` for legacy rows; required for `chain_version` 2 and 3. May be the
     /// empty string when the event chain was empty at insert time.
     pub event_tip: Option<String>,
     /// `NULL` for rows written before the principal migration (v1 and v2);
@@ -666,7 +688,9 @@ pub(crate) enum RowIdentityError {
     /// Genuinely unverifiable, not evidence of tampering — an older binary
     /// reading a newer chain lands here.
     UnknownVersion(u32),
-    /// The row claims `chain_version = 2` but is missing an identity column.
+    /// The row claims an identity encoding (2 or 3) but is missing one of its
+    /// columns. For v3 that includes a blank `caller_principal`, treated as
+    /// absent: a row naming nobody must not pass for one naming an account.
     /// No message can be reconstructed, and the shape is self-contradictory,
     /// so this counts as a detected break rather than an inability to check.
     MissingField(&'static str),
@@ -688,7 +712,7 @@ impl ChainRow {
                     .as_deref()
                     .ok_or(RowIdentityError::MissingField("event_tip"))?,
             }),
-            CHAIN_VERSION_CURRENT => Ok(ChainIdentity::V3 {
+            CHAIN_VERSION_V3 => Ok(ChainIdentity::V3 {
                 caller_role: self
                     .caller_role
                     .as_deref()
@@ -793,12 +817,31 @@ fn verify_rows(vk: &VerifyingKey, expect_key_id: Option<&str>, rows: &[ChainRow]
                 };
             }
             Err(RowIdentityError::MissingField(field)) => {
+                // Report the version the row itself declares. Formatting
+                // CHAIN_VERSION_CURRENT here sent an operator investigating a
+                // v2 row to the wrong encoding, and got worse every time the
+                // newest version moved.
+                let stored = match field {
+                    "caller_role" => row.caller_role.as_deref(),
+                    "event_tip" => row.event_tip.as_deref(),
+                    "caller_principal" => row.caller_principal.as_deref(),
+                    _ => None,
+                };
                 return VerifyOutcome::Broken {
                     rows_checked,
                     first_broken_seq: row.seq,
                     first_broken_transaction_id: row.transaction_id.clone(),
-                    expected: format!("chain_version={CHAIN_VERSION_CURRENT} row carrying {field}"),
-                    actual: format!("{field}=NULL"),
+                    expected: format!(
+                        "chain_version={} row carrying a non-empty {field}",
+                        row.chain_version
+                    ),
+                    // An empty column and an absent one send an operator to
+                    // different SQL, so they must not print the same way.
+                    actual: match stored {
+                        None => format!("{field}=NULL"),
+                        Some("") => format!("{field}='' (empty, not NULL)"),
+                        Some(other) => format!("{field}={other:?}"),
+                    },
                 };
             }
         };
@@ -1087,6 +1130,13 @@ pub struct AuditVerification {
     pub chain: VerifyOutcome,
     pub events: VerifyOutcome,
     pub binding: BindingOutcome,
+    /// How many verified rows record that the daemon could not name the caller.
+    ///
+    /// Counted separately because `Intact` alone would be true and misleading: a
+    /// host where every connection failed attribution produces a chain that
+    /// verifies perfectly and answers "who acted" with nobody. The verdict is
+    /// about tampering; this number is about how much the trail can tell you.
+    pub unattributed_rows: u64,
 }
 
 impl AuditVerification {
@@ -1111,6 +1161,18 @@ impl AuditVerification {
     }
 }
 
+/// Rows whose signed principal records an attribution failure.
+///
+/// Compares against the rendering of [`crate::auth::CallerPrincipal::Unattributed`]
+/// rather than a literal, so the two cannot drift.
+fn count_unattributed(tx_rows: &[ChainRow]) -> u64 {
+    let unattributed = crate::auth::CallerPrincipal::Unattributed.as_signed_str();
+    tx_rows
+        .iter()
+        .filter(|row| row.caller_principal.as_deref() == Some(unattributed.as_str()))
+        .count() as u64
+}
+
 /// Run all three checks with the daemon's key.
 pub fn verify_all(
     key: &AuditKey,
@@ -1121,6 +1183,7 @@ pub fn verify_all(
         chain: verify_chain(key, tx_rows),
         events: verify_event_chain(key, event_rows),
         binding: verify_event_binding(tx_rows, event_rows),
+        unattributed_rows: count_unattributed(tx_rows),
     }
 }
 
@@ -1134,6 +1197,7 @@ pub fn verify_all_with_pubkey(
         chain: verify_chain_with_pubkey(verifying_key_hex, tx_rows),
         events: verify_event_chain_with_pubkey(verifying_key_hex, event_rows),
         binding: verify_event_binding(tx_rows, event_rows),
+        unattributed_rows: count_unattributed(tx_rows),
     }
 }
 
@@ -1452,7 +1516,7 @@ mod tests {
                 event_tip,
                 caller_principal,
             } => (
-                CHAIN_VERSION_CURRENT,
+                CHAIN_VERSION_V3,
                 Some(caller_role.to_string()),
                 Some(event_tip.to_string()),
                 Some(caller_principal.to_string()),
@@ -1647,6 +1711,65 @@ mod tests {
         }
     }
 
+    /// A row *signed with* a blank principal must be rejected, and this is the
+    /// only test that can prove the guard exists.
+    ///
+    /// The sibling test that blanks a stored principal proves something weaker:
+    /// that row was signed with `uid:1000`, so it fails on signature mismatch
+    /// whether or not `identity()` filters empties. Here the signature is
+    /// perfectly valid for the blank principal, so the row verifies unless the
+    /// filter refuses it. Without the guard a daemon could sign rows that name
+    /// nobody and every one of them would report as intact.
+    #[test]
+    fn a_row_signed_with_a_blank_principal_is_rejected_even_though_it_signs() {
+        let key = fixed_key();
+        let mut content = sample_content(1, "tx-blank");
+        content.identity = ChainIdentity::V3 {
+            caller_role: "admin",
+            event_tip: "",
+            caller_principal: "",
+        };
+        let hash = key.chain_hash(&content, "");
+        // Derived from the very content that was signed, so every other field
+        // matches by construction. Building it by hand is how the first version
+        // of this test came to pass for the wrong reason: a mismatched seq made
+        // the row fail on signature, guard or no guard.
+        let row = row_for(&content, "", hash);
+        assert_eq!(
+            row.caller_principal.as_deref(),
+            Some(""),
+            "fixture must store the blank principal it signed"
+        );
+        assert_eq!(row.chain_version, CHAIN_VERSION_V3);
+        assert!(
+            matches!(verify_chain(&key, &[row]), VerifyOutcome::Broken { .. }),
+            "a v3 row naming nobody must be broken, not accepted"
+        );
+    }
+
+    /// An attribution failure is a legitimate, verifiable identity: the daemon
+    /// admits it could not name the caller, signs that admission, and the chain
+    /// stays intact. If this ever reports Broken, every honest row on a host
+    /// where `SO_PEERCRED` fails becomes a false tamper report.
+    #[test]
+    fn a_row_recording_an_attribution_failure_verifies() {
+        let key = fixed_key();
+        let principal = crate::auth::CallerPrincipal::Unattributed.as_signed_str();
+        let mut content = sample_content(1, "tx-unattributed");
+        content.identity = ChainIdentity::V3 {
+            caller_role: "observer",
+            event_tip: "",
+            caller_principal: &principal,
+        };
+        let hash = key.chain_hash(&content, "");
+        let row = row_for(&content, "", hash);
+
+        assert_eq!(
+            verify_chain(&key, &[row]),
+            VerifyOutcome::Intact { rows_checked: 1 }
+        );
+    }
+
     /// The realistic database after two upgrades: legacy rows, v2 rows, then v3
     /// rows, all in one chain. Every generation has to keep verifying, which is
     /// the whole reason the encoding is selected per row.
@@ -1716,12 +1839,11 @@ mod tests {
         }
     }
 
-    /// A row exactly as the released binary wrote it must keep verifying, and
-    /// no in-memory test can prove that: every other test in this module signs
-    /// and verifies inside one process, so both halves move together whenever a
-    /// constant changes. The hash below was captured from the v2 encoder at
-    /// v0.2.16 over the content spelled out here, and it stands in for a real
-    /// database on a real host.
+    /// A row encoded exactly as the v0.2.16 binary would have encoded it: the
+    /// content is synthetic, the hash is what that release's v2 encoder produced
+    /// over it. No in-memory test can prove this property, because every other
+    /// test in this module signs and verifies inside one process, so both halves
+    /// move together whenever a constant changes.
     ///
     /// Concretely, this catches the aliasing hazard the `ChainIdentity` docs warn
     /// about: `identity()` dispatches stored `chain_version` values against
@@ -1755,11 +1877,142 @@ mod tests {
         };
 
         assert_eq!(
-            verify_chain(&key, &[row]),
+            verify_chain(&key, std::slice::from_ref(&row)),
             VerifyOutcome::Intact { rows_checked: 1 },
             "a v2 row on disk must verify under this binary; if this fails, the v2 \
              encoding or its version dispatch changed and existing audit logs are unreadable"
         );
+
+        // Without this half the frozen constant is decorative: a build that
+        // skipped signature checking entirely would still pass the assertion
+        // above. Flipping one nibble must be rejected.
+        let mut tampered = row;
+        let flipped = match GOLDEN_V2_CHAIN_HASH.strip_prefix('b') {
+            Some(rest) => format!("a{rest}"),
+            None => format!("b{}", &GOLDEN_V2_CHAIN_HASH[1..]),
+        };
+        tampered.chain_hash = flipped;
+        assert!(
+            matches!(
+                verify_chain(&key, &[tampered]),
+                VerifyOutcome::Broken { .. }
+            ),
+            "a golden row with one nibble changed must not verify"
+        );
+    }
+
+    /// The v1 encoding is still claimed verifiable, and until now was protected
+    /// only by tests that sign and verify in one process. Frozen here for the
+    /// same reason as v2.
+    #[test]
+    fn a_legacy_v1_row_on_disk_still_verifies() {
+        const GOLDEN_V1_CHAIN_HASH: &str = "ce8b47c15414e989e099303b826fcd9985360b794220cefbbf9689d25f31fe173283687feb6d1dd265ae5aca94c8bcfb87ce33ba8c954fafdad18a59cd97c702";
+
+        let row = ChainRow {
+            chain_version: 1,
+            caller_role: None,
+            event_tip: None,
+            caller_principal: None,
+            chain_hash: GOLDEN_V1_CHAIN_HASH.to_string(),
+            ..golden_row_shape()
+        };
+        assert_eq!(
+            verify_chain(&fixed_key(), &[row]),
+            VerifyOutcome::Intact { rows_checked: 1 }
+        );
+    }
+
+    /// And v3, frozen now while the encoder that produces it is the one under
+    /// review. When v4 arrives, v3 rows will be in exactly the position v2 rows
+    /// were in before this change, and this is the test that will notice.
+    #[test]
+    fn a_v3_row_on_disk_still_verifies() {
+        const GOLDEN_V3_CHAIN_HASH: &str = "3c0d05f6ccaf9e65ccb796d4ffe96eb31a2ea67e446217c5234af916dc959d0f2c0ee3d3e5b525aece791ee7d6507efb98dcdd79f0d74dde4273859aa9627d08";
+
+        let row = ChainRow {
+            chain_version: 3,
+            caller_role: Some("admin".to_string()),
+            event_tip: Some("eventtip-golden".to_string()),
+            caller_principal: Some("uid:1000".to_string()),
+            chain_hash: GOLDEN_V3_CHAIN_HASH.to_string(),
+            ..golden_row_shape()
+        };
+        assert_eq!(
+            verify_chain(&fixed_key(), &[row]),
+            VerifyOutcome::Intact { rows_checked: 1 }
+        );
+    }
+
+    /// The golden rows above all have an empty `prev_chain_hash`, an approval id,
+    /// and content with no bytes the escape table touches. This one has the
+    /// opposite of each: a non-empty predecessor, no approval id, and a summary
+    /// carrying a backslash, `0x1F`, `0x1E`, and a NUL. A refactor of the escape
+    /// table or of the `approval_id: None` mapping changes this hash and nothing
+    /// else in the suite.
+    #[test]
+    fn the_escape_table_and_absent_approval_encoding_are_frozen() {
+        const GOLDEN_V2_AWKWARD_CHAIN_HASH: &str = "e6face6fe2346fc0f6c5c1e5845255579c8f08738406b88b0a1f6dbdf8ff85090a4b80d95bd0927ef54b0a2c4810d52ebb4bbf76cb68c865a7748df26442aa05";
+
+        let key = fixed_key();
+        let content = ChainContent {
+            seq: 8,
+            approval_id: None,
+            summary: "back\\slash and \x1funit and \x1erecord and nul\0byte",
+            identity: ChainIdentity::V2 {
+                caller_role: "dev",
+                event_tip: "",
+            },
+            ..golden_content_shape()
+        };
+        assert_eq!(
+            key.chain_hash(&content, "ba12cbe4"),
+            GOLDEN_V2_AWKWARD_CHAIN_HASH,
+            "the canonical encoding of escapes, an absent approval id, or a \
+             non-empty prev_chain_hash changed"
+        );
+    }
+
+    /// Shared literal content for the golden vectors. Spelled out rather than
+    /// derived from `sample_content` so a future edit to that helper cannot move
+    /// what the frozen hashes describe.
+    fn golden_content_shape() -> ChainContent<'static> {
+        ChainContent {
+            seq: 7,
+            key_id: CURRENT_KEY_ID,
+            transaction_id: "tx-golden",
+            request_id: "req-golden",
+            request_hash: "hash-golden",
+            action_name: "AptInstall",
+            risk_level: RiskLevel::Medium,
+            summary: "install ripgrep",
+            approval_id: Some("appr-golden"),
+            warnings_json: "[]",
+            created_at: "2026-07-29T00:00:00Z",
+            identity: ChainIdentity::LegacyV1,
+        }
+    }
+
+    /// The stored-row twin of `golden_content_shape`.
+    fn golden_row_shape() -> ChainRow {
+        ChainRow {
+            seq: 7,
+            key_id: CURRENT_KEY_ID.to_string(),
+            transaction_id: "tx-golden".to_string(),
+            request_id: "req-golden".to_string(),
+            request_hash: "hash-golden".to_string(),
+            action_name: "AptInstall".to_string(),
+            risk_level: RiskLevel::Medium,
+            summary: "install ripgrep".to_string(),
+            approval_id: Some("appr-golden".to_string()),
+            warnings_json: "[]".to_string(),
+            created_at: "2026-07-29T00:00:00Z".to_string(),
+            prev_chain_hash: String::new(),
+            chain_hash: String::new(),
+            chain_version: 1,
+            caller_role: None,
+            event_tip: None,
+            caller_principal: None,
+        }
     }
 
     #[test]
@@ -2051,6 +2304,7 @@ mod tests {
             binding: BindingOutcome::Consistent {
                 bindings_checked: 0,
             },
+            unattributed_rows: 0,
         };
         assert_eq!(verification.exit_code(), 1);
     }
@@ -2064,6 +2318,7 @@ mod tests {
                 transaction_seq: 3,
                 event_tip: "abc".to_string(),
             },
+            unattributed_rows: 0,
         };
         assert_eq!(verification.exit_code(), 1);
     }
@@ -2076,6 +2331,7 @@ mod tests {
             binding: BindingOutcome::Consistent {
                 bindings_checked: 1,
             },
+            unattributed_rows: 0,
         };
         assert_eq!(verification.exit_code(), 0);
     }
@@ -2159,6 +2415,10 @@ mod tests {
 
         // Splice in a new row between seq=1 and seq=2 with a fabricated hash.
         let forged = ChainRow {
+            // Carries a principal on purpose: without one the row is rejected as
+            // self-contradictory *before* any signature is checked, and this test
+            // exists to prove the walk stops on a bad signature.
+            caller_principal: Some("uid:1000".to_string()),
             seq: 2,
             key_id: CURRENT_KEY_ID.to_string(),
             transaction_id: "tx-forged".to_string(),
@@ -2177,7 +2437,6 @@ mod tests {
             chain_version: CHAIN_VERSION_CURRENT,
             caller_role: Some("Dev".to_string()),
             event_tip: Some(String::new()),
-            caller_principal: None,
         };
 
         // Renumber the genuine seq=2/3 rows so seq is still 1..=4.

--- a/crates/sysknife-daemon/src/audit_forward.rs
+++ b/crates/sysknife-daemon/src/audit_forward.rs
@@ -83,6 +83,14 @@ pub struct AuditEvent {
     pub chain_hash: String,
     pub key_id: String,
     pub caller_role: Option<String>,
+    /// Which account the daemon attributed the call to, taken from the signed
+    /// row rather than from the connection state, so the SIEM sees what the chain
+    /// says. `None` only for rows written before the principal existed.
+    ///
+    /// Without this the whole point of the signed principal stops at the local
+    /// database: a SOC watching this stream would still see only "an Admin did
+    /// this", and could not see an attribution failure at all.
+    pub caller_principal: Option<String>,
     pub final_status: Option<String>,
 }
 
@@ -306,6 +314,7 @@ pub fn format_rfc5424(event: &AuditEvent, facility: u8) -> String {
          risk=\"{}\" \
          approval=\"{}\" \
          role=\"{}\" \
+         principal=\"{}\" \
          chain_hash=\"{}\" \
          key_id=\"{}\"{terminal_status_param}]",
         event.seq,
@@ -314,6 +323,7 @@ pub fn format_rfc5424(event: &AuditEvent, facility: u8) -> String {
         risk,
         sd_escape(event.approval_id.as_deref().unwrap_or("")),
         sd_escape(event.caller_role.as_deref().unwrap_or("")),
+        sd_escape(event.caller_principal.as_deref().unwrap_or("")),
         sd_escape(&event.chain_hash),
         sd_escape(&event.key_id),
     );
@@ -401,6 +411,7 @@ mod tests {
             chain_hash: "deadbeef".to_string(),
             key_id: "v1".to_string(),
             caller_role: Some("Dev".to_string()),
+            caller_principal: Some("uid:1000".to_string()),
             final_status: None,
         }
     }

--- a/crates/sysknife-daemon/src/auth.rs
+++ b/crates/sysknife-daemon/src/auth.rs
@@ -61,6 +61,63 @@ pub fn denial_message(action: &str, caller: CallerRole, required: CallerRole) ->
 }
 
 // ---------------------------------------------------------------------------
+// Caller principal
+// ---------------------------------------------------------------------------
+
+/// Who asked, as opposed to what they were allowed to do.
+///
+/// [`CallerRole`] answers "was this permitted"; two members of
+/// `sysknife-admin` share a role and are indistinguishable by it. The principal
+/// answers "which account", and is signed into the audit chain
+/// ([`crate::audit_chain::ChainIdentity::V3`]) so the trail can name a person
+/// rather than a class.
+///
+/// The scheme prefix is part of the signed value on purpose. `uid:1000` was
+/// attested by the kernel through `SO_PEERCRED`; `token:vsock` means a
+/// pre-shared secret was presented and any holder of that file could have
+/// presented it. Those are different strengths of evidence and an auditor has to
+/// be able to tell them apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallerPrincipal {
+    /// A Unix-socket peer whose uid the kernel supplied at `connect()`.
+    Uid(u32),
+    /// A vsock connection authenticated by the pre-shared token. No uid exists
+    /// on that path: the peer is in another kernel.
+    VsockToken,
+    /// `SO_PEERCRED` did not yield a usable peer identity, so the daemon cannot
+    /// name the caller. The connection is still handled, at `Observer` (the
+    /// pre-existing fallback), and the row records that attribution failed
+    /// instead of inventing a uid. A signed lie about who acted would be worse
+    /// than a signed admission of ignorance.
+    Unattributed,
+}
+
+impl CallerPrincipal {
+    /// The exact string signed into the chain and stored in `caller_principal`.
+    pub fn as_signed_str(&self) -> String {
+        match self {
+            Self::Uid(uid) => format!("uid:{uid}"),
+            Self::VsockToken => "token:vsock".to_string(),
+            Self::Unattributed => "unattributed".to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for CallerPrincipal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.as_signed_str())
+    }
+}
+
+/// Role plus principal for one connection, resolved by the daemon and never
+/// taken from the request body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CallerAttribution {
+    pub role: CallerRole,
+    pub principal: CallerPrincipal,
+}
+
+// ---------------------------------------------------------------------------
 // Token authentication (vsock connections)
 // ---------------------------------------------------------------------------
 

--- a/crates/sysknife-daemon/src/auth.rs
+++ b/crates/sysknife-daemon/src/auth.rs
@@ -69,14 +69,18 @@ pub fn denial_message(action: &str, caller: CallerRole, required: CallerRole) ->
 /// [`CallerRole`] answers "was this permitted"; two members of
 /// `sysknife-admin` share a role and are indistinguishable by it. The principal
 /// answers "which account", and is signed into the audit chain
-/// ([`crate::audit_chain::ChainIdentity::V3`]) so the trail can name a person
-/// rather than a class.
+/// ([`crate::audit_chain::ChainIdentity::V3`]) so the trail can name the account
+/// rather than the class.
 ///
-/// The scheme prefix is part of the signed value on purpose. `uid:1000` was
-/// attested by the kernel through `SO_PEERCRED`; `token:vsock` means a
-/// pre-shared secret was presented and any holder of that file could have
-/// presented it. Those are different strengths of evidence and an auditor has to
-/// be able to tell them apart.
+/// An account is not a person: a uid survives `su`, shared logins, and reuse
+/// after a user is deleted. See the attribution-strength limit in `SECURITY.md`.
+///
+/// Every rendering is `scheme:value`, and the scheme is signed along with the
+/// value on purpose, because the strength of the evidence differs. `uid:1000`
+/// was attested by the kernel through `SO_PEERCRED`. `token:vsock` means a
+/// pre-shared secret was presented, and any holder of that file could have
+/// presented it. `none:unattributed` means the daemon could establish neither.
+/// A bare string would erase those distinctions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallerPrincipal {
     /// A Unix-socket peer whose uid the kernel supplied at `connect()`.
@@ -84,37 +88,102 @@ pub enum CallerPrincipal {
     /// A vsock connection authenticated by the pre-shared token. No uid exists
     /// on that path: the peer is in another kernel.
     VsockToken,
-    /// `SO_PEERCRED` did not yield a usable peer identity, so the daemon cannot
-    /// name the caller. The connection is still handled, at `Observer` (the
-    /// pre-existing fallback), and the row records that attribution failed
-    /// instead of inventing a uid. A signed lie about who acted would be worse
-    /// than a signed admission of ignorance.
+    /// The daemon could not establish an account for this connection, either
+    /// because `SO_PEERCRED` failed, or because it returned no usable pid, or
+    /// because the peer is not representable in this daemon's namespaces (the
+    /// kernel then reports the overflow uid, which names `nobody` rather than
+    /// the caller).
+    ///
+    /// The connection is still handled, at `Observer` (the pre-existing
+    /// fallback), and the row records that attribution failed instead of
+    /// inventing a uid. A signed lie about who acted would be worse than a
+    /// signed admission of ignorance.
     Unattributed,
 }
 
 impl CallerPrincipal {
-    /// The exact string signed into the chain and stored in `caller_principal`.
-    pub fn as_signed_str(&self) -> String {
+    /// Evidence class of this principal. Signed as the part before the colon.
+    ///
+    /// Split out from [`Self::as_signed_str`] so a new variant cannot be added
+    /// without declaring which class it belongs to, and so
+    /// `every_principal_renders_as_a_known_scheme` can walk the whole set.
+    pub fn scheme(&self) -> &'static str {
         match self {
-            Self::Uid(uid) => format!("uid:{uid}"),
-            Self::VsockToken => "token:vsock".to_string(),
-            Self::Unattributed => "unattributed".to_string(),
+            Self::Uid(_) => "uid",
+            Self::VsockToken => "token",
+            Self::Unattributed => "none",
         }
     }
-}
 
-impl std::fmt::Display for CallerPrincipal {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.as_signed_str())
+    /// The scheme-specific part, signed after the colon.
+    fn value(&self) -> std::borrow::Cow<'static, str> {
+        match self {
+            Self::Uid(uid) => std::borrow::Cow::Owned(uid.to_string()),
+            Self::VsockToken => std::borrow::Cow::Borrowed("vsock"),
+            Self::Unattributed => std::borrow::Cow::Borrowed("unattributed"),
+        }
+    }
+
+    /// The exact string signed into the chain and stored in `caller_principal`.
+    ///
+    /// Never empty for any variant, which matters: `ChainRow::identity` treats an
+    /// empty principal on a `chain_version = 3` row as a missing one and reports
+    /// the row broken. A variant that rendered empty would turn every honest row
+    /// on an affected host into a false tamper report.
+    pub fn as_signed_str(&self) -> String {
+        format!("{}:{}", self.scheme(), self.value())
     }
 }
 
 /// Role plus principal for one connection, resolved by the daemon and never
 /// taken from the request body.
+///
+/// Fields are private and the constructors are per transport, so the pairings
+/// that matter cannot be built by accident. In particular
+/// [`Self::unattributed`] hardcodes `Observer`: an attribution failure must never
+/// carry a privileged role, because that combination signs the worst possible
+/// record — a claim that an Admin acted, naming nobody.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CallerAttribution {
-    pub role: CallerRole,
-    pub principal: CallerPrincipal,
+    /// Authorization input. Decides what the connection may call.
+    role: CallerRole,
+    /// Audit-only. Never an authorization input: a principal must not be able to
+    /// widen what a role permits.
+    principal: CallerPrincipal,
+}
+
+impl CallerAttribution {
+    /// A Unix-socket peer, attributed to the uid `SO_PEERCRED` reported.
+    pub fn from_peer_uid(uid: u32, role: CallerRole) -> Self {
+        Self {
+            role,
+            principal: CallerPrincipal::Uid(uid),
+        }
+    }
+
+    /// A vsock peer that presented the pre-shared token.
+    pub fn from_vsock_token(role: CallerRole) -> Self {
+        Self {
+            role,
+            principal: CallerPrincipal::VsockToken,
+        }
+    }
+
+    /// A connection the daemon could not attribute. Always `Observer`.
+    pub fn unattributed() -> Self {
+        Self {
+            role: CallerRole::Observer,
+            principal: CallerPrincipal::Unattributed,
+        }
+    }
+
+    pub fn role(&self) -> CallerRole {
+        self.role
+    }
+
+    pub fn principal(&self) -> CallerPrincipal {
+        self.principal
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -546,5 +615,110 @@ mod tests {
         with_role_env(Some("  admin\n"), || {
             assert_eq!(token_role(), CallerRole::Admin)
         });
+    }
+    // ── Principal rendering ───────────────────────────────────────────────
+
+    /// Walks every variant through an exhaustive match, so adding one without
+    /// deciding how it renders is a compile error rather than a silent new
+    /// string in the audit chain.
+    ///
+    /// The empty check is the load-bearing one. `ChainRow::identity` treats an
+    /// empty `caller_principal` on a v3 row as missing and reports the row
+    /// *broken*, so a variant that rendered empty would turn every honest row on
+    /// an affected host into a false tamper report. That is a worse outcome than
+    /// the attribution failure it would be describing.
+    #[test]
+    fn every_principal_renders_as_a_non_empty_known_scheme() {
+        const SCHEMES: [&str; 3] = ["uid", "token", "none"];
+
+        for principal in [
+            CallerPrincipal::Uid(0),
+            CallerPrincipal::Uid(1000),
+            CallerPrincipal::Uid(u32::MAX),
+            CallerPrincipal::VsockToken,
+            CallerPrincipal::Unattributed,
+        ] {
+            // Exhaustive on purpose: a new variant must be added here too.
+            let expected_scheme = match principal {
+                CallerPrincipal::Uid(_) => "uid",
+                CallerPrincipal::VsockToken => "token",
+                CallerPrincipal::Unattributed => "none",
+            };
+
+            let signed = principal.as_signed_str();
+            assert!(
+                !signed.is_empty(),
+                "{principal:?} renders empty, which a v3 row reports as tampering"
+            );
+            assert_eq!(principal.scheme(), expected_scheme);
+            let (scheme, value) = signed
+                .split_once(':')
+                .unwrap_or_else(|| panic!("{principal:?} rendered {signed:?} with no scheme"));
+            assert_eq!(scheme, expected_scheme);
+            assert!(
+                !value.is_empty(),
+                "{principal:?} rendered {signed:?} with an empty value"
+            );
+            assert!(SCHEMES.contains(&scheme), "unknown scheme in {signed:?}");
+        }
+    }
+
+    /// Exact renderings, frozen. These strings are signed into audit rows, so
+    /// changing one silently re-encodes every future row and makes chains written
+    /// by two builds disagree about who acted.
+    #[test]
+    fn principal_renderings_are_frozen() {
+        assert_eq!(CallerPrincipal::Uid(0).as_signed_str(), "uid:0");
+        assert_eq!(CallerPrincipal::Uid(1000).as_signed_str(), "uid:1000");
+        assert_eq!(
+            CallerPrincipal::Uid(u32::MAX).as_signed_str(),
+            "uid:4294967295"
+        );
+        assert_eq!(CallerPrincipal::VsockToken.as_signed_str(), "token:vsock");
+        assert_eq!(
+            CallerPrincipal::Unattributed.as_signed_str(),
+            "none:unattributed"
+        );
+    }
+
+    /// No scheme may prefix another, or a stored principal could be read as
+    /// belonging to a different evidence class than the one that signed it.
+    #[test]
+    fn no_scheme_is_a_prefix_of_another() {
+        let schemes = ["uid", "token", "none"];
+        for a in schemes {
+            for b in schemes {
+                if a != b {
+                    assert!(
+                        !a.starts_with(b) && !b.starts_with(a),
+                        "scheme {a:?} and {b:?} are prefix-ambiguous"
+                    );
+                }
+            }
+        }
+    }
+
+    // ── Attribution pairing ───────────────────────────────────────────────
+
+    /// The pairing that must never exist: a privileged role with no account.
+    /// `unattributed()` hardcodes Observer, and the private fields mean no call
+    /// site can assemble the other combination.
+    #[test]
+    fn an_unattributed_caller_is_never_privileged() {
+        let caller = CallerAttribution::unattributed();
+        assert_eq!(caller.role(), CallerRole::Observer);
+        assert_eq!(caller.principal(), CallerPrincipal::Unattributed);
+    }
+
+    #[test]
+    fn transport_constructors_pick_the_matching_evidence_class() {
+        assert_eq!(
+            CallerAttribution::from_peer_uid(4242, CallerRole::Admin).principal(),
+            CallerPrincipal::Uid(4242)
+        );
+        assert_eq!(
+            CallerAttribution::from_vsock_token(CallerRole::Dev).principal(),
+            CallerPrincipal::VsockToken
+        );
     }
 }

--- a/crates/sysknife-daemon/src/checkpoint_sink.rs
+++ b/crates/sysknife-daemon/src/checkpoint_sink.rs
@@ -377,9 +377,10 @@ mod tests {
                 approval_id: None,
                 warnings_json: "[]",
                 created_at: "2026-04-24T12:00:00Z",
-                identity: ChainIdentity::V2 {
+                identity: ChainIdentity::V3 {
                     caller_role: "dev",
                     event_tip: "",
+                    caller_principal: "uid:1000",
                 },
             };
             let hash = key.chain_hash(&content, &prev);
@@ -400,6 +401,7 @@ mod tests {
                 chain_version: CHAIN_VERSION_CURRENT,
                 caller_role: Some("dev".to_string()),
                 event_tip: Some(String::new()),
+                caller_principal: Some("uid:1000".to_string()),
             });
             prev = hash;
         }

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -12,7 +12,7 @@
 //! - Unix role is derived from the peer process's Linux group membership
 //!   via `SO_PEERCRED` + `/proc/{pid}/status` + `/etc/group`, with the peer
 //!   pinned by a pidfd (`SO_PEERPIDFD`, Linux 6.5+) to guard the supplementary
-//!   group read against PID reuse (see `resolve_caller_role`). The shell never
+//!   group read against PID reuse (see `resolve_caller`). The shell never
 //!   supplies its own role.
 //! - Vsock role is derived from a pre-shared token validated against a file;
 //!   the token is generated at setup time and distributed out-of-band.
@@ -182,7 +182,7 @@ fn redact_argv(action_name: &str, params: &Value, args: &[String]) -> Vec<String
 }
 
 use crate::{
-    auth::{highest_role_from_groups, CallerAttribution, CallerPrincipal},
+    auth::{highest_role_from_groups, CallerAttribution},
     executor::{build_action_spec, rollback_spec_for, ActionExecutor},
     preview::preview_action,
     state::DaemonState,
@@ -477,7 +477,8 @@ fn pidfd_peer_still_live(pidfd: &OwnedFd) -> bool {
     std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
 }
 
-/// Resolve the caller's `CallerRole` from the peer process's group membership.
+/// Resolve who is calling: the role that decides what they may do, and the
+/// principal that records which account did it.
 ///
 /// Uses `SO_PEERCRED` (via `peer_cred()`) to obtain the peer PID and primary
 /// GID, reads `/proc/{pid}/status` for the supplementary GIDs, and resolves
@@ -503,16 +504,17 @@ pub fn resolve_caller(stream: &UnixStream) -> CallerAttribution {
     let (pid, primary_gid, uid) = match stream.peer_cred() {
         Ok(cred) => {
             let pid = match cred.pid() {
-                Some(p) if p >= 0 => p as u32,
+                // Strictly positive: the kernel writes 0 when the peer's pid is
+                // not representable in this daemon's pid namespace, and 0 is
+                // never a real peer. Accepting it read as a successful
+                // attribution of a process that cannot be named.
+                Some(p) if p > 0 => p as u32,
                 _ => {
                     eprintln!(
                         "[sysknife-daemon] WARNING: peer_cred() returned no usable pid; \
                          defaulting to Observer and recording the caller as unattributed"
                     );
-                    return CallerAttribution {
-                        role: CallerRole::Observer,
-                        principal: CallerPrincipal::Unattributed,
-                    };
+                    return CallerAttribution::unattributed();
                 }
             };
             (pid, cred.gid(), cred.uid())
@@ -522,10 +524,7 @@ pub fn resolve_caller(stream: &UnixStream) -> CallerAttribution {
                 "[sysknife-daemon] WARNING: peer_cred() failed: {e}; defaulting to Observer \
                  and recording the caller as unattributed"
             );
-            return CallerAttribution {
-                role: CallerRole::Observer,
-                principal: CallerPrincipal::Unattributed,
-            };
+            return CallerAttribution::unattributed();
         }
     };
 
@@ -569,10 +568,45 @@ pub fn resolve_caller(stream: &UnixStream) -> CallerAttribution {
     // The uid comes from the same SO_PEERCRED read as the gid, captured by the
     // kernel at connect(), so it is race-free in a way the supplementary group
     // set read from /proc is not.
-    CallerAttribution {
-        role: highest_role_from_groups(groups),
-        principal: CallerPrincipal::Uid(uid),
+    //
+    // It is not always a real account, though. The kernel translates `struct
+    // ucred` into the *reader's* namespaces, and when the peer's uid is not
+    // mappable it substitutes the overflow uid (`/proc/sys/kernel/overflowuid`,
+    // 65534 / `nobody` by default) rather than failing. A socket bind-mounted
+    // into a container reaches this path. Signing `uid:65534` there would make a
+    // positive claim that the `nobody` account acted, when the truth is that the
+    // kernel could not name the peer — exactly the false attribution
+    // `CallerPrincipal::Unattributed` exists to avoid.
+    if uid == overflow_uid() {
+        eprintln!(
+            "[sysknife-daemon] WARNING: SO_PEERCRED reported the overflow uid ({uid}) for pid \
+             {pid}; the peer is not representable in this daemon's user namespace. Recording \
+             the caller as unattributed rather than as uid:{uid}."
+        );
+        return CallerAttribution::unattributed();
     }
+
+    CallerAttribution::from_peer_uid(uid, highest_role_from_groups(groups))
+}
+
+/// The uid the kernel substitutes when a peer's uid cannot be mapped into this
+/// process's user namespace.
+///
+/// Read once from `/proc/sys/kernel/overflowuid`, falling back to the kernel's
+/// compile-time default. The fallback is not a "just in case" branch: on a host
+/// where procfs is not mounted the value is still 65534, and treating an
+/// unreadable sysctl as "no overflow uid exists" would re-open the false
+/// attribution this guards against.
+fn overflow_uid() -> u32 {
+    /// Kernel default from `include/linux/highuid.h`.
+    const DEFAULT_OVERFLOW_UID: u32 = 65534;
+    static CACHED: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::fs::read_to_string("/proc/sys/kernel/overflowuid")
+            .ok()
+            .and_then(|raw| raw.trim().parse::<u32>().ok())
+            .unwrap_or(DEFAULT_OVERFLOW_UID)
+    })
 }
 
 /// Read `/etc/group` once and return a `HashMap<gid, group_name>`.
@@ -700,7 +734,7 @@ async fn authorize_for_transaction(
 ) -> Result<bool, HandlerError> {
     match state.audit.get(transaction_id).await {
         Ok(Some(transaction)) => {
-            if authorize_action(&state.policy, &caller.role, &transaction.action_name) {
+            if authorize_action(&state.policy, &caller.role(), &transaction.action_name) {
                 Ok(true)
             } else {
                 send_error(
@@ -709,7 +743,7 @@ async fn authorize_for_transaction(
                     "authorization_failure",
                     authorization_failure_message(
                         &state.policy,
-                        &caller.role,
+                        &caller.role(),
                         &transaction.action_name,
                     ),
                 )
@@ -904,13 +938,10 @@ pub async fn vsock_connection_handler_with_executor<S>(
 
     let token_path = crate::auth::default_token_path();
     let caller = match authenticate_vsock_token(&mut framed, &token_path).await {
-        Some(role) => CallerAttribution {
-            role,
-            // A pre-shared token proves possession of a file, not the identity
-            // of a person. Recording it as such keeps the chain honest: any
-            // holder of that token could have made this call.
-            principal: CallerPrincipal::VsockToken,
-        },
+        // A pre-shared token proves possession of a file, not the identity of a
+        // person. Recording it as such keeps the chain honest: any holder of
+        // that token could have made this call.
+        Some(role) => CallerAttribution::from_vsock_token(role),
         None => {
             eprintln!("[sysknife-daemon] vsock auth failed; closing connection");
             return;
@@ -1324,12 +1355,12 @@ async fn handle_approval_details(
             .await;
         }
     };
-    if !authorize_action(&state.policy, &caller.role, &transaction.action_name) {
+    if !authorize_action(&state.policy, &caller.role(), &transaction.action_name) {
         return send_error(
             framed,
             request_id,
             "authorization_failure",
-            authorization_failure_message(&state.policy, &caller.role, &transaction.action_name),
+            authorization_failure_message(&state.policy, &caller.role(), &transaction.action_name),
         )
         .await;
     }
@@ -1756,12 +1787,12 @@ async fn handle_describe(
         )
         .await;
     }
-    if !authorize_action(&state.policy, &caller.role, action_name) {
+    if !authorize_action(&state.policy, &caller.role(), action_name) {
         return send_error(
             framed,
             request_id,
             "authorization_failure",
-            authorization_failure_message(&state.policy, &caller.role, action_name),
+            authorization_failure_message(&state.policy, &caller.role(), action_name),
         )
         .await;
     }
@@ -1846,12 +1877,12 @@ async fn handle_preview(
         }
     };
 
-    if !authorize_action(&state.policy, &caller.role, action_name) {
+    if !authorize_action(&state.policy, &caller.role(), action_name) {
         return send_error(
             framed,
             request_id,
             "authorization_failure",
-            authorization_failure_message(&state.policy, &caller.role, action_name),
+            authorization_failure_message(&state.policy, &caller.role(), action_name),
         )
         .await;
     }
@@ -1906,7 +1937,7 @@ async fn handle_preview(
         action_name: action_name.to_string(),
         request_id: request_id.to_string(),
         params: params.clone(),
-        caller_role: caller.role,
+        caller_role: caller.role(),
         request_hash: sysknife_types::RequestHash::new(request_hash.to_string()),
     };
 
@@ -1935,8 +1966,8 @@ async fn handle_preview(
         // Both resolved by the daemon from the connection, never read from the
         // request body. The role says what was permitted; the principal says
         // which account asked, which is the question an audit starts with.
-        caller_role: caller.role,
-        caller_principal: caller.principal,
+        caller_role: caller.role(),
+        caller_principal: caller.principal(),
     };
 
     let recorded = match state.audit.record_previewed(new_tx, preview.clone()).await {
@@ -1956,7 +1987,7 @@ async fn handle_preview(
     // response — if the forwarder queue is full or its task is gone, the
     // event is dropped (with a counter + WARN). The local hash-chained log
     // is always written first; the SIEM receives a copy.
-    forward_audit_event(state, &recorded.transaction.transaction_id, &caller.role);
+    forward_audit_event(state, &recorded.transaction.transaction_id, &caller.role());
 
     send_response(
         framed,
@@ -1997,6 +2028,9 @@ fn forward_audit_event(state: &DaemonState, transaction_id: &str, caller: &Calle
                     chain_hash: row.chain_hash,
                     key_id: row.key_id,
                     caller_role: Some(caller_label),
+                    // From the row, not the connection: the SIEM should see the
+                    // account the chain committed to.
+                    caller_principal: row.caller_principal,
                     final_status: None,
                 });
             }
@@ -2054,6 +2088,7 @@ fn forward_status_change_event(
                     chain_hash: row.chain_hash,
                     key_id: row.key_id,
                     caller_role: Some(caller_label),
+                    caller_principal: row.caller_principal,
                     final_status: Some(final_status_label),
                 });
             }
@@ -2160,12 +2195,12 @@ async fn handle_execute(
         }
     };
 
-    if !authorize_action(&state.policy, &caller.role, action_name) {
+    if !authorize_action(&state.policy, &caller.role(), action_name) {
         return send_error(
             framed,
             request_id,
             "authorization_failure",
-            authorization_failure_message(&state.policy, &caller.role, action_name),
+            authorization_failure_message(&state.policy, &caller.role(), action_name),
         )
         .await;
     }
@@ -2511,7 +2546,7 @@ async fn handle_execute(
             // terminal outcome of the action, not just the preview. Best-effort
             // and fire-and-forget — the local hash-chained log is the durable
             // record.
-            forward_status_change_event(state, transaction_id, &caller.role, final_status);
+            forward_status_change_event(state, transaction_id, &caller.role(), final_status);
         }
         Err(e) => {
             eprintln!(
@@ -2692,13 +2727,17 @@ async fn send_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::CallerPrincipal;
 
     /// A uid-attributed caller, the shape a Unix-socket connection produces.
     fn uid_caller(role: CallerRole) -> CallerAttribution {
-        CallerAttribution {
-            role,
-            principal: CallerPrincipal::Uid(1000),
-        }
+        uid_caller_with(1000, role)
+    }
+
+    /// A uid-attributed caller with an explicit uid, for tests that need to tell
+    /// one account from another.
+    fn uid_caller_with(uid: u32, role: CallerRole) -> CallerAttribution {
+        CallerAttribution::from_peer_uid(uid, role)
     }
     use crate::{
         state::{DaemonConfig, DaemonState},
@@ -2718,7 +2757,7 @@ mod tests {
         // On kernels with SO_PEERPIDFD the pinned peer is this very test process,
         // which is obviously still alive, so the liveness check must return true.
         // On older kernels peer_pidfd returns None and there is nothing to assert
-        // (the fallback path is exercised by resolve_caller_role below).
+        // (the fallback path is exercised by `resolve_caller` below).
         if let Some(fd) = peer_pidfd(&a) {
             assert!(
                 pidfd_peer_still_live(&fd),
@@ -2737,12 +2776,12 @@ mod tests {
         let caller = resolve_caller(&a);
 
         assert_eq!(
-            caller.principal,
+            caller.principal(),
             CallerPrincipal::Uid(unsafe { libc::geteuid() }),
             "a Unix-socket caller must be attributed to the peer uid SO_PEERCRED reports"
         );
         assert_eq!(
-            caller.principal.as_signed_str(),
+            caller.principal().as_signed_str(),
             format!("uid:{}", unsafe { libc::geteuid() }),
             "and the signed form must carry the uid scheme"
         );
@@ -2764,7 +2803,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_caller_matches_the_peers_actual_groups() {
-        // This used to call `resolve_caller_role` and discard the result,
+        // An earlier version discarded the resolved value and asserted only that nothing panicked,
         // asserting only "no panic" — it would have passed just as happily if
         // the function returned Boot for everyone.
         //
@@ -2774,7 +2813,7 @@ mod tests {
         // /proc/<pid>/status → /etc/group → role — instead of only its absence
         // of panics.
         let (a, _b) = UnixStream::pair().unwrap();
-        let role = resolve_caller(&a).role;
+        let role = resolve_caller(&a).role();
 
         let gid_map = read_gid_map();
         let expected =
@@ -2791,7 +2830,7 @@ mod tests {
         // The direction that actually matters for safety: privilege must come
         // from group membership, never from the mere act of connecting.
         let (a, _b) = UnixStream::pair().unwrap();
-        let role = resolve_caller(&a).role;
+        let role = resolve_caller(&a).role();
 
         let gid_map = read_gid_map();
         let groups = groups_for_pid(std::process::id(), &gid_map);
@@ -3091,10 +3130,7 @@ mod tests {
                 server,
                 state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -3162,10 +3198,7 @@ mod tests {
                 server,
                 state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -3205,10 +3238,7 @@ mod tests {
                 server,
                 state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -3268,10 +3298,7 @@ mod tests {
                 server,
                 state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -3343,10 +3370,7 @@ mod tests {
                 server,
                 state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -3379,10 +3403,7 @@ mod tests {
                 server,
                 handler_state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -3440,10 +3461,7 @@ mod tests {
                 server,
                 handler_state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -3514,10 +3532,7 @@ mod tests {
                 server,
                 handler_state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -3577,10 +3592,7 @@ mod tests {
                 server,
                 handler_state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -3618,18 +3630,20 @@ mod tests {
         requests: Vec<Value>,
         want_responses: usize,
     ) -> Vec<Value> {
+        exchange_as(state, uid_caller_with(1000, role), requests, want_responses).await
+    }
+
+    /// `exchange` with the caller spelled out, for tests that assert on which
+    /// account the daemon recorded.
+    async fn exchange_as(
+        state: DaemonState,
+        caller: CallerAttribution,
+        requests: Vec<Value>,
+        want_responses: usize,
+    ) -> Vec<Value> {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(
-                server,
-                state,
-                runner(),
-                crate::auth::CallerAttribution {
-                    role: role,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
-            )
-            .await;
+            unix_connection_handler(server, state, runner(), caller).await;
         });
 
         let mut framed = FramedStream::new(client);
@@ -3671,6 +3685,47 @@ mod tests {
     // ------------------------------------------------------------------
     // preview
     // ------------------------------------------------------------------
+
+    /// The account the connection was attributed to must reach the stored row.
+    ///
+    /// Everything else about the principal is tested in isolation: the resolver,
+    /// the renderings, the encoder, the store. None of that notices if
+    /// `handle_preview` passes a default instead of the connection's own caller,
+    /// because the value would still be a well-formed principal that verifies.
+    /// This is the test that fails for a hardcoded one.
+    #[tokio::test]
+    async fn the_recorded_principal_is_the_one_the_connection_was_attributed_to() {
+        let dir = tempdir().unwrap();
+        let state = test_state(&dir);
+        let audit = std::sync::Arc::clone(&state.audit);
+
+        let resps = exchange_as(
+            state,
+            uid_caller_with(4242, CallerRole::Observer),
+            vec![json!({
+                "type": "preview",
+                "request_id": "r-principal",
+                "action_name": "GetSystemState",
+                "params": {}
+            })],
+            1,
+        )
+        .await;
+
+        let transaction_id = resps[0]["transaction_id"].as_str().unwrap();
+        let row = audit
+            .fetch_chain_row(transaction_id)
+            .await
+            .expect("fetch the row just written")
+            .expect("preview records a transaction");
+
+        assert_eq!(
+            row.caller_principal.as_deref(),
+            Some("uid:4242"),
+            "the row must name the account resolved for this connection, not a default"
+        );
+        assert_eq!(row.chain_version, crate::audit_chain::CHAIN_VERSION_CURRENT);
+    }
 
     #[tokio::test]
     async fn preview_returns_hash_and_transaction_id() {
@@ -3783,10 +3838,7 @@ mod tests {
                 server,
                 handler_state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Admin,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Admin),
             )
             .await;
         });
@@ -4128,10 +4180,7 @@ mod tests {
                 server,
                 handler_state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -4189,10 +4238,7 @@ mod tests {
                 server,
                 handler_state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -4247,10 +4293,7 @@ mod tests {
                 server,
                 handler_state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Admin,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Admin),
             )
             .await;
         });
@@ -4310,10 +4353,7 @@ mod tests {
                 server,
                 state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -4527,10 +4567,7 @@ mod tests {
                 server,
                 state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -4621,10 +4658,7 @@ mod tests {
                     ps,
                     state,
                     runner(),
-                    crate::auth::CallerAttribution {
-                        role: CallerRole::Observer,
-                        principal: crate::auth::CallerPrincipal::Uid(1000),
-                    },
+                    uid_caller_with(1000, CallerRole::Observer),
                 )
                 .await;
             });
@@ -4660,10 +4694,7 @@ mod tests {
                     s,
                     state,
                     runner(),
-                    crate::auth::CallerAttribution {
-                        role: CallerRole::Observer,
-                        principal: crate::auth::CallerPrincipal::Uid(1000),
-                    },
+                    uid_caller_with(1000, CallerRole::Observer),
                 )
                 .await;
             });
@@ -4771,10 +4802,7 @@ mod tests {
                 server,
                 state,
                 runner(),
-                crate::auth::CallerAttribution {
-                    role: CallerRole::Observer,
-                    principal: crate::auth::CallerPrincipal::Uid(1000),
-                },
+                uid_caller_with(1000, CallerRole::Observer),
             )
             .await;
         });
@@ -5079,10 +5107,7 @@ mod tests {
                         state,
                         runner(),
                         executor(),
-                        CallerAttribution {
-                            role: r,
-                            principal: CallerPrincipal::VsockToken,
-                        },
+                        CallerAttribution::from_vsock_token(r),
                     )
                     .await;
                 }

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -182,7 +182,7 @@ fn redact_argv(action_name: &str, params: &Value, args: &[String]) -> Vec<String
 }
 
 use crate::{
-    auth::highest_role_from_groups,
+    auth::{highest_role_from_groups, CallerAttribution, CallerPrincipal},
     executor::{build_action_spec, rollback_spec_for, ActionExecutor},
     preview::preview_action,
     state::DaemonState,
@@ -499,18 +499,33 @@ fn pidfd_peer_still_live(pidfd: &OwnedFd) -> bool {
 /// is dropped, keeping only the race-free primary GID. On older kernels (e.g.
 /// Ubuntu 22.04) the pidfd is unavailable and the read is best-effort, as before
 /// — no worse than the previous behavior.
-pub fn resolve_caller_role(stream: &UnixStream) -> CallerRole {
-    let (pid, primary_gid) = match stream.peer_cred() {
+pub fn resolve_caller(stream: &UnixStream) -> CallerAttribution {
+    let (pid, primary_gid, uid) = match stream.peer_cred() {
         Ok(cred) => {
             let pid = match cred.pid() {
                 Some(p) if p >= 0 => p as u32,
-                _ => return CallerRole::Observer,
+                _ => {
+                    eprintln!(
+                        "[sysknife-daemon] WARNING: peer_cred() returned no usable pid; \
+                         defaulting to Observer and recording the caller as unattributed"
+                    );
+                    return CallerAttribution {
+                        role: CallerRole::Observer,
+                        principal: CallerPrincipal::Unattributed,
+                    };
+                }
             };
-            (pid, cred.gid())
+            (pid, cred.gid(), cred.uid())
         }
         Err(e) => {
-            eprintln!("[sysknife-daemon] WARNING: peer_cred() failed: {e}; defaulting to Observer");
-            return CallerRole::Observer;
+            eprintln!(
+                "[sysknife-daemon] WARNING: peer_cred() failed: {e}; defaulting to Observer \
+                 and recording the caller as unattributed"
+            );
+            return CallerAttribution {
+                role: CallerRole::Observer,
+                principal: CallerPrincipal::Unattributed,
+            };
         }
     };
 
@@ -551,7 +566,13 @@ pub fn resolve_caller_role(stream: &UnixStream) -> CallerRole {
             "[sysknife-daemon] WARNING: could not resolve groups for PID {pid}; defaulting to Observer"
         );
     }
-    highest_role_from_groups(groups)
+    // The uid comes from the same SO_PEERCRED read as the gid, captured by the
+    // kernel at connect(), so it is race-free in a way the supplementary group
+    // set read from /proc is not.
+    CallerAttribution {
+        role: highest_role_from_groups(groups),
+        principal: CallerPrincipal::Uid(uid),
+    }
 }
 
 /// Read `/etc/group` once and return a `HashMap<gid, group_name>`.
@@ -671,7 +692,7 @@ fn authorization_failure_message(
 async fn authorize_for_transaction(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     state: &DaemonState,
-    caller_role: &CallerRole,
+    caller: &CallerAttribution,
     request_id: &str,
     transaction_id: &str,
     missing_category: &str,
@@ -679,7 +700,7 @@ async fn authorize_for_transaction(
 ) -> Result<bool, HandlerError> {
     match state.audit.get(transaction_id).await {
         Ok(Some(transaction)) => {
-            if authorize_action(&state.policy, caller_role, &transaction.action_name) {
+            if authorize_action(&state.policy, &caller.role, &transaction.action_name) {
                 Ok(true)
             } else {
                 send_error(
@@ -688,7 +709,7 @@ async fn authorize_for_transaction(
                     "authorization_failure",
                     authorization_failure_message(
                         &state.policy,
-                        caller_role,
+                        &caller.role,
                         &transaction.action_name,
                     ),
                 )
@@ -845,12 +866,12 @@ pub async fn unix_connection_handler<S>(
     stream: S,
     state: DaemonState,
     runner: Arc<dyn CommandRunner + Send + Sync>,
-    caller_role: CallerRole,
+    caller: CallerAttribution,
 ) where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let executor: Arc<dyn ActionExecutor> = Arc::new(crate::executor::RealActionExecutor);
-    connection_handler_with_executor(stream, state, runner, executor, caller_role).await;
+    connection_handler_with_executor(stream, state, runner, executor, caller).await;
 }
 
 /// Handle a vsock connection: validate token from first frame, then dispatch.
@@ -882,15 +903,21 @@ pub async fn vsock_connection_handler_with_executor<S>(
     let mut framed = FramedStream::new(stream);
 
     let token_path = crate::auth::default_token_path();
-    let caller_role = match authenticate_vsock_token(&mut framed, &token_path).await {
-        Some(role) => role,
+    let caller = match authenticate_vsock_token(&mut framed, &token_path).await {
+        Some(role) => CallerAttribution {
+            role,
+            // A pre-shared token proves possession of a file, not the identity
+            // of a person. Recording it as such keeps the chain honest: any
+            // holder of that token could have made this call.
+            principal: CallerPrincipal::VsockToken,
+        },
         None => {
             eprintln!("[sysknife-daemon] vsock auth failed; closing connection");
             return;
         }
     };
 
-    dispatch_loop(&mut framed, state, runner, executor, caller_role).await;
+    dispatch_loop(&mut framed, state, runner, executor, caller).await;
 }
 
 /// Inner handler that accepts an explicit [`ActionExecutor`].
@@ -902,12 +929,12 @@ pub async fn connection_handler_with_executor<S>(
     state: DaemonState,
     runner: Arc<dyn CommandRunner + Send + Sync>,
     executor: Arc<dyn ActionExecutor>,
-    caller_role: CallerRole,
+    caller: CallerAttribution,
 ) where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let mut framed = FramedStream::new(stream);
-    dispatch_loop(&mut framed, state, runner, executor, caller_role).await;
+    dispatch_loop(&mut framed, state, runner, executor, caller).await;
 }
 
 // ---------------------------------------------------------------------------
@@ -1014,7 +1041,7 @@ async fn dispatch_loop<S>(
     state: DaemonState,
     runner: Arc<dyn CommandRunner + Send + Sync>,
     executor: Arc<dyn ActionExecutor>,
-    caller_role: CallerRole,
+    caller: CallerAttribution,
 ) where
     S: AsyncRead + AsyncWrite + Unpin,
 {
@@ -1094,7 +1121,7 @@ async fn dispatch_loop<S>(
                     framed,
                     &state,
                     Arc::clone(&runner),
-                    &caller_role,
+                    &caller,
                     request_id,
                     action_name,
                     params,
@@ -1112,7 +1139,7 @@ async fn dispatch_loop<S>(
                     framed,
                     &state,
                     Arc::clone(&executor),
-                    &caller_role,
+                    &caller,
                     request_id,
                     transaction_id,
                     action_name,
@@ -1124,16 +1151,7 @@ async fn dispatch_loop<S>(
             DaemonRequest::Approve {
                 request_id,
                 transaction_id,
-            } => {
-                handle_approve(
-                    framed,
-                    &state,
-                    &caller_role,
-                    request_id,
-                    transaction_id.as_str(),
-                )
-                .await
-            }
+            } => handle_approve(framed, &state, &caller, request_id, transaction_id.as_str()).await,
             DaemonRequest::ApprovalDetails {
                 request_id,
                 transaction_id,
@@ -1141,7 +1159,7 @@ async fn dispatch_loop<S>(
                 handle_approval_details(
                     framed,
                     &state,
-                    &caller_role,
+                    &caller,
                     request_id,
                     transaction_id.as_str(),
                 )
@@ -1184,30 +1202,11 @@ async fn dispatch_loop<S>(
                 request_id,
                 action_name,
                 params,
-            } => {
-                handle_describe(
-                    framed,
-                    &state,
-                    &caller_role,
-                    action_name,
-                    params,
-                    request_id,
-                )
-                .await
-            }
+            } => handle_describe(framed, &state, &caller, action_name, params, request_id).await,
             DaemonRequest::Cancel {
                 request_id,
                 transaction_id,
-            } => {
-                handle_cancel(
-                    framed,
-                    &state,
-                    &caller_role,
-                    request_id,
-                    transaction_id.as_str(),
-                )
-                .await
-            }
+            } => handle_cancel(framed, &state, &caller, request_id, transaction_id.as_str()).await,
         };
 
         if let Err(e) = result {
@@ -1225,14 +1224,14 @@ fn receipt_digest(receipt: &str) -> String {
 async fn handle_approve(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     state: &DaemonState,
-    caller_role: &CallerRole,
+    caller: &CallerAttribution,
     request_id: &str,
     transaction_id: &str,
 ) -> Result<(), HandlerError> {
     if !authorize_for_transaction(
         framed,
         state,
-        caller_role,
+        caller,
         request_id,
         transaction_id,
         "stale_approval",
@@ -1300,7 +1299,7 @@ async fn handle_approve(
 async fn handle_approval_details(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     state: &DaemonState,
-    caller_role: &CallerRole,
+    caller: &CallerAttribution,
     request_id: &str,
     transaction_id: &str,
 ) -> Result<(), HandlerError> {
@@ -1325,12 +1324,12 @@ async fn handle_approval_details(
             .await;
         }
     };
-    if !authorize_action(&state.policy, caller_role, &transaction.action_name) {
+    if !authorize_action(&state.policy, &caller.role, &transaction.action_name) {
         return send_error(
             framed,
             request_id,
             "authorization_failure",
-            authorization_failure_message(&state.policy, caller_role, &transaction.action_name),
+            authorization_failure_message(&state.policy, &caller.role, &transaction.action_name),
         )
         .await;
     }
@@ -1400,14 +1399,14 @@ async fn handle_query_state(
 async fn handle_cancel(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     state: &DaemonState,
-    caller_role: &CallerRole,
+    caller: &CallerAttribution,
     request_id: &str,
     transaction_id: &str,
 ) -> Result<(), HandlerError> {
     if !authorize_for_transaction(
         framed,
         state,
-        caller_role,
+        caller,
         request_id,
         transaction_id,
         "not_cancelable",
@@ -1729,7 +1728,7 @@ async fn handle_query_action(
 async fn handle_describe(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     state: &DaemonState,
-    caller_role: &CallerRole,
+    caller: &CallerAttribution,
     action_name: &str,
     params: &Value,
     request_id: &str,
@@ -1757,12 +1756,12 @@ async fn handle_describe(
         )
         .await;
     }
-    if !authorize_action(&state.policy, caller_role, action_name) {
+    if !authorize_action(&state.policy, &caller.role, action_name) {
         return send_error(
             framed,
             request_id,
             "authorization_failure",
-            authorization_failure_message(&state.policy, caller_role, action_name),
+            authorization_failure_message(&state.policy, &caller.role, action_name),
         )
         .await;
     }
@@ -1835,7 +1834,7 @@ async fn handle_preview(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     state: &DaemonState,
     runner: Arc<dyn CommandRunner + Send + Sync>,
-    caller_role: &CallerRole,
+    caller: &CallerAttribution,
     request_id: &str,
     action_name: &str,
     params: &Value,
@@ -1847,12 +1846,12 @@ async fn handle_preview(
         }
     };
 
-    if !authorize_action(&state.policy, caller_role, action_name) {
+    if !authorize_action(&state.policy, &caller.role, action_name) {
         return send_error(
             framed,
             request_id,
             "authorization_failure",
-            authorization_failure_message(&state.policy, caller_role, action_name),
+            authorization_failure_message(&state.policy, &caller.role, action_name),
         )
         .await;
     }
@@ -1907,7 +1906,7 @@ async fn handle_preview(
         action_name: action_name.to_string(),
         request_id: request_id.to_string(),
         params: params.clone(),
-        caller_role: *caller_role,
+        caller_role: caller.role,
         request_hash: sysknife_types::RequestHash::new(request_hash.to_string()),
     };
 
@@ -1933,9 +1932,11 @@ async fn handle_preview(
         risk_level: spec.risk_level,
         summary: preview.summary.clone(),
         warnings: preview.warnings.clone(),
-        // The role the daemon resolved for this connection, not anything the
-        // request carried. Signing it is what lets the audit answer "who".
-        caller_role: *caller_role,
+        // Both resolved by the daemon from the connection, never read from the
+        // request body. The role says what was permitted; the principal says
+        // which account asked, which is the question an audit starts with.
+        caller_role: caller.role,
+        caller_principal: caller.principal,
     };
 
     let recorded = match state.audit.record_previewed(new_tx, preview.clone()).await {
@@ -1955,7 +1956,7 @@ async fn handle_preview(
     // response — if the forwarder queue is full or its task is gone, the
     // event is dropped (with a counter + WARN). The local hash-chained log
     // is always written first; the SIEM receives a copy.
-    forward_audit_event(state, &recorded.transaction.transaction_id, caller_role);
+    forward_audit_event(state, &recorded.transaction.transaction_id, &caller.role);
 
     send_response(
         framed,
@@ -2143,7 +2144,7 @@ async fn handle_execute(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     state: &DaemonState,
     executor: Arc<dyn ActionExecutor>,
-    caller_role: &CallerRole,
+    caller: &CallerAttribution,
     request_id: &str,
     transaction_id: &TransactionId,
     action_name: &str,
@@ -2159,12 +2160,12 @@ async fn handle_execute(
         }
     };
 
-    if !authorize_action(&state.policy, caller_role, action_name) {
+    if !authorize_action(&state.policy, &caller.role, action_name) {
         return send_error(
             framed,
             request_id,
             "authorization_failure",
-            authorization_failure_message(&state.policy, caller_role, action_name),
+            authorization_failure_message(&state.policy, &caller.role, action_name),
         )
         .await;
     }
@@ -2510,7 +2511,7 @@ async fn handle_execute(
             // terminal outcome of the action, not just the preview. Best-effort
             // and fire-and-forget — the local hash-chained log is the durable
             // record.
-            forward_status_change_event(state, transaction_id, caller_role, final_status);
+            forward_status_change_event(state, transaction_id, &caller.role, final_status);
         }
         Err(e) => {
             eprintln!(
@@ -2691,6 +2692,14 @@ async fn send_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A uid-attributed caller, the shape a Unix-socket connection produces.
+    fn uid_caller(role: CallerRole) -> CallerAttribution {
+        CallerAttribution {
+            role,
+            principal: CallerPrincipal::Uid(1000),
+        }
+    }
     use crate::{
         state::{DaemonConfig, DaemonState},
         transport::listen::ListenTarget,
@@ -2718,8 +2727,43 @@ mod tests {
         }
     }
 
+    /// The uid must come from the kernel, not from anything the peer says. A
+    /// socketpair peer is this test process, so the expected value is knowable
+    /// and the assertion pins the wiring rather than merely the absence of a
+    /// panic.
     #[tokio::test]
-    async fn resolve_caller_role_matches_the_peers_actual_groups() {
+    async fn resolve_caller_attributes_a_unix_peer_to_its_kernel_reported_uid() {
+        let (a, _b) = UnixStream::pair().unwrap();
+        let caller = resolve_caller(&a);
+
+        assert_eq!(
+            caller.principal,
+            CallerPrincipal::Uid(unsafe { libc::geteuid() }),
+            "a Unix-socket caller must be attributed to the peer uid SO_PEERCRED reports"
+        );
+        assert_eq!(
+            caller.principal.as_signed_str(),
+            format!("uid:{}", unsafe { libc::geteuid() }),
+            "and the signed form must carry the uid scheme"
+        );
+    }
+
+    /// A vsock caller presents a shared secret, so the chain must not imply an
+    /// account. `token:vsock` says exactly what was proven: possession of a file
+    /// that any holder could have read.
+    #[test]
+    fn a_vsock_principal_does_not_claim_an_account() {
+        assert_eq!(CallerPrincipal::VsockToken.as_signed_str(), "token:vsock");
+        assert!(
+            !CallerPrincipal::VsockToken
+                .as_signed_str()
+                .starts_with("uid:"),
+            "a token must never render as a uid; that would overstate the evidence"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_caller_matches_the_peers_actual_groups() {
         // This used to call `resolve_caller_role` and discard the result,
         // asserting only "no panic" — it would have passed just as happily if
         // the function returned Boot for everyone.
@@ -2730,7 +2774,7 @@ mod tests {
         // /proc/<pid>/status → /etc/group → role — instead of only its absence
         // of panics.
         let (a, _b) = UnixStream::pair().unwrap();
-        let role = resolve_caller_role(&a);
+        let role = resolve_caller(&a).role;
 
         let gid_map = read_gid_map();
         let expected =
@@ -2743,11 +2787,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_caller_role_never_exceeds_observer_without_a_privileged_group() {
+    async fn resolve_caller_never_exceeds_observer_without_a_privileged_group() {
         // The direction that actually matters for safety: privilege must come
         // from group membership, never from the mere act of connecting.
         let (a, _b) = UnixStream::pair().unwrap();
-        let role = resolve_caller_role(&a);
+        let role = resolve_caller(&a).role;
 
         let gid_map = read_gid_map();
         let groups = groups_for_pid(std::process::id(), &gid_map);
@@ -3043,7 +3087,16 @@ mod tests {
         let state = test_state(&dir);
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(server, state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
         framed
@@ -3105,7 +3158,16 @@ mod tests {
         let state = test_state(&dir);
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(server, state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, _) =
@@ -3139,7 +3201,16 @@ mod tests {
         let state = test_state(&dir);
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(server, state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
 
@@ -3193,7 +3264,16 @@ mod tests {
         let state = test_state(&dir);
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(server, state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
 
@@ -3259,7 +3339,16 @@ mod tests {
 
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(server, state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
         framed
@@ -3286,7 +3375,16 @@ mod tests {
         let handler_state = state.clone();
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(server, handler_state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                handler_state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
 
@@ -3338,7 +3436,16 @@ mod tests {
         let handler_state = state.clone();
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(server, handler_state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                handler_state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, receipt) =
@@ -3403,7 +3510,16 @@ mod tests {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         let handler_state = state.clone();
         tokio::spawn(async move {
-            unix_connection_handler(server, handler_state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                handler_state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
         framed
@@ -3427,7 +3543,7 @@ mod tests {
         assert!(handle_approve(
             &mut broken_framed,
             &state,
-            &CallerRole::Admin,
+            &uid_caller(CallerRole::Admin),
             "approve-undelivered",
             transaction_id,
         )
@@ -3439,7 +3555,7 @@ mod tests {
         handle_approve(
             &mut retry_framed,
             &state,
-            &CallerRole::Admin,
+            &uid_caller(CallerRole::Admin),
             "approve-retry",
             transaction_id,
         )
@@ -3457,7 +3573,16 @@ mod tests {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         let handler_state = state.clone();
         tokio::spawn(async move {
-            unix_connection_handler(server, handler_state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                handler_state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, receipt) =
@@ -3495,7 +3620,16 @@ mod tests {
     ) -> Vec<Value> {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(server, state, runner(), role).await;
+            unix_connection_handler(
+                server,
+                state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: role,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
 
         let mut framed = FramedStream::new(client);
@@ -3645,7 +3779,16 @@ mod tests {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         let handler_state = state.clone();
         tokio::spawn(async move {
-            unix_connection_handler(server, handler_state, runner(), CallerRole::Admin).await;
+            unix_connection_handler(
+                server,
+                handler_state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Admin,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
         framed
@@ -3677,7 +3820,7 @@ mod tests {
                 "approve" => handle_approve(
                     &mut caller,
                     &state,
-                    &CallerRole::Observer,
+                    &uid_caller(CallerRole::Observer),
                     request_id,
                     &transaction_id,
                 )
@@ -3686,7 +3829,7 @@ mod tests {
                 "cancel" => handle_cancel(
                     &mut caller,
                     &state,
-                    &CallerRole::Observer,
+                    &uid_caller(CallerRole::Observer),
                     request_id,
                     &transaction_id,
                 )
@@ -3695,7 +3838,7 @@ mod tests {
                 _ => handle_approval_details(
                     &mut caller,
                     &state,
-                    &CallerRole::Observer,
+                    &uid_caller(CallerRole::Observer),
                     request_id,
                     &transaction_id,
                 )
@@ -3718,7 +3861,7 @@ mod tests {
         handle_approve(
             &mut admin,
             &state,
-            &CallerRole::Admin,
+            &uid_caller(CallerRole::Admin),
             "admin-approve",
             &transaction_id,
         )
@@ -3981,7 +4124,16 @@ mod tests {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         let handler_state = state.clone();
         tokio::spawn(async move {
-            unix_connection_handler(server, handler_state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                handler_state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, receipt) = preview_and_approve(
@@ -4033,7 +4185,16 @@ mod tests {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         let handler_state = state.clone();
         tokio::spawn(async move {
-            unix_connection_handler(server, handler_state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                handler_state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, receipt) =
@@ -4082,7 +4243,16 @@ mod tests {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         let handler_state = state.clone();
         tokio::spawn(async move {
-            unix_connection_handler(server, handler_state, runner(), CallerRole::Admin).await;
+            unix_connection_handler(
+                server,
+                handler_state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Admin,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut preview_stream = FramedStream::new(client);
         let params = json!({"package": "vim"});
@@ -4098,7 +4268,7 @@ mod tests {
             &mut broken_framed,
             &state,
             Arc::new(crate::executor::RealActionExecutor),
-            &CallerRole::Admin,
+            &uid_caller(CallerRole::Admin),
             "execute-disconnected",
             &typed_transaction_id,
             "AddLayeredPackage",
@@ -4136,7 +4306,16 @@ mod tests {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
 
         tokio::spawn(async move {
-            unix_connection_handler(server, state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
 
         let mut framed = FramedStream::new(client);
@@ -4344,7 +4523,16 @@ mod tests {
 
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
         tokio::spawn(async move {
-            unix_connection_handler(server, state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
         let mut framed = FramedStream::new(client);
 
@@ -4429,7 +4617,16 @@ mod tests {
         {
             let state = state.clone();
             tokio::spawn(async move {
-                unix_connection_handler(ps, state, runner(), CallerRole::Observer).await;
+                unix_connection_handler(
+                    ps,
+                    state,
+                    runner(),
+                    crate::auth::CallerAttribution {
+                        role: CallerRole::Observer,
+                        principal: crate::auth::CallerPrincipal::Uid(1000),
+                    },
+                )
+                .await;
             });
         }
         let mut framed_p = FramedStream::new(pc);
@@ -4459,7 +4656,16 @@ mod tests {
         ) -> Vec<Value> {
             let (c, s) = tokio::net::UnixStream::pair().unwrap();
             tokio::spawn(async move {
-                unix_connection_handler(s, state, runner(), CallerRole::Observer).await;
+                unix_connection_handler(
+                    s,
+                    state,
+                    runner(),
+                    crate::auth::CallerAttribution {
+                        role: CallerRole::Observer,
+                        principal: crate::auth::CallerPrincipal::Uid(1000),
+                    },
+                )
+                .await;
             });
             let mut f = FramedStream::new(c);
             f.send(
@@ -4561,7 +4767,16 @@ mod tests {
         let (client, server) = tokio::net::UnixStream::pair().unwrap();
 
         tokio::spawn(async move {
-            unix_connection_handler(server, state, runner(), CallerRole::Observer).await;
+            unix_connection_handler(
+                server,
+                state,
+                runner(),
+                crate::auth::CallerAttribution {
+                    role: CallerRole::Observer,
+                    principal: crate::auth::CallerPrincipal::Uid(1000),
+                },
+            )
+            .await;
         });
 
         let mut framed = FramedStream::new(client);
@@ -4760,7 +4975,7 @@ mod tests {
                 state,
                 runner(),
                 Arc::new(FastProgressExecutor),
-                CallerRole::Observer,
+                uid_caller(CallerRole::Observer),
             )
             .await;
         });
@@ -4859,7 +5074,17 @@ mod tests {
                 let mut framed = FramedStream::new(server);
                 let role = authenticate_vsock_token(&mut framed, &token_path).await;
                 if let Some(r) = role {
-                    dispatch_loop(&mut framed, state, runner(), executor(), r).await;
+                    dispatch_loop(
+                        &mut framed,
+                        state,
+                        runner(),
+                        executor(),
+                        CallerAttribution {
+                            role: r,
+                            principal: CallerPrincipal::VsockToken,
+                        },
+                    )
+                    .await;
                 }
             });
 
@@ -4996,7 +5221,7 @@ mod tests {
             server,
             state,
             runner(),
-            CallerRole::Observer,
+            uid_caller(CallerRole::Observer),
         ));
 
         let mut framed = FramedStream::new(client);

--- a/crates/sysknife-daemon/src/main.rs
+++ b/crates/sysknife-daemon/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use sysknife_core::{config::LacsConfig, default_database_path, default_listen_uri};
 use sysknife_daemon::audit_forward::{self, AuditForwarder, AuditSinkSpec};
-use sysknife_daemon::dispatcher::{resolve_caller_role, unix_connection_handler};
+use sysknife_daemon::dispatcher::{resolve_caller, unix_connection_handler};
 use sysknife_daemon::policy::PolicyTable;
 use sysknife_daemon::state::{DaemonConfig, DaemonState};
 use sysknife_daemon::state_collector::RealCommandRunner;
@@ -241,11 +241,11 @@ async fn unix_accept_loop(
                     Ok((stream, _addr)) => {
                         match Arc::clone(&semaphore).try_acquire_owned() {
                             Ok(permit) => {
-                                let role = resolve_caller_role(&stream);
+                                let caller = resolve_caller(&stream);
                                 let state = state.clone();
                                 let runner = Arc::clone(&runner);
                                 tokio::spawn(async move {
-                                    unix_connection_handler(stream, state, runner, role).await;
+                                    unix_connection_handler(stream, state, runner, caller).await;
                                     drop(permit);
                                 });
                             }

--- a/crates/sysknife-daemon/src/store.rs
+++ b/crates/sysknife-daemon/src/store.rs
@@ -398,6 +398,7 @@ pub use postgres::PostgresStore;
 mod tests {
     use super::*;
     use crate::audit_chain::AuditKey;
+    use crate::auth::CallerPrincipal;
     use crate::transactions::NewTransaction;
     use sysknife_types::{CallerRole, RiskLevel};
     use tempfile::tempdir;
@@ -416,6 +417,7 @@ mod tests {
             summary: "Upgrade the system".to_string(),
             warnings: vec![],
             caller_role: CallerRole::Dev,
+            caller_principal: CallerPrincipal::Uid(1000),
         }
     }
 

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -57,7 +57,8 @@ const MIGRATION_LOCK_ID: i64 = 0x5359_534b_4e49_4645;
 /// green. Mirrors `CHAIN_ROW_COLUMNS` in `transactions.rs`.
 const CHAIN_ROW_COLUMNS: &str = "seq, key_id, transaction_id, request_id, request_hash, \
      action_name, risk_level, summary, approval_id, warnings_json, \
-     created_at, prev_chain_hash, chain_hash, chain_version, caller_role, event_tip";
+     created_at, prev_chain_hash, chain_hash, chain_version, caller_role, event_tip, \
+     caller_principal";
 
 struct Migration {
     version: i64,
@@ -128,6 +129,14 @@ const MIGRATIONS: &[Migration] = &[Migration {
             "#,
             "CREATE INDEX IF NOT EXISTS audit_events_transaction_idx ON audit_events(transaction_id)",
         ],
+    },
+    // Mirrors SQLite migration 3. Nullable for the same reason: rows written
+    // before this step were signed over an encoding with no principal, so any
+    // backfill would rewrite their message and report the chain as Broken.
+    Migration {
+        version: 3,
+        name: "caller_principal",
+        statements: &["ALTER TABLE transactions ADD COLUMN IF NOT EXISTS caller_principal TEXT"],
     },
 ];
 
@@ -918,6 +927,7 @@ async fn insert_transaction(
     .await
     .map_err(map_sqlx_err)?;
     let caller_role = transaction.caller_role.as_str();
+    let caller_principal = transaction.caller_principal.as_signed_str();
 
     let chain_hash = key.chain_hash(
         &ChainContent {
@@ -932,9 +942,10 @@ async fn insert_transaction(
             approval_id: approval_id.as_deref(),
             warnings_json: &warnings_json,
             created_at: &created_at,
-            identity: ChainIdentity::V2 {
+            identity: ChainIdentity::V3 {
                 caller_role,
                 event_tip: &event_tip,
+                caller_principal: &caller_principal,
             },
         },
         &prev_chain_hash,
@@ -945,8 +956,8 @@ async fn insert_transaction(
             transaction_id, request_id, request_hash, action_name, risk_level, \
             status, approval_id, summary, warnings_json, created_at, \
             seq, key_id, chain_hash, prev_chain_hash, \
-            chain_version, caller_role, event_tip \
-         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)",
+            chain_version, caller_role, event_tip, caller_principal \
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)",
     )
     .bind(transaction_id)
     .bind(&transaction.request_id)
@@ -965,6 +976,7 @@ async fn insert_transaction(
     .bind(i64::from(CHAIN_VERSION_CURRENT))
     .bind(caller_role)
     .bind(&event_tip)
+    .bind(&caller_principal)
     .execute(&mut **tx)
     .await
     .map_err(map_sqlx_err)?;
@@ -1049,6 +1061,7 @@ fn row_to_chain_row(row: sqlx_postgres::PgRow) -> Result<ChainRow, TransactionSt
             .map_err(map_sqlx_err)? as u32,
         caller_role: row.try_get("caller_role").map_err(map_sqlx_err)?,
         event_tip: row.try_get("event_tip").map_err(map_sqlx_err)?,
+        caller_principal: row.try_get("caller_principal").map_err(map_sqlx_err)?,
     })
 }
 

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -37,7 +37,7 @@ use uuid::Uuid;
 
 use crate::audit_chain::{
     AuditEventKind, AuditKey, AuditVerification, ChainContent, ChainIdentity, ChainRow,
-    EventContent, EventRow, VerifyOutcome, CHAIN_VERSION_CURRENT, CURRENT_KEY_ID,
+    EventContent, EventRow, VerifyOutcome, CURRENT_KEY_ID,
 };
 use crate::audit_watermark::emit_chain_tip_watermark;
 use crate::store::AuditStore;
@@ -929,6 +929,13 @@ async fn insert_transaction(
     let caller_role = transaction.caller_role.as_str();
     let caller_principal = transaction.caller_principal.as_signed_str();
 
+    // As in the SQLite path: derive the stored version from the identity that was
+    // signed, so the column cannot disagree with the message.
+    let identity = ChainIdentity::V3 {
+        caller_role,
+        event_tip: &event_tip,
+        caller_principal: &caller_principal,
+    };
     let chain_hash = key.chain_hash(
         &ChainContent {
             seq,
@@ -942,11 +949,7 @@ async fn insert_transaction(
             approval_id: approval_id.as_deref(),
             warnings_json: &warnings_json,
             created_at: &created_at,
-            identity: ChainIdentity::V3 {
-                caller_role,
-                event_tip: &event_tip,
-                caller_principal: &caller_principal,
-            },
+            identity,
         },
         &prev_chain_hash,
     );
@@ -973,7 +976,7 @@ async fn insert_transaction(
     .bind(&key_id)
     .bind(&chain_hash)
     .bind(&prev_chain_hash)
-    .bind(i64::from(CHAIN_VERSION_CURRENT))
+    .bind(i64::from(identity.version()))
     .bind(caller_role)
     .bind(&event_tip)
     .bind(&caller_principal)

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -1,6 +1,6 @@
 use crate::audit_chain::{
     self, AuditEventKind, AuditKey, ChainContent, ChainIdentity, ChainRow, EventContent, EventRow,
-    VerifyOutcome, CHAIN_VERSION_CURRENT, CURRENT_KEY_ID,
+    VerifyOutcome, CURRENT_KEY_ID,
 };
 use crate::audit_watermark::emit_chain_tip_watermark;
 use crate::auth::CallerPrincipal;
@@ -75,10 +75,10 @@ pub struct NewTransaction {
     pub warnings: Vec<String>,
     /// Role the daemon resolved for the connection that asked for this action.
     ///
-    /// Chain-hashed at INSERT alongside `summary`. Before this field existed
-    /// the signed record could say what was authorised but not *who asked*,
-    /// which is the first question any audit of a privileged action starts
-    /// with. Not caller-supplied over the wire: the dispatcher passes the role
+    /// Chain-hashed at INSERT alongside `summary`. Before this field existed the
+    /// signed record could say what was authorised but not which privilege tier
+    /// asked; which *account* asked is `caller_principal` below. Not
+    /// caller-supplied over the wire: the dispatcher passes the role
     /// it resolved from `SO_PEERCRED` (or the vsock token), never a value from
     /// the request body.
     pub caller_role: CallerRole,
@@ -1117,6 +1117,14 @@ impl TransactionStore {
         let event_tip = Self::event_chain_tip(conn)?.unwrap_or_default();
         let caller_role = transaction.caller_role.as_str();
         let caller_principal = transaction.caller_principal.as_signed_str();
+        // Build the identity once and derive the stored version from it, so the
+        // chain_version column is provably the version whose message was signed.
+        // A constant here let the two drift the moment a new encoding landed.
+        let identity = ChainIdentity::V3 {
+            caller_role,
+            event_tip: &event_tip,
+            caller_principal: &caller_principal,
+        };
         let chain_hash = key.chain_hash(
             &ChainContent {
                 seq,
@@ -1130,11 +1138,7 @@ impl TransactionStore {
                 approval_id: approval_id.as_deref(),
                 warnings_json: &warnings_json,
                 created_at: &created_at,
-                identity: ChainIdentity::V3 {
-                    caller_role,
-                    event_tip: &event_tip,
-                    caller_principal: &caller_principal,
-                },
+                identity,
             },
             &prev_chain_hash,
         );
@@ -1187,7 +1191,7 @@ impl TransactionStore {
                 key_id,
                 chain_hash,
                 prev_chain_hash,
-                CHAIN_VERSION_CURRENT as i64,
+                identity.version() as i64,
                 caller_role,
                 event_tip,
                 caller_principal,
@@ -1257,6 +1261,7 @@ fn deserialize_field<T: DeserializeOwned>(value: &str) -> Result<T, serde_json::
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audit_chain::CHAIN_VERSION_CURRENT;
     use crate::audit_chain::CHAIN_VERSION_LEGACY;
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
@@ -1333,6 +1338,135 @@ mod tests {
         )
         .unwrap();
         transaction_id.to_string()
+    }
+
+    /// A database at schema version 2 holding one v2 row: the shape every host
+    /// running v0.2.13 through v0.2.16 has on disk right now.
+    ///
+    /// Built by replaying `SQLITE_MIGRATIONS[0..=1]` rather than hardcoded DDL,
+    /// so editing those migrations cannot leave this fixture describing a schema
+    /// that never existed.
+    fn v2_database(path: &Path, key: &AuditKey) -> String {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_migrations (
+                 version INTEGER PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+             );",
+        )
+        .unwrap();
+        for migration in &SQLITE_MIGRATIONS[0..=1] {
+            conn.execute_batch(migration.sql).unwrap();
+            conn.execute(
+                "INSERT INTO schema_migrations (version, name) VALUES (?1, ?2)",
+                params![migration.version, migration.name],
+            )
+            .unwrap();
+        }
+
+        let transaction_id = "tx-v2";
+        let created_at = "2026-07-01T12:00:00.000Z";
+        let chain_hash = key.chain_hash(
+            &ChainContent {
+                seq: 1,
+                key_id: CURRENT_KEY_ID,
+                transaction_id,
+                request_id: "req-v2",
+                request_hash: "hash-v2",
+                action_name: "UpdateSystem",
+                risk_level: RiskLevel::High,
+                summary: "Upgrade the system",
+                approval_id: None,
+                warnings_json: "[]",
+                created_at,
+                identity: ChainIdentity::V2 {
+                    caller_role: "admin",
+                    event_tip: "",
+                },
+            },
+            "",
+        );
+        conn.execute(
+            "INSERT INTO transactions (
+                transaction_id, request_id, request_hash, action_name, risk_level,
+                status, approval_id, summary, warnings_json, created_at,
+                seq, key_id, chain_hash, prev_chain_hash,
+                chain_version, caller_role, event_tip
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?8, ?9, 1, ?10, ?11, '', 2, 'admin', '')",
+            params![
+                transaction_id,
+                "req-v2",
+                "hash-v2",
+                "UpdateSystem",
+                serialize_field(&RiskLevel::High).unwrap(),
+                serialize_field(&JobState::Queued).unwrap(),
+                "Upgrade the system",
+                "[]",
+                created_at,
+                CURRENT_KEY_ID,
+                chain_hash,
+            ],
+        )
+        .unwrap();
+        transaction_id.to_string()
+    }
+
+    /// The upgrade every deployed host actually performs: v2 on disk, then v3
+    /// rows appended by the new daemon, in one chain.
+    ///
+    /// The v1 fixture already covers the older jump, but nothing covered this
+    /// one, and it is the only one with installed users. If migration 3 ever
+    /// backfilled a principal, or the v2 dispatch drifted, this is where a real
+    /// operator's audit log would start reporting as tampered.
+    #[test]
+    fn a_v2_database_keeps_verifying_and_accepts_v3_rows() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("tx.db");
+        let key = AuditKey::from_bytes(vec![0x42; 32]);
+        let old_transaction = v2_database(&db_path, &key);
+
+        let store = test_store(&db_path);
+
+        let version: i64 = store
+            .connection()
+            .unwrap()
+            .query_row("SELECT MAX(version) FROM schema_migrations", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(version, 3, "opening a v2 database must apply migration 3");
+
+        let rows = store.fetch_chain_rows().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].transaction_id, old_transaction);
+        assert_eq!(rows[0].chain_version, audit_chain::CHAIN_VERSION_V2);
+        assert_eq!(
+            rows[0].caller_principal, None,
+            "migration 3 must not invent a principal for a row signed without one"
+        );
+        assert!(matches!(
+            store.verify_audit_chain(&key).unwrap(),
+            audit_chain::VerifyOutcome::Intact { rows_checked: 1 }
+        ));
+
+        // Append under the new encoding and re-verify the mixed chain.
+        let mut fresh = queued_transaction();
+        fresh.caller_principal = CallerPrincipal::Uid(4242);
+        store.record(fresh).unwrap();
+
+        let rows = store.fetch_chain_rows().unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[1].chain_version, audit_chain::CHAIN_VERSION_CURRENT);
+        assert_eq!(rows[1].caller_principal.as_deref(), Some("uid:4242"));
+        assert_eq!(
+            rows[1].prev_chain_hash, rows[0].chain_hash,
+            "the v3 row must chain onto the v2 row, not start a new chain"
+        );
+        assert!(matches!(
+            store.verify_audit_chain(&key).unwrap(),
+            audit_chain::VerifyOutcome::Intact { rows_checked: 2 }
+        ));
     }
 
     #[test]
@@ -1543,7 +1677,6 @@ mod tests {
 
     // ── Audit chain integration tests ────────────────────────────────────
 
-    #[test]
     /// The store must persist the principal the dispatcher resolved, under the
     /// v3 tag, or the chain claims an encoding whose evidence is missing. Reads
     /// the columns directly rather than through the verifier, so a mismatch
@@ -1581,6 +1714,7 @@ mod tests {
         ));
     }
 
+    #[test]
     fn record_writes_audit_chain_columns() {
         let dir = tempdir().unwrap();
         let store = test_store(dir.path().join("tx.db"));
@@ -1655,7 +1789,10 @@ mod tests {
                         summary: format!("worker {w} record {r}"),
                         warnings: vec![],
                         caller_role: CallerRole::Dev,
-                        caller_principal: CallerPrincipal::Uid(1000),
+                        // Distinct per worker: with every row claiming the same
+                        // account, the chain could attribute a row to the wrong
+                        // caller under contention and still verify.
+                        caller_principal: CallerPrincipal::Uid(3000 + w as u32),
                     };
                     store
                         .record(tx)
@@ -1678,6 +1815,34 @@ mod tests {
                 );
             }
             other => panic!("chain must be Intact under concurrent writes; got {other:?}"),
+        }
+
+        // (a2) every row must still name the worker that wrote it. The summary
+        // carries the worker id independently of the principal, so a row whose
+        // principal drifted onto another worker's insert is detectable.
+        {
+            let conn = store.connection().unwrap();
+            let mut stmt = conn
+                .prepare("SELECT summary, caller_principal FROM transactions")
+                .unwrap();
+            let pairs: Vec<(String, Option<String>)> = stmt
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+            assert_eq!(pairs.len(), TOTAL);
+            for (summary, principal) in pairs {
+                let worker: u32 = summary
+                    .split_whitespace()
+                    .nth(1)
+                    .and_then(|w| w.parse().ok())
+                    .unwrap_or_else(|| panic!("unexpected summary {summary:?}"));
+                assert_eq!(
+                    principal.as_deref(),
+                    Some(format!("uid:{}", 3000 + worker).as_str()),
+                    "row {summary:?} was attributed to the wrong account"
+                );
+            }
         }
 
         // (b) seq must be a contiguous run 1..=TOTAL with no gaps and no duplicates.

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -3,6 +3,7 @@ use crate::audit_chain::{
     VerifyOutcome, CHAIN_VERSION_CURRENT, CURRENT_KEY_ID,
 };
 use crate::audit_watermark::emit_chain_tip_watermark;
+use crate::auth::CallerPrincipal;
 use rusqlite::{params, Connection, TransactionBehavior};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -81,6 +82,14 @@ pub struct NewTransaction {
     /// it resolved from `SO_PEERCRED` (or the vsock token), never a value from
     /// the request body.
     pub caller_role: CallerRole,
+    /// Which account asked, as opposed to what its role permitted.
+    ///
+    /// Chain-hashed at INSERT alongside `caller_role`. The role alone cannot
+    /// separate two members of `sysknife-admin`, so a trail built only from it
+    /// answers "an Admin did this" and stops there. Like the role, this is
+    /// resolved by the dispatcher from the connection, never read from the
+    /// request body. See [`crate::auth::CallerPrincipal`].
+    pub caller_principal: CallerPrincipal,
 }
 
 /// One forward-only SQLite schema step, applied in `version` order and
@@ -182,6 +191,17 @@ const SQLITE_MIGRATIONS: &[SqliteMigration] = &[
                 ON audit_events(transaction_id);
         "#,
     },
+    // Nullable for the same reason the v2 columns are: rows written before this
+    // step were signed over an encoding with no principal field, so backfilling
+    // any value would rewrite their message and report the chain as Broken.
+    // `chain_version` keeps selecting the encoding per row.
+    SqliteMigration {
+        version: 3,
+        name: "caller_principal",
+        sql: r#"
+            ALTER TABLE transactions ADD COLUMN caller_principal TEXT;
+        "#,
+    },
 ];
 
 /// Column list for every `ChainRow` read, kept next to the mapper below.
@@ -192,7 +212,8 @@ const SQLITE_MIGRATIONS: &[SqliteMigration] = &[
 /// as a verification failure rather than a compile error.
 const CHAIN_ROW_COLUMNS: &str = "seq, key_id, transaction_id, request_id, request_hash, \
      action_name, risk_level, summary, approval_id, warnings_json, \
-     created_at, prev_chain_hash, chain_hash, chain_version, caller_role, event_tip";
+     created_at, prev_chain_hash, chain_hash, chain_version, caller_role, event_tip, \
+     caller_principal";
 
 fn chain_row_from_sqlite(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChainRow> {
     Ok(ChainRow {
@@ -214,6 +235,7 @@ fn chain_row_from_sqlite(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChainRow> 
         chain_version: row.get::<_, i64>(13)? as u32,
         caller_role: row.get(14)?,
         event_tip: row.get(15)?,
+        caller_principal: row.get(16)?,
     })
 }
 
@@ -1094,6 +1116,7 @@ impl TransactionStore {
         // cannot land between the read and the insert.
         let event_tip = Self::event_chain_tip(conn)?.unwrap_or_default();
         let caller_role = transaction.caller_role.as_str();
+        let caller_principal = transaction.caller_principal.as_signed_str();
         let chain_hash = key.chain_hash(
             &ChainContent {
                 seq,
@@ -1107,9 +1130,10 @@ impl TransactionStore {
                 approval_id: approval_id.as_deref(),
                 warnings_json: &warnings_json,
                 created_at: &created_at,
-                identity: ChainIdentity::V2 {
+                identity: ChainIdentity::V3 {
                     caller_role,
                     event_tip: &event_tip,
+                    caller_principal: &caller_principal,
                 },
             },
             &prev_chain_hash,
@@ -1145,8 +1169,9 @@ impl TransactionStore {
                 prev_chain_hash,
                 chain_version,
                 caller_role,
-                event_tip
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+                event_tip,
+                caller_principal
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
             params![
                 transaction_id,
                 request_id,
@@ -1165,6 +1190,7 @@ impl TransactionStore {
                 CHAIN_VERSION_CURRENT as i64,
                 caller_role,
                 event_tip,
+                caller_principal,
             ],
         )?;
 
@@ -1518,6 +1544,43 @@ mod tests {
     // ── Audit chain integration tests ────────────────────────────────────
 
     #[test]
+    /// The store must persist the principal the dispatcher resolved, under the
+    /// v3 tag, or the chain claims an encoding whose evidence is missing. Reads
+    /// the columns directly rather than through the verifier, so a mismatch
+    /// between what was signed and what was stored is visible.
+    #[test]
+    fn record_persists_the_caller_principal_under_the_current_encoding() {
+        let dir = tempdir().unwrap();
+        let store = test_store(dir.path().join("tx.db"));
+        let mut tx = queued_transaction();
+        tx.caller_principal = CallerPrincipal::Uid(4242);
+        store.record(tx).unwrap();
+
+        let conn = store.connection().unwrap();
+        let (version, role, principal): (i64, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT chain_version, caller_role, caller_principal FROM transactions",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+
+        assert_eq!(version, i64::from(audit_chain::CHAIN_VERSION_CURRENT));
+        assert_eq!(role.as_deref(), Some("dev"));
+        assert_eq!(
+            principal.as_deref(),
+            Some("uid:4242"),
+            "the row must name the account the dispatcher resolved"
+        );
+
+        // And the signature must agree with those columns.
+        let key = AuditKey::from_bytes(vec![0x42; 32]);
+        assert!(matches!(
+            store.verify_audit_chain(&key).unwrap(),
+            audit_chain::VerifyOutcome::Intact { .. }
+        ));
+    }
+
     fn record_writes_audit_chain_columns() {
         let dir = tempdir().unwrap();
         let store = test_store(dir.path().join("tx.db"));
@@ -1592,6 +1655,7 @@ mod tests {
                         summary: format!("worker {w} record {r}"),
                         warnings: vec![],
                         caller_role: CallerRole::Dev,
+                        caller_principal: CallerPrincipal::Uid(1000),
                     };
                     store
                         .record(tx)
@@ -1773,6 +1837,7 @@ mod tests {
             summary: "Upgrade the system".to_string(),
             warnings: vec![],
             caller_role: CallerRole::Dev,
+            caller_principal: CallerPrincipal::Uid(1000),
         }
     }
 

--- a/crates/sysknife-daemon/tests/accept_loop.rs
+++ b/crates/sysknife-daemon/tests/accept_loop.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::sync::Arc;
 
 use serde_json::{json, Value};
-use sysknife_daemon::dispatcher::{resolve_caller_role, unix_connection_handler};
+use sysknife_daemon::dispatcher::{resolve_caller, unix_connection_handler};
 use sysknife_daemon::state::{DaemonConfig, DaemonState};
 use sysknife_daemon::state_collector::CommandRunner;
 use sysknife_daemon::transport::{framing::FramedStream, listen::ListenTarget};
@@ -56,11 +56,11 @@ async fn start_daemon(dir: &tempfile::TempDir) -> std::path::PathBuf {
 
     tokio::spawn(async move {
         while let Ok((stream, _)) = listener.accept().await {
-            let role = resolve_caller_role(&stream);
+            let caller = resolve_caller(&stream);
             let state = state.clone();
             let runner = Arc::clone(&runner);
             tokio::spawn(async move {
-                unix_connection_handler(stream, state, runner, role).await;
+                unix_connection_handler(stream, state, runner, caller).await;
             });
         }
     });

--- a/crates/sysknife-daemon/tests/bootstrap.rs
+++ b/crates/sysknife-daemon/tests/bootstrap.rs
@@ -85,6 +85,7 @@ fn transaction_records_are_persisted() {
         summary: "Stage system update".into(),
         warnings: vec!["reboot required".into()],
         caller_role: CallerRole::Dev,
+        caller_principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
     };
 
     let record = store.record(transaction).expect("record tx");

--- a/crates/sysknife-daemon/tests/concurrency_guard.rs
+++ b/crates/sysknife-daemon/tests/concurrency_guard.rs
@@ -403,8 +403,5 @@ fn exclusive_resource_is_derived_from_the_action_argv() {
 
 /// A caller attributed to a uid, as a Unix-socket connection would be.
 fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
-    sysknife_daemon::auth::CallerAttribution {
-        role,
-        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-    }
+    sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, role)
 }

--- a/crates/sysknife-daemon/tests/concurrency_guard.rs
+++ b/crates/sysknife-daemon/tests/concurrency_guard.rs
@@ -80,7 +80,7 @@ async fn spawn_handler(
     let (client, server) = UnixStream::pair().unwrap();
     let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(MockRunner);
     tokio::spawn(async move {
-        connection_handler_with_executor(server, state, runner, executor, role).await;
+        connection_handler_with_executor(server, state, runner, executor, uid_caller(role)).await;
     });
     FramedStream::new(client)
 }
@@ -399,4 +399,12 @@ fn exclusive_resource_is_derived_from_the_action_argv() {
         None,
         "a systemctl action holds no package-manager lock"
     );
+}
+
+/// A caller attributed to a uid, as a Unix-socket connection would be.
+fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
+    sysknife_daemon::auth::CallerAttribution {
+        role,
+        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+    }
 }

--- a/crates/sysknife-daemon/tests/connection_deadline.rs
+++ b/crates/sysknife-daemon/tests/connection_deadline.rs
@@ -67,7 +67,7 @@ fn spawn_handler(
     let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(MockRunner);
     let executor: Arc<dyn ActionExecutor> = Arc::new(InstantSuccessExecutor);
     let handle = tokio::spawn(async move {
-        connection_handler_with_executor(server, state, runner, executor, role).await;
+        connection_handler_with_executor(server, state, runner, executor, uid_caller(role)).await;
     });
     (FramedStream::new(client), handle)
 }
@@ -132,5 +132,13 @@ async fn a_served_connection_still_accepts_a_second_request() {
             resp["type"], "preview_response",
             "request {request_id} on a reused connection must still be served: {resp}"
         );
+    }
+}
+
+/// A caller attributed to a uid, as a Unix-socket connection would be.
+fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
+    sysknife_daemon::auth::CallerAttribution {
+        role,
+        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
     }
 }

--- a/crates/sysknife-daemon/tests/connection_deadline.rs
+++ b/crates/sysknife-daemon/tests/connection_deadline.rs
@@ -137,8 +137,5 @@ async fn a_served_connection_still_accepts_a_second_request() {
 
 /// A caller attributed to a uid, as a Unix-socket connection would be.
 fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
-    sysknife_daemon::auth::CallerAttribution {
-        role,
-        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-    }
+    sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, role)
 }

--- a/crates/sysknife-daemon/tests/coverage_gaps.rs
+++ b/crates/sysknife-daemon/tests/coverage_gaps.rs
@@ -421,8 +421,5 @@ fn cleanup_stale_queued_does_not_clobber_running_rows() {
 
 /// A caller attributed to a uid, as a Unix-socket connection would be.
 fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
-    sysknife_daemon::auth::CallerAttribution {
-        role,
-        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-    }
+    sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, role)
 }

--- a/crates/sysknife-daemon/tests/coverage_gaps.rs
+++ b/crates/sysknife-daemon/tests/coverage_gaps.rs
@@ -63,7 +63,7 @@ async fn spawn_handler_with_role(state: DaemonState, role: CallerRole) -> Framed
     let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(MockRunner);
     let executor: Arc<dyn ActionExecutor> = Arc::new(MockExecutor { exit_code: 0 });
     tokio::spawn(async move {
-        connection_handler_with_executor(server, state, runner, executor, role).await;
+        connection_handler_with_executor(server, state, runner, executor, uid_caller(role)).await;
     });
     FramedStream::new(client)
 }
@@ -97,6 +97,7 @@ fn make_transaction(action: &str) -> NewTransaction {
         summary: format!("Test {action}"),
         warnings: vec![],
         caller_role: CallerRole::Dev,
+        caller_principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
     }
 }
 
@@ -120,6 +121,7 @@ fn list_transactions_limit_is_capped_at_100() {
                 summary: format!("tx {i}"),
                 warnings: vec![],
                 caller_role: CallerRole::Dev,
+                caller_principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
             })
             .expect("record tx");
     }
@@ -192,6 +194,7 @@ async fn list_job_history_returns_recorded_transactions() {
             summary: "Stage system update".into(),
             warnings: vec![],
             caller_role: CallerRole::Dev,
+            caller_principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
         })
         .await
         .expect("record tx");
@@ -414,4 +417,12 @@ fn cleanup_stale_queued_does_not_clobber_running_rows() {
         .map(|r| r.status);
     assert_eq!(queued_status, Some(JobState::Canceled));
     assert_eq!(promoted_status, Some(JobState::Running));
+}
+
+/// A caller attributed to a uid, as a Unix-socket connection would be.
+fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
+    sysknife_daemon::auth::CallerAttribution {
+        role,
+        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+    }
 }

--- a/crates/sysknife-daemon/tests/fail_closed_paths.rs
+++ b/crates/sysknife-daemon/tests/fail_closed_paths.rs
@@ -60,7 +60,7 @@ async fn spawn_handler(
     let (client, server) = UnixStream::pair().unwrap();
     let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(MockRunner);
     tokio::spawn(async move {
-        connection_handler_with_executor(server, state, runner, executor, role).await;
+        connection_handler_with_executor(server, state, runner, executor, uid_caller(role)).await;
     });
     FramedStream::new(client)
 }
@@ -181,4 +181,12 @@ async fn preview_never_reaches_the_executor() {
         resp.get("transaction_id").is_some(),
         "preview must return a transaction to approve: {resp}"
     );
+}
+
+/// A caller attributed to a uid, as a Unix-socket connection would be.
+fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
+    sysknife_daemon::auth::CallerAttribution {
+        role,
+        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+    }
 }

--- a/crates/sysknife-daemon/tests/fail_closed_paths.rs
+++ b/crates/sysknife-daemon/tests/fail_closed_paths.rs
@@ -185,8 +185,5 @@ async fn preview_never_reaches_the_executor() {
 
 /// A caller attributed to a uid, as a Unix-socket connection would be.
 fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
-    sysknife_daemon::auth::CallerAttribution {
-        role,
-        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-    }
+    sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, role)
 }

--- a/crates/sysknife-daemon/tests/lifecycle_events.rs
+++ b/crates/sysknife-daemon/tests/lifecycle_events.rs
@@ -49,10 +49,7 @@ async fn spawn_handler(state: DaemonState) -> FramedStream<UnixStream> {
             state,
             runner,
             executor,
-            sysknife_daemon::auth::CallerAttribution {
-                role: CallerRole::Admin,
-                principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-            },
+            sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, CallerRole::Admin),
         )
         .await;
     });
@@ -71,10 +68,7 @@ async fn spawn_handler_with_executor(
             state,
             runner,
             executor,
-            sysknife_daemon::auth::CallerAttribution {
-                role: CallerRole::Admin,
-                principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-            },
+            sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, CallerRole::Admin),
         )
         .await;
     });
@@ -382,12 +376,4 @@ async fn rollback_execution_includes_lifecycle_events() {
             .any(|l| l.contains("attempting automatic rollback")),
         "should have rollback attempt event; got: {lines:?}"
     );
-}
-
-/// A caller attributed to a uid, as a Unix-socket connection would be.
-fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
-    sysknife_daemon::auth::CallerAttribution {
-        role,
-        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-    }
 }

--- a/crates/sysknife-daemon/tests/lifecycle_events.rs
+++ b/crates/sysknife-daemon/tests/lifecycle_events.rs
@@ -44,7 +44,17 @@ async fn spawn_handler(state: DaemonState) -> FramedStream<UnixStream> {
     let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(MockRunner);
     let executor: Arc<dyn ActionExecutor> = Arc::new(sysknife_daemon::executor::RealActionExecutor);
     tokio::spawn(async move {
-        connection_handler_with_executor(server, state, runner, executor, CallerRole::Admin).await;
+        connection_handler_with_executor(
+            server,
+            state,
+            runner,
+            executor,
+            sysknife_daemon::auth::CallerAttribution {
+                role: CallerRole::Admin,
+                principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+            },
+        )
+        .await;
     });
     FramedStream::new(client)
 }
@@ -56,7 +66,17 @@ async fn spawn_handler_with_executor(
     let (client, server) = UnixStream::pair().unwrap();
     let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(MockRunner);
     tokio::spawn(async move {
-        connection_handler_with_executor(server, state, runner, executor, CallerRole::Admin).await;
+        connection_handler_with_executor(
+            server,
+            state,
+            runner,
+            executor,
+            sysknife_daemon::auth::CallerAttribution {
+                role: CallerRole::Admin,
+                principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+            },
+        )
+        .await;
     });
     FramedStream::new(client)
 }
@@ -362,4 +382,12 @@ async fn rollback_execution_includes_lifecycle_events() {
             .any(|l| l.contains("attempting automatic rollback")),
         "should have rollback attempt event; got: {lines:?}"
     );
+}
+
+/// A caller attributed to a uid, as a Unix-socket connection would be.
+fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
+    sysknife_daemon::auth::CallerAttribution {
+        role,
+        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+    }
 }

--- a/crates/sysknife-daemon/tests/postgres_store.rs
+++ b/crates/sysknife-daemon/tests/postgres_store.rs
@@ -22,6 +22,7 @@ fn new_transaction() -> NewTransaction {
         summary: "Restart sshd".to_string(),
         warnings: vec!["brief connection interruption".to_string()],
         caller_role: CallerRole::Dev,
+        caller_principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
     }
 }
 
@@ -127,7 +128,7 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
     .await
     .expect("read schema migration version");
     assert_eq!(
-        migration, 2,
+        migration, 3,
         "every migration in MIGRATIONS must have applied"
     );
     assert!(store
@@ -148,6 +149,11 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
     assert_eq!(legacy_chain_row.chain_version, 1);
     assert_eq!(legacy_chain_row.caller_role, None);
     assert_eq!(legacy_chain_row.event_tip, None);
+    assert_eq!(
+        legacy_chain_row.caller_principal, None,
+        "migration 3 must not backfill a principal onto a row that was signed \
+         without one; any value here would rewrite its message"
+    );
 
     let events_table_exists: bool =
         sqlx_core::query_scalar::query_scalar("SELECT to_regclass('audit_events') IS NOT NULL")
@@ -171,6 +177,22 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
         .await
         .expect("record previewed transaction");
     let transaction_id = &recorded.transaction.transaction_id;
+
+    let fresh_chain_row = store
+        .fetch_chain_row(&recorded.transaction.transaction_id)
+        .await
+        .expect("fetch the row just written")
+        .expect("the row exists");
+    assert_eq!(
+        fresh_chain_row.chain_version,
+        sysknife_daemon::audit_chain::CHAIN_VERSION_CURRENT
+    );
+    assert_eq!(
+        fresh_chain_row.caller_principal.as_deref(),
+        Some("uid:1000"),
+        "the Postgres insert must persist the principal the dispatcher resolved, \
+         exactly as the SQLite path does"
+    );
     assert_eq!(
         store
             .get_preview(transaction_id)
@@ -308,11 +330,12 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
             .expect("count migrations");
     // Idempotence: reconnecting re-runs `initialize`, which must not record a
     // migration a second time.
-    assert_eq!(migration_count, 2);
+    assert_eq!(migration_count, 3);
 
     for (version, name) in [
         (1_i64, "initial_audit_schema"),
         (2, "caller_identity_and_approval_events"),
+        (3, "caller_principal"),
     ] {
         let migration_row = sqlx_core::query::query(
             "SELECT version, name FROM schema_migrations WHERE version = $1",

--- a/crates/sysknife-daemon/tests/preview_approval.rs
+++ b/crates/sysknife-daemon/tests/preview_approval.rs
@@ -214,6 +214,7 @@ fn previewed_transactions_persist_preview_state() {
         summary: "Stage system update".to_string(),
         warnings: vec!["system reboot required".to_string()],
         caller_role: CallerRole::Dev,
+        caller_principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
     };
 
     let recorded = store

--- a/crates/sysknife-daemon/tests/preview_state_warning.rs
+++ b/crates/sysknife-daemon/tests/preview_state_warning.rs
@@ -49,10 +49,7 @@ async fn preview_warns_when_state_collection_fails() {
             state,
             runner,
             executor,
-            sysknife_daemon::auth::CallerAttribution {
-                role: CallerRole::Admin,
-                principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-            },
+            sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, CallerRole::Admin),
         )
         .await;
     });

--- a/crates/sysknife-daemon/tests/preview_state_warning.rs
+++ b/crates/sysknife-daemon/tests/preview_state_warning.rs
@@ -44,7 +44,17 @@ async fn preview_warns_when_state_collection_fails() {
     let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(FailingHostnameRunner);
     let executor: Arc<dyn ActionExecutor> = Arc::new(RealActionExecutor);
     tokio::spawn(async move {
-        connection_handler_with_executor(server, state, runner, executor, CallerRole::Admin).await;
+        connection_handler_with_executor(
+            server,
+            state,
+            runner,
+            executor,
+            sysknife_daemon::auth::CallerAttribution {
+                role: CallerRole::Admin,
+                principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+            },
+        )
+        .await;
     });
     let mut framed = FramedStream::new(client);
 

--- a/crates/sysknife-daemon/tests/query_action_exit_codes.rs
+++ b/crates/sysknife-daemon/tests/query_action_exit_codes.rs
@@ -286,8 +286,5 @@ async fn other_action_nonzero_exit_returns_execution_failure() {
 
 /// A caller attributed to a uid, as a Unix-socket connection would be.
 fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
-    sysknife_daemon::auth::CallerAttribution {
-        role,
-        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-    }
+    sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, role)
 }

--- a/crates/sysknife-daemon/tests/query_action_exit_codes.rs
+++ b/crates/sysknife-daemon/tests/query_action_exit_codes.rs
@@ -90,8 +90,14 @@ async fn spawn_handler(
     let (client, server) = UnixStream::pair().unwrap();
     let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(MockRunner);
     tokio::spawn(async move {
-        connection_handler_with_executor(server, state, runner, executor, CallerRole::Observer)
-            .await;
+        connection_handler_with_executor(
+            server,
+            state,
+            runner,
+            executor,
+            uid_caller(CallerRole::Observer),
+        )
+        .await;
     });
     FramedStream::new(client)
 }
@@ -276,4 +282,12 @@ async fn other_action_nonzero_exit_returns_execution_failure() {
         resp["category"], "execution_failure",
         "error category must be execution_failure: {resp}"
     );
+}
+
+/// A caller attributed to a uid, as a Unix-socket connection would be.
+fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
+    sysknife_daemon::auth::CallerAttribution {
+        role,
+        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+    }
 }

--- a/crates/sysknife-daemon/tests/rollback.rs
+++ b/crates/sysknife-daemon/tests/rollback.rs
@@ -111,10 +111,7 @@ async fn spawn_handler_with_executor(
             state,
             runner,
             executor,
-            sysknife_daemon::auth::CallerAttribution {
-                role: CallerRole::Admin,
-                principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-            },
+            sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, CallerRole::Admin),
         )
         .await;
     });
@@ -405,12 +402,4 @@ async fn non_rollbackable_action_does_not_trigger_rollback() {
         completed["result"]["rollback_ref"].is_null(),
         "rollback_ref must be null for non-rollbackable actions"
     );
-}
-
-/// A caller attributed to a uid, as a Unix-socket connection would be.
-fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
-    sysknife_daemon::auth::CallerAttribution {
-        role,
-        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
-    }
 }

--- a/crates/sysknife-daemon/tests/rollback.rs
+++ b/crates/sysknife-daemon/tests/rollback.rs
@@ -106,7 +106,17 @@ async fn spawn_handler_with_executor(
     let (client, server) = UnixStream::pair().unwrap();
     let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(MockRunner);
     tokio::spawn(async move {
-        connection_handler_with_executor(server, state, runner, executor, CallerRole::Admin).await;
+        connection_handler_with_executor(
+            server,
+            state,
+            runner,
+            executor,
+            sysknife_daemon::auth::CallerAttribution {
+                role: CallerRole::Admin,
+                principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+            },
+        )
+        .await;
     });
     FramedStream::new(client)
 }
@@ -395,4 +405,12 @@ async fn non_rollbackable_action_does_not_trigger_rollback() {
         completed["result"]["rollback_ref"].is_null(),
         "rollback_ref must be null for non-rollbackable actions"
     );
+}
+
+/// A caller attributed to a uid, as a Unix-socket connection would be.
+fn uid_caller(role: sysknife_types::CallerRole) -> sysknife_daemon::auth::CallerAttribution {
+    sysknife_daemon::auth::CallerAttribution {
+        role,
+        principal: sysknife_daemon::auth::CallerPrincipal::Uid(1000),
+    }
 }

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -252,7 +252,7 @@ extra reviewer scrutiny:
 | Action allowlist | `crates/sysknife-brain/src/planning_tools/propose_plan.rs` (`KNOWN_ACTIONS`) | Adding a name here makes it proposable by the LLM |
 | Role policy | `crates/sysknife-daemon/src/policy.rs` (`min_role_for_action`) | Governs which groups can execute which actions |
 | Approval / replay | `crates/sysknife-daemon/src/transactions.rs` | Hash freshness and TOCTOU protection |
-| Caller auth | `crates/sysknife-daemon/src/dispatcher.rs` (`resolve_caller_role`) | SO_PEERCRED group-to-role mapping |
+| Caller auth | `crates/sysknife-daemon/src/dispatcher.rs` (`resolve_caller`) | SO_PEERCRED uid + group-to-role mapping |
 | Audit log | `crates/sysknife-brain/src/audit.rs`, `crates/sysknife-brain/src/journal.rs` | Safety fence record and journald forwarding |
 
 When adding a new action to `KNOWN_ACTIONS`, you must also:

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,539 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,548 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,548 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,561 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -138,7 +138,7 @@ flow.
 
 ## Status
 
-189 typed actions · 1,548 Rust tests + 72 frontend tests · MIT
+189 typed actions · 1,561 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -138,7 +138,7 @@ flow.
 
 ## Status
 
-189 typed actions · 1,539 Rust tests + 72 frontend tests · MIT
+189 typed actions · 1,548 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -25,9 +25,10 @@ the daemon made about one action, at the moment it made it:
 | `warnings_json` | Warnings surfaced to the user before approval |
 | `created_at` | When the row was written |
 | `caller_role` | Which privilege tier the daemon resolved for the connection that asked |
+| `caller_principal` | **Which account** asked: `uid:<n>`, `token:vsock`, or `unattributed` |
 | `event_tip` | The approval-event chain tip at insert time (see below) |
 
-These thirteen fields are serialized into a stable, self-describing byte
+These fourteen fields are serialized into a stable, self-describing byte
 string (tag + value pairs, with a prefix-free escape scheme so no field's
 content can be crafted to alias another field's boundary), then signed. The
 resulting signature *is* the row's `chain_hash` — there is no separate hash
@@ -40,17 +41,46 @@ back) is **not** part of the signed content. The chain protects the
 state — a scope decision, not an oversight (see [Limits](#limits-and-honest-scope)).
 ```
 
-```admonish info title="Rows written before v0.2.13"
-`caller_role` and `event_tip` were added in v0.2.13. Rows written by an
-earlier daemon were signed over an encoding that has no such fields, so each
-row carries a `chain_version` column and verification reproduces the exact
-encoding that row was signed under. An upgraded daemon appends v2 rows onto
-an existing v1 chain and the whole chain still verifies in one walk — an
-upgrade never makes a healthy audit log look tampered.
+```admonish info title="Three row encodings coexist"
+The signed field set grew twice, and each row records which encoding it was
+signed under in its `chain_version` column:
 
-The version is not a hiding place: relabelling a v2 row as v1 to erase its
-`caller_role` makes verification re-encode it without the identity fields, so
-the stored signature no longer verifies and the row reports as broken.
+| Version | Added | Since |
+|---|---|---|
+| 1 | the base fields | before v0.2.13 |
+| 2 | `caller_role`, `event_tip` | v0.2.13 |
+| 3 | `caller_principal` | v0.3.0 |
+
+Verification reproduces the exact encoding each row claims, so an upgraded
+daemon appends v3 rows onto a chain that already holds v1 and v2 rows and the
+whole thing still verifies in one walk. An upgrade never makes a healthy audit
+log look tampered, and older rows are never backfilled: writing a principal
+into a row that was signed without one would change the message it was signed
+over and report the chain as broken.
+
+The version is not a hiding place in either direction. Relabelling a v3 row as
+v2 to erase which account acted makes verification re-encode it without the
+principal, so the stored signature no longer verifies. A v3 row whose principal
+is missing or blank is reported as broken rather than accepted, because it
+claims an encoding that names an account while naming none.
+```
+
+```admonish tip title="Role versus principal"
+They answer different questions and the distinction is the point of v3.
+`caller_role` says **what was permitted**; on a host with two admins it cannot
+separate them. `caller_principal` says **which account asked**.
+
+The scheme prefix is signed along with the value because the strength of the
+evidence differs: `uid:1000` was attested by the kernel through `SO_PEERCRED`,
+while `token:vsock` only proves that someone could read the pre-shared token
+file. A bare string would erase that difference. `unattributed` appears when
+`SO_PEERCRED` yielded no usable peer: the daemon records that attribution failed
+instead of inventing a uid, because a signed lie about who acted is worse than a
+signed admission of ignorance.
+
+What a uid does *not* prove: shared logins, `su` into a service account, and uid
+reuse after a user is deleted all weaken it. It identifies an account, not a
+human.
 ```
 
 ## The hash chain: each entry links to the one before it

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -10,8 +10,10 @@ for a security-sensitive deployment, this is the page to try to break.
 
 ## What gets recorded
 
-Each row in the transaction table (`sysknife history`) captures the decision
-the daemon made about one action, at the moment it made it:
+Each row in the transaction table captures the decision the daemon made about
+one action, at the moment it made it. `sysknife history` renders a subset;
+`caller_role`, `caller_principal` and `event_tip` are chain fields, read with
+`sysknife audit verify` or directly from the database:
 
 | Field | What it commits to |
 |---|---|
@@ -25,12 +27,15 @@ the daemon made about one action, at the moment it made it:
 | `warnings_json` | Warnings surfaced to the user before approval |
 | `created_at` | When the row was written |
 | `caller_role` | Which privilege tier the daemon resolved for the connection that asked |
-| `caller_principal` | **Which account** asked: `uid:<n>`, `token:vsock`, or `unattributed` |
+| `caller_principal` | **Which account** asked: `uid:<n>`, `token:vsock`, or `none:unattributed` |
 | `event_tip` | The approval-event chain tip at insert time (see below) |
 
-These fourteen fields are serialized into a stable, self-describing byte
+These fields are serialized into a stable, self-describing byte
 string (tag + value pairs, with a prefix-free escape scheme so no field's
 content can be crafted to alias another field's boundary), then signed. The
+count is per encoding, because the field set grew: v1 signs eleven pairs, v2
+fourteen, v3 fifteen — the fields above plus the `chain_version` tag that names
+the encoding (see below). The
 resulting signature *is* the row's `chain_hash` — there is no separate hash
 step, because Ed25519 already commits to the message.
 
@@ -49,7 +54,7 @@ signed under in its `chain_version` column:
 |---|---|---|
 | 1 | the base fields | before v0.2.13 |
 | 2 | `caller_role`, `event_tip` | v0.2.13 |
-| 3 | `caller_principal` | v0.3.0 |
+| 3 | `caller_principal` | 0.3.0 (unreleased) |
 
 Verification reproduces the exact encoding each row claims, so an upgraded
 daemon appends v3 rows onto a chain that already holds v1 and v2 rows and the
@@ -73,10 +78,17 @@ separate them. `caller_principal` says **which account asked**.
 The scheme prefix is signed along with the value because the strength of the
 evidence differs: `uid:1000` was attested by the kernel through `SO_PEERCRED`,
 while `token:vsock` only proves that someone could read the pre-shared token
-file. A bare string would erase that difference. `unattributed` appears when
-`SO_PEERCRED` yielded no usable peer: the daemon records that attribution failed
-instead of inventing a uid, because a signed lie about who acted is worse than a
+file. A bare string would erase that difference. `none:unattributed` appears when the daemon could
+not establish an account: `SO_PEERCRED` failed, or returned no usable pid, or the
+peer is not representable in the daemon's namespaces, in which case the kernel
+reports the overflow uid (`nobody`) rather than failing. Recording that failure
+beats inventing a uid, because a signed lie about who acted is worse than a
 signed admission of ignorance.
+
+A chain full of `none:unattributed` rows still verifies as intact, and that is
+honest but incomplete, so `sysknife audit verify` reports the count separately
+(`unattributed_rows` in `--json` and on the `sysknife_audit_verify` tool). Intact
+is a statement about tampering, not about how much the trail can tell you.
 
 What a uid does *not* prove: shared logins, `su` into a service account, and uid
 reuse after a user is deleted all weaken it. It identifies an account, not a

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -290,7 +290,7 @@ forget" model — the LLM never sees what the commands produced.
    `sudo usermod -aG docker ci-runner`.
 
 5. Transaction logged to SQLite with both action names, params,
-   caller role, and timestamps.
+   caller role and principal, and timestamps.
 
 **What works well:** The role-based authorization
 (`crates/sysknife-daemon/src/policy.rs:24`) ensures the caller has

--- a/docs/vm-daemon-setup.md
+++ b/docs/vm-daemon-setup.md
@@ -96,7 +96,7 @@ ssh -fN \
 
 Authorization is **not** carried by the tunnel. The daemon reads the connecting
 peer's credentials with `SO_PEERCRED` and resolves that peer's group membership
-(`resolve_caller_role` in `crates/sysknife-daemon/src/dispatcher.rs`). Over a
+(`resolve_caller` in `crates/sysknife-daemon/src/dispatcher.rs`). Over a
 forwarded socket the connecting peer is the `sshd` process on the remote side,
 running as the SSH user, so:
 

--- a/scripts/check_public_claims.sh
+++ b/scripts/check_public_claims.sh
@@ -38,8 +38,8 @@ reject_pattern() {
 # with one command. Quoting a subset (e.g. excluding the GUI crate) makes the
 # number unverifiable from the documented command, which is how it silently
 # came to mean two different things.
-reject_pattern '1,(2[0-9][0-9]|3[0-9][0-9]|4[0-9][0-9]|5[0-2][0-9]|53[0-8])( Rust)? tests' \
-    'test count is stale; the release baseline is 1,539 Rust tests' \
+reject_pattern '1,(2[0-9][0-9]|3[0-9][0-9]|4[0-9][0-9]|5[0-3][0-9]|54[0-7])( Rust)? tests' \
+    'test count is stale; the release baseline is 1,548 Rust tests' \
     "${claim_files[@]}"
 reject_pattern 'until npm publish lands|publish[- ]pending' \
     'setup package is documented as unpublished' "${claim_files[@]}"
@@ -69,8 +69,8 @@ required_test_count_docs=(
     "$repo_root/docs/distro-support.md"
 )
 for path in "${required_test_count_docs[@]}"; do
-    if ! grep -Fq '1,539 Rust tests' "$path"; then
-        printf 'Verified test baseline missing from %s: expected 1,539 Rust tests\n' \
+    if ! grep -Fq '1,548 Rust tests' "$path"; then
+        printf 'Verified test baseline missing from %s: expected 1,548 Rust tests\n' \
             "$path" >&2
         exit 1
     fi

--- a/scripts/check_public_claims.sh
+++ b/scripts/check_public_claims.sh
@@ -38,8 +38,8 @@ reject_pattern() {
 # with one command. Quoting a subset (e.g. excluding the GUI crate) makes the
 # number unverifiable from the documented command, which is how it silently
 # came to mean two different things.
-reject_pattern '1,(2[0-9][0-9]|3[0-9][0-9]|4[0-9][0-9]|5[0-3][0-9]|54[0-7])( Rust)? tests' \
-    'test count is stale; the release baseline is 1,548 Rust tests' \
+reject_pattern '1,(2[0-9][0-9]|3[0-9][0-9]|4[0-9][0-9]|5[0-5][0-9]|56[0-0])( Rust)? tests' \
+    'test count is stale; the release baseline is 1,561 Rust tests' \
     "${claim_files[@]}"
 reject_pattern 'until npm publish lands|publish[- ]pending' \
     'setup package is documented as unpublished' "${claim_files[@]}"
@@ -69,8 +69,8 @@ required_test_count_docs=(
     "$repo_root/docs/distro-support.md"
 )
 for path in "${required_test_count_docs[@]}"; do
-    if ! grep -Fq '1,548 Rust tests' "$path"; then
-        printf 'Verified test baseline missing from %s: expected 1,548 Rust tests\n' \
+    if ! grep -Fq '1,561 Rust tests' "$path"; then
+        printf 'Verified test baseline missing from %s: expected 1,561 Rust tests\n' \
             "$path" >&2
         exit 1
     fi

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -140,8 +140,8 @@ run_cargo_doc() {
 run_rust_group() {
     printf '\n### rust\n'
     run_step 'rust: cargo fmt --all --check' cargo fmt --all --check
-    run_step 'rust: cargo clippy --workspace --all-features --locked -- -D warnings' \
-        cargo clippy --workspace --all-features --locked -- -D warnings
+    run_step 'rust: cargo clippy --workspace --all-features --all-targets --locked -- -D warnings' \
+        cargo clippy --workspace --all-features --all-targets --locked -- -D warnings
 
     if [[ "$mode" == "full" ]]; then
         run_step 'rust: cargo doc (RUSTDOCFLAGS=-D warnings)' run_cargo_doc


### PR DESCRIPTION
## Why

The signed chain bound each row to a `CallerRole`. Two members of
`sysknife-admin` produced identical signed records, so the trail answered "an
Admin did this" and stopped one question short of where an investigation starts.
`SECURITY.md` carried this as a known gap.

## What

`chain_version = 3` adds `caller_principal`, resolved by the daemon from the same
`SO_PEERCRED` read that already yields the role, never taken from the request body.

| Principal | Evidence it represents |
|---|---|
| `uid:<n>` | Unix-socket peer, uid attested by the kernel at `connect()` |
| `token:vsock` | vsock peer authenticated by the pre-shared token: possession of a file, not an account |
| `unattributed` | `SO_PEERCRED` yielded no usable peer; handled at `Observer`, and the row admits attribution failed rather than inventing a uid |

The scheme is signed alongside the value on purpose: a bare string would erase the
difference between a kernel-attested account and a shared secret.

**Additive, so no existing audit log is invalidated.** v1, v2 and v3 rows coexist
in one chain, each verifying under the encoding it claims. Migration 3 adds a
nullable column in both backends and backfills nothing, because writing a
principal into a row that was signed without one would change its message.

## An aliasing hazard found on the way, and fixed

The v2 encoder signed `CHAIN_VERSION_CURRENT`, and `ChainRow::identity()`
dispatched stored versions against the same constant. Bumping it for a new
encoding would have re-encoded **every v2 row on disk** while the entire unit
suite stayed green, because in-memory tests sign and verify under one constant. I
confirmed that: bumping the constant alone left all 63 audit-chain tests passing.

`CHAIN_VERSION_V2` is now a stable literal, and
`a_row_written_by_the_previous_release_still_verifies` pins the on-disk contract
with a golden `chain_hash` captured from the v0.2.16 encoder. That test is the
only thing in the suite that can notice this class of break.

## Verification

- `cargo nextest run --workspace --locked` — **1548 passed, 0 failed**
- `cargo clippy --workspace --all-features --locked -- -D warnings` clean; `cargo fmt --all --check` clean
- **Live Postgres contract run locally under podman**, not left to CI: migrations 1-3 apply, and the legacy row assertion proves migration 3 does not backfill a principal
- **Mutation-checked**: removing the `push_field` that signs the principal makes `editing_the_stored_principal_breaks_the_row` fail, so the tamper test has real discriminating power
- `mdbook build` clean; claims guard and its meta-test pass with the baseline moved 1,539 → 1,548

New tests: golden v2 vector verifies; two admins are distinguishable in the signed
record; editing the stored principal breaks the row; downgrading a v3 row to v2 to
hide the account breaks it; a v3 row with a missing *or blank* principal is broken;
a chain spanning all three encodings verifies; a future version reports
cannot-verify naming the supported range; a Unix peer is attributed to its
kernel-reported uid; a vsock caller never renders as a uid; both stores persist it.

## Scope note

`caller_principal` is signed and stored but not exposed on the wire, which is
exactly the treatment `caller_role` already gets: `sysknife history` shows neither.
Surfacing both belongs in one follow-up that touches the proto, rather than being
smuggled in here.

## Docs

`SECURITY.md` Layer 3 documents the principal and its three forms, and the
known-limitations row becomes the honest bounds instead of a gap: a uid is only as
meaningful as account hygiene (shared logins, `su`, uid reuse), and pre-upgrade
rows stay role-only by design. `docs/the-audit-chain.md` gains the three-encoding
table and a role-versus-principal section.

## Out of scope

`apps/sysknife-shell` (frozen GUI).