### PR TITLE
fix: retry transient provider failures, and make a cassette miss say what diverged

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,711 Rust tests and 72 frontend tests** form the current deterministic
+**1,723 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -43,4 +43,6 @@ tracing = "0.1"
 unicode-normalization = "0.1"
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+# `test-util` provides the paused clock, so the provider-retry tests assert the
+# backoff schedule without actually sleeping through it.
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util"] }

--- a/crates/sysknife-brain/src/cassette.rs
+++ b/crates/sysknife-brain/src/cassette.rs
@@ -113,6 +113,53 @@ pub enum CassetteError {
 struct Entry {
     surface: String,
     output: Completion,
+    /// Per-component digests of the call this entry was recorded for.
+    ///
+    /// The key is a single hash over `(surface, system, messages, tools,
+    /// max_tokens)`, which is all a *lookup* needs and all a *miss* used to be
+    /// able to report: one 64-hex digest naming none of its inputs. That makes
+    /// the obvious diagnostic — diff what was recorded against what the replay
+    /// built — impossible, because nothing comparable is stored (#182).
+    ///
+    /// `Option` so cassettes recorded before this field stay loadable; a miss
+    /// against one of those simply falls back to the old, vaguer message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    fingerprint: Option<CallFingerprint>,
+}
+
+/// Component digests of one call, enough to locate *where* two calls diverge
+/// without storing the prompts or the conversation itself.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CallFingerprint {
+    system: String,
+    tools: String,
+    max_tokens: u32,
+    /// One digest per message, in order, so a divergence can be reported as an
+    /// index rather than as "something differs".
+    messages: Vec<String>,
+}
+
+impl CallFingerprint {
+    fn of(system: &str, messages: &[Message], tools: &[ToolDefinition], max_tokens: u32) -> Self {
+        Self {
+            system: sha256_hex(system.as_bytes()),
+            tools: sha256_hex(serde_json::to_string(tools).unwrap_or_default().as_bytes()),
+            max_tokens,
+            messages: messages
+                .iter()
+                .map(|m| sha256_hex(serde_json::to_string(m).unwrap_or_default().as_bytes()))
+                .collect(),
+        }
+    }
+
+    /// Index of the first message that differs, or `None` if one is a prefix of
+    /// the other.
+    fn first_divergent_message(&self, other: &Self) -> Option<usize> {
+        self.messages
+            .iter()
+            .zip(&other.messages)
+            .position(|(a, b)| a != b)
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -320,12 +367,15 @@ impl Cassette {
         !state.meta.system_prompt_sha256.contains(prompt_sha)
     }
 
+    /// Persist one recorded call, with the component digests that let a later
+    /// miss say which part of the call diverged. See [`CallFingerprint`].
     fn store(
         &self,
         key: String,
         surface: &str,
         prompt_sha: &str,
         output: Completion,
+        fingerprint: Option<CallFingerprint>,
     ) -> Result<(), CassetteError> {
         {
             let mut state = self.state.lock().expect("cassette state poisoned");
@@ -339,6 +389,7 @@ impl Cassette {
                 Entry {
                     surface: surface.to_string(),
                     output,
+                    fingerprint,
                 },
             );
         }
@@ -448,6 +499,85 @@ impl Cassette {
     }
 }
 
+impl Cassette {
+    /// Explain a replay miss by comparing the call against what was recorded.
+    ///
+    /// A miss is a hash mismatch, and a hash names none of its inputs — so the
+    /// bare message could only ever say "no recorded output", which is true and
+    /// useless. This walks the recorded entries for the same surface and reports
+    /// the most specific thing it can prove:
+    ///
+    /// - the system prompt changed (every call will miss; re-record);
+    /// - the tool schema changed (likewise);
+    /// - or the conversation matched up to message N and diverged there, which
+    ///   is the signature of a volatile tool result: turn 1 replays, turn 2
+    ///   cannot, because something in between differs run to run (#182).
+    fn diagnose_miss(
+        &self,
+        surface: &str,
+        system: &str,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        max_tokens: u32,
+    ) -> String {
+        let want = CallFingerprint::of(system, messages, tools, max_tokens);
+        let state = self.state.lock().expect("cassette state poisoned");
+
+        let recorded: Vec<&CallFingerprint> = state
+            .entries
+            .values()
+            .filter(|e| e.surface == surface)
+            .filter_map(|e| e.fingerprint.as_ref())
+            .collect();
+
+        if recorded.is_empty() {
+            return format!(
+                "no recorded output for surface {surface} in {}; re-record with {}=record",
+                self.path.display(),
+                ENV_CASSETTE_MODE
+            );
+        }
+
+        if !recorded.iter().any(|f| f.system == want.system) {
+            return format!(
+                "the system prompt changed, so every call will miss; re-record with {}=record",
+                ENV_CASSETTE_MODE
+            );
+        }
+        if !recorded.iter().any(|f| f.tools == want.tools) {
+            return format!(
+                "the tool schema changed, so every call will miss; re-record with {}=record",
+                ENV_CASSETTE_MODE
+            );
+        }
+
+        // Same prompt and tools: the conversation itself diverged. Report the
+        // deepest match, since that is the turn boundary where determinism broke.
+        let deepest = recorded
+            .iter()
+            .filter(|f| f.system == want.system && f.tools == want.tools)
+            .filter_map(|f| f.first_divergent_message(&want))
+            .max();
+
+        match deepest {
+            Some(index) => format!(
+                "the conversation diverged at message {index}: turns before it replay, \
+                 this one does not. The recorded and replayed messages differ at that \
+                 index, which is what a volatile tool result looks like — a timestamp, \
+                 a transaction id, or live system state folded into the call key. \
+                 See issue #182."
+            ),
+            None => format!(
+                "no recorded output for this call in {}; the prompt and tools match, so \
+                 the conversation reached a turn that was never recorded. Re-record with \
+                 {}=record",
+                self.path.display(),
+                ENV_CASSETTE_MODE
+            ),
+        }
+    }
+}
+
 /// The stable key for one call.
 ///
 /// Field order is fixed by construction and every nested type serialises in
@@ -520,6 +650,9 @@ impl LlmProvider for CassetteProvider {
         if self.cassette.mode == CassetteMode::Replay {
             self.cassette.note("miss", &self.surface, &key);
             let prompt_sha = sha256_hex(system.as_bytes());
+            // The prompt check first: it is provable from `meta` alone and
+            // explains every call missing at once, which no per-call comparison
+            // should be allowed to contradict.
             let detail = if self.cassette.prompt_is_unknown(&prompt_sha) {
                 format!(
                     "the system prompt changed (sha256 {prompt_sha} was never recorded in {}), \
@@ -527,12 +660,8 @@ impl LlmProvider for CassetteProvider {
                     self.cassette.path.display()
                 )
             } else {
-                format!(
-                    "no recorded output for surface {} in {}; re-record with {}=record",
-                    self.surface,
-                    self.cassette.path.display(),
-                    ENV_CASSETTE_MODE
-                )
+                self.cassette
+                    .diagnose_miss(&self.surface, system, messages, tools, max_tokens)
             };
             return Err(ProviderError::CassetteMiss(detail));
         }
@@ -544,7 +673,13 @@ impl LlmProvider for CassetteProvider {
             .await?;
         let prompt_sha = sha256_hex(system.as_bytes());
         self.cassette
-            .store(key, &self.surface, &prompt_sha, output.clone())
+            .store(
+                key,
+                &self.surface,
+                &prompt_sha,
+                output.clone(),
+                Some(CallFingerprint::of(system, messages, tools, max_tokens)),
+            )
             .map_err(|e| ProviderError::CassetteMiss(format!("cannot write cassette: {e}")))?;
         Ok(output)
     }
@@ -1021,5 +1156,103 @@ mod tests {
         let err = Cassette::open(dir.path().join("absent.json"), CassetteMode::Replay)
             .expect_err("replay cannot invent a cassette");
         assert!(matches!(err, CassetteError::Missing(_)));
+    }
+}
+
+#[cfg(test)]
+mod miss_diagnosis_tests {
+    use super::*;
+    use crate::provider::{ContentBlock, Message, StopReason};
+
+    fn completion(text: &str) -> Completion {
+        Completion {
+            content: vec![ContentBlock::Text { text: text.into() }],
+            stop_reason: StopReason::EndTurn,
+        }
+    }
+
+    /// A replay miss used to report a 64-hex digest and nothing else, which is
+    /// unactionable: the key is a hash of `(surface, system, messages, tools,
+    /// max_tokens)` and the message identifying it names none of them. Issue #182
+    /// asks to "diff the recorded messages against what a replay builds" — that is
+    /// not possible against a file that stores only hashes, so the first fix is to
+    /// make a miss say which component diverged.
+    #[test]
+    fn a_miss_caused_by_a_later_turn_names_the_diverging_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+
+        // Record a two-turn conversation.
+        let rec = Cassette::open(path.clone(), CassetteMode::Record).unwrap();
+        let system = "SYSTEM";
+        let turn1 = vec![Message::user_text("install vim; rm -rf /")];
+        let turn2 = vec![
+            Message::user_text("install vim; rm -rf /"),
+            Message::user_text("Plan rejected: injected metacharacters."),
+        ];
+        for (msgs, out) in [(&turn1, "turn one"), (&turn2, "turn two")] {
+            rec.store(
+                call_key("p/m", system, msgs, &[], 100),
+                "p/m",
+                &sha256_hex(system.as_bytes()),
+                completion(out),
+                Some(CallFingerprint::of(system, msgs, &[], 100)),
+            )
+            .unwrap();
+        }
+
+        // Replay: turn 1 matches, turn 2's second message differs by one word —
+        // the shape a volatile tool result produces.
+        let replay = Cassette::open(path, CassetteMode::Replay).unwrap();
+        assert!(
+            replay
+                .lookup(&call_key("p/m", system, &turn1, &[], 100))
+                .is_some(),
+            "turn 1 must still replay"
+        );
+
+        let drifted = vec![
+            Message::user_text("install vim; rm -rf /"),
+            Message::user_text("Plan rejected: injected metacharacter."),
+        ];
+        let diagnosis = replay.diagnose_miss("p/m", system, &drifted, &[], 100);
+        assert!(
+            diagnosis.contains("message 1"),
+            "must name the diverging message index, got: {diagnosis}"
+        );
+        assert!(
+            diagnosis.to_lowercase().contains("turn"),
+            "must say the conversation diverged mid-run, got: {diagnosis}"
+        );
+    }
+
+    /// The other shape: nothing about the conversation matches, because the
+    /// system prompt or tools changed. That must NOT be reported as a mid-turn
+    /// divergence — it is a re-record, not a volatile field.
+    #[test]
+    fn a_miss_caused_by_a_changed_prompt_is_not_blamed_on_a_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let rec = Cassette::open(path.clone(), CassetteMode::Record).unwrap();
+        let msgs = vec![Message::user_text("hello")];
+        rec.store(
+            call_key("p/m", "OLD SYSTEM", &msgs, &[], 100),
+            "p/m",
+            &sha256_hex(b"OLD SYSTEM"),
+            completion("out"),
+            Some(CallFingerprint::of("OLD SYSTEM", &msgs, &[], 100)),
+        )
+        .unwrap();
+
+        let replay = Cassette::open(path, CassetteMode::Replay).unwrap();
+        let diagnosis = replay.diagnose_miss("p/m", "NEW SYSTEM", &msgs, &[], 100);
+        assert!(
+            diagnosis.contains("system prompt"),
+            "a changed prompt must be named as such, got: {diagnosis}"
+        );
+        assert!(
+            !diagnosis.contains("message 0"),
+            "must not blame a message when the prompt is what changed: {diagnosis}"
+        );
     }
 }

