### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.2.16",
+  "version": "0.3.0",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
-## [0.3.0] — unreleased
+## [0.3.0] — 2026-07-29
 
 The signed audit chain now records **which account** acted, not only which role.
 Schema version 3, with a real migration and no rewrite of existing rows.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.2.16"
+version = "0.3.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.2.16"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.2.16"
+version = "0.3.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.2.16"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.2.16"
+version = "0.3.0"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.2.16"
+version = "0.3.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.2.16"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.2.16"
+version = "0.3.0"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.2.16"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,11 +15,11 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.10" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.2.10" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.2.10" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.3.0" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.3.0" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.3.0" }
 chrono = "0.4"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.2.10" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.3.0" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -39,7 +39,7 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.2.12", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.3.0", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.2.16",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.2.16",
+      "version": "0.3.0",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "@vitest/coverage-v8": "^4.1.4",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.2.16",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.2.16"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.2.10" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.2.10" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.3.0" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.3.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.2.16",
+  "version": "0.3.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.2.16"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.2.10" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.10" }
+sysknife-core = { path = "../sysknife-core", version = "0.3.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.3.0" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.2.16"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.2.16"
+version = "0.3.0"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.2.10" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.3.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.2.16"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -11,8 +11,8 @@ keywords = ["linux", "sysadmin", "daemon", "security"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.2.10" }
-sysknife-types = { path = "../sysknife-types", version = "0.2.10" }
+sysknife-core = { path = "../sysknife-core", version = "0.3.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.3.0" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -55,7 +55,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.2.10" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.3.0" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.2.16"
+version = "0.3.0"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.2.16"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.2.10" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.3.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -54,7 +54,7 @@ signed under in its `chain_version` column:
 |---|---|---|
 | 1 | the base fields | before v0.2.13 |
 | 2 | `caller_role`, `event_tip` | v0.2.13 |
-| 3 | `caller_principal` | 0.3.0 (unreleased) |
+| 3 | `caller_principal` | 0.3.0 |
 
 Verification reproduces the exact encoding each row claims, so an upgraded
 daemon appends v3 rows onto a chain that already holds v1 and v2 rows and the

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.2.16",
+  "version": "0.3.0",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.2.16",
+  "version": "0.3.0",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.2.16",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why a minor bump

`chain_version = 3` adds a signed field to the audit chain (#133), so a 0.3.0
daemon writes rows a 0.2.x binary cannot reproduce. Existing v1 and v2 rows are
untouched and keep verifying under either build. Chain v2 shipped as a patch
(0.2.13), but it landed before the encoding had external consumers; a signed
format that older verifiers cannot read is not a patch.

## What is in it

From #133, after six independent reviews (Codex terra plus five toolkit
reviewers) whose findings all landed before this bump:

- Rows sign **which account** acted, not only which role: `uid:<n>`,
  `token:vsock`, or `none:unattributed`, with the scheme signed alongside the
  value because the evidence differs in strength.
- A version-aliasing hazard fixed that would otherwise have made the *next*
  encoding bump report every existing audit log as unverifiable. Each generation
  now signs and dispatches on its own frozen literal, with golden on-disk vectors
  for all three.
- A peer outside the daemon's namespaces is no longer signed as a real account:
  the kernel substitutes the overflow uid (`nobody`) rather than failing.
- The principal reaches the SIEM, and `sysknife audit verify` reports
  `unattributed_rows` next to the verdict, because `Intact` is a statement about
  tampering rather than about how much the trail can attribute.
- CI now lints test targets, which is what let a duplicated `#[test]` attribute
  silently drop a test through every previous check.

## Version sites

`scripts/check_release_versions.sh v0.3.0` → **All release versions match 0.3.0**,
covering the eight Cargo manifests, `apps/sysknife-shell` package/lock/tauri
config, `packages/setup`, `.codex-plugin/plugin.json`, and both version fields in
`server.json`.

Internal dependency requirements moved from `^0.2.10` to `0.3.0` in the same
commit: a caret 0.2 requirement cannot resolve a 0.3.0 sibling, so publishing
would have failed at the first crate otherwise. `Cargo.lock` regenerated.

## Verification

- `cargo nextest run --workspace --locked` — 1561 passed, 0 failed
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings` clean
- `registry-manifest.test.sh` → `cargo sysknife-cli@0.3.0 (mcp-server)` with a rendered ownership marker
- `smithery-manifest.test.sh` OK; `check_public_claims.sh` consistent
- CHANGELOG dated, and the docs version row for chain v3 now names a release that will exist

## After merge

Signed tag `v0.3.0`, then the two manual steps the release workflow files as an
issue: MCP Registry publish and the Glama build spec.