### PR TITLE
chore: derive every published number from evidence, not from memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,10 @@ jobs:
         run: ./node_modules/.bin/tsc --noEmit
 
       - name: Test
-        run: ./node_modules/.bin/vitest run
+        # Wrapper around the same vitest command; it also fails when the
+        # published frontend test count no longer matches the suite.
+        working-directory: ${{ github.workspace }}
+        run: scripts/test_baseline.sh --frontend
 
   rust:
     runs-on: ubuntu-latest
@@ -172,7 +175,10 @@ jobs:
           tool: cargo-nextest
 
       - name: Test workspace
-        run: cargo nextest run --workspace --locked
+        # Wrapper around the same nextest command; it also fails when the
+        # published test count in tests/evidence/workspace-tests.json no longer
+        # matches the suite, because the docs derive their figure from it.
+        run: scripts/test_baseline.sh
 
   postgres-contract:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ newgrp sysknife                       # or log out and back in
 npx sysknife-setup --no-binary --daemon-mode=skip
 ```
 
-Ubuntu 24.04 is validated with 65/65 stories on a live VM. Ubuntu 22.04 and
+Ubuntu 24.04 is validated by the live-VM story suite; the recorded pass rate
+lives in `tests/evidence/story-runs/`. Ubuntu 22.04 and
 26.04 have passed bootstrap and smoke tests but not the full story suite.
 Fedora Atomic is the rpm-ostree target; record a current Silverblue 44 VM run
 before treating a release as current-validated. Plain Fedora Workstation and
@@ -255,11 +256,11 @@ milestone.
 | Tamper-evident Ed25519-signed audit chain | ✅ |
 | RFC 5424 syslog forwarding (Splunk / Sentinel / QRadar) | ✅ |
 | Postgres backend (RDS / Cloud SQL / Neon / Supabase) | ✅ |
-| **Ubuntu 24.04 support** — 65/65 stories pass on a live VM with gpt-4.1 | ✅ |
+| **Ubuntu 24.04 support** — live-VM story suite, pass rate recorded in `tests/evidence/story-runs/` | ✅ |
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,561 Rust tests and 72 frontend tests** form the current deterministic
+**1,681 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM
@@ -305,7 +306,7 @@ All config files that may contain API keys are created with `chmod 0600`.
 
 See [ROADMAP.md](ROADMAP.md) for the full milestone breakdown.
 
-- ✅ **Ubuntu 24.04** — 65/65 stories validated on a live VM (gpt-4.1)
+- ✅ **Ubuntu 24.04** — validated by the live-VM story suite (pass rate in `tests/evidence/story-runs/`)
 - ✅ **Ubuntu 22.04 / 26.04** — VM tooling complete; smoke tests pass on all three LTSes
 - 📋 Telegram inline-button approvals
 - 📋 `sysknife audit export` (CEF / NDJSON for SIEM ingest)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,8 +15,8 @@ later) because that is where the users are; Fedora Atomic 41+ is eligible and it
 rpm-ostree action families work, it just needs a fresh validation run. See
 [docs/distro-support.md](docs/distro-support.md).
 
-- Ubuntu 22.04 full action parity (65/65 stories)
-- Ubuntu 26.04 full action parity (65/65 stories)
+- Ubuntu 22.04 full action parity (every Ubuntu story)
+- Ubuntu 26.04 full action parity (every Ubuntu story)
 - record a current Fedora Silverblue 44 full VM run
 - dnf action family (Fedora Workstation non-atomic)
 - pacman action family (Arch/Manjaro)

--- a/docs/adr/0004-per-distro-prompt-dispatch.md
+++ b/docs/adr/0004-per-distro-prompt-dispatch.md
@@ -26,7 +26,8 @@ After adding Debian actions this caused two problems:
 2. **Context window waste**: every planning call carried ~40% action names that
    could never legally be executed on the current host.
 
-The E2E story suite (65/65 passing on Ubuntu 24.04 with gpt-4.1) validated
+The E2E story suite (recorded at the time as 65/65 passing on Ubuntu 24.04 with
+gpt-4.1 — see the correction note at the end of this ADR) validated
 that per-distro isolation fixes (1) and reduces prompt size meaningfully.
 
 ## Decision
@@ -79,3 +80,14 @@ which reads `/etc/os-release` at startup. If detection fails, `distro_hint` is
 - `docs/research/prompt-composition-patterns.md` — survey of dynamic
   prompt patterns that informed this design (dynamic middleware, template
   composition, conditional blocks)
+
+## Correction (2026-08-05)
+
+The "65/65" figure quoted above was never backed by a run: no story set of that
+size has existed, and the Ubuntu family contains 50 stories. The first
+measurements traceable to an artifact are 46/50 on 22.04 and 45/50 on 24.04 with
+`openai/gpt-oss-120b`. The decision this ADR records — structural per-distro
+prompt isolation — is unaffected, and was independently confirmed later: the two
+Fedora actions that still reached Ubuntu plans came from the *tool schema*, which
+this ADR did not cover, not from the prompt. Published figures now derive from
+`tests/evidence/` and are enforced by `scripts/check_evidence_claims.py`.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -14,7 +14,7 @@ validation before a release.
 | **Dev stories (local, no VM)** | LLM plan structure for read-only stories; runs on any Linux host | 1-3 min | After brain/prompt changes |
 | CI smoke (container) | Daemon + Ollama + read-only stories in a Linux runner | 5-10 min | Opt-in (PR label `e2e` or manual trigger) |
 | E2E Atomic VM | **Real Silverblue** in QEMU/KVM, full stack, all 54 stories | 15-30 min first boot; 2-3 min subsequent | Local / pre-release |
-| **E2E Ubuntu VM** | **Ubuntu 24.04** cloud image, full story suite, 65/65 stories | ~15 min first boot; ~2 min subsequent | After Ubuntu action changes |
+| **E2E Ubuntu VM** | **Ubuntu 24.04** cloud image, full story suite (pass rate in `tests/evidence/story-runs/`) | ~15 min first boot; ~2 min subsequent | After Ubuntu action changes |
 | Manual QA | Real Silverblue/Kinoite hardware, destructive actions, GUI | 30-60 min | Before releases + demo video |
 
 No single layer is enough on its own. Use the ones that match your change.
@@ -47,17 +47,35 @@ names, risk levels, parameters). It does **not** execute the actions — it
 tests plan structure only. This works on any Linux host because the story
 scripts check the JSON plan output, not the results of `df`, `ps`, etc.
 
-**LLM provider:** auto-detected from environment variables (same logic as
-the product's `BrainConfig::from_env`):
+**LLM provider:** the harness mirrors the product's `BrainConfig::from_env`,
+which auto-detects exactly two providers:
 
-| Variable set | Provider used | Model |
+| Condition | Provider | Default model |
 |---|---|---|
-| `ANTHROPIC_API_KEY` | `anthropic` | `claude-sonnet-4-6` |
-| `OPENAI_API_KEY` | `openai` | `gpt-4.1` |
-| `GEMINI_API_KEY` | `gemini` | `gemini-2.0-flash` |
-| neither | `ollama` | `qwen3:8b` (must be pulled; CPU-only is impractical — use `SYSKNIFE_LLM_MODEL=llama3.2:3b` on CPU) |
+| `ANTHROPIC_API_KEY` set and non-blank | `anthropic` | `claude-sonnet-4-6` |
+| otherwise | `ollama` | `qwen3:8b` (must be pulled; CPU-only is impractical — use `SYSKNIFE_LLM_MODEL=llama3.2:3b` on CPU) |
 
-Override with `SYSKNIFE_LLM_PROVIDER` and `SYSKNIFE_LLM_MODEL`.
+The other six providers are supported but never auto-detected: setting the key
+alone does nothing, because `from_env` only consults `ANTHROPIC_API_KEY`. Each
+needs `SYSKNIFE_LLM_PROVIDER` **and** its key:
+
+| `SYSKNIFE_LLM_PROVIDER` | Key | Default model |
+|---|---|---|
+| `openai` | `OPENAI_API_KEY` | `gpt-4.1` |
+| `gemini` | `GEMINI_API_KEY` | `gemini-2.0-flash` |
+| `groq` | `GROQ_API_KEY` | `llama-3.3-70b-versatile` |
+| `deepseek` | `DEEPSEEK_API_KEY` | `deepseek-chat` |
+| `mistral` | `MISTRAL_API_KEY` | `mistral-large-latest` |
+| `xai` | `XAI_API_KEY` | `grok-3` |
+
+This table listed three auto-detected providers and omitted four entirely, which
+is how a run with only `GROQ_API_KEY` exported silently fell through to the
+uninstalled Ollama fallback and failed all fifty stories with an error naming the
+wrong provider. `tests/e2e/provider-parity.test.sh` now derives the provider list
+and the default models from `config.rs` and fails when this table drifts again.
+
+Override the model with `SYSKNIFE_LLM_MODEL` (leave it *unset* rather than empty:
+an empty value wins over the per-provider default).
 
 ```sh
 # Run the default read-only stories with an Anthropic key