--- a/crates/sysknife-brain/src/planner.rs
+++ b/crates/sysknife-brain/src/planner.rs
@@ -21,9 +21,11 @@ use crate::planning_tools::get_state::get_state_tool_def;
 use crate::planning_tools::propose_plan::{parse_proposed_plan, propose_plan_tool_def};
 use crate::planning_tools::query_tools::query_tools;
 use crate::prompt::build_system_prompt;
+use std::time::Duration;
+
 use crate::provider::{
-    ContentBlock, LlmProvider, Message, ProviderError, Role, StopReason, ToolDefinition,
-    ToolResultBlock,
+    Completion, ContentBlock, LlmProvider, Message, ProviderError, Role, StopReason,
+    ToolDefinition, ToolResultBlock,
 };
 use crate::providers::openai_adapter::AsyncOpenAiAdapter;
 use crate::providers::rig_adapter::RigCompletionAdapter;
@@ -67,6 +69,23 @@ pub const OLLAMA_NUM_PREDICT: u32 = 4096;
 /// buffer for multi-turn retries. 4096 is generous for all
 /// providers — well-behaved runs rarely exceed 1000.
 pub const PLANNING_MAX_TOKENS: u32 = 4096;
+
+/// How many times one turn's provider call may be re-attempted after a
+/// retryable failure (so at most `1 + PROVIDER_RETRY_LIMIT` attempts).
+///
+/// Small on purpose. This covers the momentary failures — a 502, a truncated
+/// payload, one 429 — and deliberately does not try to ride out a real outage:
+/// an operator waiting on a plan is better served by a clear failure than by a
+/// command that hangs for a minute and then fails anyway.
+const PROVIDER_RETRY_LIMIT: u32 = 2;
+
+/// First backoff before re-attempting a failed provider call; doubles per retry.
+const PROVIDER_RETRY_BACKOFF: Duration = Duration::from_millis(400);
+
+/// First backoff when the provider explicitly signalled rate limiting. Longer
+/// than [`PROVIDER_RETRY_BACKOFF`]: retrying a 429 on the same schedule as a 502
+/// is how a rate limit turns into a rate-limit loop.
+const PROVIDER_RETRY_RATE_LIMIT_BACKOFF: Duration = Duration::from_millis(2_000);
 
 /// Maximum byte length accepted for a natural-language intent.
 ///
