### PR TITLE
ci: publish the MCP Registry listing from Actions, not by hand

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,144 @@
+# Publish server.json to the official MCP Registry.
+#
+# Why this exists as a workflow rather than a documented manual step: the
+# registry mints publishing permissions from the identity that authenticates.
+# `mcp-publisher login github` (device code) authenticates the *user*, and the
+# token it returns carries only that user's personal namespace,
+# `io.github.<user>/*`, because the OAuth grant does not include `read:org`.
+# Publishing `io.github.lacs-project/sysknife` from a laptop therefore fails with
+# 403 even for an org admin whose membership is public.
+#
+# GitHub Actions OIDC authenticates the *repository*, so the namespace is derived
+# from the repository owner and matches `server.json` by construction. It also
+# needs no secret: `id-token: write` is the whole credential.
+#
+# Ordering matters. The registry validator fetches the **published** crate's
+# rendered README and looks for the `mcp-name:` ownership marker, so this can only
+# succeed once crates.io serves the version named in `server.json`. The release
+# workflow therefore calls this after its crates.io job, and the manual entry
+# point exists for retries and for backfilling a version that was released before
+# this workflow did.
+name: publish-mcp
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to publish from. Defaults to the calling ref.
+        type: string
+        required: false
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (tag, branch or SHA) whose server.json to publish
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+# Never let two publishes of the same ref race: the registry takes the first and
+# rejects the second as a duplicate version, which reads like a real failure.
+concurrency:
+  group: publish-mcp-${{ inputs.ref || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to the MCP Registry
+    runs-on: ubuntu-latest
+    permissions:
+      # The only credential this workflow needs. Without it `login github-oidc`
+      # has no token to exchange.
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+
+      - name: Read the version being published
+        id: manifest
+        run: |
+          set -euo pipefail
+          version="$(jq -r .version server.json)"
+          name="$(jq -r .name server.json)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          printf 'publishing %s version %s\n' "$name" "$version"
+
+      # A version already in the registry cannot be replaced, and re-publishing
+      # returns an error that is indistinguishable from a real one at a glance.
+      # Checking first makes a re-run of this workflow a no-op instead of a red X.
+      - name: Skip if the registry already has this version
+        id: already
+        env:
+          # Through the environment, never interpolated into the script body: a
+          # `${{ }}` expression is pasted in before the shell ever sees it, so a
+          # value containing shell syntax would execute rather than compare.
+          SERVER_NAME: ${{ steps.manifest.outputs.name }}
+          SERVER_VERSION: ${{ steps.manifest.outputs.version }}
+        run: |
+          set -euo pipefail
+          present="$(curl -fsS \
+            "https://registry.modelcontextprotocol.io/v0/servers?search=sysknife" \
+            | jq -r --arg n "$SERVER_NAME" --arg v "$SERVER_VERSION" \
+              '[.servers[] | select((.server.name // .name) == $n and (.server.version // .version) == $v)] | length')"
+          if [ "$present" -gt 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::registry already serves $SERVER_VERSION; nothing to do"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mcp-publisher
+        if: steps.already.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          base="https://github.com/modelcontextprotocol/registry/releases/latest/download"
+          curl -fsSL "${base}/mcp-publisher_${os}_${arch}.tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher --help >/dev/null
+
+      - name: Validate server.json
+        if: steps.already.outputs.skip == 'false'
+        run: ./mcp-publisher validate
+
+      - name: Authenticate with repository identity
+        if: steps.already.outputs.skip == 'false'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish
+        if: steps.already.outputs.skip == 'false'
+        run: ./mcp-publisher publish
+
+      # Read the version back from the registry rather than trusting the exit
+      # code: a publish that reports success but leaves the old version latest
+      # would otherwise close out a release that never reached users.
+      - name: Verify the registry serves it
+        if: steps.already.outputs.skip == 'false'
+        env:
+          SERVER_NAME: ${{ steps.manifest.outputs.name }}
+          SERVER_VERSION: ${{ steps.manifest.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            latest="$(curl -fsS \
+              "https://registry.modelcontextprotocol.io/v0/servers?search=sysknife" \
+              | jq -r --arg n "$SERVER_NAME" \
+                '[.servers[]
+                  | select((.server.name // .name) == $n)
+                  | select(._meta["io.modelcontextprotocol.registry/official"].isLatest == true)
+                  | (.server.version // .version)] | first // "none"')"
+            if [ "$latest" = "$SERVER_VERSION" ]; then
+              printf 'registry latest is %s\n' "$latest"
+              exit 0
+            fi
+            printf 'attempt %s: registry latest is %s, waiting\n' "$attempt" "$latest"
+            sleep 10
+          done
+          echo "::error::registry did not report $SERVER_VERSION as latest"
+          exit 1

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -54,7 +54,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,19 @@ jobs:
             "dist/sysknife-${VERSION}-linux-x86_64.spdx.json" \
             "dist/sysknife-${VERSION}-linux-aarch64.spdx.json"
 
+  publish-registry:
+    name: Publish to the MCP Registry
+    # After crates.io on purpose: the registry validator fetches the published
+    # crate's rendered README to confirm the `mcp-name:` ownership marker, so it
+    # cannot succeed before that version exists on crates.io.
+    needs: [preflight, publish-crates]
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish-mcp.yml
+    with:
+      ref: ${{ github.ref }}
+
   post-release-checklist:
     name: File the manual post-release steps
     # Only after publication actually succeeded: a checklist for a release that
@@ -331,29 +344,11 @@ jobs:
           version_no_v="${VERSION#v}"
 
           cat > body.md <<EOF
-          \`${VERSION}\` is published to npm, crates.io, and GitHub Releases. Two
-          directory listings still point at the previous version, and neither can be
-          updated from CI.
+          \`${VERSION}\` is published to npm, crates.io, GitHub Releases and the
+          official MCP Registry. One directory listing still points at the previous
+          version and cannot be updated from CI.
 
-          ### 1. Official MCP Registry
-
-          \`server.json\` already names \`sysknife-cli@${version_no_v}\`. The validator reads
-          the **published** crate's rendered README for the \`mcp-name:\` marker, so this
-          step only works now that crates.io has the version.
-
-          \`\`\`sh
-          mcp-publisher login github   # device code, cannot run unattended
-          mcp-publisher publish        # from the repository root
-          \`\`\`
-
-          Verify:
-
-          \`\`\`sh
-          curl -sS "https://registry.modelcontextprotocol.io/v0/servers?search=sysknife" \\
-            | grep -o '"version":"${version_no_v}"'
-          \`\`\`
-
-          ### 2. Glama build spec
+          ### Glama build spec
 
           Browser-only: <https://glama.ai/mcp/servers/lacs-project/sysknife/admin/dockerfile>
 
@@ -372,7 +367,11 @@ jobs:
           ### Notes
 
           - Checksum above is read from this release's \`sha256sums-linux-x86_64.txt\`, not hand-copied.
-          - Neither step blocks users installing \`${VERSION}\`; they affect discovery only.
+          - This does not block users installing \`${VERSION}\`; it affects discovery only.
+          - The MCP Registry publish is no longer manual: the \`publish-registry\` job
+            authenticates with GitHub Actions OIDC, which is what makes the
+            \`io.github.lacs-project/*\` namespace available. A device-code login from a
+            laptop only ever gets the personal namespace and is rejected with 403.
           - Close this issue once both are done.
           EOF
 

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -96,17 +96,17 @@ registry-ready. To publish the listing:
    ```sh
    brew install mcp-publisher   # or download from the registry's GitHub Releases
    ```
-3. **Authenticate as the `lacs-project` org** — pick one:
-   - Local, interactive (one-time device-flow login in a browser):
-     ```sh
-     mcp-publisher login github
-     ```
-   - CI, headless (no stored secret), inside a GitHub Actions job with
-     `permissions: id-token: write` (the `./` reflects the binary downloaded
-     into the job's working directory rather than a PATH install):
-     ```sh
-     ./mcp-publisher login github-oidc
-     ```
+3. **Authenticate as the `lacs-project` org.** In practice there is one option,
+   not two: see [Authentication: namespace comes from the
+   identity](#authentication-namespace-comes-from-the-identity) below. Inside a
+   GitHub Actions job with `permissions: id-token: write` (the `./` reflects the
+   binary downloaded into the job's working directory rather than a PATH install):
+   ```sh
+   ./mcp-publisher login github-oidc
+   ```
+   The `publish-registry` job in `.github/workflows/release.yml` does this on every
+   tag, and `.github/workflows/publish-mcp.yml` can be dispatched by hand for a
+   retry or a backfill.
 4. **Validate and publish** (from the repo root):
    ```sh
    mcp-publisher validate   # checks server.json against the live registry
@@ -119,6 +119,34 @@ registry-ready. To publish the listing:
    curl "https://registry.modelcontextprotocol.io/v0/servers?search=sysknife"
    ```
    The `count` in the response metadata goes from `0` to `1`.
+
+## Authentication: namespace comes from the identity
+
+`server.json` publishes `io.github.lacs-project/sysknife`, and the registry mints
+publishing permissions from whoever authenticated, not from what the manifest
+asks for. That distinction is the whole reason this cannot be done from a laptop.
+
+`mcp-publisher login github` authenticates the **user**. The registry token it
+returns carries a single permission:
+
+```json
+{"action": "publish", "resource": "io.github.vladimirrott/*"}
+```
+
+so `publish` fails with `403 Forbidden ... You have permission to publish:
+io.github.vladimirrott/*. Attempting to publish: io.github.lacs-project/sysknife`.
+Making org membership public does not fix it, and neither does being an org admin:
+the device-flow OAuth grant does not carry `read:org`, so the registry never sees
+the membership at all. Verified 2026-07-30 on two consecutive fresh logins with
+membership already public.
+
+`mcp-publisher login github-oidc` authenticates the **repository**. The namespace
+is derived from the repository owner, so it matches `server.json` by construction,
+and the credential is `permissions: id-token: write` rather than a stored secret.
+
+The practical consequence: a release published from a laptop can reach crates.io,
+npm and GitHub Releases but *cannot* reach the MCP Registry. Publish the registry
+listing from Actions.
 
 ## Downstream propagation
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -88,23 +88,26 @@ unverifiable tag on a published release is worse than an unsigned one.
 
 ## Manual steps after publication
 
-Two directory listings cannot be updated from CI, so the release workflow files
-a checklist issue titled `Post-release manual steps for <tag>` and assigns it to
+One directory listing cannot be updated from CI, so the release workflow files a
+checklist issue titled `Post-release manual steps for <tag>` and assigns it to
 whoever pushed the tag. It carries the exact commands and the real checksum read
 from that release's `sha256sums-linux-x86_64.txt`.
 
-1. **Official MCP Registry.** `mcp-publisher login github` is a device-code flow
-   and cannot run unattended. The publish must also wait for crates.io to have
-   the version, because the validator reads the *published* crate's rendered
-   README for the `mcp-name:` marker.
-2. **Glama build spec.** The admin form is browser-only. Only the build steps
-   change per release, to the new binary URL and checksum. Leave the
-   `mcp-proxy --` prefix in the CMD arguments alone; that is how Glama exposes a
-   stdio server over HTTP.
+- **Glama build spec.** The admin form is browser-only. Only the build steps
+  change per release, to the new binary URL and checksum. Leave the
+  `mcp-proxy --` prefix in the CMD arguments alone; that is how Glama exposes a
+  stdio server over HTTP.
 
-Neither step blocks anyone installing the release. They affect discovery only, so
-they are not release blockers, which is exactly why they need a ticket rather
-than a line in a log nobody reads.
+This does not block anyone installing the release. It affects discovery only, so
+it is not a release blocker, which is exactly why it needs a ticket rather than a
+line in a log nobody reads.
+
+The **official MCP Registry** publish used to sit on that list and no longer
+does. The `publish-registry` job runs after `publish-crates` and authenticates
+with GitHub Actions OIDC. That ordering is required, because the registry
+validator reads the *published* crate's rendered README for the `mcp-name:`
+marker, and the OIDC identity is required for a different reason: see
+[the registry notes](mcp-registry.md#authentication-namespace-comes-from-the-identity).
 
 ## Registry details
 

--- a/tests/release/release-rehearsal.test.sh
+++ b/tests/release/release-rehearsal.test.sh
@@ -39,13 +39,26 @@ release_workflow="${repo_root}/.github/workflows/release.yml"
 grep -Fq 'check_registry_versions.sh' "$release_workflow"
 grep -Fq 'already exists; skipping' "$release_workflow"
 
-# Two directory listings cannot be automated: the MCP Registry needs a
-# device-code login and Glama's build spec is browser-only. Both were therefore
-# forgotten after releases. The workflow now files a checklist issue naming
-# them, with the freshly published checksum filled in, so the work is visible
-# without anyone reading a build log. Assert the job and both venues survive.
+# The MCP Registry listing is published by CI, and the ordering is the part
+# worth pinning: the registry validator reads the *published* crate's rendered
+# README for the ownership marker, so a publish job that stopped depending on
+# publish-crates would fail with an error that looks like a permissions problem.
+publish_mcp_workflow="${repo_root}/.github/workflows/publish-mcp.yml"
+grep -Fq './.github/workflows/publish-mcp.yml' "$release_workflow"
+grep -Fq 'publish-crates' "$release_workflow"
+grep -Fq 'mcp-publisher publish' "$publish_mcp_workflow"
+# OIDC is not an implementation detail here. A device-code login mints a token
+# for the *user's* namespace, so it cannot publish io.github.lacs-project/*;
+# only the repository identity can. Swapping this back would 403 at release
+# time, long after the change looked fine.
+grep -Fq 'login github-oidc' "$publish_mcp_workflow"
+grep -Fq 'id-token: write' "$publish_mcp_workflow"
+
+# Glama's build spec stays browser-only, so it is still forgotten after releases
+# unless something names it. The workflow files a checklist issue with the
+# freshly published checksum filled in, so the work is visible without anyone
+# reading a build log.
 grep -Fq 'Post-release manual steps' "$release_workflow"
-grep -Fq 'mcp-publisher publish' "$release_workflow"
 grep -Fq 'glama.ai' "$release_workflow"
 # The checklist is only useful if it carries the real checksum for this tag,
 # and only honest if it appears after publication actually succeeded.
@@ -58,6 +71,14 @@ grep -Eq 'needs: \[release\]' "$release_workflow"
 # posture that cannot silently drift.
 for workflow in "${repo_root}"/.github/workflows/*.yml; do
     while IFS= read -r uses_line; do
+        # A reusable workflow in this same repository is referenced by path and
+        # cannot carry a SHA at all: GitHub resolves `./...` at the caller's own
+        # commit, so it is pinned by construction and always to this tree. The
+        # exemption is deliberately anchored to `./` so a third-party
+        # `owner/repo/.github/workflows/x.yml@ref` still has to be pinned.
+        if printf '%s\n' "$uses_line" | grep -Eq 'uses:[[:space:]]+\./'; then
+            continue
+        fi
         if ! printf '%s\n' "$uses_line" | grep -Eq 'uses:[[:space:]]+[^@[:space:]]+@[0-9a-f]{40}([[:space:]]|$)'; then
             printf 'FAIL: %s action is not pinned to a 40-hex SHA: %s\n' \
                 "$(basename "$workflow")" "$uses_line" >&2


### PR DESCRIPTION
## Summary

The "Official MCP Registry" item on every post-release checklist could not actually be completed by hand, and today's `v0.4.0` release proved it.

`mcp-publisher login github` authenticates the **user**, and the registry mints publishing permissions from the identity that authenticated. The token comes back with exactly one permission:

```json
{"action": "publish", "resource": "io.github.vladimirrott/*"}
```

while `server.json` publishes `io.github.lacs-project/sysknife`, so `publish` returns:

```
403 Forbidden: You do not have permission to publish this server.
You have permission to publish: io.github.vladimirrott/*.
Attempting to publish: io.github.lacs-project/sysknife.
```

The error suggests making org membership public. It already is: `curl https://api.github.com/users/vladimirrott/orgs` returns `["lacs-project"]` to an anonymous caller, and the account is an org admin. The real cause is that the device-flow OAuth grant carries no `read:org`, so the registry cannot see the membership at all. Reproduced on two consecutive fresh logins.

`mcp-publisher login github-oidc` authenticates the **repository**: the namespace is derived from the repository owner, matches the manifest by construction, and the only credential is `permissions: id-token: write`. It is also what the registry's own guide recommends.

## Related Issue

[#138](https://github.com/lacs-project/sysknife/issues/138), the `v0.4.0` post-release checklist. This removes the registry item from that list permanently, and publishes `0.4.0` itself via a manual dispatch once merged.

## Validation

- [x] Tests added or updated (not applicable: CI configuration and docs, no library behaviour change)
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

`yamllint .github/workflows/*.yml` clean, `markdownlint-cli2` clean on both edited docs, `cargo nextest run --workspace --locked` 1585/1585 unchanged.

Security notes on the workflow itself:

- Every `${{ }}` value reaching a `run:` block goes through `env:` first, so a value containing shell syntax is compared rather than executed.
- `contents: read` at the top, `id-token: write` only on the job that needs it, `persist-credentials: false` on checkout, no secrets at all.
- The install step takes `latest` from the registry's own releases, matching their documented snippet. Worth revisiting if we want a pinned publisher version.

## Notes for Reviewers

- **Ordering is load-bearing.** `publish-registry` needs `publish-crates`, because the registry validator fetches the *published* crate's rendered README looking for the `mcp-name:` marker. Run it earlier and it fails in a way that looks like a permissions problem.
- **Re-runs are safe.** The job queries the registry first and skips when the version is already served, so a re-run is a no-op instead of a duplicate-version error that reads like a real failure.
- **It verifies rather than trusts.** After publishing it reads the version back and requires `isLatest` to equal the version in `server.json`, retrying five times, so a publish that succeeds without becoming latest still fails the job.
- `publish-mcp.yml` is `workflow_call` + `workflow_dispatch` on purpose: the release path gets ordering, and a human keeps a retry path that needs no local login.