@@ -307,8 +325,9 @@ follow-up if Windows contributor interest warrants it.
 
 ## Running the Ubuntu 24.04 E2E suite
 
-Ubuntu 24.04 support is validated (65/65 stories pass on a live VM with
-gpt-4.1). The `ubuntu-vm.sh` script mirrors the `atomic-vm.sh` workflow but
+Ubuntu 24.04 support is validated by the live-VM story suite. The pass rate and
+the model that produced it are recorded in `tests/evidence/story-runs/`, written
+by the run itself. The `ubuntu-vm.sh` script mirrors the `atomic-vm.sh` workflow but
 uses a Ubuntu 24.04 cloud image instead of a Fedora Atomic ISO.
 
 See [docs/contributing/ubuntu-vm-testing.md](ubuntu-vm-testing.md) for the

--- a/docs/contributing/ubuntu-vm-testing.md
+++ b/docs/contributing/ubuntu-vm-testing.md
@@ -121,11 +121,17 @@ and the daemon IPC. Only the network hop is served from disk.
 
 ```sh
 # Record. Costs one live run; the cassette lands inside the VM.
+# `ubuntu` is the whole Ubuntu story family, derived from the story files. It
+# replaced `$(seq 55 104)`, a hand-typed range that stops covering the suite the
+# moment story 105 is added. SYSKNIFE_RESULTS_JSON writes the machine-readable
+# result every published pass rate has to derive from.
 CASSETTE=tests/e2e/cassettes/ubuntu-jammy-gpt-oss-120b.json
+RESULTS=tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json
 GROQ_API_KEY=gsk-... \
 SYSKNIFE_LLM_PROVIDER=groq SYSKNIFE_LLM_MODEL=openai/gpt-oss-120b \
 SYSKNIFE_CASSETTE="$CASSETTE" SYSKNIFE_CASSETTE_MODE=record \
-UBUNTU_RELEASE=jammy ./tests/e2e/ubuntu-vm.sh run $(seq 55 104)
+SYSKNIFE_RESULTS_JSON="$RESULTS" \
+UBUNTU_RELEASE=jammy ./tests/e2e/ubuntu-vm.sh run ubuntu
 
 # Copy it out of the guest (the suite runs as root, so read it with sudo).
 UBUNTU_RELEASE=jammy ./tests/e2e/ubuntu-vm.sh ssh "sudo cat $CASSETTE" > "$CASSETTE"
@@ -140,7 +146,12 @@ UBUNTU_RELEASE=jammy ./tests/e2e/ubuntu-vm.sh ssh \
 SYSKNIFE_CASSETTE="$CASSETTE" SYSKNIFE_CASSETTE_MODE=replay \
 SYSKNIFE_LLM_PROVIDER=groq SYSKNIFE_LLM_MODEL=openai/gpt-oss-120b \
 GROQ_API_KEY=unused-under-replay \
-UBUNTU_RELEASE=jammy ./tests/e2e/ubuntu-vm.sh run $(seq 55 104)
+UBUNTU_RELEASE=jammy ./tests/e2e/ubuntu-vm.sh run ubuntu
+
+# Copy the evidence out of the guest the same way as the cassette, then commit it:
+# every published pass rate is checked against these files by
+# scripts/check_evidence_claims.py, so a figure with no run behind it fails CI.
+UBUNTU_RELEASE=jammy ./tests/e2e/ubuntu-vm.sh ssh "sudo cat $RESULTS" > "$RESULTS"
 ```
 
 A key still has to be *present* under replay, because `BrainConfig::from_env`

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -45,7 +45,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 
 | Distro | Action backend | Evidence | Launch tier |
 |---|---|---|---|
-| **Ubuntu 24.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | 65/65 stories on a live VM with `gpt-4.1` | **Validated** |
+| **Ubuntu 24.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite; pass rate and model recorded in `tests/evidence/story-runs/` | **Validated** |
 | **Ubuntu 22.04 LTS** | Ubuntu/apt family | VM bootstrap and smoke tests | **Smoke-tested** |
 | **Ubuntu 26.04 LTS** | Ubuntu/apt family | VM bootstrap, smoke tests, and sudo-rs sudoers verification (26.04 ships sudo-rs 0.2.x; `visudo -cf` parses the SysKnife sudoers and every grant — including the trailing-`*` wildcard grants — is honoured) | **Smoke-tested** |
 | **Every other Ubuntu 20.04+ release** (20.04, 20.10, 21.x, 23.x, 25.x, 26.10, …) | Ubuntu/apt family | Eligible by release family; no per-release VM run | **Smoke-tested** |
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,561 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,681 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -138,7 +138,7 @@ flow.
 
 ## Status
 
-189 typed actions · 1,561 Rust tests + 72 frontend tests · MIT
+189 typed actions · 1,681 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,7 +57,7 @@ build (measured 6m56s on Ubuntu 24.04, 11m43s on 22.04).
 
 > **ℹ️ Fedora / Silverblue**
 >
-> Ubuntu 24.04 is validated with 65/65 stories on a live VM. Ubuntu 22.04 and
+> Ubuntu 24.04 is validated by the live-VM story suite. Ubuntu 22.04 and
 > 26.04 have smoke-test coverage. Fedora Atomic uses the rpm-ostree action
 > family and requires a current Silverblue 44 validation run for each release.
 > Plain Fedora remains experimental. See [distro support](distro-support.md).