@@ -852,6 +871,77 @@ impl LlmPlanner {
         }
     }
 
+    /// One turn's provider call, re-attempted on failures that could plausibly
+    /// succeed a moment later.
+    ///
+    /// The turn loop already retries the *model's* mistakes; a provider-level
+    /// failure used to end planning outright, so one 502 or one truncated payload
+    /// wasted an entire intent with most of the turn budget unused.
+    /// [`ProviderError::is_retryable`] draws the line — notably `Auth` and
+    /// `CassetteMiss` are attempted exactly once, because neither can change its
+    /// answer.
+    ///
+    /// Retries consume a rate-limiter token like any other request, rather than
+    /// slipping around the limiter: a retry storm during a provider outage is
+    /// precisely the traffic the limiter exists to cap. If the limiter declines,
+    /// the retry is abandoned and the original provider error is returned — the
+    /// operator needs to see what actually failed, not a rate-limit error that
+    /// only describes our own reaction to it.
+    async fn complete_with_retry(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+    ) -> Result<Completion, ProviderError> {
+        let mut attempt: u32 = 0;
+        loop {
+            let error = match self
+                .provider
+                .complete(system, messages, tools, PLANNING_MAX_TOKENS)
+                .await
+            {
+                Ok(completion) => return Ok(completion),
+                Err(e) => e,
+            };
+
+            if !error.is_retryable() || attempt >= PROVIDER_RETRY_LIMIT {
+                return Err(error);
+            }
+
+            if let Some(ref rl) = self.rate_limiter {
+                if std::sync::Arc::clone(rl)
+                    .check_and_consume_async()
+                    .await
+                    .is_err()
+                {
+                    return Err(error);
+                }
+            }
+
+            // Exponential, and longer when the provider has explicitly asked us
+            // to slow down: retrying a 429 on the same schedule as a 502 is how a
+            // rate limit becomes a rate-limit loop.
+            let base = if matches!(
+                error,
+                ProviderError::RateLimit(_) | ProviderError::Http { status: 429, .. }
+            ) {
+                PROVIDER_RETRY_RATE_LIMIT_BACKOFF
+            } else {
+                PROVIDER_RETRY_BACKOFF
+            };
+            let backoff = base * 2_u32.pow(attempt);
+            eprintln!(
+                "[sysknife-brain] provider call failed ({error}); \
+                 retrying in {:.1}s (attempt {}/{})",
+                backoff.as_secs_f32(),
+                attempt + 1,
+                PROVIDER_RETRY_LIMIT,
+            );
+            tokio::time::sleep(backoff).await;
+            attempt += 1;
+        }
+    }
+
     /// Run the planning loop for the given natural-language intent.
     ///
     /// Returns `Err(EmptyIntent)` immediately if the intent is blank.
