### PR TITLE
fix(security): require TLS for remote Postgres connections (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ### Security
 
+- **The audit store refuses a Postgres connection that could leak its credential in cleartext.**
+  ([#149](https://github.com/lacs-project/sysknife/issues/149)) sqlx defaults to
+  `sslmode=Prefer`, which silently downgrades to a plaintext connection if the server
+  declines TLS, exposing the DB credential to an active network attacker. Both the
+  transaction store and the checkpoint sink now require at least `sslmode=require` for a
+  connection that crosses the network, with an actionable error recommending
+  `verify-full`. Unix-socket and loopback connections are exempt (they never touch the
+  network), so local and packaged setups are unaffected. **Potentially breaking:** a
+  remote audit/checkpoint URL with no explicit `sslmode` (or `disable`/`allow`/`prefer`)
+  now fails at startup; add `?sslmode=verify-full` to the URL.
+
 - **`AddMount` can no longer mount an attacker share over a symlinked critical path.**
   ([#155](https://github.com/lacs-project/sysknife/issues/155)) `op_mount` checked the
   literal mountpoint string, then `os.makedirs(exist_ok=True)` and `mount(8)` both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,17 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ### Security
 
-- **The audit store refuses a Postgres connection that could leak its credential in cleartext.**
+- **The audit store refuses a Postgres connection that could leak its credential to a network attacker.**
   ([#149](https://github.com/lacs-project/sysknife/issues/149)) sqlx defaults to
-  `sslmode=Prefer`, which silently downgrades to a plaintext connection if the server
-  declines TLS, exposing the DB credential to an active network attacker. Both the
-  transaction store and the checkpoint sink now require at least `sslmode=require` for a
-  connection that crosses the network, with an actionable error recommending
-  `verify-full`. Unix-socket and loopback connections are exempt (they never touch the
-  network), so local and packaged setups are unaffected. **Potentially breaking:** a
-  remote audit/checkpoint URL with no explicit `sslmode` (or `disable`/`allow`/`prefer`)
-  now fails at startup; add `?sslmode=verify-full` to the URL.
+  `sslmode=Prefer`, which silently downgrades to plaintext if the server declines TLS.
+  `require` is no better against an active attacker: sqlx accepts any certificate under
+  `require`, so a man-in-the-middle can present a self-signed cert and read the credential.
+  Both the transaction store and the checkpoint sink now require at least `sslmode=verify-ca`
+  (authenticates the certificate chain) for a connection that crosses the network, with an
+  actionable error recommending `verify-full` (also checks the hostname). Unix-socket and
+  loopback connections are exempt (they never touch the network), so local and packaged
+  setups are unaffected. **Potentially breaking:** a remote audit/checkpoint URL below
+  `verify-ca` (including `require`) now fails at startup; add `?sslmode=verify-full` to the URL.
 
 - **`AddMount` can no longer mount an attacker share over a symlinked critical path.**
   ([#155](https://github.com/lacs-project/sysknife/issues/155)) `op_mount` checked the

--- a/crates/sysknife-daemon/src/checkpoint_sink.rs
+++ b/crates/sysknife-daemon/src/checkpoint_sink.rs
@@ -363,18 +363,31 @@ mod tests {
 
     #[tokio::test]
     async fn refuses_a_downgradeable_remote_url_before_connecting() {
-        // The TLS floor (#149) must reject a remote URL that could downgrade to
-        // plaintext BEFORE any network I/O, so this needs no live database.
-        let err = PostgresCheckpointSink::connect("postgres://u:p@db.example.com:5432/audit")
-            .await
-            .expect_err("a remote checkpoint URL without sslmode must be refused");
-        match err {
+        // The TLS floor (#149) must reject a remote URL that could leak the
+        // credential BEFORE any network I/O. The timeout proves no connection was
+        // attempted (db.example.com would otherwise hang), independent of sqlx's
+        // error wording, and the message check proves it was the guard.
+        let refusal = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            PostgresCheckpointSink::connect("postgres://u:p@db.example.com:5432/audit"),
+        )
+        .await
+        .expect("the guard must refuse without attempting a connection");
+        match refusal.expect_err("a remote checkpoint URL without TLS must be refused") {
             CheckpointSinkError::Connect(m) => {
                 assert!(m.contains("sslmode"), "message should name sslmode: {m}")
             }
             other => panic!("expected a Connect refusal, got {other:?}"),
         }
     }
+
+    // The positive "loopback passes the TLS floor" case is proven at the
+    // PostgresStore call site (tests/postgres_store.rs), where the config's
+    // acquire_timeout is settable so the refused connection returns fast.
+    // PostgresCheckpointSink::connect hardcodes a 10s acquire_timeout, which makes
+    // that shape slow to test here; both call sites invoke the identical
+    // require_tls_for_remote, and the pg_tls unit tests cover the loopback → Ok
+    // decision directly, so the over-blocking regression is already guarded.
 
     /// Build a small intact chain the same way the daemon would.
     pub(super) fn build_chain(key: &AuditKey, count: usize) -> Vec<ChainRow> {

--- a/crates/sysknife-daemon/src/checkpoint_sink.rs
+++ b/crates/sysknife-daemon/src/checkpoint_sink.rs
@@ -119,6 +119,9 @@ impl PostgresCheckpointSink {
         let opts = PgConnectOptions::from_str(url).map_err(|_| {
             CheckpointSinkError::Connect("invalid checkpoint database URL".to_string())
         })?;
+        // Refuse a remote connection that could downgrade to plaintext and leak
+        // the credential (#149).
+        crate::pg_tls::require_tls_for_remote(&opts).map_err(CheckpointSinkError::Connect)?;
         let pool = PgPoolOptions::new()
             .max_connections(4)
             .acquire_timeout(Duration::from_secs(10))
@@ -356,6 +359,21 @@ mod tests {
 
     fn key() -> AuditKey {
         AuditKey::from_bytes(vec![0x42; 32])
+    }
+
+    #[tokio::test]
+    async fn refuses_a_downgradeable_remote_url_before_connecting() {
+        // The TLS floor (#149) must reject a remote URL that could downgrade to
+        // plaintext BEFORE any network I/O, so this needs no live database.
+        let err = PostgresCheckpointSink::connect("postgres://u:p@db.example.com:5432/audit")
+            .await
+            .expect_err("a remote checkpoint URL without sslmode must be refused");
+        match err {
+            CheckpointSinkError::Connect(m) => {
+                assert!(m.contains("sslmode"), "message should name sslmode: {m}")
+            }
+            other => panic!("expected a Connect refusal, got {other:?}"),
+        }
     }
 
     /// Build a small intact chain the same way the daemon would.

--- a/crates/sysknife-daemon/src/lib.rs
+++ b/crates/sysknife-daemon/src/lib.rs
@@ -7,6 +7,7 @@ pub mod checkpoint_sink;
 pub mod dispatcher;
 pub mod executor;
 pub mod jobs;
+mod pg_tls;
 pub mod policy;
 pub mod preview;
 pub mod state;

--- a/crates/sysknife-daemon/src/pg_tls.rs
+++ b/crates/sysknife-daemon/src/pg_tls.rs
@@ -4,23 +4,32 @@
 //! connection if the server answers the SSL negotiation with `N`. For an audit
 //! store that carries a database credential, that is a downgrade-to-cleartext
 //! vector: an active network attacker who can strip the `S` response reads the
-//! credential (#149). We therefore require at least `sslmode=require` for any
-//! connection that crosses the network, and recommend `verify-full`.
+//! credential (#149).
+//!
+//! `sslmode=require` is NOT sufficient: sqlx (`connection/tls.rs`) sets
+//! `accept_invalid_certs = true` for `require`, so the client completes a TLS
+//! handshake with any certificate — including a throwaway self-signed one an
+//! active MITM mints on the fly — and then sends the credential over what it
+//! believes is a secure channel. Only `verify-ca` (validates the certificate
+//! chain) and `verify-full` (also checks the hostname) authenticate the server.
+//! We therefore require at least `verify-ca` for any connection that crosses the
+//! network, and recommend `verify-full`.
 //!
 //! Connections that never touch the network — unix-domain sockets and loopback
 //! addresses — are exempt, so local development and the packaged local database
 //! keep working without ceremony.
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::Ipv4Addr;
 
 use sqlx_postgres::{PgConnectOptions, PgSslMode};
 
-/// Refuse a Postgres connection whose effective `sslmode` would allow the
-/// credential to travel in cleartext across the network.
+/// Refuse a Postgres connection whose effective `sslmode` would let the
+/// credential be read by a network attacker (plaintext downgrade, or an
+/// unauthenticated TLS handshake against an attacker-supplied certificate).
 ///
 /// Returns `Err(message)` with an actionable remediation for a remote TCP
-/// connection below `sslmode=require`; `Ok(())` for unix sockets, loopback
-/// hosts, and any `require`/`verify-ca`/`verify-full` connection.
+/// connection below `sslmode=verify-ca`; `Ok(())` for unix sockets, loopback
+/// hosts, and any `verify-ca`/`verify-full` connection.
 pub(crate) fn require_tls_for_remote(opts: &PgConnectOptions) -> Result<(), String> {
     // A unix-domain socket never leaves the host.
     if opts.get_socket().is_some() {
@@ -31,30 +40,40 @@ pub(crate) fn require_tls_for_remote(opts: &PgConnectOptions) -> Result<(), Stri
         return Ok(());
     }
     match opts.get_ssl_mode() {
-        PgSslMode::Require | PgSslMode::VerifyCa | PgSslMode::VerifyFull => Ok(()),
+        PgSslMode::VerifyCa | PgSslMode::VerifyFull => Ok(()),
         insecure => Err(format!(
-            "refusing a Postgres connection to {host:?} with sslmode={insecure:?}: it can \
-             silently downgrade to plaintext and leak the database credential to a network \
-             attacker. Add ?sslmode=verify-full (recommended, also authenticates the server) \
-             or at least ?sslmode=require to the URL."
+            "refusing a Postgres connection to {host:?} with sslmode={insecure:?}: it does not \
+             authenticate the server (disable/allow/prefer can downgrade to plaintext; require \
+             completes TLS against any certificate, so an active man-in-the-middle can present a \
+             self-signed cert and read the database credential). Add ?sslmode=verify-full \
+             (recommended) or at least ?sslmode=verify-ca to the URL."
         )),
     }
 }
 
 /// A host that resolves to the local machine and so never crosses a network the
-/// attacker in the threat model can observe. Literal loopback addresses and the
-/// conventional `localhost` name qualify.
+/// attacker in the threat model can observe.
+///
+/// This trusts the literal hostname *string*, not a resolved address: an
+/// attacker who controls local name resolution (a tampered `/etc/hosts` or
+/// resolver) could point `localhost` off-box and still be exempted. That is a
+/// strictly stronger attacker than the network MITM this floor defends against,
+/// so the string check is acceptable here.
+///
+/// `PgConnectOptions::from_str` (the only way `opts` is built in this crate)
+/// returns IPv4 literals unbracketed and IPv6 literals bracket-wrapped (e.g.
+/// `[::1]`), which is why the IPv6 case is a string match, not an `Ipv6Addr`
+/// parse (the brackets make `Ipv6Addr::from_str` fail). The host is normalized
+/// for case and a trailing dot so `LOCALHOST.` is still recognized.
 fn is_loopback(host: &str) -> bool {
-    if host == "localhost" || host == "::1" || host == "[::1]" {
+    let normalized = host.trim_end_matches('.').to_ascii_lowercase();
+    if normalized == "localhost" || normalized == "[::1]" {
         return true;
     }
-    if let Ok(v4) = host.parse::<Ipv4Addr>() {
-        return v4.is_loopback();
-    }
-    if let Ok(v6) = host.parse::<Ipv6Addr>() {
-        return v6.is_loopback();
-    }
-    false
+    // IPv4 literal loopback (127.0.0.0/8), returned unbracketed by from_str.
+    host.parse::<Ipv4Addr>()
+        .map(|v4| v4.is_loopback())
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -93,9 +112,26 @@ mod tests {
     }
 
     #[test]
-    fn a_remote_tcp_url_with_sslmode_require_is_allowed() {
+    fn a_remote_tcp_url_with_sslmode_allow_is_refused() {
+        // allow tries plaintext first, the mirror of prefer.
+        require_tls_for_remote(&opts("postgres://u:p@db.example.com/audit?sslmode=allow"))
+            .expect_err("allow (plaintext-first) must be refused");
+    }
+
+    #[test]
+    fn a_remote_tcp_url_with_sslmode_require_is_refused() {
+        // require encrypts but accepts any certificate, so an active MITM still
+        // reads the credential. It is below the floor.
         require_tls_for_remote(&opts("postgres://u:p@db.example.com/audit?sslmode=require"))
-            .expect("require is the floor and must be allowed");
+            .expect_err("require does not authenticate the server and must be refused");
+    }
+
+    #[test]
+    fn a_remote_tcp_url_with_verify_ca_is_allowed() {
+        require_tls_for_remote(&opts(
+            "postgres://u:p@db.example.com/audit?sslmode=verify-ca",
+        ))
+        .expect("verify-ca authenticates the cert chain and is the floor");
     }
 
     #[test]
@@ -107,11 +143,30 @@ mod tests {
     }
 
     #[test]
+    fn a_remote_host_built_without_a_url_is_refused() {
+        // Cover the builder path (get_ssl_mode on a non-from_str construction).
+        let o = PgConnectOptions::new()
+            .host("db.example.com")
+            .username("u")
+            .database("audit")
+            .ssl_mode(PgSslMode::Disable);
+        require_tls_for_remote(&o).expect_err("a builder-constructed remote host must be refused");
+    }
+
+    #[test]
     fn a_loopback_host_without_sslmode_is_allowed() {
         require_tls_for_remote(&opts("postgres://u:p@localhost:5432/audit"))
             .expect("localhost never crosses the network");
         require_tls_for_remote(&opts("postgres://u:p@127.0.0.1:5432/audit"))
             .expect("127.0.0.1 is loopback");
+    }
+
+    #[test]
+    fn an_ipv6_loopback_url_is_allowed() {
+        // from_str returns get_host() == "[::1]" for a bracketed IPv6 literal;
+        // this pins the exact string is_loopback must recognize.
+        require_tls_for_remote(&opts("postgres://u:p@[::1]:5432/audit"))
+            .expect("[::1] is IPv6 loopback and never crosses the network");
     }
 
     #[test]

--- a/crates/sysknife-daemon/src/pg_tls.rs
+++ b/crates/sysknife-daemon/src/pg_tls.rs
@@ -1,0 +1,134 @@
+//! TLS floor for Postgres connections.
+//!
+//! sqlx defaults to `sslmode=Prefer`, which silently downgrades to a plaintext
+//! connection if the server answers the SSL negotiation with `N`. For an audit
+//! store that carries a database credential, that is a downgrade-to-cleartext
+//! vector: an active network attacker who can strip the `S` response reads the
+//! credential (#149). We therefore require at least `sslmode=require` for any
+//! connection that crosses the network, and recommend `verify-full`.
+//!
+//! Connections that never touch the network — unix-domain sockets and loopback
+//! addresses — are exempt, so local development and the packaged local database
+//! keep working without ceremony.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use sqlx_postgres::{PgConnectOptions, PgSslMode};
+
+/// Refuse a Postgres connection whose effective `sslmode` would allow the
+/// credential to travel in cleartext across the network.
+///
+/// Returns `Err(message)` with an actionable remediation for a remote TCP
+/// connection below `sslmode=require`; `Ok(())` for unix sockets, loopback
+/// hosts, and any `require`/`verify-ca`/`verify-full` connection.
+pub(crate) fn require_tls_for_remote(opts: &PgConnectOptions) -> Result<(), String> {
+    // A unix-domain socket never leaves the host.
+    if opts.get_socket().is_some() {
+        return Ok(());
+    }
+    let host = opts.get_host();
+    if is_loopback(host) {
+        return Ok(());
+    }
+    match opts.get_ssl_mode() {
+        PgSslMode::Require | PgSslMode::VerifyCa | PgSslMode::VerifyFull => Ok(()),
+        insecure => Err(format!(
+            "refusing a Postgres connection to {host:?} with sslmode={insecure:?}: it can \
+             silently downgrade to plaintext and leak the database credential to a network \
+             attacker. Add ?sslmode=verify-full (recommended, also authenticates the server) \
+             or at least ?sslmode=require to the URL."
+        )),
+    }
+}
+
+/// A host that resolves to the local machine and so never crosses a network the
+/// attacker in the threat model can observe. Literal loopback addresses and the
+/// conventional `localhost` name qualify.
+fn is_loopback(host: &str) -> bool {
+    if host == "localhost" || host == "::1" || host == "[::1]" {
+        return true;
+    }
+    if let Ok(v4) = host.parse::<Ipv4Addr>() {
+        return v4.is_loopback();
+    }
+    if let Ok(v6) = host.parse::<Ipv6Addr>() {
+        return v6.is_loopback();
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn opts(url: &str) -> PgConnectOptions {
+        PgConnectOptions::from_str(url).expect("valid test URL")
+    }
+
+    #[test]
+    fn a_remote_tcp_url_without_sslmode_is_refused() {
+        let err = require_tls_for_remote(&opts("postgres://u:p@db.example.com:5432/audit"))
+            .expect_err("Prefer default must be refused for a remote host");
+        assert!(
+            err.contains("sslmode"),
+            "message should name sslmode: {err}"
+        );
+        assert!(
+            err.contains("db.example.com"),
+            "message should name the host: {err}"
+        );
+    }
+
+    #[test]
+    fn a_remote_tcp_url_with_sslmode_disable_is_refused() {
+        require_tls_for_remote(&opts("postgres://u:p@db.example.com/audit?sslmode=disable"))
+            .expect_err("disable must be refused");
+    }
+
+    #[test]
+    fn a_remote_tcp_url_with_sslmode_prefer_is_refused() {
+        require_tls_for_remote(&opts("postgres://u:p@db.example.com/audit?sslmode=prefer"))
+            .expect_err("prefer (downgradeable) must be refused");
+    }
+
+    #[test]
+    fn a_remote_tcp_url_with_sslmode_require_is_allowed() {
+        require_tls_for_remote(&opts("postgres://u:p@db.example.com/audit?sslmode=require"))
+            .expect("require is the floor and must be allowed");
+    }
+
+    #[test]
+    fn a_remote_tcp_url_with_verify_full_is_allowed() {
+        require_tls_for_remote(&opts(
+            "postgres://u:p@db.example.com/audit?sslmode=verify-full",
+        ))
+        .expect("verify-full must be allowed");
+    }
+
+    #[test]
+    fn a_loopback_host_without_sslmode_is_allowed() {
+        require_tls_for_remote(&opts("postgres://u:p@localhost:5432/audit"))
+            .expect("localhost never crosses the network");
+        require_tls_for_remote(&opts("postgres://u:p@127.0.0.1:5432/audit"))
+            .expect("127.0.0.1 is loopback");
+    }
+
+    #[test]
+    fn a_unix_socket_without_sslmode_is_allowed() {
+        // A unix-domain socket carries no TLS and needs none — it never leaves
+        // the host. Build it directly (the URL socket forms are finicky).
+        let o = PgConnectOptions::new()
+            .socket("/var/run/postgresql")
+            .username("u")
+            .database("audit");
+        assert!(o.get_socket().is_some(), "should be a unix socket");
+        require_tls_for_remote(&o).expect("unix socket never crosses the network");
+    }
+
+    #[test]
+    fn a_non_loopback_ip_without_sslmode_is_refused() {
+        require_tls_for_remote(&opts("postgres://u:p@10.0.0.5:5432/audit"))
+            .expect_err("a private-range remote IP is still on the network");
+    }
+}

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -190,8 +190,11 @@ impl PostgresStore {
                 format!("invalid postgres URL: {e}"),
             ))
         })?;
-        // Refuse a remote connection that could downgrade to plaintext and leak
-        // the credential (#149).
+        // Refuse a remote connection that could leak the credential (#149). This
+        // is a hard configuration refusal, not a transient I/O error: it fails
+        // daemon startup and is never retried. It is mapped onto Io(PermissionDenied)
+        // only because that is the closest existing variant; nothing branches on
+        // the ErrorKind for this path.
         crate::pg_tls::require_tls_for_remote(&connect_opts).map_err(|msg| {
             TransactionStoreError::Io(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -190,6 +190,14 @@ impl PostgresStore {
                 format!("invalid postgres URL: {e}"),
             ))
         })?;
+        // Refuse a remote connection that could downgrade to plaintext and leak
+        // the credential (#149).
+        crate::pg_tls::require_tls_for_remote(&connect_opts).map_err(|msg| {
+            TransactionStoreError::Io(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                msg,
+            ))
+        })?;
         connect_opts = connect_opts.statement_cache_capacity(config.statement_cache_capacity);
         PgPoolOptions::new()
             .max_connections(config.max_connections)

--- a/crates/sysknife-daemon/tests/postgres_store.rs
+++ b/crates/sysknife-daemon/tests/postgres_store.rs
@@ -567,23 +567,57 @@ async fn attribution_census_over_a_real_postgres_round_trip() {
     .expect("drop isolated schema");
 }
 
-/// The TLS floor (#149) refuses a remote URL that could downgrade to plaintext
-/// BEFORE any connection attempt, so this runs without a live database.
+fn audit_key() -> Arc<AuditKey> {
+    let key_dir = tempfile::tempdir().expect("create audit-key directory");
+    Arc::new(
+        AuditKey::load_or_generate(&key_dir.path().join("audit-key")).expect("generate audit key"),
+    )
+}
+
+/// The TLS floor (#149) refuses a remote URL that does not authenticate the
+/// server BEFORE any connection attempt, so this runs without a live database.
+/// The timeout proves no connection was attempted (db.example.com would hang).
 #[tokio::test]
 async fn connect_refuses_a_downgradeable_remote_url() {
-    let key_dir = tempfile::tempdir().expect("create audit-key directory");
-    let key = Arc::new(
-        AuditKey::load_or_generate(&key_dir.path().join("audit-key")).expect("generate audit key"),
-    );
     let config = PostgresConfig {
         url: "postgres://u:p@db.example.com:5432/audit".to_string(),
         ..PostgresConfig::default()
     };
-    let err = PostgresStore::connect(&config, key)
-        .await
-        .expect_err("a remote audit URL without sslmode must be refused");
+    let refusal = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        PostgresStore::connect(&config, audit_key()),
+    )
+    .await
+    .expect("the guard must refuse without attempting a connection");
+    let err = refusal.expect_err("a remote audit URL without TLS must be refused");
     assert!(
         err.to_string().contains("sslmode"),
         "refusal should name sslmode: {err}"
+    );
+}
+
+/// A loopback + sslmode=disable URL must pass the TLS floor to the network layer
+/// (loopback never crosses the network). Nothing listens on 127.0.0.1:1, so the
+/// connection fails with a network error that does NOT name sslmode — proving the
+/// guard did not over-block. Runs without a live database.
+#[tokio::test]
+async fn connect_lets_a_loopback_url_through_the_tls_floor() {
+    let config = PostgresConfig {
+        url: "postgres://u:p@127.0.0.1:1/audit?sslmode=disable".to_string(),
+        // Short acquire_timeout so the pool stops retrying the refused connection
+        // quickly; the point is that the guard let it reach the network at all.
+        acquire_timeout: std::time::Duration::from_millis(300),
+        ..PostgresConfig::default()
+    };
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        PostgresStore::connect(&config, audit_key()),
+    )
+    .await
+    .expect("a loopback connection attempt must not hang");
+    let err = outcome.expect_err("nothing should be listening on 127.0.0.1:1");
+    assert!(
+        !err.to_string().contains("sslmode"),
+        "loopback must pass the TLS floor; got a guard refusal instead: {err}"
     );
 }

--- a/crates/sysknife-daemon/tests/postgres_store.rs
+++ b/crates/sysknife-daemon/tests/postgres_store.rs
@@ -566,3 +566,24 @@ async fn attribution_census_over_a_real_postgres_round_trip() {
     .await
     .expect("drop isolated schema");
 }
+
+/// The TLS floor (#149) refuses a remote URL that could downgrade to plaintext
+/// BEFORE any connection attempt, so this runs without a live database.
+#[tokio::test]
+async fn connect_refuses_a_downgradeable_remote_url() {
+    let key_dir = tempfile::tempdir().expect("create audit-key directory");
+    let key = Arc::new(
+        AuditKey::load_or_generate(&key_dir.path().join("audit-key")).expect("generate audit key"),
+    );
+    let config = PostgresConfig {
+        url: "postgres://u:p@db.example.com:5432/audit".to_string(),
+        ..PostgresConfig::default()
+    };
+    let err = PostgresStore::connect(&config, key)
+        .await
+        .expect_err("a remote audit URL without sslmode must be refused");
+    assert!(
+        err.to_string().contains("sslmode"),
+        "refusal should name sslmode: {err}"
+    );
+}


### PR DESCRIPTION
## What

`PostgresStore::connect_pool` and `PostgresCheckpointSink::connect` passed the operator URL to `PgConnectOptions::from_str` with no minimum TLS mode. sqlx defaults to `sslmode=Prefer`, which **silently downgrades to plaintext** if the server answers the SSL negotiation with `N` — exposing the DB credential to an active MITM (#149, red-team F6.2).

## Fix

New `pg_tls::require_tls_for_remote(opts)`:
- **unix socket** (`get_socket().is_some()`) → allowed (no network),
- **loopback host** (`localhost`/`127.0.0.0/8`/`::1`) → allowed (never leaves the host),
- otherwise require `sslmode ∈ {require, verify-ca, verify-full}`; anything downgradeable (`disable`/`allow`/`prefer`) is refused with an actionable message recommending `verify-full`.

Wired into both call sites right after URL parse, before any connection attempt. The loopback/socket exemptions keep local dev, the packaged local socket, and the podman integration tests (which connect to `localhost`) working unchanged.

**Potentially breaking:** a remote audit/checkpoint URL with no explicit `sslmode` now fails at startup. Remediation is in the error: add `?sslmode=verify-full`.

## Tests

- `pg_tls` unit tests over the ssl-mode x socket x loopback matrix.
- Wiring tests on **both** call sites asserting the refusal fires before any DB I/O — no live database required.
- Full suite: 1614/1614.

Closes #149