--- a/scripts/check_evidence_claims.py
+++ b/scripts/check_evidence_claims.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Every number SysKnife publishes must come from evidence, not from memory.
+
+The README claimed "65/65 stories" validated on a live VM in eight places. No
+run had ever produced that number — the real measurements were 46/50 and 45/50 —
+and it survived for months because nothing connected the claim to a measurement.
+The test count rotted the same way, in the opposite direction: three docs said
+"1,561 Rust tests" and check_public_claims.sh *required* that literal string
+while the suite had grown to 1,681.
+
+So each published figure is checked against the artifact that produced it:
+
+  workspace tests   tests/evidence/workspace-tests.json  (scripts/test_baseline.sh)
+  frontend tests    tests/evidence/workspace-tests.json  (--frontend)
+  typed actions     counted from the action catalogue source
+  story pass rate   tests/evidence/story-runs/*.json      (run-stories.sh)
+
+A story claim additionally has to name a *full* family run. Subset runs record an
+empty `story_set`, so a four-story probe can never be quoted as the headline.
+
+Run via scripts/check_public_claims.sh; tests/release/public-claims.test.sh
+mutates each claim and asserts this rejects it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# Files that carry public claims. Kept in step with claim_files in
+# check_public_claims.sh; a file listed there but not here is simply unchecked
+# for numbers, which is why the pristine-fixture guard in the test matters.
+CLAIM_FILES = (
+    "README.md",
+    "ROADMAP.md",
+    "docs/introduction.md",
+    "docs/quickstart.md",
+    "docs/distro-support.md",
+    "docs/contributing/ubuntu-vm-testing.md",
+    "docs/contributing/testing.md",
+    "packages/setup/index.js",
+)
+
+# Docs that must state the workspace test baseline, not merely avoid
+# contradicting it. Dropping the figure would otherwise pass silently.
+REQUIRE_TEST_COUNT = (
+    "README.md",
+    "docs/introduction.md",
+    "docs/distro-support.md",
+)
+
+TEST_BASELINE = "tests/evidence/workspace-tests.json"
+STORY_RUNS = "tests/evidence/story-runs"
+ACTION_SOURCE = "crates/sysknife-brain/src/planning_tools/propose_plan.rs"
+
+# Full family sets that run-stories.sh can run and record. A claim may only rest
+# on one of these.
+FULL_STORY_SETS = ("ubuntu", "atomic")
+
+
+class Failure(Exception):
+    pass
+
+
+def read_claim_files(root: Path) -> dict[str, str]:
+    texts = {}
+    for rel in CLAIM_FILES:
+        path = root / rel
+        if path.exists():
+            texts[rel] = path.read_text()
+    if not texts:
+        raise Failure(f"no claim files found under {root}")
+    return texts
+
+
+def count_actions(root: Path) -> int:
+    """Count entries in the brain's KNOWN_ACTIONS table."""
+    source = root / ACTION_SOURCE
+    if not source.exists():
+        raise Failure(f"action catalogue source is missing: {ACTION_SOURCE}")
+    text = source.read_text()
+    marker = "pub const KNOWN_ACTIONS: &[(&str, &str)] = &["
+    if marker not in text:
+        raise Failure(f"{ACTION_SOURCE} no longer declares KNOWN_ACTIONS as expected")
+    table = text.split(marker, 1)[1].split("\n];", 1)[0]
+    # Entries open with `("ActionName",` at the start of a line.
+    count = len(re.findall(r'^\s*\("([A-Za-z0-9]+)",', table, re.M))
+    if count < 50:
+        raise Failure(
+            f"only {count} actions parsed from {ACTION_SOURCE}; the pattern has drifted"
+        )
+    return count
+
+
+def check_figure(texts: dict[str, str], noun: str, expected: int) -> list[str]:
+    """Every `<n> <noun>` in the docs must equal `expected`."""
+    problems = []
+    pattern = re.compile(rf"([0-9][0-9,]*)\s+{re.escape(noun)}")
+    for rel, text in texts.items():
+        for match in pattern.finditer(text):
+            claimed = int(match.group(1).replace(",", ""))
+            if claimed != expected:
+                problems.append(
+                    f"{rel}: claims {match.group(1)} {noun}, evidence says "
+                    f"{expected:,} — regenerate the figure, do not retype it"
+                )
+    return problems
+
+
+def load_story_runs(root: Path) -> list[dict]:
+    directory = root / STORY_RUNS
+    if not directory.is_dir():
+        return []
+    runs = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            runs.append(json.loads(path.read_text()))
+        except json.JSONDecodeError as exc:
+            raise Failure(f"{path.name} is not readable JSON: {exc}") from exc
+    return runs
+
+
+def check_story_claims(texts: dict[str, str], runs: list[dict]) -> list[str]:
+    problems = []
+    pattern = re.compile(r"([0-9]+)\s*/\s*([0-9]+)\s+stories")
+    for rel, text in texts.items():
+        for line in text.splitlines():
+            match = pattern.search(line)
+            if not match:
+                continue
+            passed, total = int(match.group(1)), int(match.group(2))
+            backing = [
+                run
+                for run in runs
+                if run.get("story_set") in FULL_STORY_SETS
+                and run.get("totals", {}).get("passed") == passed
+                and run.get("totals", {}).get("total") == total
+            ]
+            if not backing:
+                problems.append(
+                    f"{rel}: claims {passed}/{total} stories with no run in "
+                    f"{STORY_RUNS}/ to back it. Record one with "
+                    f"SYSKNIFE_RESULTS_JSON=... run-stories.sh ubuntu, or drop the figure."
+                )
+                continue
+            # If the line names a model, the run that produced the number has to
+            # be a run of that model. "65/65 with gpt-4.1" was wrong twice over.
+            models = re.findall(r"`([a-z0-9][a-z0-9._/-]*(?:gpt|claude|llama|qwen)[a-z0-9._/-]*)`", line)
+            models += re.findall(r"\b(gpt-[0-9][a-z0-9.-]*)\b", line)
+            for model in set(models):
+                if not any(model in run.get("surface", "") for run in backing):
+                    surfaces = sorted({run.get("surface", "?") for run in backing})
+                    problems.append(
+                        f"{rel}: attributes {passed}/{total} stories to {model}, "
+                        f"but the run recording that result used {', '.join(surfaces)}"
+                    )
+    return problems
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    try:
+        texts = read_claim_files(root)
+
+        baseline_path = root / TEST_BASELINE
+        if not baseline_path.exists():
+            raise Failure(
+                f"{TEST_BASELINE} is missing; record it with "
+                "UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh"
+            )
+        baseline = json.loads(baseline_path.read_text())
+        for field in ("tests", "frontend_tests"):
+            if not isinstance(baseline.get(field), int):
+                raise Failure(f"{TEST_BASELINE} has no integer '{field}' field")
+
+        problems = []
+        problems += check_figure(texts, "Rust tests", baseline["tests"])
+        problems += check_figure(texts, "frontend tests", baseline["frontend_tests"])
+        problems += check_figure(texts, "typed actions", count_actions(root))
+        problems += check_story_claims(texts, load_story_runs(root))
+
+        expected_tests = f"{baseline['tests']:,} Rust tests"
+        for rel in REQUIRE_TEST_COUNT:
+            if rel in texts and expected_tests not in texts[rel]:
+                problems.append(
+                    f"{rel}: does not state the measured baseline "
+                    f"({expected_tests})"
+                )
+
+        if problems:
+            print("Claims that do not derive from evidence:", file=sys.stderr)
+            for problem in problems:
+                print(f"  - {problem}", file=sys.stderr)
+            return 1
+    except Failure as exc:
+        print(f"Evidence check could not run: {exc}", file=sys.stderr)
+        return 1
+
+    print("Published figures match the evidence artifacts.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_public_claims.sh
+++ b/scripts/check_public_claims.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+# The helpers live next to this script, not inside the tree being checked: the
+# mutation fixture in tests/release/public-claims.test.sh copies only claim files
+# and evidence, so a path relative to repo_root would not resolve there.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 claim_files=(
     "$repo_root/README.md"
@@ -29,18 +33,16 @@ reject_pattern() {
     fi
 }
 
-# Any count below the current baseline is stale. The range must be widened
-# whenever the baseline moves: it once stopped at 1,347 while reality was at
-# 1,490, so the guard sat green through 85 tests of drift.
-#
-# The baseline counts the WHOLE workspace — exactly what
-# `cargo nextest run --workspace --locked` prints — so a reader can verify it
-# with one command. Quoting a subset (e.g. excluding the GUI crate) makes the
-# number unverifiable from the documented command, which is how it silently
-# came to mean two different things.
-reject_pattern '1,(2[0-9][0-9]|3[0-9][0-9]|4[0-9][0-9]|5[0-5][0-9]|56[0-0])( Rust)? tests' \
-    'test count is stale; the release baseline is 1,561 Rust tests' \
-    "${claim_files[@]}"
+# Numeric claims — test counts, the action count, story pass rates — are checked
+# against the artifacts that produced them by check_evidence_claims.py. This used
+# to be a hand-maintained blacklist of stale ranges plus a required literal
+# ("1,561 Rust tests"), which meant the guard itself had to be edited whenever
+# reality moved, and it was not: the range stopped at 1,560 while the suite had
+# grown to 1,681, so the docs, the guard, and the code all disagreed at once.
+if ! python3 "$script_dir/check_evidence_claims.py" "$repo_root"; then
+    printf 'Invalid public claim: a published figure does not derive from evidence\n' >&2
+    exit 1
+fi
 reject_pattern 'until npm publish lands|publish[- ]pending' \
     'setup package is documented as unpublished' "${claim_files[@]}"
 reject_pattern 'Fedora([^\n]|$)*(Workstation|Server)([^\n]|$)*fully supported|(Workstation|Server)([^\n]|$)*fully supported' \
@@ -62,19 +64,6 @@ required_receipt_docs=(
     "$repo_root/assets/demo/mcp-flow-mock.sh"
     "$repo_root/packages/setup/index.js"
 )
-
-required_test_count_docs=(
-    "$repo_root/README.md"
-    "$repo_root/docs/introduction.md"
-    "$repo_root/docs/distro-support.md"
-)
-for path in "${required_test_count_docs[@]}"; do
-    if ! grep -Fq '1,561 Rust tests' "$path"; then
-        printf 'Verified test baseline missing from %s: expected 1,561 Rust tests\n' \
-            "$path" >&2
-        exit 1
-    fi
-done
 
 for path in "${required_receipt_docs[@]}"; do
     if ! grep -Fq 'sysknife approve <transaction-id>' "$path"; then

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -148,8 +148,12 @@ run_rust_group() {
     fi
 
     if have cargo-nextest; then
-        run_step 'rust: cargo nextest run --workspace --locked' \
-            cargo nextest run --workspace --locked
+        # Through test_baseline.sh, which runs the same command and additionally
+        # holds tests/evidence/workspace-tests.json to the suite's real size.
+        # Published test counts derive from that artifact, so the check belongs
+        # where the number is actually known.
+        run_step 'rust: cargo nextest run --workspace --locked (+ test baseline)' \
+            bash "$repo_root/scripts/test_baseline.sh"
     else
         record WARN 'rust: cargo nextest run -- SKIPPED (cargo-nextest not found; install: cargo install cargo-nextest --locked)'
     fi
@@ -179,8 +183,9 @@ frontend_tsc() (
 )
 
 frontend_vitest() (
-    cd "$repo_root/apps/sysknife-shell" || exit 1
-    ./node_modules/.bin/vitest run
+    # Via test_baseline.sh --frontend for the same reason as the Rust suite: the
+    # published frontend test count derives from the recorded baseline.
+    bash "$repo_root/scripts/test_baseline.sh" --frontend
 )
 
 run_frontend_group() {
@@ -210,7 +215,7 @@ run_frontend_group() {
     fi
 
     run_step 'frontend: tsc --noEmit' frontend_tsc
-    run_step 'frontend: vitest run' frontend_vitest
+    run_step 'frontend: vitest run (+ test baseline)' frontend_vitest
 }
 
 # ---------------------------------------------------------------------------
@@ -274,6 +279,7 @@ run_hygiene_group() {
     run_step 'hygiene: release-rehearsal.test.sh' bash "$repo_root/tests/release/release-rehearsal.test.sh"
     run_step 'hygiene: ubuntu-vm-bootstrap.test.sh' bash "$repo_root/tests/e2e/ubuntu-vm-bootstrap.test.sh"
     run_step 'hygiene: provider-parity.test.sh' bash "$repo_root/tests/e2e/provider-parity.test.sh"
+    run_step 'hygiene: story-metadata.test.sh' bash "$repo_root/tests/e2e/story-metadata.test.sh"
 
     if have markdownlint-cli2; then
         run_step 'hygiene: markdownlint-cli2' hygiene_markdownlint

--- a/scripts/record_test_baseline.py
+++ b/scripts/record_test_baseline.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Read or update one suite's count in the test-baseline evidence artifact.
+
+Split out of test_baseline.sh because the artifact has to be *merged*, not
+rewritten: the Rust and frontend counts are produced by different commands in
+different CI jobs, so whichever runs second must leave the other's measurement
+alone. Doing that in shell means hand-rolled JSON editing, which is how a
+measurement gets replaced by a guess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+COMMANDS = {
+    "tests": "cargo nextest run --workspace --locked",
+    "frontend_tests": "vitest run (apps/sysknife-shell)",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", required=True, type=Path)
+    parser.add_argument("--field", required=True, choices=sorted(COMMANDS))
+    parser.add_argument("--count", type=int)
+    parser.add_argument("--commit")
+    parser.add_argument(
+        "--read",
+        action="store_true",
+        help="print the recorded count and exit; nothing is written",
+    )
+    args = parser.parse_args()
+
+    doc: dict = {}
+    if args.artifact.exists():
+        doc = json.loads(args.artifact.read_text())
+
+    if args.read:
+        value = doc.get(args.field)
+        if value is None:
+            return 1
+        print(value)
+        return 0
+
+    if args.count is None:
+        parser.error("--count is required unless --read is given")
+
+    doc["version"] = 1
+    doc[args.field] = args.count
+    doc.setdefault("commands", {})[args.field] = COMMANDS[args.field]
+    # Recorded per field: one suite's figure can be fresh while the other is
+    # stale, and a single timestamp would hide that.
+    doc.setdefault("measured_at", {})[args.field] = subprocess.run(
+        ["date", "--iso-8601=seconds"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    doc.setdefault("commit", {})[args.field] = args.commit or "unknown"
+
+    args.artifact.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_baseline.sh
+++ b/scripts/test_baseline.sh
@@ -38,6 +38,14 @@ fi
 output="$(mktemp)"
 trap 'rm -f "$output"' EXIT
 
+# Both runners colourise their summaries when CI=true, even with output piped, so
+# the count is read from de-colourised text. Skipping this cost a CI run: vitest
+# passed 72/72 and the parse then reported no count at all, because the line
+# arrives as `ESC[2m      Tests ESC[22m ... (72)ESC[39m`.
+strip_ansi() {
+    sed -E "s/$(printf '\033')\[[0-9;]*[a-zA-Z]//g" "$1"
+}
+
 if [[ "$suite" == "frontend" ]]; then
     shell_dir="$repo_root/apps/sysknife-shell"
     if [[ ! -x "$shell_dir/node_modules/.bin/vitest" ]]; then
@@ -52,7 +60,7 @@ if [[ "$suite" == "frontend" ]]; then
     # "      Tests  72 passed (72)" — the parenthesised figure is the total, which
     # counts skipped and failed tests too, so it is the suite size rather than a
     # pass count.
-    count="$(sed -nE 's/^[[:space:]]*Tests[[:space:]]+.*\(([0-9]+)\)[[:space:]]*$/\1/p' "$output" | tail -1)"
+    count="$(strip_ansi "$output" | sed -nE 's/^[[:space:]]*Tests[[:space:]]+.*\(([0-9]+)\)[[:space:]]*$/\1/p' | tail -1)"
 else
     set +e
     cargo nextest run --workspace --locked "$@" 2>&1 | tee "$output"
@@ -61,7 +69,7 @@ else
     # "Starting 1681 tests across 37 binaries" — present whether the run passes or
     # fails, unlike the Summary line, whose shape changes on failure
     # ("1503/1675 tests run" vs "1681 tests run").
-    count="$(sed -nE 's/^[[:space:]]*Starting ([0-9]+) tests? across .*/\1/p' "$output" | tail -1)"
+    count="$(strip_ansi "$output" | sed -nE 's/^[[:space:]]*Starting ([0-9]+) tests? across .*/\1/p' | tail -1)"
 fi
 
 if [[ -z "$count" ]]; then

--- a/scripts/test_baseline.sh
+++ b/scripts/test_baseline.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# test_baseline.sh — run a test suite and hold the published test count to what
+# it actually reports.
+#
+# Three docs quoted "1,561 Rust tests" and check_public_claims.sh *required* that
+# exact string, so the figure was pinned by hand in four places at once. The suite
+# had meanwhile grown to 1,681. Nothing was lying on purpose; there was simply no
+# path from the measurement to the claim, so the claim could only decay.
+#
+# This is that path. The count comes from the test runner's own output, lands in
+# tests/evidence/workspace-tests.json, and scripts/check_public_claims.sh reads
+# the figure from there instead of carrying a literal. Regenerate deliberately:
+#
+#   UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh              # Rust workspace
+#   UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh --frontend   # vitest
+#
+# Without UPDATE_TEST_BASELINE the run verifies instead: a suite whose size no
+# longer matches the recorded baseline fails, because a published claim derives
+# from that baseline. Remaining arguments are forwarded to the runner, so this is
+# a drop-in for the plain `cargo nextest run --workspace --locked` step.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+artifact="$repo_root/tests/evidence/workspace-tests.json"
+recorder="$repo_root/scripts/record_test_baseline.py"
+
+# Which suite to measure. The two live in different CI jobs, so each verifies its
+# own field against the shared artifact rather than one job measuring both.
+suite="rust"
+field="tests"
+if [[ "${1:-}" == "--frontend" ]]; then
+    suite="frontend"
+    field="frontend_tests"
+    shift
+fi
+
+output="$(mktemp)"
+trap 'rm -f "$output"' EXIT
+
+if [[ "$suite" == "frontend" ]]; then
+    shell_dir="$repo_root/apps/sysknife-shell"
+    if [[ ! -x "$shell_dir/node_modules/.bin/vitest" ]]; then
+        printf 'test_baseline: vitest is not installed; run npm ci in %s first.\n' \
+            "${shell_dir#"$repo_root"/}" >&2
+        exit 1
+    fi
+    set +e
+    (cd "$shell_dir" && ./node_modules/.bin/vitest run "$@") 2>&1 | tee "$output"
+    status="${PIPESTATUS[0]}"
+    set -e
+    # "      Tests  72 passed (72)" — the parenthesised figure is the total, which
+    # counts skipped and failed tests too, so it is the suite size rather than a
+    # pass count.
+    count="$(sed -nE 's/^[[:space:]]*Tests[[:space:]]+.*\(([0-9]+)\)[[:space:]]*$/\1/p' "$output" | tail -1)"
+else
+    set +e
+    cargo nextest run --workspace --locked "$@" 2>&1 | tee "$output"
+    status="${PIPESTATUS[0]}"
+    set -e
+    # "Starting 1681 tests across 37 binaries" — present whether the run passes or
+    # fails, unlike the Summary line, whose shape changes on failure
+    # ("1503/1675 tests run" vs "1681 tests run").
+    count="$(sed -nE 's/^[[:space:]]*Starting ([0-9]+) tests? across .*/\1/p' "$output" | tail -1)"
+fi
+
+if [[ -z "$count" ]]; then
+    printf '\ntest_baseline: could not read a %s test count from the run output.\n' "$suite" >&2
+    printf 'The count is what the published claim rests on, so a run that does not\n' >&2
+    printf 'report one is a failure rather than something to skip quietly.\n' >&2
+    exit 1
+fi
+
+regenerate_hint() {
+    if [[ "$suite" == "frontend" ]]; then
+        printf '  UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh --frontend\n' >&2
+    else
+        printf '  UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh\n' >&2
+    fi
+}
+
+if [[ "$status" -ne 0 ]]; then
+    printf '\ntest_baseline: %s suite failed; baseline left untouched (%s tests started).\n' \
+        "$suite" "$count" >&2
+    exit "$status"
+fi
+
+if [[ "${UPDATE_TEST_BASELINE:-0}" == "1" ]]; then
+    mkdir -p "$(dirname "$artifact")"
+    # Only this suite's field is rewritten. The other was measured by a different
+    # command — in CI, a different job — so overwriting it from here would
+    # replace a measurement with a guess.
+    python3 "$recorder" \
+        --artifact "$artifact" \
+        --field "$field" \
+        --count "$count" \
+        --commit "$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+    printf '\ntest_baseline: recorded %s %s tests in %s\n' \
+        "$count" "$suite" "${artifact#"$repo_root"/}"
+    exit 0
+fi
+
+if [[ ! -f "$artifact" ]]; then
+    printf '\ntest_baseline: no baseline at %s. Record one:\n' "${artifact#"$repo_root"/}" >&2
+    regenerate_hint
+    exit 1
+fi
+
+recorded="$(python3 "$recorder" --artifact "$artifact" --field "$field" --read || true)"
+if [[ -z "$recorded" ]]; then
+    printf '\ntest_baseline: %s has no readable "%s" field. Record one:\n' \
+        "${artifact#"$repo_root"/}" "$field" >&2
+    regenerate_hint
+    exit 1
+fi
+
+if [[ "$recorded" != "$count" ]]; then
+    printf '\ntest_baseline: %s suite has %s tests, baseline says %s.\n' \
+        "$suite" "$count" "$recorded" >&2
+    printf 'Published claims derive from the baseline, so it has to move with the\n' >&2
+    printf 'suite. Regenerate and commit it:\n' >&2
+    regenerate_hint
+    exit 1
+fi
+
+printf '\ntest_baseline: %s %s tests, matching the recorded baseline.\n' "$count" "$suite"

--- a/tests/e2e/provider-parity.test.sh
+++ b/tests/e2e/provider-parity.test.sh
@@ -128,6 +128,35 @@ for n in 91 92 93; do
         || report "story-$n.sh treats a cassette miss as an acceptable empty plan"
 done
 
+# The contributor docs carry a provider table. It listed three auto-detected
+# providers when from_env auto-detects two, and omitted four providers outright —
+# which is how a run with only GROQ_API_KEY exported fell through to the
+# uninstalled Ollama fallback. Derive both the provider names and their default
+# models from config.rs so the table cannot drift again.
+testing_doc="$repo_root/docs/contributing/testing.md"
+if [ ! -f "$testing_doc" ]; then
+    report "docs/contributing/testing.md is missing; the provider table cannot be checked"
+else
+    for key in "${keys[@]}"; do
+        provider="$(printf '%s' "${key%_API_KEY}" | tr '[:upper:]' '[:lower:]')"
+        grep -Fq -- "$provider" "$testing_doc" \
+            || report "docs/contributing/testing.md does not mention provider $provider"
+    done
+
+    # `pub const DEFAULT_GROQ_MODEL: &str = "llama-3.3-70b-versatile";`
+    mapfile -t default_models < <(
+        grep -oE 'DEFAULT_[A-Z0-9]+_MODEL: &str = "[^"]+"' "$config_rs" |
+            sed -E 's/.*"([^"]+)"$/\1/'
+    )
+    if [ "${#default_models[@]}" -lt 8 ]; then
+        report "found only ${#default_models[@]} default models in config.rs; the pattern has drifted"
+    fi
+    for model in "${default_models[@]}"; do
+        grep -Fq -- "$model" "$testing_doc" \
+            || report "docs/contributing/testing.md does not list default model $model"
+    done
+fi
+
 if [ "$failures" -ne 0 ]; then
     printf '\n%d provider-parity failure(s) across %d providers.\n' "$failures" "${#keys[@]}" >&2
     exit 1

--- a/tests/e2e/run-stories.sh
+++ b/tests/e2e/run-stories.sh
@@ -17,6 +17,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOG_DIR="$SCRIPT_DIR/logs"
 STORY_DIR="$SCRIPT_DIR/stories"
 
+# `--metadata` prints the derived story table and exits without running
+# anything. It is handled before the preflight on purpose: the table comes from
+# story files in the repo, so it is checkable on any host, and
+# tests/e2e/story-metadata.test.sh asserts on THIS parser instead of
+# reimplementing it. A second parser is a second answer.
+METADATA_ONLY=0
+if [[ "${1:-}" == "--metadata" ]]; then
+  METADATA_ONLY=1
+  shift
+fi
+
 mkdir -p "$LOG_DIR"
 
 # ---------------------------------------------------------------------------
@@ -25,22 +36,22 @@ mkdir -p "$LOG_DIR"
 
 preflight_ok=true
 
-if [[ ! -f /var/lib/sysknife-e2e/ready ]]; then
+if [[ $METADATA_ONLY -eq 0 ]] && [[ ! -f /var/lib/sysknife-e2e/ready ]]; then
   echo "ERROR: /var/lib/sysknife-e2e/ready not found. Run provisioning first."
   preflight_ok=false
 fi
 
-if ! systemctl is-active --quiet sysknife-daemon 2>/dev/null; then
+if [[ $METADATA_ONLY -eq 0 ]] && ! systemctl is-active --quiet sysknife-daemon 2>/dev/null; then
   echo "ERROR: sysknife-daemon is not running."
   preflight_ok=false
 fi
 
-if ! command -v sysknife &>/dev/null; then
+if [[ $METADATA_ONLY -eq 0 ]] && ! command -v sysknife &>/dev/null; then
   echo "ERROR: sysknife not found in PATH."
   preflight_ok=false
 fi
 
-if ! command -v jq &>/dev/null; then
+if [[ $METADATA_ONLY -eq 0 ]] && ! command -v jq &>/dev/null; then
   echo "ERROR: jq not found in PATH."
   preflight_ok=false
 fi
@@ -129,75 +140,91 @@ ALLOW_DESTRUCTIVE="${SYSKNIFE_ALLOW_DESTRUCTIVE:-0}"
 # and tolerant of the CPU fallback. Override with SYSKNIFE_STORY_TIMEOUT.
 STORY_TIMEOUT="${SYSKNIFE_STORY_TIMEOUT:-600}"
 
+# ---------------------------------------------------------------------------
+# Story metadata — derived, never restated
+# ---------------------------------------------------------------------------
+# Every story opens with `# Story N[ (tags)]: Title`, so the title and the
+# distro family are already recorded in the story file. They used to be
+# duplicated into a 54-entry STORY_NAMES table here, which had already drifted
+# apart from the files: the table stopped at 54, so all 50 Ubuntu stories
+# printed as a bare "Story 73" with no name in every results table we have
+# published. Derive both instead — a second copy of a fact is a copy that will
+# disagree.
 declare -A STORY_NAMES
-STORY_NAMES[1]="Check disk usage"
-STORY_NAMES[2]="Memory pressure diagnosis"
-STORY_NAMES[3]="Service health check"
-STORY_NAMES[4]="Firewall inspection"
-STORY_NAMES[5]="List layered packages"
-STORY_NAMES[6]="Running containers overview"
-STORY_NAMES[7]="SSH key inventory"
-STORY_NAMES[8]="Layer vim via rpm-ostree (destructive)"
-STORY_NAMES[9]="Create a toolbox (destructive)"
-STORY_NAMES[10]="Add SSH authorized key (destructive)"
-STORY_NAMES[11]="Deployment status + kernel arguments"
-STORY_NAMES[12]="SysKnife activity log — today"
-STORY_NAMES[13]="Service logs for firewalld"
-STORY_NAMES[14]="Triple compound — disk + memory + services"
-STORY_NAMES[15]="Rollback history"
-STORY_NAMES[16]="Network status + firewall rules"
-STORY_NAMES[17]="Container list + specific info"
-STORY_NAMES[18]="Restart bluetooth service (destructive)"
-STORY_NAMES[19]="Update system (destructive)"
-STORY_NAMES[20]="Add user to wheel group (destructive)"
-STORY_NAMES[21]="GetSystemState direct request"
-STORY_NAMES[22]="ListProcesses direct"
-STORY_NAMES[23]="SetTimezone — Europe/Berlin (destructive)"
-STORY_NAMES[24]="StopService — cups (destructive)"
-STORY_NAMES[25]="ListUsers direct"
-STORY_NAMES[26]="ListUsers + ListGroups compound"
-STORY_NAMES[27]="SetServiceEnabled — sshd at boot (destructive)"
-STORY_NAMES[28]="GetKernelArguments + ListDeployments compound"
-STORY_NAMES[29]="Triple compound — processes + network + memory"
-STORY_NAMES[30]="RemoveAuthorizedKey — user alice (destructive)"
-STORY_NAMES[31]="RemoveUserFromGroup — alice from docker (destructive)"
-STORY_NAMES[32]="Security audit — SSH keys + users + groups"
-STORY_NAMES[33]="SetKernelArguments — blacklist nouveau (destructive)"
-STORY_NAMES[34]="RollbackDeployment — resist query temptation (destructive)"
-STORY_NAMES[35]="ConfigureFirewall — open port 8080 (destructive)"
-STORY_NAMES[36]="CreateUser — devteam account (destructive)"
-STORY_NAMES[37]="DeleteUser — oldstaff removal (destructive)"
-STORY_NAMES[38]="Diagnostic compound — processes + nginx logs + job history"
-STORY_NAMES[39]="SetDnsServers — Cloudflare 1.1.1.1 + 1.0.0.1 (destructive)"
-STORY_NAMES[40]="RebaseSystem — Fedora Silverblue 41 (destructive)"
-STORY_NAMES[41]="Read compound — repos + containers + network"
-STORY_NAMES[42]="MaskService cups — not SetServiceEnabled (destructive)"
-STORY_NAMES[43]="CleanupDeployments — free deployment disk (destructive)"
-STORY_NAMES[44]="SetHostname — workstation-42 (destructive)"
-STORY_NAMES[45]="RebootSystem — kernel activation framing (destructive)"
-STORY_NAMES[46]="GetPendingUpdates — check not apply"
-STORY_NAMES[47]="ListInstalledFlatpaks — local vs remote"
-STORY_NAMES[48]="GetServiceStatus — nginx single unit"
-STORY_NAMES[49]="ListTimers — scheduled tasks"
-STORY_NAMES[50]="ReloadService — nginx without restart (destructive)"
-STORY_NAMES[51]="ReloadDaemon — after unit file creation (destructive)"
-STORY_NAMES[52]="UpdateFlatpak — Firefox (destructive)"
-STORY_NAMES[53]="RemoveBasePackage — gedit from base image (destructive)"
-STORY_NAMES[54]="UpdateFlatpak — update all, no specific app (destructive)"
+declare -A STORY_FAMILY
+ALL_STORY_IDS=()
+UBUNTU_STORY_IDS=()
+
+for _story_file in "$STORY_DIR"/story-*.sh; do
+    [ -f "$_story_file" ] || continue
+    _header="$(sed -n '2p' "$_story_file")"
+    # `# Story 62 (ubuntu, medium-risk): Unhold a package`
+    #             ^tags                   ^title
+    if [[ "$_header" =~ ^#\ Story\ ([0-9]+)(\ \(([^\)]*)\))?:\ (.*)$ ]]; then
+        _id="${BASH_REMATCH[1]}"
+        _tags="${BASH_REMATCH[3]}"
+        _title="${BASH_REMATCH[4]}"
+    else
+        # A story whose header cannot be parsed would otherwise vanish from the
+        # derived sets without a word, which is the failure this replaced.
+        printf 'ERROR: unparseable story header in %s: %s\n' "$_story_file" "$_header" >&2
+        exit 1
+    fi
+    STORY_NAMES[$_id]="$_title"
+    if [[ "$_tags" == *ubuntu* ]]; then
+        STORY_FAMILY[$_id]="ubuntu"
+        UBUNTU_STORY_IDS+=("$_id")
+    else
+        STORY_FAMILY[$_id]="atomic"
+    fi
+    ALL_STORY_IDS+=("$_id")
+done
+
+# Numeric order, so results tables read in story order rather than glob order
+# (story-10 sorts before story-2 as a string).
+mapfile -t ALL_STORY_IDS < <(printf '%s\n' "${ALL_STORY_IDS[@]}" | sort -n)
+mapfile -t UBUNTU_STORY_IDS < <(printf '%s\n' "${UBUNTU_STORY_IDS[@]}" | sort -n)
+
+if [[ $METADATA_ONLY -eq 1 ]]; then
+  for n in "${ALL_STORY_IDS[@]}"; do
+    printf '%s\t%s\t%s\n' "$n" "${STORY_FAMILY[$n]}" "${STORY_NAMES[$n]}"
+  done
+  exit 0
+fi
 
 declare -A RESULTS
 declare -A DURATIONS
 declare -A MESSAGES
 
-if [[ $# -gt 0 ]]; then
+STORY_SET=""
+
+if [[ "${1:-}" == "ubuntu" ]]; then
+  # The whole Ubuntu family, derived from the story headers. Documented runs
+  # used to spell this `$(seq 55 104)`, a hand-typed range that silently stops
+  # covering the suite the moment story 105 is added.
+  STORY_SET="ubuntu"
+  STORIES=("${UBUNTU_STORY_IDS[@]}")
+elif [[ "${1:-}" == "atomic" ]]; then
+  STORY_SET="atomic"
+  mapfile -t STORIES < <(
+    for n in "${ALL_STORY_IDS[@]}"; do
+      [[ "${STORY_FAMILY[$n]}" == "atomic" ]] && printf '%s\n' "$n"
+    done
+  )
+elif [[ $# -gt 0 ]]; then
   STORIES=("$@")
 elif [[ "$ALLOW_DESTRUCTIVE" == "1" ]]; then
-  STORIES=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 \
-           21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 \
-           41 42 43 44 45 46 47 48 49 50 51 52 53 54)
+  STORY_SET="atomic"
+  mapfile -t STORIES < <(
+    for n in "${ALL_STORY_IDS[@]}"; do
+      [[ "${STORY_FAMILY[$n]}" == "atomic" ]] && printf '%s\n' "$n"
+    done
+  )
 else
   # Read-only and non-destructive stories only. Stories self-gate via
   # SYSKNIFE_ALLOW_DESTRUCTIVE — skipped ones still appear in results as SKIP.
+  # This subset is curated, not derivable: it is the atomic-family stories that
+  # need no live rpm-ostree host, which no header tag records.
   STORIES=(1 2 3 4 5 6 7 11 12 13 14 15 16 17 \
            21 22 25 26 28 29 32 38 41 46 47 48 49)
 fi
@@ -351,6 +378,64 @@ if [[ $ratelimit_count -gt 0 ]]; then
 fi
 echo "Logs:    $LOG_DIR/"
 echo ""
+
+# ---------------------------------------------------------------------------
+# Machine-readable evidence
+# ---------------------------------------------------------------------------
+# Every validation number SysKnife publishes has to come from a run, not from a
+# person's memory of one. The README claimed "65/65 stories validated" in eight
+# places for months with no artifact behind it and no number that could produce
+# it; scripts/check_public_claims.sh now refuses any N/M story claim that does
+# not match one of these files.
+#
+# Opt-in via SYSKNIFE_RESULTS_JSON so a two-story debugging run cannot overwrite
+# a full-suite record. `story_set` names the derived set that was run, and is
+# empty for an explicit story list — the checker only honours a full family set,
+# so a four-story probe can never become the headline figure.
+if [[ -n "${SYSKNIFE_RESULTS_JSON:-}" ]]; then
+  results_dir="$(dirname "$SYSKNIFE_RESULTS_JSON")"
+  mkdir -p "$results_dir"
+
+  cassette_sha="null"
+  if [[ -n "${SYSKNIFE_CASSETTE:-}" ]] && [[ -f "${SYSKNIFE_CASSETTE}" ]]; then
+    cassette_sha="\"$(sha256sum "${SYSKNIFE_CASSETTE}" | cut -d' ' -f1)\""
+  fi
+
+  # The release the stories actually ran against, read from the host they ran on
+  # rather than from whatever the operator typed on the command line.
+  release="$(. /etc/os-release 2>/dev/null && printf '%s' "${VERSION_ID:-unknown}")"
+  distro_id="$(. /etc/os-release 2>/dev/null && printf '%s' "${ID:-unknown}")"
+
+  {
+    printf '{\n'
+    printf '  "version": 1,\n'
+    printf '  "distro_id": "%s",\n' "$distro_id"
+    printf '  "release": "%s",\n' "$release"
+    printf '  "surface": "%s/%s",\n' "${SYSKNIFE_LLM_PROVIDER:-unset}" "${SYSKNIFE_LLM_MODEL:-provider-default}"
+    printf '  "cassette_mode": "%s",\n' "${CASSETTE_MODE_NORMALIZED:-live}"
+    printf '  "cassette_sha256": %s,\n' "$cassette_sha"
+    printf '  "story_set": "%s",\n' "$STORY_SET"
+    printf '  "ran_at": "%s",\n' "$(date --iso-8601=seconds)"
+    printf '  "totals": {\n'
+    printf '    "total": %d,\n' "$total"
+    printf '    "passed": %d,\n' "$pass_count"
+    printf '    "failed": %d,\n' "$fail_count"
+    printf '    "skipped": %d,\n' "$skip_count"
+    printf '    "rate_limited": %d\n' "$ratelimit_count"
+    printf '  },\n'
+    printf '  "stories": {\n'
+    sep=""
+    for n in "${STORIES[@]}"; do
+      printf '%s    "%s": { "verdict": "%s", "name": "%s" }' \
+        "$sep" "$n" "${RESULTS[$n]}" "${STORY_NAMES[$n]//\"/\\\"}"
+      sep=",\n"
+    done
+    printf '\n  }\n'
+    printf '}\n'
+  } > "$SYSKNIFE_RESULTS_JSON"
+  echo "Evidence: $SYSKNIFE_RESULTS_JSON"
+  echo ""
+fi
 
 # ---------------------------------------------------------------------------
 # Cassette replay audit

--- a/tests/e2e/story-metadata.test.sh
+++ b/tests/e2e/story-metadata.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# story-metadata.test.sh — the story table must be derived from the story files,
+# and the derivation must fail loudly rather than skip what it cannot read.
+#
+# `run-stories.sh` used to carry a 54-entry STORY_NAMES table alongside the 104
+# story files. It had already drifted: the table stopped at 54, so every one of
+# the 50 Ubuntu stories printed as a bare "Story 73" with no name in every
+# results table ever published, and the documented full run spelled its story set
+# as the hand-typed range `$(seq 55 104)`.
+#
+# This test asserts on `run-stories.sh --metadata` — the real parser — rather
+# than reimplementing the header regex. A second parser would be a second answer.
+#
+# Host-side only: no VM, no daemon, no network.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+runner="$repo_root/tests/e2e/run-stories.sh"
+story_dir="$repo_root/tests/e2e/stories"
+
+failures=0
+report() {
+    printf 'FAIL  %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+[ -x "$runner" ] || { printf 'missing runner: %s\n' "$runner" >&2; exit 1; }
+
+metadata="$(bash "$runner" --metadata)"
+derived_count="$(printf '%s\n' "$metadata" | grep -c .)"
+file_count="$(find "$story_dir" -maxdepth 1 -name 'story-*.sh' | wc -l)"
+
+# A regex that quietly matched nothing would make every assertion below vacuous.
+if [ "$file_count" -lt 100 ]; then
+    report "only $file_count story files found; the glob has drifted"
+fi
+if [ "$derived_count" -ne "$file_count" ]; then
+    report "derived $derived_count stories from $file_count files — the parser is dropping some"
+fi
+
+# Every derived id must name a real file, and the id in the header must match the
+# id in the filename. A copy-pasted header (story-73.sh opening "# Story 37")
+# would otherwise mislabel results and land one story's name on another.
+while IFS=$'\t' read -r id family name; do
+    [ -n "$id" ] || continue
+    if [ ! -f "$story_dir/story-$id.sh" ]; then
+        report "derived story $id has no story-$id.sh"
+        continue
+    fi
+    header_id="$(sed -n '2p' "$story_dir/story-$id.sh" | sed -nE 's/^# Story ([0-9]+).*/\1/p')"
+    if [ "$header_id" != "$id" ]; then
+        report "story-$id.sh header claims story $header_id"
+    fi
+    case "$family" in
+        ubuntu | atomic) ;;
+        *) report "story $id has unknown family '$family'" ;;
+    esac
+    if [ -z "$name" ]; then
+        report "story $id derived an empty name"
+    fi
+done <<< "$metadata"
+
+# Both families must be populated: a filter that silently classified everything
+# one way would still satisfy the count check above.
+ubuntu_count="$(printf '%s\n' "$metadata" | awk -F'\t' '$2 == "ubuntu"' | grep -c .)"
+atomic_count="$(printf '%s\n' "$metadata" | awk -F'\t' '$2 == "atomic"' | grep -c .)"
+if [ "$ubuntu_count" -lt 1 ] || [ "$atomic_count" -lt 1 ]; then
+    report "family split is degenerate: $ubuntu_count ubuntu, $atomic_count atomic"
+fi
+
+duplicates="$(printf '%s\n' "$metadata" | cut -f1 | sort | uniq -d)"
+if [ -n "$duplicates" ]; then
+    report "duplicate story ids derived: $(printf '%s' "$duplicates" | tr '\n' ' ')"
+fi
+
+# Mutation: an unreadable header must stop the run. If the parser skipped it
+# instead, a story could drop out of the suite without a word — which is the
+# failure mode the old hand-maintained table had.
+mutant="$(mktemp -d)"
+trap 'rm -rf "$mutant"' EXIT
+cp "$runner" "$mutant/run-stories.sh"
+cp -r "$story_dir" "$mutant/stories"
+printf '#!/usr/bin/env bash\n# this header says nothing about a story\nexit 0\n' \
+    > "$mutant/stories/story-9999.sh"
+if bash "$mutant/run-stories.sh" --metadata >/dev/null 2>&1; then
+    report "an unparseable story header did not fail the derivation"
+fi
+
+# ...and the pristine copy must still pass, or the mutation above proved nothing.
+rm -f "$mutant/stories/story-9999.sh"
+if ! bash "$mutant/run-stories.sh" --metadata >/dev/null 2>&1; then
+    report "the unmutated copy also fails — the mutation result is meaningless"
+fi
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%d story-metadata failure(s).\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'Story metadata derived cleanly: %d stories (%d ubuntu, %d atomic).\n' \
+    "$derived_count" "$ubuntu_count" "$atomic_count"

--- a/tests/evidence/README.md
+++ b/tests/evidence/README.md
@@ -1,0 +1,41 @@
+# Evidence for published numbers
+
+Every figure SysKnife publishes — test counts, the action count, story pass rates
+— is checked against a file in here by `scripts/check_evidence_claims.py`, which
+runs as part of `scripts/check_public_claims.sh` in CI. A number that no artifact
+produces fails the build.
+
+This exists because the README claimed "65/65 stories" validated on a live VM in
+eight places. No run ever produced that figure; no story set of that size has
+existed, and the Ubuntu family contains 50 stories. The first measurements
+traceable to a run are 46/50 on 22.04 and 45/50 on 24.04 with
+`openai/gpt-oss-120b`. The test count had rotted the other way: three docs said
+"1,561 Rust tests" and the claims checker *required* that exact string while the
+suite had grown past 1,600.
+
+## `workspace-tests.json`
+
+Suite sizes, one field per suite, each written by the command that measured it:
+
+```sh
+UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh              # Rust workspace
+UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh --frontend   # vitest
+```
+
+Without `UPDATE_TEST_BASELINE` those commands *verify* instead, and they are what
+CI runs in place of the bare test commands — so a suite that grows without the
+baseline moving fails in the job that knows the real number.
+
+## `story-runs/*.json`
+
+One file per live-VM story run, written by `tests/e2e/run-stories.sh` when
+`SYSKNIFE_RESULTS_JSON` is set. Each records the release, the provider/model
+surface, the cassette mode and hash, per-story verdicts, and the totals. See
+`docs/contributing/ubuntu-vm-testing.md` for the full recording procedure.
+
+Only a run of a complete story family (`ubuntu` or `atomic`) may back a published
+figure. Subset runs record an empty `story_set`, so a four-story probe cannot be
+quoted as a headline result.
+
+Regenerating any of these is a deliberate act with a real run behind it. Editing
+one by hand defeats the only thing it is for.

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -1,0 +1,17 @@
+{
+  "commands": {
+    "frontend_tests": "vitest run (apps/sysknife-shell)",
+    "tests": "cargo nextest run --workspace --locked"
+  },
+  "commit": {
+    "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
+    "tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4"
+  },
+  "frontend_tests": 72,
+  "measured_at": {
+    "frontend_tests": "2026-08-05T09:23:15-06:00",
+    "tests": "2026-08-05T09:23:07-06:00"
+  },
+  "tests": 1681,
+  "version": 1
+}

--- a/tests/release/public-claims.test.sh
+++ b/tests/release/public-claims.test.sh
@@ -20,12 +20,19 @@ trap 'rm -rf "$fixture"' EXIT
 # with claim_files/demo_source in check_public_claims.sh.
 fixture_files=(
     "README.md"
+    "ROADMAP.md"
     "docs/introduction.md"
     "docs/quickstart.md"
     "docs/distro-support.md"
     "docs/contributing/ubuntu-vm-testing.md"
+    "docs/contributing/testing.md"
     "packages/setup/index.js"
     "assets/demo/mcp-flow-mock.sh"
+    # Evidence the numeric claims derive from, and the source the action count is
+    # counted out of. Without these the checker aborts on its own input check and
+    # every assert_rejected below would pass for the wrong reason.
+    "tests/evidence/workspace-tests.json"
+    "crates/sysknife-brain/src/planning_tools/propose_plan.rs"
 )
 for rel in "${fixture_files[@]}"; do
     mkdir -p "$fixture/$(dirname "$rel")"
@@ -47,14 +54,17 @@ assert_rejected() {
     fi
 }
 
-# Derive the baseline from the checker rather than repeating the literal here.
-# When the baseline moved, this mutation silently became a no-op: the sed matched
-# nothing, the checker legitimately passed, and the assertion below then blamed
-# the checker. A test whose mutation can stop mutating is worse than no test.
-baseline="$(grep -oE "expected [0-9],[0-9]{3} Rust tests" "$checker" | head -1 \
-    | grep -oE '[0-9],[0-9]{3}')"
+# Derive the baseline from the evidence artifact rather than repeating the
+# literal here. When the baseline moved, this mutation silently became a no-op:
+# the sed matched nothing, the checker legitimately passed, and the assertion
+# below then blamed the checker. A test whose mutation can stop mutating is worse
+# than no test — so every mutation below is confirmed to have applied.
+baseline="$(python3 -c "
+import json,sys
+print(f\"{json.load(open(sys.argv[1]))['tests']:,}\")
+" "$repo_root/tests/evidence/workspace-tests.json")"
 if [[ -z "$baseline" ]]; then
-    printf 'FAIL: could not read the test-count baseline from %s\n' "$checker" >&2
+    printf 'FAIL: could not read the test count from the evidence artifact\n' >&2
     exit 1
 fi
 sed -i "s/${baseline} Rust tests/1,256 Rust tests/" "$fixture/README.md"
@@ -62,8 +72,72 @@ if ! grep -q '1,256 Rust tests' "$fixture/README.md"; then
     printf 'FAIL: baseline mutation did not apply; fixture would pass vacuously\n' >&2
     exit 1
 fi
-assert_rejected 'old test count'
+assert_rejected 'test count that disagrees with the evidence artifact'
 cp "$repo_root/README.md" "$fixture/README.md"
+
+# A figure with no artifact at all behind it. This is the "65/65 stories" shape:
+# published for months, never produced by a run.
+printf '\nUbuntu 24.04 is validated with 49/50 stories on a live VM.\n' >> "$fixture/README.md"
+assert_rejected 'story pass rate with no recorded run'
+cp "$repo_root/README.md" "$fixture/README.md"
+
+# ...and the same claim IS accepted once a run records it. Without this the rule
+# could simply reject every story claim and every mutation above would still pass.
+mkdir -p "$fixture/tests/evidence/story-runs"
+cat > "$fixture/tests/evidence/story-runs/fixture-run.json" <<'RUN'
+{
+  "version": 1,
+  "distro_id": "ubuntu",
+  "release": "24.04",
+  "surface": "groq/openai/gpt-oss-120b",
+  "story_set": "ubuntu",
+  "totals": { "total": 50, "passed": 49, "failed": 1, "skipped": 0, "rate_limited": 0 }
+}
+RUN
+printf '\nUbuntu 24.04 is validated with 49/50 stories on a live VM.\n' >> "$fixture/README.md"
+if ! "$checker" "$fixture" >/dev/null 2>&1; then
+    printf 'FAIL: checker rejected a story claim that its recorded run backs\n' >&2
+    exit 1
+fi
+
+# Backed by a run, but attributed to a model that did not produce it.
+sed -i 's|49/50 stories on a live VM.|49/50 stories on a live VM with gpt-4.1.|' "$fixture/README.md"
+grep -q 'gpt-4.1' "$fixture/README.md" || {
+    printf 'FAIL: model-attribution mutation did not apply\n' >&2
+    exit 1
+}
+assert_rejected 'story pass rate attributed to the wrong model'
+cp "$repo_root/README.md" "$fixture/README.md"
+
+# A subset run must never back a headline: probes record an empty story_set.
+python3 - "$fixture/tests/evidence/story-runs/fixture-run.json" <<'SUBSET'
+import json, sys
+path = sys.argv[1]
+doc = json.load(open(path))
+doc["story_set"] = ""
+doc["totals"] = {"total": 4, "passed": 4, "failed": 0, "skipped": 0, "rate_limited": 0}
+json.dump(doc, open(path, "w"), indent=2)
+SUBSET
+printf '\nUbuntu 24.04 is validated with 4/4 stories on a live VM.\n' >> "$fixture/README.md"
+assert_rejected 'four-story probe quoted as a headline figure'
+cp "$repo_root/README.md" "$fixture/README.md"
+rm -rf "$fixture/tests/evidence/story-runs"
+
+# The action count is derived from the catalogue source, so a retyped one fails.
+actions="$(grep -oE '[0-9]+ typed actions' "$fixture/docs/introduction.md" | head -1 | grep -oE '^[0-9]+')"
+if [[ -z "$actions" ]]; then
+    printf 'FAIL: could not find the typed-action count in the fixture\n' >&2
+    exit 1
+fi
+sed -i "s/${actions} typed actions/999 typed actions/" "$fixture/docs/introduction.md"
+assert_rejected 'action count that disagrees with the catalogue source'
+cp "$repo_root/docs/introduction.md" "$fixture/docs/introduction.md"
+
+# No evidence at all must fail loudly rather than pass for lack of anything to
+# compare against.
+mv "$fixture/tests/evidence/workspace-tests.json" "$fixture/tests/evidence/held.json"
+assert_rejected 'missing test-baseline artifact'
+mv "$fixture/tests/evidence/held.json" "$fixture/tests/evidence/workspace-tests.json"
 
 printf '\nFedora Workstation 44 is fully supported.\n' >> "$fixture/README.md"
 assert_rejected 'plain Fedora fully supported'


### PR DESCRIPTION
## Summary

Stacked on #176 (contains its three commits; review only `c29c00c`).

The README claimed **65/65 stories** validated on a live VM, in eight places. No
run ever produced that figure — no story set of that size has existed, and the
Ubuntu family contains 50 stories. The first measurements traceable to a run are
46/50 on 22.04 and 45/50 on 24.04 with `openai/gpt-oss-120b`.

The test count had rotted the opposite way, and the guard was part of the rot:
three docs said "1,561 Rust tests", `check_public_claims.sh` *required* that
literal string, and a second rule blacklisted counts up to 1,560 as stale. The
suite was at 1,681. Docs, guard and reality disagreed simultaneously, and fixing
it meant hand-editing four numbers.

Each published figure now derives from the artifact that produced it:

| Figure | Evidence | Produced by |
|---|---|---|
| workspace tests | `tests/evidence/workspace-tests.json` | `scripts/test_baseline.sh` |
| frontend tests | same file, own field | `scripts/test_baseline.sh --frontend` |
| typed actions | counted from the `KNOWN_ACTIONS` source | — |
| story pass rate | `tests/evidence/story-runs/*.json` | `run-stories.sh` |

`scripts/check_evidence_claims.py` compares every figure in the claim files to
those artifacts and fails when they disagree, when a figure has no artifact behind
it, or when a story claim is attributed to a model that did not produce it.

**The Ubuntu claims lose their number rather than gain a wrong one.** No story-run
artifact exists yet, so the docs now state what is validated and point at where the
pass rate is recorded. The figure returns when a full run produces one — which is
the immediate follow-up, and needs a network path the provider does not block.

**Guards run where the number is known.** `test_baseline.sh` wraps the test
commands CI already ran, so a suite that grows without the baseline moving fails in
the `rust` / `frontend` job rather than at docs-lint time.

## Magic numbers removed while here

- **The 54-entry `STORY_NAMES` table is gone** — names and distro family derive
  from each story's own header. That table had already drifted: it stopped at 54,
  so all 50 Ubuntu stories printed as a bare `Story 73` with no name in every
  results table published so far. An unparseable header now fails the run instead
  of quietly dropping a story.
- **`run-stories.sh ubuntu`** (and `atomic`) replaces the documented
  `$(seq 55 104)`, a hand-typed range that stops covering the suite the moment
  story 105 lands. Derived: 104 stories = 54 atomic + 50 ubuntu.
- **ROADMAP** targets said "full action parity (65/65 stories)" — a suite size
  that never existed.
- **The contributor provider table** listed three auto-detected providers when
  `from_env` auto-detects two, and omitted four providers outright. That is how a
  run with only `GROQ_API_KEY` exported fell through to the uninstalled Ollama
  fallback and failed fifty stories with an error naming the wrong provider. It now
  separates auto-detected from explicit-only, and `provider-parity.test.sh` derives
  the provider list *and* every default model from `config.rs`.

## Related Issue

Follow-up to the Ubuntu VM validation in #171 and the planner fixes in #176.

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

- 1,681 tests, `clippy --all-targets -D warnings` clean, `ci-local.sh` green.
- Postgres contract 5/5 on podman. (It failed 3/5 mid-session; the cause was a
  reaped container, not this change — the same reaping took the test VM and
  `/tmp`.)
- `markdownlint-cli2` and `shellcheck --severity=warning` over all 142 scripts,
  run under the exact CI invocations because this host lacks both; both clean, and
  a deliberately broken script confirms the shellcheck harness can fail.

New mutations in `public-claims.test.sh`: a wrong test count, a story claim with no
run behind it, a story claim attributed to the wrong model, a subset run quoted as
a headline, a retyped action count, and a missing artifact — **plus the positive
case**, that a story claim its recorded run backs is accepted. Without that last
one the rule could simply reject every figure and every mutation above would still
pass. `story-metadata.test.sh` asserts on the real parser rather than
reimplementing the header regex, and mutates in an unreadable header to prove the
derivation fails loudly.

Meta-check: neutering `check_evidence_claims.py` makes `public-claims.test.sh`
fail at its first mutation, so the new assertions are load-bearing.

## Notes for Reviewers

**ADR 0004** keeps its original text with a correction note appended rather than
being rewritten. The decision it records stands, and was independently confirmed:
the two Fedora actions still reaching Ubuntu plans came from the tool schema,
which that ADR did not cover.

**The `story_set` field is the load-bearing part of the story rule.** A claim may
only rest on a run of a complete family, because subset runs record it empty.
Without that, the four-story probe from #176 could have been published as 4/4.

**`measured_at` and `commit` are per field**, since one suite's figure can be fresh
while the other is stale, and a single timestamp would hide exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f