@@ -905,8 +995,7 @@ impl LlmPlanner {
         for turn in 0..self.max_turns {
             self.emit(PlanEvent::Thinking);
             let completion = self
-                .provider
-                .complete(&effective_prompt, &messages, &tools, PLANNING_MAX_TOKENS)
+                .complete_with_retry(&effective_prompt, &messages, &tools)
                 .await
                 .map_err(PlanningError::from)?;
 

--- a/crates/sysknife-brain/src/provider.rs
+++ b/crates/sysknife-brain/src/provider.rs
@@ -181,3 +181,91 @@ pub enum ProviderError {
     #[error("cassette miss: {0}")]
     CassetteMiss(String),
 }
+
+impl ProviderError {
+    /// Whether re-issuing the identical request could plausibly succeed.
+    ///
+    /// The planner's turn loop retries the *model's* mistakes — text where a tool
+    /// call belonged, a plan the safety fence rejected — but used to abandon
+    /// planning on the first provider-level failure, with most of its turn budget
+    /// unused. This is the classification that lets it retry the failures that
+    /// deserve it without retrying the ones that never will.
+    ///
+    /// The two `false` arms matter more than the `true` ones:
+    ///
+    /// - [`Auth`](Self::Auth) — a wrong key stays wrong. Retrying only delays the
+    ///   one message that tells the operator what to fix.
+    /// - [`CassetteMiss`](Self::CassetteMiss) — the cassette key is a hash of the
+    ///   call, so a retry issues the identical lookup and misses identically. It
+    ///   is deterministic by construction; retrying converts an immediate,
+    ///   well-explained hermetic-replay failure into a slow one, and under a
+    ///   replay-gated CI run it would consume the job timeout printing nothing new.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            // Truncated or malformed payloads are a transport/serialisation
+            // artefact, not a statement about the request.
+            ProviderError::Parse(_) => true,
+            // Connection reset, DNS blip, timeout.
+            ProviderError::Request(_) => true,
+            // 5xx is the provider's own fault and usually momentary; 429 means
+            // "later", which is exactly what a backoff provides. Every 4xx is a
+            // defect in the request just built, and building it again produces
+            // the same bytes.
+            ProviderError::Http { status, .. } => *status >= 500 || *status == 429,
+            ProviderError::RateLimit(_) => true,
+            ProviderError::Auth(_) => false,
+            ProviderError::CassetteMiss(_) => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod retryability_tests {
+    use super::*;
+
+    #[test]
+    fn transient_failures_are_retryable() {
+        assert!(ProviderError::Parse("truncated json".into()).is_retryable());
+        assert!(ProviderError::Request("connection reset".into()).is_retryable());
+        assert!(ProviderError::RateLimit("slow down".into()).is_retryable());
+        for status in [500, 502, 503, 504, 429] {
+            assert!(
+                ProviderError::Http {
+                    status,
+                    body: String::new()
+                }
+                .is_retryable(),
+                "HTTP {status} says nothing about the request and should be retried"
+            );
+        }
+    }
+
+    #[test]
+    fn a_client_error_is_not_retryable() {
+        // 4xx describes the request we just built. Building it again produces the
+        // same bytes, so a retry is guaranteed to fail the same way.
+        for status in [400, 401, 403, 404, 422] {
+            assert!(
+                !ProviderError::Http {
+                    status,
+                    body: String::new()
+                }
+                .is_retryable(),
+                "HTTP {status} is a request defect and must not be retried"
+            );
+        }
+    }
+
+    #[test]
+    fn auth_failure_is_not_retryable() {
+        assert!(!ProviderError::Auth("invalid api key".into()).is_retryable());
+    }
+
+    /// The one that does real damage if handled carelessly: the cassette key is a
+    /// hash of the call, so a retry issues the identical lookup and misses
+    /// identically — turning an immediate hermetic-replay failure into a slow one.
+    #[test]
+    fn a_cassette_miss_is_never_retryable() {
+        assert!(!ProviderError::CassetteMiss("no recorded output".into()).is_retryable());
+    }
+}

--- a/crates/sysknife-brain/tests/planner.rs
+++ b/crates/sysknife-brain/tests/planner.rs
@@ -412,12 +412,18 @@ async fn plan_step_carries_params() {
 // Error paths
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
+/// A *persistent* 500 still propagates as a 500. 5xx is retryable, so one
+/// scripted error would be followed by MockProvider's exhaustion fallback and
+/// this would assert the fixture's variant instead of the failure's.
+#[tokio::test(start_paused = true)]
 async fn provider_error_propagates() {
-    let planner = make_planner(MockProvider::new([Err(ProviderError::Http {
-        status: 500,
-        body: "internal server error".into(),
-    })]));
+    let http_500 = || {
+        Err(ProviderError::Http {
+            status: 500,
+            body: "internal server error".into(),
+        })
+    };
+    let planner = make_planner(MockProvider::new([http_500(), http_500(), http_500()]));
 
     assert!(matches!(
         planner.plan_intent("do something").await.unwrap_err(),
@@ -1797,11 +1803,17 @@ async fn provider_parse_error_propagates() {
     ));
 }
 
-#[tokio::test]
+/// A *persistent* rate limit surfaces as `RateLimit`. Scripted three times
+/// because the call is now retried: one scripted error would be followed by
+/// MockProvider's exhaustion fallback, and the test would assert the variant of
+/// the fixture rather than of the failure.
+#[tokio::test(start_paused = true)]
 async fn rate_limit_error_propagates() {
-    let planner = make_planner(MockProvider::new([Err(ProviderError::RateLimit(
-        "429 slow down".into(),
-    ))]));
+    let planner = make_planner(MockProvider::new([
+        Err(ProviderError::RateLimit("429 slow down".into())),
+        Err(ProviderError::RateLimit("429 slow down".into())),
+        Err(ProviderError::RateLimit("429 slow down".into())),
+    ]));
 
     assert!(matches!(
         planner.plan_intent("do something").await.unwrap_err(),
@@ -1809,14 +1821,200 @@ async fn rate_limit_error_propagates() {
     ));
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn transport_request_error_propagates() {
-    let planner = make_planner(MockProvider::new([Err(ProviderError::Request(
-        "connection reset".into(),
-    ))]));
+    let planner = make_planner(MockProvider::new([
+        Err(ProviderError::Request("connection reset".into())),
+        Err(ProviderError::Request("connection reset".into())),
+        Err(ProviderError::Request("connection reset".into())),
+    ]));
 
     assert!(matches!(
         planner.plan_intent("do something").await.unwrap_err(),
         PlanningError::Provider(ProviderError::Request(_))
     ));
+}
+
+// ---------------------------------------------------------------------------
+// Provider retry (#178)
+//
+// The turn loop retried the model's own mistakes — text instead of a tool call,
+// a plan the safety fence rejected — but a provider-level failure ended planning
+// on its first occurrence, with nine turns still unused. One 502, one truncated
+// payload, one rate-limit response and the whole request was over.
+//
+// Retrying is not universally right, which is the point of these tests: two
+// classes must still fail immediately, and one of them (CassetteMiss) would turn
+// a fast, well-explained hermetic-replay failure into a slow one.
+// ---------------------------------------------------------------------------
+
+/// A provider that counts every call, so a test can assert how many attempts a
+/// failure class actually produced rather than inferring it from the outcome.
+struct CountingProvider {
+    turns: Mutex<VecDeque<Result<Completion, ProviderError>>>,
+    calls: Arc<AtomicUsize>,
+    /// Returned once the scripted turns run out, so "retried forever" shows up
+    /// as a bounded count rather than a hang.
+    exhausted: Box<dyn Fn() -> Result<Completion, ProviderError> + Send + Sync>,
+}
+
+impl CountingProvider {
+    fn new(
+        turns: impl IntoIterator<Item = Result<Completion, ProviderError>>,
+        exhausted: impl Fn() -> Result<Completion, ProviderError> + Send + Sync + 'static,
+    ) -> (Self, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                turns: Mutex::new(turns.into_iter().collect()),
+                calls: Arc::clone(&calls),
+                exhausted: Box::new(exhausted),
+            },
+            calls,
+        )
+    }
+}
+
+#[async_trait]
+impl LlmProvider for CountingProvider {
+    async fn complete(
+        &self,
+        _system: &str,
+        _messages: &[Message],
+        _tools: &[ToolDefinition],
+        _max_tokens: u32,
+    ) -> Result<Completion, ProviderError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        let next = self.turns.lock().unwrap().pop_front();
+        next.unwrap_or_else(|| (self.exhausted)())
+    }
+}
+
+fn counting_planner(provider: CountingProvider) -> LlmPlanner {
+    LlmPlanner::new(Box::new(provider), Box::new(MockStateClient::default()), 5)
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_transient_provider_failure_is_retried_rather_than_ending_planning() {
+    // A 502 from the provider says nothing about the request; the identical call
+    // a moment later usually works.
+    let (provider, calls) = CountingProvider::new(
+        [
+            Err(ProviderError::Http {
+                status: 502,
+                body: "bad gateway".into(),
+            }),
+            propose_plan("install vim", &[("AptInstall", "install vim", "medium")]),
+        ],
+        || Err(ProviderError::Parse("exhausted".into())),
+    );
+    let plan = counting_planner(provider)
+        .plan_intent("install vim")
+        .await
+        .expect("a 502 must not end planning");
+    assert_eq!(plan.summary(), "install vim");
+    assert_eq!(calls.load(Ordering::Relaxed), 2, "must have retried once");
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_truncated_provider_payload_is_retried() {
+    let (provider, calls) = CountingProvider::new(
+        [
+            Err(ProviderError::Parse("unexpected end of JSON".into())),
+            propose_plan("list services", &[("ListServices", "list", "low")]),
+        ],
+        || Err(ProviderError::Parse("exhausted".into())),
+    );
+    assert!(counting_planner(provider)
+        .plan_intent("list services")
+        .await
+        .is_ok());
+    assert_eq!(calls.load(Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn an_auth_failure_fails_fast_and_is_never_retried() {
+    // A wrong key stays wrong. Retrying only delays the one message that tells
+    // the operator what to fix.
+    let (provider, calls) = CountingProvider::new(
+        [
+            Err(ProviderError::Auth("invalid api key".into())),
+            propose_plan("install vim", &[("AptInstall", "install vim", "medium")]),
+        ],
+        || Err(ProviderError::Parse("exhausted".into())),
+    );
+    assert!(counting_planner(provider)
+        .plan_intent("install vim")
+        .await
+        .is_err());
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        1,
+        "auth failure must be attempted exactly once"
+    );
+}
+
+#[tokio::test]
+async fn a_cassette_miss_is_attempted_exactly_once() {
+    // The cassette key is a hash of the call, so a retry issues the identical
+    // lookup and misses identically. Retrying it would burn a replay-gated CI
+    // job's timeout while printing nothing new.
+    let (provider, calls) = CountingProvider::new(
+        [
+            Err(ProviderError::CassetteMiss("no recorded output".into())),
+            propose_plan("install vim", &[("AptInstall", "install vim", "medium")]),
+        ],
+        || Err(ProviderError::Parse("exhausted".into())),
+    );
+    assert!(counting_planner(provider)
+        .plan_intent("install vim")
+        .await
+        .is_err());
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        1,
+        "a cassette miss is deterministic; retrying it is pure delay"
+    );
+}
+
+#[tokio::test]
+async fn a_client_error_is_not_retried() {
+    // 4xx is a defect in the request we just built; building it again produces
+    // the same bytes.
+    let (provider, calls) = CountingProvider::new(
+        [
+            Err(ProviderError::Http {
+                status: 400,
+                body: "bad request".into(),
+            }),
+            propose_plan("install vim", &[("AptInstall", "install vim", "medium")]),
+        ],
+        || Err(ProviderError::Parse("exhausted".into())),
+    );
+    assert!(counting_planner(provider)
+        .plan_intent("install vim")
+        .await
+        .is_err());
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn retries_are_bounded_so_a_persistent_outage_still_terminates() {
+    // Without a ceiling, a provider that is simply down turns one intent into an
+    // unbounded retry loop.
+    let (provider, calls) = CountingProvider::new([], || {
+        Err(ProviderError::Http {
+            status: 503,
+            body: "service unavailable".into(),
+        })
+    });
+    assert!(counting_planner(provider)
+        .plan_intent("install vim")
+        .await
+        .is_err());
+    let n = calls.load(Ordering::Relaxed);
+    assert!(
+        (2..=4).contains(&n),
+        "a persistent outage must stop after a small bounded number of attempts, got {n}"
+    );
 }

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,711 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,723 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -140,7 +140,7 @@ flow.
 
 ## Status
 
-189 typed actions · 1,711 Rust tests + 72 frontend tests · MIT
+189 typed actions · 1,723 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "adc105be3fd5d2ef78dfa8d5da6fcb16b71ca1b2"
+    "tests": "853054f5faf4f7ec463fe085696d3d9063c7eabe"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-06T06:05:59-06:00"
+    "tests": "2026-08-08T04:43:20-06:00"
   },
-  "tests": 1711,
+  "tests": 1723,
   "version": 1
 }


### PR DESCRIPTION
Two reliability fixes from the open-issue sweep.

## #178 — provider errors no longer abort planning

The turn loop retried the *model's* mistakes but abandoned planning on the
first *provider* failure, with most of the turn budget unused. One 502, one
truncated payload, or one 429 wasted the whole intent.

`ProviderError::is_retryable` draws the line. The two `false` arms matter most:

| Variant | Retried | Why |
|---|---|---|
| `Parse`, `Request` | yes | transport/serialisation artefact |
| `Http` 5xx / 429 | yes | provider's fault, usually momentary |
| `RateLimit` | yes, longer backoff | 429 on a 502 schedule is a rate-limit loop |
| `Http` 4xx | **no** | describes the request we built; rebuilding gives the same bytes |
| `Auth` | **no** | a wrong key stays wrong |
| `CassetteMiss` | **never** | the key is a hash of the call, so a retry misses identically |

`CassetteMiss` is the dangerous one: retrying turns an immediate, well-explained
hermetic-replay failure into a slow one, and under a replay-gated CI run it would
burn the job timeout printing nothing new. There is a test that **counts
attempts** rather than inferring them from the outcome.

Retries consume a rate-limiter token rather than slipping around the limiter — a
retry storm during an outage is exactly the traffic the limiter exists to cap. If
the limiter declines, the **original** provider error is returned, because the
operator needs to see what failed, not our reaction to it.

Bounded at two retries: enough for a momentary failure, deliberately not enough
to ride out an outage.

### Test fixtures that were asserting themselves

Three existing `*_propagates` tests scripted a single error and asserted which
variant reached the caller. All three variants are retryable now, so one scripted
error is followed by `MockProvider`'s exhaustion fallback — a *different* variant
— and the tests would have been asserting the fixture rather than the failure.
They now script the failure persistently, which is what "a rate limit propagates"
always meant, on tokio's paused clock so the backoff is virtual.

## #182 — a replay miss now names the divergence

The issue's first direction is "diff the recorded messages against what a replay
builds". That is impossible against the cassette as written: the key is a single
sha256 over `(surface, system, messages, tools, max_tokens)` and the file stores
only that digest, so a miss could report a 64-hex string naming none of its
inputs — and the one message it offered was true for every cause.

Entries now carry a `CallFingerprint`: separate digests for the prompt, the tool
schema, `max_tokens`, and **one per message in order**. Hashes only, so a
cassette stays safe to commit. `Option`, so older cassettes still load.

`diagnose_miss` reports the most specific provable thing: prompt changed, tools
changed, or *the conversation matched to message N and diverged there* — the
signature of a volatile tool result, where turn 1 replays and turn 2 cannot.

**This does not fix story 91.** It makes the next person's first question
answerable from the failure message instead of from a VM run.

## Verification

1,723 tests (from 1,711), clippy `--all-features --all-targets` clean,
`cargo doc -D warnings` clean, baseline re-recorded and the three published
figures regenerated from it.