### PR TITLE
fix(security): close the forwarded-socket caveat gap with daemon machine-id (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,12 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   `Intact` for a chain that has nothing to do with those actions. The env-only heuristic
   could not tell a forwarded unix socket from a local one. The daemon now reports a salted
   hash of its `/etc/machine-id` (never the raw id), and `audit verify` compares it to this
-  host's: a mismatch prints the wrong-machine caveat, a match stays quiet, and if the daemon
-  can't be reached it falls back to the previous heuristic (never worse than before).
+  host's. Only a **mismatch** is treated as decisive (different machine-id ⇒ different
+  machine ⇒ print the caveat); a **match** is inconclusive — cloned VM/container images share
+  one `/etc/machine-id` — so it falls back to the existing heuristic and never suppresses a
+  warning the heuristic would raise (vsock and explicit `SYSKNIFE_SOCKET` still always warn).
+  The query runs only for the unix-`SYSKNIFE_LISTEN_URI` case it can help, so `audit verify`
+  stays offline otherwise.
 
 - **`AptAutoremove` binds the deletion set the operator approved.**
   ([#151](https://github.com/lacs-project/sysknife/issues/151)) The approval covered only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   body costs nothing. The pre-auth window itself remains bounded by the existing
   `VSOCK_AUTH_FRAME_TIMEOUT_SECS`.
 
+- **`audit verify` warns when the daemon you administered is a different machine, even over a forwarded unix socket.**
+  ([#146](https://github.com/lacs-project/sysknife/issues/146)) Completes the partial fix in
+  0.5.0. Verification reads a local store, so an operator who tunnels a unix socket to another
+  host, acts there, then runs `audit verify` reads their own machine's chain and sees
+  `Intact` for a chain that has nothing to do with those actions. The env-only heuristic
+  could not tell a forwarded unix socket from a local one. The daemon now reports a salted
+  hash of its `/etc/machine-id` (never the raw id), and `audit verify` compares it to this
+  host's: a mismatch prints the wrong-machine caveat, a match stays quiet, and if the daemon
+  can't be reached it falls back to the previous heuristic (never worse than before).
+
 - **`AptAutoremove` binds the deletion set the operator approved.**
   ([#151](https://github.com/lacs-project/sysknife/issues/151)) The approval covered only
   the action name and empty params, but `apt-get autoremove -y` resolves the deletion set

--- a/apps/sysknife-cli/src/client.rs
+++ b/apps/sysknife-cli/src/client.rs
@@ -480,6 +480,10 @@ impl DaemonClient {
         resp.get("state")?
             .get("machine_id_hash")?
             .as_str()
+            // Treat an empty string the same as absent, symmetric with the daemon
+            // side (which never emits Some("")), so a stray "" can never be read
+            // as a machine-id that matches anything.
+            .filter(|s| !s.is_empty())
             .map(String::from)
     }
 
@@ -1032,6 +1036,22 @@ mod tests {
     fn machine_id_hash_is_none_when_the_daemon_is_unreachable() {
         let client = DaemonClient::new(PathBuf::from("/tmp/sysknife-no-such-socket-mid146.sock"));
         assert_eq!(client.machine_id_hash(), None);
+    }
+
+    #[test]
+    fn machine_id_hash_treats_an_empty_string_as_absent() {
+        // A stray "" must never be read as a machine-id that could match anything.
+        let socket_path = temp_socket_path();
+        let handle = serve_sync(&socket_path, |mut stream| {
+            let raw = read_framed(&mut stream).unwrap();
+            let req: Value = serde_json::from_slice(&raw).unwrap();
+            let resp = state_response_with(Some(""), &req["request_id"]);
+            write_framed(&mut stream, &serde_json::to_vec(&resp).unwrap()).unwrap();
+        });
+        let got = DaemonClient::new(socket_path.clone()).machine_id_hash();
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&socket_path);
+        assert_eq!(got, None);
     }
 
     // -----------------------------------------------------------------------

--- a/apps/sysknife-cli/src/client.rs
+++ b/apps/sysknife-cli/src/client.rs
@@ -463,6 +463,26 @@ impl DaemonClient {
         }
     }
 
+    /// Best-effort query of the daemon's machine-id hash (#146), used only to
+    /// decide the `audit verify` wrong-machine caveat. Any failure — no daemon
+    /// reachable, a timeout, or an older daemon that does not report the field —
+    /// yields `None`, and the caller falls back to the env-based heuristic.
+    pub fn machine_id_hash(&self) -> Option<String> {
+        let mut stream = self.connect_sync().ok()?;
+        let req = serde_json::to_vec(&serde_json::json!({
+            "type": "query_state",
+            "request_id": "cli-machine-id"
+        }))
+        .ok()?;
+        stream.write_frame(&req).ok()?;
+        let raw = stream.read_frame().ok()?;
+        let resp: Value = serde_json::from_slice(&raw).ok()?;
+        resp.get("state")?
+            .get("machine_id_hash")?
+            .as_str()
+            .map(String::from)
+    }
+
     fn query_action_inner(
         &self,
         action_name: &str,
@@ -958,6 +978,60 @@ mod tests {
         assert_eq!(state.services(), &["sshd.service", "nginx.service"]);
         assert_eq!(state.layered_packages(), &["vim"]);
         assert_eq!(state.users(), &["alice", "bob"]);
+    }
+
+    fn state_response_with(machine_id_hash: Option<&str>, request_id: &Value) -> Value {
+        let mut state = serde_json::json!({
+            "host_name": "h", "deployment": "", "services": [], "flatpaks": [],
+            "toolboxes": [], "layered_packages": [], "containers": [], "users": []
+        });
+        if let Some(h) = machine_id_hash {
+            state["machine_id_hash"] = serde_json::json!(h);
+        }
+        serde_json::json!({
+            "type": "state_response",
+            "request_id": request_id,
+            "state": state
+        })
+    }
+
+    #[test]
+    fn machine_id_hash_queries_state_and_extracts_the_hash() {
+        let socket_path = temp_socket_path();
+        let handle = serve_sync(&socket_path, |mut stream| {
+            let raw = read_framed(&mut stream).unwrap();
+            let req: Value = serde_json::from_slice(&raw).unwrap();
+            assert_eq!(req["type"].as_str(), Some("query_state"));
+            let resp = state_response_with(Some("abc123"), &req["request_id"]);
+            write_framed(&mut stream, &serde_json::to_vec(&resp).unwrap()).unwrap();
+        });
+        let got = DaemonClient::new(socket_path.clone()).machine_id_hash();
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&socket_path);
+        assert_eq!(got.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn machine_id_hash_is_none_when_the_daemon_omits_the_field() {
+        // An older daemon that does not report machine_id_hash -> None, so the
+        // caller falls back to the env heuristic rather than misreading absence.
+        let socket_path = temp_socket_path();
+        let handle = serve_sync(&socket_path, |mut stream| {
+            let raw = read_framed(&mut stream).unwrap();
+            let req: Value = serde_json::from_slice(&raw).unwrap();
+            let resp = state_response_with(None, &req["request_id"]);
+            write_framed(&mut stream, &serde_json::to_vec(&resp).unwrap()).unwrap();
+        });
+        let got = DaemonClient::new(socket_path.clone()).machine_id_hash();
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&socket_path);
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn machine_id_hash_is_none_when_the_daemon_is_unreachable() {
+        let client = DaemonClient::new(PathBuf::from("/tmp/sysknife-no-such-socket-mid146.sock"));
+        assert_eq!(client.machine_id_hash(), None);
     }
 
     // -----------------------------------------------------------------------

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -167,6 +167,77 @@ fn remote_daemon_caveat(
     ))
 }
 
+/// Whether the daemon the client is configured to reach is this machine or a
+/// different one — the question the env heuristic cannot answer for a forwarded
+/// unix socket (#146).
+#[derive(Debug, PartialEq, Eq)]
+enum SocketOrigin {
+    /// A different machine; carry this caveat.
+    Remote(String),
+    /// Definitively this machine; suppress the caveat.
+    Local,
+    /// Could not determine (no socket configured, daemon unreachable, an older
+    /// daemon without the field, or /etc/machine-id unreadable). Fall back to the
+    /// env heuristic.
+    Unknown,
+}
+
+/// The configured daemon socket: `SYSKNIFE_SOCKET` (an explicit override) wins,
+/// else `config.toml`/unit-provided `SYSKNIFE_LISTEN_URI`. Returns the raw value,
+/// which env var it came from, and the parsed target.
+fn configured_socket_target() -> Option<(String, &'static str, crate::client::SocketTarget)> {
+    for source in ["SYSKNIFE_SOCKET", "SYSKNIFE_LISTEN_URI"] {
+        if let Ok(raw) = std::env::var(source) {
+            if let Ok(target) = crate::client::SocketTarget::try_from_str(&raw) {
+                return Some((raw, source, target));
+            }
+        }
+    }
+    None
+}
+
+/// Pure decision: compare the daemon's reported machine-id hash to the local one.
+/// Split from the I/O so the verdict logic is deterministically testable.
+fn socket_origin_from(
+    local_hash: Option<&str>,
+    daemon_hash: Option<&str>,
+    raw: &str,
+    source: &str,
+    target: &crate::client::SocketTarget,
+) -> SocketOrigin {
+    match (local_hash, daemon_hash) {
+        (Some(l), Some(d)) if l == d => SocketOrigin::Local,
+        (Some(_), Some(_)) => match remote_daemon_caveat(Some((raw, source)), target) {
+            Some(caveat) => SocketOrigin::Remote(caveat),
+            None => SocketOrigin::Unknown,
+        },
+        _ => SocketOrigin::Unknown,
+    }
+}
+
+/// Ask the configured daemon for its machine-id hash and compare it to this
+/// host's. Definitive when the daemon answers; otherwise `Unknown`.
+fn daemon_socket_origin() -> SocketOrigin {
+    let Some((raw, source, target)) = configured_socket_target() else {
+        return SocketOrigin::Unknown;
+    };
+    let local = sysknife_daemon::state_collector::machine_id_hash();
+    let daemon = crate::client::DaemonClient::new(target.clone()).machine_id_hash();
+    socket_origin_from(local.as_deref(), daemon.as_deref(), &raw, source, &target)
+}
+
+/// The wrong-machine caveat for `audit verify`. Prefers the definitive
+/// machine-id comparison (which closes the forwarded-unix-socket gap #146); when
+/// that cannot run, falls back to the env-only heuristic so behavior is never
+/// worse than before.
+fn resolve_daemon_socket_caveat() -> Option<String> {
+    match daemon_socket_origin() {
+        SocketOrigin::Remote(caveat) => Some(caveat),
+        SocketOrigin::Local => None,
+        SocketOrigin::Unknown => remote_daemon_caveat_from_env(),
+    }
+}
+
 /// The caveat that belongs next to a verification verdict when no independent
 /// checkpoint anchor is configured.
 ///
@@ -1100,7 +1171,7 @@ fn emit_verification(
             } else {
                 json!({"configured": false, "caveat": anchor_caveat(false)})
             },
-            "daemon_socket_caveat": remote_daemon_caveat_from_env(),
+            "daemon_socket_caveat": resolve_daemon_socket_caveat(),
             // Null rather than zero when no census was taken. A machine reader
             // that alerts on low attribution must be able to tell "no rows were
             // read" from "no row named an account"; a zero for both is the
@@ -1170,7 +1241,7 @@ fn emit_verification(
         };
         emit_attribution(log, &census, standing);
     }
-    if let Some(caveat) = remote_daemon_caveat_from_env() {
+    if let Some(caveat) = resolve_daemon_socket_caveat() {
         log.println(&caveat);
     }
     if let Some(caveat) = anchor_caveat(anchor_configured()) {
@@ -2166,6 +2237,70 @@ mod tests {
         assert!(
             !caveat.contains("sysknife-other.sock"),
             "and must not name the socket it did not dial, got: {caveat}"
+        );
+    }
+
+    fn unix_target() -> crate::client::SocketTarget {
+        crate::client::SocketTarget::Unix("/run/sysknife/daemon.sock".into())
+    }
+
+    #[test]
+    fn socket_origin_is_local_when_the_daemon_machine_id_matches() {
+        // Same hash -> the daemon is this machine -> suppress the caveat (#146).
+        assert_eq!(
+            socket_origin_from(
+                Some("same-hash"),
+                Some("same-hash"),
+                "unix:///run/sysknife/daemon.sock",
+                "SYSKNIFE_LISTEN_URI",
+                &unix_target(),
+            ),
+            SocketOrigin::Local
+        );
+    }
+
+    #[test]
+    fn socket_origin_is_remote_when_a_forwarded_unix_socket_is_another_machine() {
+        // The exact gap #146 closes: a unix socket via SYSKNIFE_LISTEN_URI whose
+        // daemon reports a different machine-id must now warn.
+        match socket_origin_from(
+            Some("local-hash"),
+            Some("remote-hash"),
+            "unix:///run/sysknife/daemon.sock",
+            "SYSKNIFE_LISTEN_URI",
+            &unix_target(),
+        ) {
+            SocketOrigin::Remote(caveat) => {
+                assert!(caveat.contains("SYSKNIFE_LISTEN_URI"), "{caveat}");
+                assert!(caveat.contains("forwarded"), "{caveat}");
+            }
+            other => panic!("a forwarded unix socket on another machine must warn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn socket_origin_is_unknown_when_the_daemon_or_local_id_is_missing() {
+        // Daemon unreachable / older daemon without the field -> fall back.
+        assert_eq!(
+            socket_origin_from(
+                Some("local"),
+                None,
+                "unix:///x",
+                "SYSKNIFE_LISTEN_URI",
+                &unix_target()
+            ),
+            SocketOrigin::Unknown
+        );
+        // Local /etc/machine-id unreadable -> cannot decide -> fall back.
+        assert_eq!(
+            socket_origin_from(
+                None,
+                Some("daemon"),
+                "unix:///x",
+                "SYSKNIFE_LISTEN_URI",
+                &unix_target()
+            ),
+            SocketOrigin::Unknown
         );
     }
 

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -167,37 +167,50 @@ fn remote_daemon_caveat(
     ))
 }
 
-/// Whether the daemon the client is configured to reach is this machine or a
-/// different one — the question the env heuristic cannot answer for a forwarded
-/// unix socket (#146).
+/// The machine-id comparison verdict for `audit verify` (#146).
+///
+/// Only a *mismatch* is a reliable signal: two hosts with different
+/// `/etc/machine-id` are definitely different machines, so a forwarded socket to
+/// one of them warrants the wrong-machine caveat — which is what closes the gap.
+/// A *match* is deliberately NOT treated as proof of "this machine": cloned VM
+/// and container images routinely share one `/etc/machine-id`, so equal hashes
+/// can mean two distinct clones. The check therefore only ever ADDS a warning;
+/// it never suppresses one the transport heuristic would raise (a hash match
+/// falls through to `Unknown` → the heuristic, which keeps vsock-always-warns and
+/// the explicit-`SYSKNIFE_SOCKET` warning intact).
 #[derive(Debug, PartialEq, Eq)]
 enum SocketOrigin {
-    /// A different machine; carry this caveat.
+    /// The daemon's machine-id differs from this host's: a different machine.
     Remote(String),
-    /// Definitively this machine; suppress the caveat.
-    Local,
-    /// Could not determine (no socket configured, daemon unreachable, an older
-    /// daemon without the field, or /etc/machine-id unreadable). Fall back to the
-    /// env heuristic.
+    /// Inconclusive — daemon unreachable, an older daemon without the field,
+    /// `/etc/machine-id` unreadable, or hashes that MATCH (not proof of local,
+    /// because clones share a machine-id). Fall back to the env heuristic.
     Unknown,
 }
 
-/// The configured daemon socket: `SYSKNIFE_SOCKET` (an explicit override) wins,
-/// else `config.toml`/unit-provided `SYSKNIFE_LISTEN_URI`. Returns the raw value,
-/// which env var it came from, and the parsed target.
+/// The configured daemon socket the client would dial: `SYSKNIFE_SOCKET` (an
+/// explicit override) wins, else `config.toml`/unit-provided
+/// `SYSKNIFE_LISTEN_URI`. Matches `resolve_socket_target`'s precedence: a
+/// set-but-unparseable `SYSKNIFE_SOCKET` short-circuits to `None` (it is never
+/// silently skipped in favor of `SYSKNIFE_LISTEN_URI`, which the client would
+/// not dial).
 fn configured_socket_target() -> Option<(String, &'static str, crate::client::SocketTarget)> {
-    for source in ["SYSKNIFE_SOCKET", "SYSKNIFE_LISTEN_URI"] {
-        if let Ok(raw) = std::env::var(source) {
-            if let Ok(target) = crate::client::SocketTarget::try_from_str(&raw) {
-                return Some((raw, source, target));
-            }
+    if let Ok(raw) = std::env::var("SYSKNIFE_SOCKET") {
+        let target = crate::client::SocketTarget::try_from_str(&raw).ok()?;
+        return Some((raw, "SYSKNIFE_SOCKET", target));
+    }
+    if let Ok(raw) = std::env::var("SYSKNIFE_LISTEN_URI") {
+        if let Ok(target) = crate::client::SocketTarget::try_from_str(&raw) {
+            return Some((raw, "SYSKNIFE_LISTEN_URI", target));
         }
     }
     None
 }
 
 /// Pure decision: compare the daemon's reported machine-id hash to the local one.
-/// Split from the I/O so the verdict logic is deterministically testable.
+/// Split from the I/O so the verdict logic is deterministically testable. Only a
+/// definite mismatch yields `Remote`; everything else is `Unknown` (see the enum
+/// docs for why a match is not `Local`).
 fn socket_origin_from(
     local_hash: Option<&str>,
     daemon_hash: Option<&str>,
@@ -206,34 +219,42 @@ fn socket_origin_from(
     target: &crate::client::SocketTarget,
 ) -> SocketOrigin {
     match (local_hash, daemon_hash) {
-        (Some(l), Some(d)) if l == d => SocketOrigin::Local,
-        (Some(_), Some(_)) => match remote_daemon_caveat(Some((raw, source)), target) {
-            Some(caveat) => SocketOrigin::Remote(caveat),
-            None => SocketOrigin::Unknown,
-        },
+        (Some(l), Some(d)) if l != d => SocketOrigin::Remote(
+            // Given `Some(socket_env)`, remote_daemon_caveat always returns Some
+            // (it only returns None for an unset socket).
+            remote_daemon_caveat(Some((raw, source)), target)
+                .expect("a configured socket always yields a caveat message"),
+        ),
         _ => SocketOrigin::Unknown,
     }
 }
 
 /// Ask the configured daemon for its machine-id hash and compare it to this
-/// host's. Definitive when the daemon answers; otherwise `Unknown`.
+/// host's. `Remote` only on a definite mismatch; otherwise `Unknown`.
+///
+/// The query only runs for a unix socket configured via `SYSKNIFE_LISTEN_URI` —
+/// the one case the env heuristic is silent on. For an explicit `SYSKNIFE_SOCKET`
+/// or a vsock target the heuristic already warns, so a round-trip could not add
+/// anything and is skipped (keeping `audit verify` offline in those cases).
 fn daemon_socket_origin() -> SocketOrigin {
     let Some((raw, source, target)) = configured_socket_target() else {
         return SocketOrigin::Unknown;
     };
+    if source != "SYSKNIFE_LISTEN_URI" || !matches!(target, crate::client::SocketTarget::Unix(_)) {
+        return SocketOrigin::Unknown;
+    }
     let local = sysknife_daemon::state_collector::machine_id_hash();
     let daemon = crate::client::DaemonClient::new(target.clone()).machine_id_hash();
     socket_origin_from(local.as_deref(), daemon.as_deref(), &raw, source, &target)
 }
 
-/// The wrong-machine caveat for `audit verify`. Prefers the definitive
-/// machine-id comparison (which closes the forwarded-unix-socket gap #146); when
-/// that cannot run, falls back to the env-only heuristic so behavior is never
-/// worse than before.
+/// The wrong-machine caveat for `audit verify`. A definite machine-id mismatch
+/// adds the caveat (closing the forwarded-unix-socket gap #146); otherwise it
+/// falls back to the env-only heuristic, so behavior is never worse than before
+/// and the heuristic's vsock/explicit-override warnings are never suppressed.
 fn resolve_daemon_socket_caveat() -> Option<String> {
     match daemon_socket_origin() {
         SocketOrigin::Remote(caveat) => Some(caveat),
-        SocketOrigin::Local => None,
         SocketOrigin::Unknown => remote_daemon_caveat_from_env(),
     }
 }
@@ -2245,8 +2266,11 @@ mod tests {
     }
 
     #[test]
-    fn socket_origin_is_local_when_the_daemon_machine_id_matches() {
-        // Same hash -> the daemon is this machine -> suppress the caveat (#146).
+    fn socket_origin_is_unknown_when_hashes_match_because_clones_share_machine_id() {
+        // A hash match is NOT proof of "this machine": cloned VM/container images
+        // routinely share one /etc/machine-id, so equal hashes can be two distinct
+        // clones. A match must therefore fall through to the heuristic (Unknown),
+        // never suppress a warning it would otherwise raise (#146 review).
         assert_eq!(
             socket_origin_from(
                 Some("same-hash"),
@@ -2255,14 +2279,14 @@ mod tests {
                 "SYSKNIFE_LISTEN_URI",
                 &unix_target(),
             ),
-            SocketOrigin::Local
+            SocketOrigin::Unknown
         );
     }
 
     #[test]
     fn socket_origin_is_remote_when_a_forwarded_unix_socket_is_another_machine() {
         // The exact gap #146 closes: a unix socket via SYSKNIFE_LISTEN_URI whose
-        // daemon reports a different machine-id must now warn.
+        // daemon reports a DIFFERENT machine-id (the reliable direction) must warn.
         match socket_origin_from(
             Some("local-hash"),
             Some("remote-hash"),
@@ -2301,6 +2325,95 @@ mod tests {
                 &unix_target()
             ),
             SocketOrigin::Unknown
+        );
+    }
+
+    /// A one-shot mock daemon on a unix socket that answers `query_state` with a
+    /// `state_response` reporting the given machine-id hash, so the whole
+    /// query → compare → verdict chain can be driven end-to-end.
+    fn spawn_mock_daemon(
+        sock: std::path::PathBuf,
+        reported_hash: &str,
+    ) -> std::thread::JoinHandle<()> {
+        use std::io::{Read, Write};
+        use std::os::unix::net::UnixListener;
+        let listener = UnixListener::bind(&sock).expect("bind mock daemon");
+        let reported = reported_hash.to_string();
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut lenb = [0u8; 4];
+                if stream.read_exact(&mut lenb).is_err() {
+                    return;
+                }
+                let len = u32::from_le_bytes(lenb) as usize;
+                let mut body = vec![0u8; len];
+                let _ = stream.read_exact(&mut body);
+                let resp = serde_json::json!({
+                    "type": "state_response",
+                    "request_id": "cli-machine-id",
+                    "state": {
+                        "host_name": "other", "deployment": "", "services": [], "flatpaks": [],
+                        "toolboxes": [], "layered_packages": [], "containers": [], "users": [],
+                        "machine_id_hash": reported
+                    }
+                });
+                let bytes = serde_json::to_vec(&resp).unwrap();
+                let _ = stream.write_all(&(bytes.len() as u32).to_le_bytes());
+                let _ = stream.write_all(&bytes);
+            }
+        })
+    }
+
+    // A hash that cannot equal this host's real /etc/machine-id hash.
+    const NOT_THIS_HOST: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    #[test]
+    fn daemon_socket_origin_warns_end_to_end_when_the_forwarded_daemon_is_another_machine() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // The local side reads the real /etc/machine-id; skip where it is absent.
+        if sysknife_daemon::state_collector::machine_id_hash().is_none() {
+            return;
+        }
+        let sock = std::env::temp_dir().join(format!("sk146-wire-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&sock);
+        let server = spawn_mock_daemon(sock.clone(), NOT_THIS_HOST);
+        std::env::remove_var("SYSKNIFE_SOCKET");
+        std::env::set_var("SYSKNIFE_LISTEN_URI", format!("unix://{}", sock.display()));
+        let origin = daemon_socket_origin();
+        std::env::remove_var("SYSKNIFE_LISTEN_URI");
+        let _ = server.join();
+        let _ = std::fs::remove_file(&sock);
+        assert!(
+            matches!(origin, SocketOrigin::Remote(_)),
+            "a forwarded daemon reporting a different machine-id must warn, got {origin:?}"
+        );
+    }
+
+    #[test]
+    fn daemon_socket_origin_skips_the_query_for_an_explicit_socket_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        if sysknife_daemon::state_collector::machine_id_hash().is_none() {
+            return;
+        }
+        // Same mismatching mock daemon, but reached via SYSKNIFE_SOCKET: the
+        // heuristic already warns for that, so the query is skipped and the
+        // verdict is Unknown (NOT Remote), proving no round-trip is attempted.
+        let sock = std::env::temp_dir().join(format!("sk146-skip-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&sock);
+        let server = spawn_mock_daemon(sock.clone(), NOT_THIS_HOST);
+        std::env::set_var("SYSKNIFE_SOCKET", format!("unix://{}", sock.display()));
+        std::env::remove_var("SYSKNIFE_LISTEN_URI");
+        let origin = daemon_socket_origin();
+        std::env::remove_var("SYSKNIFE_SOCKET");
+        // The query was skipped, so nothing connected; unblock the mock's accept()
+        // with a throwaway connection so its thread exits, then clean up.
+        let _ = std::os::unix::net::UnixStream::connect(&sock);
+        let _ = server.join();
+        let _ = std::fs::remove_file(&sock);
+        assert_eq!(
+            origin,
+            SocketOrigin::Unknown,
+            "SYSKNIFE_SOCKET must skip the machine-id query and fall back to the heuristic"
         );
     }
 

--- a/crates/sysknife-daemon/src/state_collector.rs
+++ b/crates/sysknife-daemon/src/state_collector.rs
@@ -15,6 +15,40 @@ pub struct CollectedState {
     pub layered_packages: Vec<String>,
     pub containers: Vec<String>,
     pub users: Vec<String>,
+    /// A stable per-machine identity a client can compare against its own, so
+    /// `audit verify` can tell whether the daemon it talked to is this machine or
+    /// a forwarded/remote one (#146). It is a salted hash of `/etc/machine-id`,
+    /// never the raw id (systemd treats the raw machine-id as confidential and
+    /// warns against exposing it). `None` when `/etc/machine-id` is unreadable.
+    #[serde(default)]
+    pub machine_id_hash: Option<String>,
+}
+
+/// Domain-separated hash of the local `/etc/machine-id`, or `None` if it cannot
+/// be read. Both the daemon (here) and the client compute this the same way, so
+/// equal hashes mean the same machine without either side revealing the raw id.
+pub fn machine_id_hash() -> Option<String> {
+    let raw = std::fs::read_to_string("/etc/machine-id").ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(hash_machine_id(trimmed))
+}
+
+/// The exact hashing both sides must agree on. Split out so it can be tested
+/// deterministically without depending on the host's `/etc/machine-id`.
+pub fn hash_machine_id(machine_id: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(b"sysknife-machine-id-v1\0");
+    hasher.update(machine_id.as_bytes());
+    let bytes = hasher.finalize();
+    bytes.iter().fold(String::with_capacity(64), |mut s, b| {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+        s
+    })
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -148,6 +182,7 @@ pub fn collect_state(runner: &dyn CommandRunner) -> Result<CollectedState, Colle
         layered_packages,
         containers,
         users,
+        machine_id_hash: machine_id_hash(),
     })
 }
 
@@ -476,11 +511,24 @@ mod tests {
             layered_packages: vec!["vim".to_string()],
             containers: vec!["dev-box".to_string()],
             users: vec!["alice".to_string()],
+            machine_id_hash: Some("deadbeef".to_string()),
         };
 
         let json = serde_json::to_string(&state).unwrap();
         let restored: CollectedState = serde_json::from_str(&json).unwrap();
         assert_eq!(state, restored);
+    }
+
+    #[test]
+    fn machine_id_hash_is_stable_domain_separated_and_hides_the_raw_id() {
+        // Deterministic and dependent on the input.
+        assert_eq!(hash_machine_id("abc"), hash_machine_id("abc"));
+        assert_ne!(hash_machine_id("abc"), hash_machine_id("abd"));
+        // 64 hex chars (sha256) and never the raw id.
+        let h = hash_machine_id("0123456789abcdef0123456789abcdef");
+        assert_eq!(h.len(), 64);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(!h.contains("0123456789abcdef"));
     }
 
     #[test]


### PR DESCRIPTION
## What

`audit verify` reads a **local** store, so an operator who forwards a unix socket to another host (`ssh -L`), acts there, then runs `audit verify` reads their own machine's chain and sees `Intact` for a chain unrelated to those actions. The env-only heuristic (shipped in 0.5.0) could not distinguish a forwarded unix socket (`SYSKNIFE_LISTEN_URI`) from a local config socket, so that case stayed silent (#146).

## Fix

- The daemon reports a salted SHA-256 hash of `/etc/machine-id` in its `state_response` (never the raw id — systemd treats it as confidential). `None` when unreadable.
- `audit verify` queries the configured daemon for that hash and compares it to this host's:
  - **different machine** → print the wrong-machine caveat (closes the forwarded-unix-socket gap),
  - **same machine** → stay quiet,
  - **unreachable / older daemon without the field** → fall back to the previous env heuristic (never worse than before).

The comparison (`socket_origin_from`) is a pure, tested function; the query reuses the existing sync client with its socket timeouts, so `verify` cannot hang on it. `remote_daemon_caveat_from_env` (the heuristic) is unchanged and still the fallback.

## Tests

- `machine_id_hash` is stable, domain-separated, 64-hex, and never contains the raw id.
- `socket_origin` verdict: match → Local, mismatch → Remote(caveat naming `SYSKNIFE_LISTEN_URI` + "forwarded"), missing either hash → Unknown.
- Client `machine_id_hash`: extracts the field, tolerates a daemon that omits it, and an unreachable daemon → `None`.

Closes #146