### PR TITLE
docs(security): document the vsock bearer-token replay threat model (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ### Security
 
+- **Documented the vsock bearer-token replay risk and its threat model.**
+  ([#152](https://github.com/lacs-project/sysknife/issues/152)) The vsock pre-shared token is
+  sent in the clear as the first frame and is a replayable bearer credential: an adjacent
+  party who can observe one legitimate connection can reuse it to authenticate as
+  `SYSKNIFE_TOKEN_ROLE` and mint a fresh receipt. This is inherent to a bearer token over an
+  unencrypted channel and cannot be closed at the application layer. `SECURITY.md` (new "vsock
+  transport authentication" section) and `docs/vm-daemon-setup.md` now state the threat model,
+  the operator mitigations (isolate the vsock namespace, prefer forwarding the Unix socket over
+  `ssh -L`, lowest role, rotate the token), and the paths to fully close it (a nonce/HMAC
+  challenge, or TLS/WireGuard under vsock). A code comment marks the residual risk at the auth
+  site.
+
 - **A stalled connection can no longer pin megabytes of memory with a false length header.**
   ([#150](https://github.com/lacs-project/sysknife/issues/150)) `FramedStream::recv`
   pre-allocated the full claimed body (`vec![0u8; len]`, up to 4 MiB) before reading a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -146,6 +146,48 @@ single-use, 15-minute bearer value makes timing recovery impractical. The
 daemon uses constant-time comparison when validating the signed commitment
 before issuing a receipt.
 
+### vsock transport authentication — threat model and residual risk
+
+Over a Unix socket the caller's identity is attested by the kernel
+(`SO_PEERCRED`) and cannot be forged or replayed. Over **vsock** (the daemon in
+a VM) there is no equivalent: the client authenticates with a **pre-shared
+bearer token** sent as the first frame, and possession of the token — a file,
+not an account — is the whole of the proof (`token:vsock` in the principal
+table above).
+
+This has a residual risk that cannot be fully closed at the application layer
+([#152](https://github.com/lacs-project/sysknife/issues/152)):
+
+- **The token is a replayable bearer credential over an unencrypted channel.**
+  An adjacent party that can observe one legitimate vsock connection (a
+  co-located guest that can see the traffic, a compromised hypervisor path, a
+  vsock proxy) reads the token from the first frame and can open its own
+  connection, authenticate as the configured role (`SYSKNIFE_TOKEN_ROLE`,
+  default `Dev`), and from there mint a fresh one-time approval receipt. The
+  approval-receipt and atomic-claim layers above stop *replay of a captured
+  request*, but not an attacker who holds the token and constructs their own.
+
+- **Why it is inherent.** A bearer token over a channel with no confidentiality
+  or peer authentication is, by construction, replayable by anyone who can read
+  the channel. Closing it fully requires either confidentiality + peer
+  authentication under the vsock (TLS or a WireGuard underlay), or a
+  per-connection challenge so the token is never sent in the clear (a
+  nonce/HMAC handshake, which defeats a *passive* observer but still not an
+  active man-in-the-middle). Both are larger changes tracked on #152.
+
+**Operator guidance (do this until the deeper mitigation lands):**
+
+- Treat the vsock token as a secret with the blast radius of `SYSKNIFE_TOKEN_ROLE`.
+  Prefer the lowest role that works; do not give the vsock path `admin`.
+- Run the daemon only where the vsock namespace is **isolated**: a single
+  trusted host↔guest pair on a hypervisor you control, not a multi-tenant host
+  where other guests share the vsock namespace.
+- Rotate the token file on any suspicion of exposure; the daemon reloads it.
+- For anything crossing an untrusted boundary, forward the daemon's **Unix**
+  socket over an authenticated, encrypted transport (`ssh -L`) instead of
+  exposing vsock directly — SSH gives the confidentiality and peer
+  authentication vsock does not.
+
 ---
 
 ## Deployment — User and Group Setup

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -1059,6 +1059,17 @@ pub async fn connection_handler_with_executor<S>(
 /// The response sent back to the *client* stays a uniform generic rejection
 /// regardless of cause — these logs are server-side only and must never be
 /// used to build a client-observable auth oracle.
+///
+/// RESIDUAL RISK (#152): the token is a pre-shared **bearer** credential sent in
+/// the clear as this first frame. Anyone who can observe one legitimate vsock
+/// connection can read it and authenticate as the configured role, then mint a
+/// fresh approval receipt — the approval/claim layers stop replay of a captured
+/// request, not an attacker who holds the token. This is inherent to a bearer
+/// token over an unencrypted channel and cannot be closed here; the threat
+/// model, operator mitigations (isolate the vsock namespace, prefer forwarding
+/// the Unix socket over `ssh -L`), and the paths to fully close it (a
+/// nonce/HMAC challenge, or TLS/WireGuard under vsock) are documented in
+/// SECURITY.md under "vsock transport authentication".
 async fn authenticate_vsock_token(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     token_path: &std::path::Path,

--- a/docs/vm-daemon-setup.md
+++ b/docs/vm-daemon-setup.md
@@ -252,6 +252,19 @@ cat /sys/class/vsock/local_cid   # e.g. prints "10"
 vsock connections require a pre-shared token to authenticate the host to the
 daemon. This prevents other processes on the host from connecting.
 
+> **Security note — the vsock token is a replayable bearer credential.**
+> It is sent in the clear as the first frame, so anyone who can observe a
+> legitimate vsock connection can capture and reuse it to authenticate as
+> `SYSKNIFE_TOKEN_ROLE` (see
+> [#152](https://github.com/lacs-project/sysknife/issues/152) and the "vsock
+> transport authentication" section of `SECURITY.md`). Run the daemon only where
+> the vsock namespace is isolated (a single trusted host↔guest pair on a
+> hypervisor you control), give the vsock path the **lowest** role that works
+> (not `admin`), rotate the token on any suspicion of exposure, and for anything
+> crossing an untrusted boundary forward the daemon's **Unix** socket over
+> `ssh -L` instead — SSH gives the confidentiality and peer authentication vsock
+> does not.
+
 The token file holds **only the trimmed token itself** — no `role:` prefix.
 The role granted to a token-authenticated connection comes from a separate
 env var, `SYSKNIFE_TOKEN_ROLE` (default `Dev` if unset), read by the daemon


### PR DESCRIPTION
## What

The vsock pre-shared token is sent in the clear as the first frame and is a **replayable bearer credential**: an adjacent party who can observe one legitimate connection can reuse the token to authenticate as `SYSKNIFE_TOKEN_ROLE` and mint a fresh one-time receipt. The approval-receipt and atomic-claim layers stop *replay of a captured request*, but not an attacker who holds the token and constructs their own (#152, red-team F6.1).

This is inherent to a bearer token over an unencrypted channel and cannot be closed at the application layer. Per the issue, the near-term deliverable is documenting the threat model and residual risk.

## Change

- **`SECURITY.md`** — new "vsock transport authentication — threat model and residual risk" section: the attack, why it is inherent, operator mitigations, and the paths to fully close it.
- **`docs/vm-daemon-setup.md`** — the same operator guidance beside the token-distribution steps (isolate the vsock namespace, lowest role, rotate the token, prefer forwarding the Unix socket over `ssh -L`).
- **Code comment** at `authenticate_vsock_token` marking the residual risk and pointing to `SECURITY.md`.

The deeper mitigations (a nonce/HMAC challenge that never sends the token in the clear, or TLS/WireGuard under vsock) are noted as the path to fully close it; both are larger protocol changes.

Closes #152