### PR TITLE
fix(planner): scope the action catalogue per distro, and stop shipping plans the daemon cannot run

### DIFF
--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 use clap::CommandFactory;
 use serde_json::{json, Value};
 use sysknife_brain::config::BrainConfig;
-use sysknife_brain::planner::{LlmPlanner, PlanRiskLevel};
+use sysknife_brain::planner::{LlmPlanner, Plan, PlanRiskLevel};
 use sysknife_brain::PlanEvent;
 use sysknife_types::{
     DistroHint, RiskLevel, TransactionId, DISTRO_FAMILY_DEBIAN, DISTRO_FAMILY_FEDORA,
@@ -413,6 +413,35 @@ fn plan_risk_of(risk: RiskLevel) -> PlanRiskLevel {
 /// higher risk than was approved.
 fn authoritative_plan_risk(action_name: &str) -> PlanRiskLevel {
     plan_risk_of(sysknife_daemon::preview::gate_risk(action_name))
+}
+
+/// Refuse a plan whose parameters the daemon would refuse, before the operator
+/// is asked to approve it.
+///
+/// [`authoritative_plan_risk`] asks the catalogue about a step by *name* only,
+/// so nothing built its `ActionSpec` until the daemon did — at execution, after
+/// approval. A live Ubuntu 22.04 run showed what that costs: "block port 0 in
+/// the firewall" produced an approvable `UfwDeny{port_or_service:"0"}` even
+/// though the daemon's `validated_port_or_service` rejects port 0 outright, so
+/// the operator was shown a plan that could only fail.
+///
+/// [`sysknife_daemon::executor::build_action_spec`] is the daemon's own
+/// construction path, params and all, and it is pure — so calling it here
+/// validates against the single source of truth rather than a second copy of
+/// each rule that could drift from it. Anything it rejects here would have
+/// failed at execution anyway; the only change is *when* the user finds out.
+fn reject_unrunnable_params(plan: &Plan) -> Result<(), CliError> {
+    for step in plan.steps() {
+        if let Err(e) =
+            sysknife_daemon::executor::build_action_spec(step.action_name(), step.params())
+        {
+            return Err(CliError::PlanningFailed(format!(
+                "step {} has parameters the daemon cannot run: {e}",
+                step.action_name()
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Fail-closed check run at execution time: is the live daemon's risk for a step
@@ -1456,6 +1485,12 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
     finish_spinner(&spinner);
 
     let plan = plan_result.map_err(|e| CliError::PlanningFailed(e.to_string()))?;
+
+    // Before anything is displayed or approved: refuse a plan the daemon could
+    // not run as written. A parameter the executor rejects is a planning
+    // failure, not an execution failure, and the operator should never be asked
+    // to approve one.
+    reject_unrunnable_params(&plan)?;
 
     // Surface any step where the planner's proposed risk disagreed with the
     // authoritative ActionSpec risk. A mismatch is a useful signal in its own
@@ -2530,7 +2565,7 @@ mod tests {
         );
     }
     use sysknife_brain::action_name::ActionName;
-    use sysknife_brain::planner::{AuthorizedPlan, Plan, PlanStep};
+    use sysknife_brain::planner::{AuthorizedPlan, PlanStep};
 
     /// Serialize env-var mutations so concurrent tests do not race on
     /// `SYSKNIFE_SOCKET`.  All tests that call `set_var` / `remove_var` must
@@ -2646,6 +2681,98 @@ mod tests {
         let h0 = since_to_hours("1970-01-01T00:00:00Z").unwrap();
         let h1 = since_to_hours("1970-01-01T01:00:00Z").unwrap();
         assert_eq!(h0, h1 + 1, "timestamps 1 h apart must differ by exactly 1");
+    }
+
+    // -----------------------------------------------------------------------
+    // reject_unrunnable_params — plan-time parameter validation
+    //
+    // `authoritative_plan_risk` asks the daemon catalogue about a step by NAME
+    // only, so nothing built its ActionSpec until the daemon did — at execution,
+    // after the operator had already approved. A live 22.04 run showed the cost:
+    // "block port 0 in the firewall" produced an approvable
+    // `UfwDeny{port_or_service:"0"}` even though the daemon's
+    // `validated_port_or_service` rejects port 0 outright.
+    // -----------------------------------------------------------------------
+
+    fn ufw_deny_plan(port: &str) -> Plan {
+        Plan::new(
+            "block a port".into(),
+            "block a port".into(),
+            "explanation".into(),
+            vec![PlanStep::new(
+                ActionName::parse("UfwDeny").unwrap(),
+                "deny inbound traffic".into(),
+                PlanRiskLevel::High,
+                serde_json::json!({ "port_or_service": port }),
+            )
+            .unwrap()],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn a_reserved_port_is_rejected_at_plan_time() {
+        let err = reject_unrunnable_params(&ufw_deny_plan("0"))
+            .expect_err("port 0 must not survive planning");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("UfwDeny") && msg.contains("port_or_service"),
+            "the error must name the step and the offending param, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_real_port_passes_plan_time_validation() {
+        // The guard must not be a blanket refusal: the same action with a valid
+        // port has to pass, or it would break every firewall plan.
+        reject_unrunnable_params(&ufw_deny_plan("23")).expect("port 23 is valid");
+        reject_unrunnable_params(&ufw_deny_plan("22/tcp")).expect("22/tcp is valid");
+        reject_unrunnable_params(&ufw_deny_plan("OpenSSH")).expect("an app profile is valid");
+    }
+
+    #[test]
+    fn a_missing_required_param_is_rejected_at_plan_time() {
+        // Port 0 is one instance of a general defect: any param the daemon would
+        // refuse used to reach the approval prompt. This covers the other half.
+        let plan = Plan::new(
+            "install".into(),
+            "install a package".into(),
+            "explanation".into(),
+            vec![PlanStep::new(
+                ActionName::parse("AptInstall").unwrap(),
+                "install".into(),
+                PlanRiskLevel::Medium,
+                serde_json::json!({}),
+            )
+            .unwrap()],
+        )
+        .unwrap();
+        let err = reject_unrunnable_params(&plan)
+            .expect_err("AptInstall without a package is unrunnable");
+        assert!(err.to_string().contains("AptInstall"));
+    }
+
+    #[test]
+    fn every_catalogued_no_param_action_passes_plan_time_validation() {
+        // Guard against the validator rejecting the ordinary case: every action
+        // the daemon builds from an empty params object must still plan.
+        for action in ["GetDiskUsage", "UfwStatus", "AptUpdate", "ListServices"] {
+            let plan = Plan::new(
+                "read".into(),
+                "read state".into(),
+                "explanation".into(),
+                vec![PlanStep::new(
+                    ActionName::parse(action).unwrap(),
+                    "read".into(),
+                    PlanRiskLevel::Low,
+                    serde_json::json!({}),
+                )
+                .unwrap()],
+            )
+            .unwrap();
+            reject_unrunnable_params(&plan)
+                .unwrap_or_else(|e| panic!("{action} should plan cleanly: {e}"));
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/sysknife-brain/src/planner.rs
+++ b/crates/sysknife-brain/src/planner.rs
@@ -517,15 +517,20 @@ impl From<PlanValidationError> for PlanningError {
 
 /// Drives the LLM planning loop.
 ///
-/// Tool definitions are built once at construction time and reused across all
-/// planning calls. The system prompt is rebuilt per `plan_intent()` call to
-/// include current user preferences and, when set, a distro-specific action
-/// family hint.
+/// Tool definitions and the system prompt are both rebuilt per `plan_intent()`
+/// call, from the same state: current user preferences and, when set, a
+/// distro-specific action family hint.
+///
+/// The tools used to be snapshotted in [`LlmPlanner::new`]. That was safe only
+/// while the schema was distro-agnostic — [`with_distro`] runs *after* `new`, so
+/// a construction-time snapshot could not reflect the hint, and the Debian
+/// `propose_plan` schema went out offering every Fedora action.
+///
+/// [`with_distro`]: LlmPlanner::with_distro
 pub struct LlmPlanner {
     provider: Box<dyn LlmProvider>,
     state_client: Box<dyn StateClient>,
     max_turns: usize,
-    tools: Vec<ToolDefinition>,
     audit_log: Option<SafetyAuditLog>,
     prefs_path: Option<std::path::PathBuf>,
     progress_tx: Option<tokio::sync::mpsc::UnboundedSender<PlanEvent>>,
@@ -548,14 +553,6 @@ impl LlmPlanner {
             provider,
             state_client,
             max_turns,
-            tools: {
-                let mut t = vec![get_state_tool_def()];
-                t.extend(query_tools());
-                t.push(crate::planning_tools::preferences::remember_tool_def());
-                t.push(crate::planning_tools::preferences::forget_tool_def());
-                t.push(propose_plan_tool_def());
-                t
-            },
             audit_log: None,
             prefs_path: None,
             progress_tx: None,
@@ -607,6 +604,22 @@ impl LlmPlanner {
     pub fn with_rate_limiter(mut self, rl: crate::rate_limit::RateLimiter) -> Self {
         self.rate_limiter = Some(std::sync::Arc::new(rl));
         self
+    }
+
+    /// The tools offered for one planning call: the query tools, the preference
+    /// tools, and a `propose_plan` schema scoped to the detected distro family.
+    ///
+    /// Built per call, not cached, because [`Self::with_distro`] can only run
+    /// after [`Self::new`] — see the type-level note on `LlmPlanner`.
+    fn tool_defs(&self) -> Vec<ToolDefinition> {
+        let mut t = vec![get_state_tool_def()];
+        t.extend(query_tools());
+        t.push(crate::planning_tools::preferences::remember_tool_def());
+        t.push(crate::planning_tools::preferences::forget_tool_def());
+        t.push(propose_plan_tool_def(
+            self.distro_hint.as_ref().map(|h| h.family),
+        ));
+        t
     }
 
     /// Attach a [`DistroHint`] to guide action-family selection in the prompt.
@@ -886,17 +899,14 @@ impl LlmPlanner {
             };
             build_system_prompt(prefs_content.as_deref(), self.distro_hint.as_ref())
         };
+        // Same lifetime as the prompt: one build per plan, reused across turns.
+        let tools = self.tool_defs();
 
         for turn in 0..self.max_turns {
             self.emit(PlanEvent::Thinking);
             let completion = self
                 .provider
-                .complete(
-                    &effective_prompt,
-                    &messages,
-                    &self.tools,
-                    PLANNING_MAX_TOKENS,
-                )
+                .complete(&effective_prompt, &messages, &tools, PLANNING_MAX_TOKENS)
                 .await
                 .map_err(PlanningError::from)?;
 

--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -7,6 +7,8 @@
 use crate::action_name::ActionName;
 use crate::planner::{Plan, PlanRiskLevel, PlanStep, PlanningError};
 use crate::provider::ToolDefinition;
+use sysknife_core::action_family::{DEBIAN_ONLY_ACTIONS, FEDORA_ONLY_ACTIONS};
+use sysknife_types::{DISTRO_FAMILY_DEBIAN, DISTRO_FAMILY_FEDORA};
 
 // ---------------------------------------------------------------------------
 // Tool definition
@@ -448,15 +450,45 @@ pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
      "list Multipass VMs and their state — no params; Ubuntu only; read-only"),
 ];
 
-pub fn propose_plan_tool_def() -> ToolDefinition {
-    let action_enum: Vec<serde_json::Value> = KNOWN_ACTIONS
+/// Is `action` runnable on `family`, given the family fence in
+/// [`sysknife_core::action_family`]?
+///
+/// `None` — no distro hint — offers everything: without a detected family there
+/// is no basis to exclude an action, and a generic deployment still has to be
+/// able to plan.
+fn available_on(action: &str, family: Option<&str>) -> bool {
+    match family {
+        Some(DISTRO_FAMILY_DEBIAN) => !FEDORA_ONLY_ACTIONS.contains(&action),
+        Some(DISTRO_FAMILY_FEDORA) => !DEBIAN_ONLY_ACTIONS.contains(&action),
+        _ => true,
+    }
+}
+
+/// Build the `propose_plan` tool definition, offering only the actions that the
+/// detected distro family can actually run.
+///
+/// The filter is not a nicety. `prompt.rs` renders per-distro prose and a test
+/// asserts the Debian prompt names no Fedora action, but this schema used to
+/// hand every host all 189 actions regardless — so the model could pick a
+/// `firewall-cmd` or `toolbox` action on Ubuntu having never seen it in the
+/// prompt, and did, in two live VM stories. Prose cannot fix that; only not
+/// offering the action can.
+pub fn propose_plan_tool_def(family: Option<&str>) -> ToolDefinition {
+    // One filtered pass feeds both the enum and the catalogue, so the model can
+    // never be told about an action the enum would reject.
+    let offered: Vec<&(&str, &str)> = KNOWN_ACTIONS
+        .iter()
+        .filter(|(name, _)| available_on(name, family))
+        .collect();
+
+    let action_enum: Vec<serde_json::Value> = offered
         .iter()
         .map(|(name, _)| serde_json::Value::String((*name).into()))
         .collect();
 
     // Build a compact catalogue so the model can match intent to action by
     // purpose.  Format: "Name — description" on its own line.
-    let action_catalogue: String = KNOWN_ACTIONS
+    let action_catalogue: String = offered
         .iter()
         .map(|(name, desc)| format!("{name} — {desc}"))
         .collect::<Vec<_>>()
@@ -888,5 +920,126 @@ mod tests {
             "steps": [{ "action_name": "ListJobHistory", "summary": "show recent activity", "risk_level": "low", "params": {} }]
         });
         parse_proposed_plan("show history", &input).unwrap();
+    }
+
+    // ── distro-scoped catalogue ──────────────────────────────────────────────
+    //
+    // `prompt.rs` isolates the per-distro *prose* (a passing test asserts the
+    // Debian prompt names no Fedora action), but the tool schema sitting beside
+    // it offered all 189 actions to every host. Two Ubuntu VM story failures
+    // came from exactly that gap: the model answered "show the current firewall
+    // rules" with `GetFirewallState` (`firewall-cmd`, absent on Ubuntu) and
+    // "what development containers do I have" with `ListToolboxes` (`toolbox`,
+    // likewise). Neither name appears anywhere in the Debian prompt — the model
+    // read them out of the enum.
+
+    /// Action names offered in the `action_name` enum of a built tool def.
+    fn offered_actions(def: &ToolDefinition) -> Vec<String> {
+        def.input_schema["properties"]["steps"]["items"]["properties"]["action_name"]["enum"]
+            .as_array()
+            .expect("action_name must carry an enum of allowed names")
+            .iter()
+            .map(|v| v.as_str().expect("enum entries are strings").to_string())
+            .collect()
+    }
+
+    #[test]
+    fn debian_tool_def_omits_fedora_only_actions() {
+        let def = propose_plan_tool_def(Some(DISTRO_FAMILY_DEBIAN));
+        let offered = offered_actions(&def);
+        let catalogue = def.input_schema["properties"]["steps"]["items"]["properties"]
+            ["action_name"]["description"]
+            .as_str()
+            .expect("action_name carries a catalogue description")
+            .to_string();
+
+        for name in FEDORA_ONLY_ACTIONS {
+            assert!(
+                !offered.contains(&name.to_string()),
+                "Debian tool def offered Fedora-only action {name}"
+            );
+            // The catalogue prose is the other half of the leak: an action the
+            // enum rejects must not be advertised in the description either.
+            assert!(
+                !catalogue.contains(&format!("{name} — ")),
+                "Debian catalogue described Fedora-only action {name}"
+            );
+        }
+        // The Ubuntu twins of the two actions that actually leaked in the VM
+        // must still be on offer, or this filter has broken the distro it is
+        // meant to serve.
+        for kept in ["UfwStatus", "DistroboxList", "AptInstall"] {
+            assert!(
+                offered.contains(&kept.to_string()),
+                "Debian tool def dropped Ubuntu action {kept}"
+            );
+        }
+    }
+
+    #[test]
+    fn fedora_tool_def_omits_debian_only_actions() {
+        let def = propose_plan_tool_def(Some(DISTRO_FAMILY_FEDORA));
+        let offered = offered_actions(&def);
+        for name in DEBIAN_ONLY_ACTIONS {
+            assert!(
+                !offered.contains(&name.to_string()),
+                "Fedora tool def offered Debian-only action {name}"
+            );
+        }
+        for kept in ["GetFirewallState", "ListToolboxes", "AddLayeredPackage"] {
+            assert!(
+                offered.contains(&kept.to_string()),
+                "Fedora tool def dropped Fedora action {kept}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_family_tool_def_offers_every_action() {
+        // No hint means no basis to exclude anything: a generic deployment must
+        // still be able to plan for whatever it is running on.
+        let offered = offered_actions(&propose_plan_tool_def(None));
+        assert_eq!(offered.len(), KNOWN_ACTIONS.len());
+    }
+
+    #[test]
+    fn every_offered_action_is_described_in_the_catalogue() {
+        // The enum and the catalogue are derived from one filtered iterator; if
+        // they are ever built from two separate passes, this catches the drift
+        // where the model is told about an action it is not allowed to name.
+        for family in [Some(DISTRO_FAMILY_DEBIAN), Some(DISTRO_FAMILY_FEDORA), None] {
+            let def = propose_plan_tool_def(family);
+            let catalogue = def.input_schema["properties"]["steps"]["items"]["properties"]
+                ["action_name"]["description"]
+                .as_str()
+                .expect("action_name carries a catalogue description")
+                .to_string();
+            let offered = offered_actions(&def);
+            assert!(!offered.is_empty(), "no actions offered for {family:?}");
+
+            // Entries are `Name — description`, one per line. A description may
+            // itself contain both " — " and an embedded newline
+            // (`CreateScheduledJob` does), so an entry is identified by its
+            // *leading* name, not by counting separators.
+            let described: Vec<&str> = catalogue
+                .lines()
+                .filter_map(|l| l.split_once(" — ").map(|(name, _)| name))
+                .filter(|name| KNOWN_ACTIONS.iter().any(|(known, _)| known == name))
+                .collect();
+
+            for name in &offered {
+                assert!(
+                    described.contains(&name.as_str()),
+                    "{name} is in the enum but missing from the catalogue for {family:?}"
+                );
+            }
+            assert_eq!(
+                described.len(),
+                offered.len(),
+                "catalogue describes {} actions but the enum allows {} for {family:?}",
+                described.len(),
+                offered.len()
+            );
+        }
     }
 }

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -817,6 +817,11 @@ const DEBIAN_SELECTION_RULES: &str = r#"
 - `AptAutoremove` removes orphaned dependency packages only — LOW.
 - `AptListUpgradable` lists packages with available upgrades — LOW, read-only. Use for "what updates are pending?" or "are there pending updates?" on Ubuntu/Debian. (Fedora equivalent: `GetPendingUpdates`.)
 - `AptHistoryList` reads the apt transaction log — LOW, read-only. Use for "what was recently installed/removed?", "show apt history".
+- `AptHold` / `AptUnhold` control whether apt is ALLOWED to touch a package, which is a different question from what to install. A hold "will prevent the package from being automatically installed, upgraded or removed" (apt-mark(8)), so read the sentence for permission, not for the verb:
+  - "hold nginx where it is", "stop nginx from being upgraded", "freeze nginx at this version" → `AptHold` — MEDIUM.
+  - "let nginx be upgraded again", "allow nginx to upgrade", "stop holding nginx", "unfreeze nginx" → `AptUnhold` — MEDIUM.
+  `AptInstall` does not lift a hold and `AptUpgrade` skips held packages, so proposing either for "let nginx be upgraded again" leaves the hold in place and does nothing the user asked for. This is the same pair as `SnapHold` / `SnapUnhold`, one package manager over.
+  Pinning to a *named* version or release is a different action — `SetAptPin` — because it writes an apt preferences rule rather than a hold flag.
 - `CheckPendingReboot` checks `/var/run/reboot-required` — LOW, read-only. Use for "do I need to reboot?", "is a reboot pending?". Ubuntu/Debian only; on Fedora use `GetPendingUpdates`.
 - `AddPpa` / `RemovePpa` add or remove a Launchpad PPA — MEDIUM. Param: `name` in `<user>/<ppa>` format (e.g. `"deadsnakes/ppa"`). Requires `software-properties-common` at runtime.
 - `GrubGetKargs` reads the current GRUB kernel command line — LOW, read-only.
@@ -824,6 +829,7 @@ const DEBIAN_SELECTION_RULES: &str = r#"
 - `SnapRevert` rolls a snap back to its previous revision — MEDIUM.
 - `SnapClassicInstall` installs a snap with classic confinement (full system access) — MEDIUM.
 - `UfwAllow` and `UfwDeny` mutate firewall rules — HIGH (lock-out risk on remote sessions).
+- A ufw rule's port must be a real port: 1-65535, optionally with `/tcp` or `/udp`, or a ufw app-profile name (`OpenSSH`, `Nginx Full`). **Port 0 is reserved and cannot carry traffic**, so "block port 0" is not a rule the firewall can hold — the daemon rejects it and the plan fails. When the user names port 0, or any number above 65535, do not emit a `UfwAllow`/`UfwDeny`/`UfwLimit` step for it: say what is wrong with the value and ask which port they meant.
 - `UfwEnable` and `UfwDisable` toggle the firewall on/off — HIGH.
 - `UfwDeleteRule` removes a numbered rule (`ufw status numbered` shows indices) — HIGH. Use when the user says "delete rule 3" or "remove rule number N". Param: `rule_number` (positive integer). Never use for named port/service removal — use `UfwDeny` or `UfwReset` instead.
 - `UfwLimit` adds rate-limiting on a port/service (blocks IPs with >6 connections/30 s) — HIGH. Use for SSH brute-force mitigation ("rate limit SSH", "limit port 22"). Prefer `UfwAllow` when the intent is simply to open a port without rate limiting.
@@ -1329,6 +1335,57 @@ mod tests {
         assert!(prompt.contains("GetSystemState"));
         // Must teach the decision rule in the disambiguation section.
         assert!(prompt.contains("State and diagnostic action disambiguation"));
+    }
+
+    /// Port 0 is reserved, so a firewall rule naming it is not a rule.
+    ///
+    /// The daemon has always refused it (`validated_port_or_service` rejects 0
+    /// and anything above 65535), but the prompt never said so, so "block port 0
+    /// in the firewall" cost a live call and produced `UfwDeny{"0"}` — a plan
+    /// that could only fail. The CLI now also refuses such a plan at plan time;
+    /// this line is what stops the model proposing one in the first place.
+    #[test]
+    fn debian_prompt_states_the_valid_port_range() {
+        let hint = debian_hint();
+        let p = build_system_prompt(None, Some(&hint));
+        assert!(
+            p.contains("1-65535"),
+            "Debian prompt must state the valid port range for ufw rules"
+        );
+        assert!(
+            p.contains("port 0"),
+            "Debian prompt must call out port 0 specifically — it is the value the model actually emitted"
+        );
+    }
+
+    /// A held package is one apt refuses to change, so restoring permission is
+    /// `AptUnhold` — never an install.
+    ///
+    /// In a live 22.04 run the planner answered "let the nginx package be
+    /// upgraded again" with `AptInstall{nginx}`: it read "upgraded" as the verb
+    /// and missed that the sentence is about permission. That plan leaves the
+    /// hold in place, so it does nothing the user asked for. The selection rules
+    /// listed no `AptHold`/`AptUnhold` guidance at all, which is why the model
+    /// had nothing to key on — the snap twins worked in the same run only
+    /// because their catalogue entries say "auto-refresh".
+    #[test]
+    fn debian_prompt_maps_permission_language_to_unhold() {
+        let hint = debian_hint();
+        let p = build_system_prompt(None, Some(&hint));
+        assert!(
+            p.contains("AptUnhold") && p.contains("AptHold"),
+            "Debian prompt must name both halves of the hold pair"
+        );
+        // The mapping, not just the names: the phrasing that failed and the
+        // reason an install is the wrong answer.
+        assert!(
+            p.contains("upgraded again"),
+            "Debian prompt must map permission-restoring phrasing to AptUnhold"
+        );
+        assert!(
+            p.contains("does not lift a hold"),
+            "Debian prompt must say why AptInstall is not a substitute for AptUnhold"
+        );
     }
 
     /// The shared `EXAMPLES` block is spliced into all three prompts, so every

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -256,12 +256,12 @@ lists the information they want, treat it as a **direct read-only request** —
 not as an open-ended diagnosis. Go straight to `propose_plan` with the listed
 actions. Do NOT call `get_system_state` to "gather context" first.
 
-User: "Something broke after my last system update — check what toolbox containers I have, list my configured Flatpak remotes, and tell me if any services are in a failed state"
+User: "Something broke after my last system update — tell me if any services are in a failed state, show me what is listening on the network, and check how much disk space is left"
 
 Three explicit read-only requests, each mapping directly to an action:
-- "toolbox containers I have" → `ListToolboxes`
-- "configured Flatpak remotes" → `ListFlatpakRemotes`
 - "services in a failed state" → `ListServices`
+- "what is listening on the network" → `GetListeningPorts`
+- "how much disk space is left" → `GetDiskUsage`
 
 Do NOT call `get_system_state`, `query_services`, or any query tool first.
 The complaint framing does NOT change the planning rule.
@@ -269,24 +269,24 @@ Call `propose_plan` immediately:
 
 ```json
 {
-  "summary": "List toolbox containers, Flatpak remotes, and service states",
-  "explanation": "The user described a problem and then listed three specific read-only things to inspect. All three map directly to named actions — ListToolboxes, ListFlatpakRemotes, ListServices. The complaint framing does not require a diagnostic state query first.",
+  "summary": "List service states, listening ports, and disk usage",
+  "explanation": "The user described a problem and then listed three specific read-only things to inspect. All three map directly to named actions — ListServices, GetListeningPorts, GetDiskUsage. The complaint framing does not require a diagnostic state query first.",
   "steps": [
-    {
-      "action_name": "ListToolboxes",
-      "summary": "List all toolbox containers",
-      "risk_level": "low",
-      "params": {}
-    },
-    {
-      "action_name": "ListFlatpakRemotes",
-      "summary": "List configured Flatpak remotes",
-      "risk_level": "low",
-      "params": {}
-    },
     {
       "action_name": "ListServices",
       "summary": "List systemd services to identify any in a failed state",
+      "risk_level": "low",
+      "params": {}
+    },
+    {
+      "action_name": "GetListeningPorts",
+      "summary": "Show listening TCP/UDP sockets and the process bound to each",
+      "risk_level": "low",
+      "params": {}
+    },
+    {
+      "action_name": "GetDiskUsage",
+      "summary": "Show disk space usage for all mounted filesystems",
       "risk_level": "low",
       "params": {}
     }
@@ -1280,8 +1280,17 @@ mod tests {
         let prompt = build_system_prompt(None, None);
         // Example D covers complaint/diagnostic framing — must include the key
         // actions and the explicit anti-pattern instruction.
-        assert!(prompt.contains("ListToolboxes"));
-        assert!(prompt.contains("ListFlatpakRemotes"));
+        //
+        // Its three actions are deliberately no-param and cross-distro. The
+        // originals (`ListToolboxes`, `ListFlatpakRemotes`) were neither: both
+        // are user-scoped and require `username`, which the example showed as
+        // `params: {}` while the params section tells the model to call
+        // `query_current_user` when no username is given — so the example
+        // demonstrated a plan the daemon rejects with MissingParam. And
+        // `ListToolboxes` needs `toolbox`, which Ubuntu does not have.
+        assert!(prompt.contains("ListServices"));
+        assert!(prompt.contains("GetListeningPorts"));
+        assert!(prompt.contains("GetDiskUsage"));
         // Must explicitly teach: complaint framing does not justify get_system_state.
         assert!(
             prompt.contains("complaint")
@@ -1322,10 +1331,30 @@ mod tests {
         assert!(prompt.contains("State and diagnostic action disambiguation"));
     }
 
-    // example_d uses ListToolboxes and ListFlatpakRemotes — these are in the
-    // EXAMPLES const (shared), so the generic prompt must also contain them
-    // even though they are Fedora-specific actions. The generic prompt does NOT
-    // list them in risk tables; they only appear in the examples section.
-    // The isolation tests above use None (generic) and do NOT check for
-    // ListToolboxes/ListFlatpakRemotes as forbidden — which is correct.
+    /// The shared `EXAMPLES` block is spliced into all three prompts, so every
+    /// action it demonstrates must be runnable on every family.
+    ///
+    /// This is the test that was missing. Example D used to walk through
+    /// `ListToolboxes`, and the note that stood here declared that "correct"
+    /// because the isolation tests only forbade a hand-listed set of Fedora
+    /// names. So the Ubuntu prompt shipped a worked example of a `toolbox`
+    /// action, and in a live 22.04 VM the planner answered "what development
+    /// containers do I have running" with `ListToolboxes` — an action whose
+    /// binary Ubuntu does not have.
+    #[test]
+    fn shared_examples_demonstrate_only_cross_distro_actions() {
+        for (family, actions) in [
+            ("Fedora-only", FEDORA_ONLY_ACTION_NAMES),
+            ("Debian-only", DEBIAN_ONLY_ACTION_NAMES),
+        ] {
+            for action in actions {
+                assert!(
+                    !EXAMPLES.contains(action),
+                    "shared EXAMPLES demonstrates {family} action {action}; \
+                     every prompt embeds this block, so it must name only \
+                     actions that run on every family"
+                );
+            }
+        }
+    }
 }

--- a/crates/sysknife-core/src/action_family.rs
+++ b/crates/sysknife-core/src/action_family.rs
@@ -19,7 +19,26 @@
 
 /// Fedora-family action names that are NOT available on Debian-family distros.
 ///
-/// These are rpm-ostree shaped actions.
+/// These are rpm-ostree shaped actions, plus the three tool families whose
+/// binary ships only on the Fedora side and has a full Ubuntu twin here:
+///
+/// | Fedora tool | action(s) | Ubuntu twin |
+/// |---|---|---|
+/// | `firewall-cmd` | `GetFirewallState`, `ConfigureFirewall` | `UfwStatus`, `UfwAllow`/`UfwDeny` |
+/// | `toolbox` | `ListToolboxes`, `CreateToolbox`, `RemoveToolbox` | `DistroboxList`, `DistroboxCreate`, `DistroboxRemove` |
+///
+/// Those five were classified cross-distro until an Ubuntu VM story run caught
+/// the planner answering "show the current firewall rules" with
+/// `GetFirewallState` and "what development containers do I have" with
+/// `ListToolboxes` — `firewall-cmd` and `toolbox` are not installed on Ubuntu,
+/// so both plans were approvable and then unrunnable. `prompt.rs` already
+/// treated them as Fedora-only and the story suite already accepted only the
+/// Ubuntu twin on Ubuntu; this list was the one place that still said "All".
+///
+/// Flatpak is deliberately NOT in here: the un-prefixed `InstallFlatpak`
+/// family covers remotes, search, and app info, which the `Ubuntu*Flatpak`
+/// actions do not, so scoping it to Fedora would remove capability from Ubuntu
+/// rather than redirect it.
 pub const FEDORA_ONLY_ACTIONS: &[&str] = &[
     "AddLayeredPackage",
     "RemoveLayeredPackage",
@@ -36,6 +55,14 @@ pub const FEDORA_ONLY_ACTIONS: &[&str] = &[
     "RebaseSystem",
     "GetKernelArguments",
     "SetKernelArguments",
+    // firewalld — Ubuntu uses ufw (installable via apt, but never the default,
+    // and managing firewalld while ufw holds the rules is a footgun).
+    "GetFirewallState",
+    "ConfigureFirewall",
+    // toolbox — Ubuntu uses distrobox.
+    "ListToolboxes",
+    "CreateToolbox",
+    "RemoveToolbox",
 ];
 
 /// Debian-family action names that are NOT available on Fedora-family distros.

--- a/docs/action-reference.md
+++ b/docs/action-reference.md
@@ -65,9 +65,9 @@ Every row is derived from the live code: the command from each action's `ActionS
 
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
-| `ListToolboxes` | `sudo runuser -l testuser -c "XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox list"` | Low | All | – | – | list toolbox containers for a user — param: username\* |
-| `CreateToolbox` | `sudo runuser -l testuser -c "XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox create --container 'sysknife-dev' --release '41'"` | Medium | All | – | – | create a toolbox container — params: username\*, name\*; optional: image, release |
-| `RemoveToolbox` | `sudo runuser -l testuser -c "XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox rm 'sysknife-dev'"` | Medium | All | – | – | remove a toolbox container — params: username\*, name\* |
+| `ListToolboxes` | `sudo runuser -l testuser -c "XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox list"` | Low | Fedora | – | – | list toolbox containers for a user — param: username\* |
+| `CreateToolbox` | `sudo runuser -l testuser -c "XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox create --container 'sysknife-dev' --release '41'"` | Medium | Fedora | – | – | create a toolbox container — params: username\*, name\*; optional: image, release |
+| `RemoveToolbox` | `sudo runuser -l testuser -c "XDG_RUNTIME_DIR=/run/user/$(id -u) toolbox rm 'sysknife-dev'"` | Medium | Fedora | – | – | remove a toolbox container — params: username\*, name\* |
 
 ## Services
 
@@ -178,8 +178,8 @@ Every row is derived from the live code: the command from each action's `ActionS
 |---|---|---|---|---|---|---|
 | `ConfigureWifi` | `sudo nmcli device wifi connect CafeHotspot` | High | All | – | – | connect to a Wi-Fi network — params: ssid\*, password (optional for open networks) |
 | `SetDnsServers` | `sudo resolvectl dns wlp1s0 1.1.1.1 8.8.8.8` | High | All | – | – | set DNS servers for an interface — params: interface\* (e.g. wlp1s0), servers\* (string\[\]) |
-| `ConfigureFirewall` | `sudo sh -c "firewall-cmd --permanent --zone='public' --add-service='ssh' && firewall-cmd --reload"` | High | All | – | – | add/remove a service in a firewalld zone — params: zone\*, service\*, enabled\* (bool) |
-| `GetFirewallState` | `firewall-cmd --list-all` | Low | All | – | – | show current firewalld zones, open services, and port rules — no params |
+| `ConfigureFirewall` | `sudo sh -c "firewall-cmd --permanent --zone='public' --add-service='ssh' && firewall-cmd --reload"` | High | Fedora | – | – | add/remove a service in a firewalld zone — params: zone\*, service\*, enabled\* (bool) |
+| `GetFirewallState` | `firewall-cmd --list-all` | Low | Fedora | – | – | show current firewalld zones, open services, and port rules — no params |
 | `GetNetworkStatus` | `ip -brief addr` | Low | All | – | – | show network interfaces, IP addresses, and connection state — no params |
 | `GetListeningPorts` | `ss -tulpnH` | Low | All | – | – | show listening TCP/UDP sockets and the process bound to each (ss -tulpn) — no params; read-only; use for "what is listening on port X?" |
 


### PR DESCRIPTION
## Summary

Fixes the four planner defects that the first real Ubuntu VM validation left
standing at 46/50, and each one turned out to be a different kind of bug than
"the model is flaky".

| Story | Intent | Was | Now |
|---|---|---|---|
| 73 | "show the current firewall rules on this Ubuntu server" | `GetFirewallState` (`firewall-cmd`, absent on Ubuntu) | `UfwStatus` |
| 101 | "what development containers do I have running" | `ListToolboxes` (`toolbox`, absent on Ubuntu) | `DistroboxList` |
| 62 | "let the nginx package be upgraded again" | `AptInstall{nginx}` — leaves the hold in place | `AptUnhold{nginx}` |
| 92 | "block port 0 in the firewall" | `UfwDeny{port_or_service:"0"}` — unrunnable | refused, no rule emitted |

Three commits, one root cause each.

**1. The tool schema was not distro-scoped (73, 101).** `prompt.rs` isolates per
distro and `debian_prompt_omits_fedora_actions` proves the Debian prompt never
names `GetFirewallState`. The model read it out of `propose_plan`'s schema
instead, which handed every host the same enum of all 189 actions plus a
catalogue describing them. Prose cannot fix that. `propose_plan_tool_def` now
takes the detected family and filters through the family fence in
`sysknife-core`, one pass feeding both the enum and the catalogue.

`LlmPlanner` also had to stop snapshotting its tools in `new()`: `with_distro`
runs *after* `new`, so a construction-time snapshot could not see the hint at
all. That ordering hazard is what made the bug possible.

firewalld (`GetFirewallState`, `ConfigureFirewall`) and toolbox
(`ListToolboxes`, `CreateToolbox`, `RemoveToolbox`) move to
`FEDORA_ONLY_ACTIONS`. Each has a full Ubuntu twin, `prompt.rs` already treated
them as Fedora-only, and the story suite already accepted only the Ubuntu twin
on Ubuntu — this list was the one place still saying `All`. Flatpak
deliberately stays cross-distro: the un-prefixed actions cover remotes, search
and app info that the `Ubuntu*Flatpak` ones do not, so scoping it would remove
capability rather than redirect it.

Ubuntu is now offered 169 actions (catalogue 20,798 -> 19,016 chars), Fedora 123
(-36.7%).

**2. Prompt guidance that was simply absent (62, 92).** The selection rules had
no `AptHold`/`AptUnhold` mapping at all, so the model keyed on the verb
"upgraded" rather than the permission the sentence is about. They now map both
directions by phrasing, quote `apt-mark(8)` on what a hold prevents (verified
against the manpage on the 22.04 box under test), and state that `AptInstall`
does not lift a hold and `AptUpgrade` skips held packages. The firewall rules
now give the real port range and name port 0 as reserved.

**3. Plan-time parameter validation (defence in depth for 92).**
`authoritative_plan_risk` asks the catalogue about a step by *name* only, so
nothing built its `ActionSpec` until the daemon did — at execution, after
approval. `run_intent` now calls `build_action_spec` for every step as soon as
the plan arrives. That is the daemon's own construction path, params and all,
and it is pure, so there is no second copy of any rule to drift. Nothing is
newly forbidden: anything rejected here would have failed at execution anyway.
The only change is when the user finds out, and that they are no longer asked to
approve it first.

## Related Issue

Follow-up to the Ubuntu VM validation in #171 (46/50 on 22.04, 45/50 on 24.04).

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

**Unit:** 1681 pass (was 1675), `clippy --all-targets -D warnings` clean,
`cargo fmt` clean, Postgres contract green, `ci-local.sh` green apart from the
docker-vs-podman Postgres launcher, which the same tests pass under podman.

New tests, in the order the mistakes were made: the enum/catalogue filter per
family; that neither family loses its own actions (a filter that broke Ubuntu
would otherwise pass); that the two derived strings cannot drift; that the
shared `EXAMPLES` block names no family-specific action — the guard that was
missing; both prompt mappings including the exact phrasing that failed; port 0
rejected at plan time with the step and param named; valid ports, `22/tcp` and
an app-profile name still accepted, so the guard is not a blanket refusal; a
missing required param rejected too; and four ordinary no-param actions still
planning cleanly.

**Live, on Ubuntu 22.04 with `openai/gpt-oss-120b`,** attributed per increment:

- After commit 1: 73 PASS, 101 PASS (both previously FAIL), 62 and 92 still FAIL.
- After commits 2-3: 62 PASS -> `AptUnhold{package:"nginx"}`, 92 PASS.

Story 92 passes because of the *prompt*, not the guard: the model now answers
"port 0 is not a valid port number for firewall rules". The plan-time guard was
never triggered in that run, and stands on its unit tests.

## Notes for Reviewers

**The cassette is stale and this PR does not refresh it.** Every commit here
changes the system prompt or the tool schema, and the cassette is keyed on both,
so `tests/e2e/cassettes/ubuntu-jammy-gpt-oss-120b.json` now misses every call by
design. A re-record needs a network path the model provider does not block;
until then the four stories above are attributed by live probe rather than by
replay. Re-recording is the immediate follow-up, and the headline "46/50" in the
docs should be refreshed from that run rather than adjusted by hand.

**A finding worth its own issue, surfaced by story 92's log.** The planner cannot
express "there is nothing to do". The model's first attempt was
`{"steps":[],"summary":"No firewall rule applied"}`, which the safety fence
rejects with `'steps' must not be empty`, so it burned a turn and then proposed
an adjacent read-only action (`UfwStatus`) to satisfy the schema. For an
impossible request the honest output is a refusal, and there is currently no way
to say it: every refusal becomes either `PlannerStuck` or an invented step.

**Deliberately not done here:** the five reclassified actions are now refused by
the CLI routing guard and the daemon family fence on Debian hosts, not just
omitted from the planner's options. That is the intended semantics — running
`firewall-cmd` on a ufw box was never something to facilitate — but it is a
behaviour change beyond planning and worth a second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f
