### PR TITLE
fix: give Ubuntu its own state action and close the family fence (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ milestone.
 | Component | State |
 |---|---|
 | `sysknife-brain` — LLM planner, tool loop, safety fence | ✅ |
-| `sysknife-daemon` — 189 typed actions, auth, preview, transactions | ✅ |
+| `sysknife-daemon` — 190 typed actions, auth, preview, transactions | ✅ |
 | Live IPC + streaming + atomic-host rollback (rpm-ostree) | ✅ |
 | Terminal approval gate — one-time, TTL-bounded receipts | ✅ |
 | MCP server (Claude Code / Cursor / any MCP client) | ✅ |
@@ -260,7 +260,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,723 Rust tests and 72 frontend tests** form the current deterministic
+**1,727 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/src/distro_routing.rs
+++ b/apps/sysknife-cli/src/distro_routing.rs
@@ -240,19 +240,46 @@ mod tests {
     // Generic actions are allowed everywhere
     // -----------------------------------------------------------------------
 
+    /// Silverblue, not plain Fedora: `GetSystemState` runs `rpm-ostree status`,
+    /// which a dnf-based Fedora Workstation does not have — and plain Fedora is
+    /// `is_supported() == false` besides. The old fixture used `Fedora`, so it
+    /// asserted an rpm-ostree action was fine on a host without rpm-ostree.
     #[test]
-    fn get_system_state_allowed_on_fedora() {
-        let distro = DistroId::Fedora { version: 41 };
+    fn get_system_state_allowed_on_fedora_atomic() {
+        let distro = DistroId::FedoraSilverblue { version: 41 };
         assert!(check_action_distro("GetSystemState", Some(&distro)).is_ok());
     }
 
+    /// This pair used to assert that `GetSystemState` was "generic, allowed
+    /// everywhere". It is not: it runs `rpm-ostree status --json`, so on an apt
+    /// host it failed with `command not found` — *after* the operator had
+    /// approved it. The routing guard now refuses it up front, and `GetHostState`
+    /// is what Ubuntu answers the same question with (#181).
     #[test]
-    fn get_system_state_allowed_on_ubuntu() {
+    fn get_system_state_is_refused_on_ubuntu_before_approval() {
         let distro = DistroId::Ubuntu {
             major: 24,
             minor: 4,
         };
-        assert!(check_action_distro("GetSystemState", Some(&distro)).is_ok());
+        assert!(
+            check_action_distro("GetSystemState", Some(&distro)).is_err(),
+            "an rpm-ostree action must not reach an apt host's approval prompt"
+        );
+    }
+
+    #[test]
+    fn get_host_state_is_the_ubuntu_counterpart() {
+        let ubuntu = DistroId::Ubuntu {
+            major: 24,
+            minor: 4,
+        };
+        assert!(check_action_distro("GetHostState", Some(&ubuntu)).is_ok());
+
+        let fedora = DistroId::FedoraSilverblue { version: 41 };
+        assert!(
+            check_action_distro("GetHostState", Some(&fedora)).is_err(),
+            "the fence runs both ways: Fedora has GetSystemState"
+        );
     }
 
     #[test]

--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -1503,11 +1503,25 @@ mod tests {
         assert!(result.unwrap_err().contains("Debian-family"));
     }
 
+    /// `GetSystemState` used to stand in for "a generic action" here. It is not
+    /// one — it runs rpm-ostree and is now Fedora-fenced (#181) — so this test
+    /// needs an action that genuinely belongs to neither family, or it stops
+    /// testing what its name says.
     #[test]
     fn check_plan_steps_distro_allows_generic_action() {
-        let distro = sysknife_core::distro::DistroId::Fedora { version: 41 };
-        let result = check_plan_steps_distro(["GetSystemState"].into_iter(), Some(&distro));
+        let distro = sysknife_core::distro::DistroId::Ubuntu {
+            major: 24,
+            minor: 4,
+        };
+        let result = check_plan_steps_distro(["GetMemoryInfo"].into_iter(), Some(&distro));
         assert!(result.is_ok());
+
+        let atomic = sysknife_core::distro::DistroId::FedoraSilverblue { version: 41 };
+        let result = check_plan_steps_distro(["GetMemoryInfo"].into_iter(), Some(&atomic));
+        assert!(
+            result.is_ok(),
+            "a generic action is generic on both families"
+        );
     }
 
     #[test]

--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -31,7 +31,9 @@ use sysknife_types::{DISTRO_FAMILY_DEBIAN, DISTRO_FAMILY_FEDORA, DISTRO_FAMILY_O
 pub const KNOWN_ACTIONS: &[(&str, &str)] = &[
     // Deployment and boot — no params
     ("GetSystemState",
-     "full rpm-ostree deployment snapshot: layered packages, pinned/staged deployments, booted/pending OSTree refs"),
+     "full rpm-ostree deployment snapshot: layered packages, pinned/staged deployments, booted/pending OSTree refs — Fedora/atomic only; on Ubuntu use GetHostState"),
+    ("GetHostState",
+     "what this host is: OS release, kernel, architecture, virtualization, machine identity (hostnamectl) — Ubuntu/Debian counterpart to GetSystemState, which reports deployments an apt host does not have"),
     ("CollectDiagnostics",
      "recent system journal log (last 500 lines) for error diagnosis and troubleshooting"),
     ("GetDeploymentHistory",

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -244,7 +244,7 @@ about what SysKnife has done, not about current system state.
    action: the update action differs per distro, and this example is shared by
    all of them.
 2. Call `propose_plan` with `ListJobHistory` if the user wants to see the full
-   log, or `GetSystemState` if the query answered the question and you just need
+   log, or `{STATE_ACTION}` if the query answered the question and you just need
    a plan to finish.
 
 Do NOT call `query_deployments` or `get_system_state` for this — those show
@@ -349,7 +349,7 @@ immediately, never a state query first.
 
 User: "what operating system and hardware am I running on?"
 
-This maps directly to `GetSystemState` — it returns an OS/hardware snapshot.
+This maps directly to `{STATE_ACTION}` — it returns an OS/hardware snapshot.
 Do NOT use `CollectDiagnostics`. That action gathers a support-level diagnostic
 bundle for when something is broken. It is the wrong tool for a general "show
 me my system" question.
@@ -363,10 +363,10 @@ me my system" question.
 ```json
 {
   "summary": "Show operating system and hardware information",
-  "explanation": "The user asked for an OS and hardware overview. GetSystemState returns exactly this. CollectDiagnostics is for support-level diagnostic bundles when something is broken — it is not the right action here.",
+  "explanation": "The user asked for an OS and hardware overview. {STATE_ACTION} returns exactly this. CollectDiagnostics is for support-level diagnostic bundles when something is broken — it is not the right action here.",
   "steps": [
     {
-      "action_name": "GetSystemState",
+      "action_name": "{STATE_ACTION}",
       "summary": "Get a snapshot of OS version, hardware, and overall system state",
       "risk_level": "low",
       "params": {}
@@ -378,9 +378,8 @@ me my system" question.
 ### Example F — date, time, timezone, and NTP queries
 
 **Key rule:** Any question about the current time, date, clock, or timezone →
-`GetDateTime`. Never `GetSystemState`. `GetSystemState` returns rpm-ostree
-deployment data (OS layers, pinned deployments, OSTree refs) — it does NOT
-return clock data.
+`GetDateTime`. Never `{STATE_ACTION}`. `{STATE_ACTION}` returns
+{STATE_RETURNS} — it does NOT return clock data.
 
 User: "what time is it?"
 User: "what is today's date?"
@@ -392,7 +391,7 @@ All four map directly to `GetDateTime`. Call `propose_plan` immediately:
 ```json
 {
   "summary": "Show the current date and time",
-  "explanation": "The user asked for the current time. GetDateTime runs timedatectl and returns the date, time, timezone, and NTP sync status. GetSystemState is for OS/deployment snapshots — not for clock queries.",
+  "explanation": "The user asked for the current time. GetDateTime runs timedatectl and returns the date, time, timezone, and NTP sync status. {STATE_ACTION} is for host/OS snapshots — not for clock queries.",
   "steps": [
     {
       "action_name": "GetDateTime",
@@ -405,7 +404,7 @@ All four map directly to `GetDateTime`. Call `propose_plan` immediately:
 ```
 
 **WRONG:**
-- use `GetSystemState` for a time query ← WRONG ACTION: it returns OSTree/rpm-ostree data, not clock data
+- use `{STATE_ACTION}` for a time query ← WRONG ACTION: it returns {STATE_RETURNS}, not clock data
 - call `get_system_state` (planning tool) first ← FORBIDDEN
 "#;
 
@@ -414,7 +413,7 @@ const CROSS_DISTRO_RISK_TABLES: &str = r#"
 
 ### Low risk — no approval required, always audited
 
-GetSystemState, CollectDiagnostics,
+{STATE_ACTION}, CollectDiagnostics,
 ListServices, GetServiceLogs, GetServiceStatus, ListTimers,
 GetNetworkStatus, GetDiskUsage, GetDateTime, ListProcesses, GetMemoryInfo,
 GetAuthorizedKeys, ListContainers, GetContainerInfo,
@@ -468,9 +467,9 @@ const CROSS_DISTRO_DISAMBIGUATION: &str = r#"
 - `GetDateTime` — returns the current date, time, timezone, and NTP sync
   status via `timedatectl`. Use for **any** question about the current time,
   date, clock, timezone, or NTP ("what time is it?", "what is today's date?",
-  "what timezone am I in?", "is NTP enabled?"). Do NOT use `GetSystemState`
+  "what timezone am I in?", "is NTP enabled?"). Do NOT use `{STATE_ACTION}`
   for time or date questions — it returns OS deployment data, not clock data.
-- `GetSystemState` — returns a high-level snapshot of OS version, kernel,
+- `{STATE_ACTION}` — returns a high-level snapshot of OS version, kernel,
   hardware, running service count, and overall health. Use for "what OS am I
   running?", "what hardware do I have?", "show me a system overview",
   "what is my system configuration?". This is the correct default for any
@@ -480,11 +479,11 @@ const CROSS_DISTRO_DISAMBIGUATION: &str = r#"
   service errors, hardware info, recent failures. Use ONLY when the user
   describes something broken ("something is wrong", "nothing is working",
   "generate a diagnostic report for support"). Do NOT use for general state
-  questions — `GetSystemState` is almost always the right choice there.
+  questions — `{STATE_ACTION}` is almost always the right choice there.
 
 **Decision rule:** if the user is asking *what time or date it is*, use
 `GetDateTime`. If the user is asking *what their system is*, use
-`GetSystemState`. If the user is asking *why something broke*, use
+`{STATE_ACTION}`. If the user is asking *why something broke*, use
 `CollectDiagnostics`.
 
 ## Service action disambiguation
@@ -503,7 +502,7 @@ const CROSS_DISTRO_PARAMS: &str = r#"
 These are the EXACT JSON param keys the daemon accepts. Use the key names
 below verbatim — the daemon rejects unknown or misspelled keys.
 
-**No params** — use `{}`: GetSystemState, CollectDiagnostics,
+**No params** — use `{}`: {STATE_ACTION}, CollectDiagnostics,
 ListServices, ListTimers, ReloadDaemon, GetDiskUsage, ListProcesses,
 GetMemoryInfo, GetDateTime, GetNetworkStatus,
 ListUsers, ListGroups.
@@ -623,7 +622,7 @@ Two additional tools let you manage user preferences:
 
 After calling `remember` or `forget`, you must still call `propose_plan` to
 finish. If the user's only intent was to save/remove a preference, propose a
-single `GetSystemState` low-risk step with a summary confirming the preference
+single `{STATE_ACTION}` low-risk step with a summary confirming the preference
 change.
 "#;
 
@@ -987,23 +986,61 @@ pub fn build_system_prompt(
 // Per-distro render functions
 // ---------------------------------------------------------------------------
 
+/// The action a given family answers "what is this host?" with.
+///
+/// The shared prompt blocks — the worked examples, the risk tables, the
+/// disambiguation rules — are empirically validated and must keep their wording.
+/// They also have to name an action that actually exists on the host. Fedora's
+/// `GetSystemState` reports rpm-ostree *deployments*, which an apt host does not
+/// have, so naming it in the Debian prompt is exactly what the family fence
+/// forbids (#181).
+///
+/// So the shared blocks carry placeholders and each renderer substitutes its own
+/// pair. `returns` is substituted as well as `name` because three of the
+/// occurrences justify their advice with rpm-ostree specifics — without it the
+/// Debian prompt would claim `GetHostState` "returns OSTree data".
+struct StateAction {
+    name: &'static str,
+    /// What it returns, phrased to drop into mid-sentence.
+    returns: &'static str,
+}
+
+const FEDORA_STATE_ACTION: StateAction = StateAction {
+    name: "GetSystemState",
+    returns: "rpm-ostree deployment data (OS layers, pinned deployments, OSTree refs)",
+};
+
+const DEBIAN_STATE_ACTION: StateAction = StateAction {
+    name: "GetHostState",
+    returns: "host identity data (OS release, kernel, architecture)",
+};
+
+/// Append a shared block with the per-family state action substituted in.
+fn push_shared(s: &mut String, block: &str, state: &StateAction) {
+    s.push_str(
+        &block
+            .replace("{STATE_ACTION}", state.name)
+            .replace("{STATE_RETURNS}", state.returns),
+    );
+}
+
 fn render_fedora_prompt(prefs: Option<&str>, hint: &sysknife_types::DistroHint) -> String {
     let version = hint.version.as_deref().unwrap_or("(version unknown)");
     let mut s = String::with_capacity(8192);
     s.push_str(PREAMBLE);
     s.push_str(SPOTLIGHTING_CLAUSE);
-    s.push_str(EXAMPLES);
-    s.push_str(CROSS_DISTRO_RISK_TABLES);
+    push_shared(&mut s, EXAMPLES, &FEDORA_STATE_ACTION);
+    push_shared(&mut s, CROSS_DISTRO_RISK_TABLES, &FEDORA_STATE_ACTION);
     s.push_str(FEDORA_RISK_TABLES);
-    s.push_str(CROSS_DISTRO_RISK_RULES);
+    push_shared(&mut s, CROSS_DISTRO_RISK_RULES, &FEDORA_STATE_ACTION);
     s.push_str(&FEDORA_HEADER.replacen("{}", version, 1));
     s.push_str(FEDORA_SELECTION_RULES);
     s.push_str(FEDORA_DISAMBIGUATION);
-    s.push_str(CROSS_DISTRO_DISAMBIGUATION);
-    s.push_str(CROSS_DISTRO_PARAMS);
+    push_shared(&mut s, CROSS_DISTRO_DISAMBIGUATION, &FEDORA_STATE_ACTION);
+    push_shared(&mut s, CROSS_DISTRO_PARAMS, &FEDORA_STATE_ACTION);
     s.push_str(FEDORA_PARAMS);
     s.push_str(CONSTRAINTS);
-    s.push_str(PREFERENCE_TOOLS);
+    push_shared(&mut s, PREFERENCE_TOOLS, &FEDORA_STATE_ACTION);
     append_prefs(&mut s, prefs);
     s
 }
@@ -1013,18 +1050,18 @@ fn render_debian_prompt(prefs: Option<&str>, hint: &sysknife_types::DistroHint) 
     let mut s = String::with_capacity(8192);
     s.push_str(PREAMBLE);
     s.push_str(SPOTLIGHTING_CLAUSE);
-    s.push_str(EXAMPLES);
-    s.push_str(CROSS_DISTRO_RISK_TABLES);
+    push_shared(&mut s, EXAMPLES, &DEBIAN_STATE_ACTION);
+    push_shared(&mut s, CROSS_DISTRO_RISK_TABLES, &DEBIAN_STATE_ACTION);
     s.push_str(DEBIAN_RISK_TABLES);
-    s.push_str(CROSS_DISTRO_RISK_RULES);
+    push_shared(&mut s, CROSS_DISTRO_RISK_RULES, &DEBIAN_STATE_ACTION);
     s.push_str(&DEBIAN_HEADER.replacen("{}", version, 1));
     s.push_str(DEBIAN_SELECTION_RULES);
     s.push_str(DEBIAN_COUNTERINTUITIVE);
-    s.push_str(CROSS_DISTRO_DISAMBIGUATION);
-    s.push_str(CROSS_DISTRO_PARAMS);
+    push_shared(&mut s, CROSS_DISTRO_DISAMBIGUATION, &DEBIAN_STATE_ACTION);
+    push_shared(&mut s, CROSS_DISTRO_PARAMS, &DEBIAN_STATE_ACTION);
     s.push_str(DEBIAN_PARAMS);
     s.push_str(CONSTRAINTS);
-    s.push_str(PREFERENCE_TOOLS);
+    push_shared(&mut s, PREFERENCE_TOOLS, &DEBIAN_STATE_ACTION);
     append_prefs(&mut s, prefs);
     s
 }
@@ -1033,14 +1070,14 @@ fn render_generic_prompt(prefs: Option<&str>) -> String {
     let mut s = String::with_capacity(4096);
     s.push_str(PREAMBLE);
     s.push_str(SPOTLIGHTING_CLAUSE);
-    s.push_str(EXAMPLES);
-    s.push_str(CROSS_DISTRO_RISK_TABLES);
-    s.push_str(CROSS_DISTRO_RISK_RULES);
+    push_shared(&mut s, EXAMPLES, &FEDORA_STATE_ACTION);
+    push_shared(&mut s, CROSS_DISTRO_RISK_TABLES, &FEDORA_STATE_ACTION);
+    push_shared(&mut s, CROSS_DISTRO_RISK_RULES, &FEDORA_STATE_ACTION);
     s.push_str(GENERIC_HEADER);
-    s.push_str(CROSS_DISTRO_DISAMBIGUATION);
-    s.push_str(CROSS_DISTRO_PARAMS);
+    push_shared(&mut s, CROSS_DISTRO_DISAMBIGUATION, &FEDORA_STATE_ACTION);
+    push_shared(&mut s, CROSS_DISTRO_PARAMS, &FEDORA_STATE_ACTION);
     s.push_str(CONSTRAINTS);
-    s.push_str(PREFERENCE_TOOLS);
+    push_shared(&mut s, PREFERENCE_TOOLS, &FEDORA_STATE_ACTION);
     append_prefs(&mut s, prefs);
     s
 }
@@ -1204,6 +1241,47 @@ mod tests {
             leaked.is_empty(),
             "the Debian prompt names Fedora-only actions: {leaked:?}"
         );
+    }
+
+    /// The shared blocks carry `{STATE_ACTION}` / `{STATE_RETURNS}` placeholders.
+    /// A renderer that forgot to substitute would ship the literal brace text to
+    /// the model, and every test above would still pass — none of them look for
+    /// it. This is the one that would catch it.
+    #[test]
+    fn no_rendered_prompt_leaks_an_unsubstituted_placeholder() {
+        let prompts = [
+            ("debian", build_system_prompt(None, Some(&debian_hint()))),
+            ("fedora", build_system_prompt(None, Some(&fedora_hint()))),
+            ("generic", build_system_prompt(None, None)),
+        ];
+        for (name, p) in prompts {
+            assert!(
+                !p.contains("{STATE_ACTION}") && !p.contains("{STATE_RETURNS}"),
+                "the {name} prompt shipped an unsubstituted placeholder"
+            );
+        }
+    }
+
+    /// Each family must name its own state action, and only its own. Fencing
+    /// GetSystemState is only half the fix — the Debian prompt has to positively
+    /// name the replacement, or the model is left with no way to answer "what is
+    /// this host?" at all (#181).
+    #[test]
+    fn each_family_prompt_names_its_own_state_action() {
+        let debian = build_system_prompt(None, Some(&debian_hint()));
+        assert!(
+            debian.contains("GetHostState"),
+            "the Debian prompt must name the action that replaces GetSystemState"
+        );
+        assert!(!debian.contains("GetSystemState"));
+        assert!(
+            !debian.contains("rpm-ostree deployment data"),
+            "the Debian prompt must not justify its state action with rpm-ostree semantics"
+        );
+
+        let fedora = build_system_prompt(None, Some(&fedora_hint()));
+        assert!(fedora.contains("GetSystemState"));
+        assert!(!fedora.contains("GetHostState"));
     }
 
     /// Same, for the planner-preference list: an action the Debian tool schema

--- a/crates/sysknife-core/src/action_family.rs
+++ b/crates/sysknife-core/src/action_family.rs
@@ -30,17 +30,20 @@
 /// `rpm-ostree` and is missing from this list fails the build rather than being
 /// quietly offered to an apt host.
 ///
-/// One documented exception: `GetSystemState` also runs `rpm-ostree status`, but
-/// it is woven through fifteen places in the shared, empirically-validated prompt
-/// blocks as *the* state action, with no Ubuntu equivalent to put in its place.
-/// Fencing it needs a prompt restructure validated against the story suite, so it
-/// is tracked separately rather than done blind.
+/// There are no exceptions. `GetSystemState` was the last one: it runs
+/// `rpm-ostree status --json` and was reachable from every host because it was
+/// woven through the shared prompt blocks as *the* state action, with nothing on
+/// the Ubuntu side to put in its place. `GetHostState` is now that counterpart,
+/// so the fence is complete and `UNFENCED_BY_DECISION` is empty (#181).
 ///
 /// Flatpak is deliberately NOT in here: the un-prefixed `InstallFlatpak` family
 /// covers remotes, search, and app info, which the `Ubuntu*Flatpak` actions do
 /// not, so scoping it to Fedora would remove capability from Ubuntu rather than
 /// redirect it.
 pub const FEDORA_ONLY_ACTIONS: &[&str] = &[
+    // Reports rpm-ostree *deployments*, which an apt host does not have. Its
+    // Debian counterpart is `GetHostState`.
+    "GetSystemState",
     "AddLayeredPackage",
     "RemoveLayeredPackage",
     "ReplaceLayeredPackage",
@@ -107,6 +110,9 @@ pub const NON_CANONICAL_ON_DEBIAN: &[&str] = &[
 /// Grouped by underlying tool: apt, snap, ufw, distrobox, netplan, grub, plus
 /// the Ubuntu-only tiers (AppArmor, cloud-init, flatpak, fail2ban, Pro, …).
 pub const DEBIAN_ONLY_ACTIONS: &[&str] = &[
+    // The Debian answer to "what is this host?" — counterpart to Fedora's
+    // `GetSystemState`, which describes deployments an apt host has none of.
+    "GetHostState",
     "AptUpdate",
     "AptUpgrade",
     "AptInstall",

--- a/crates/sysknife-daemon/src/actions/system_info.rs
+++ b/crates/sysknife-daemon/src/actions/system_info.rs
@@ -2,7 +2,7 @@ use super::{command_mechanism, ActionSpec};
 use sysknife_types::RiskLevel;
 
 pub fn specs() -> Vec<ActionSpec> {
-    vec![get_memory_info_spec()]
+    vec![get_memory_info_spec(), get_host_state()]
 }
 
 pub fn get_memory_info_spec() -> ActionSpec {
@@ -12,5 +12,53 @@ pub fn get_memory_info_spec() -> ActionSpec {
         risk_level: RiskLevel::Low,
         reboot_required: false,
         rollback_available: false,
+    }
+}
+
+/// The Debian-family answer to "what is this host?" — the counterpart to
+/// Fedora's `GetSystemState`.
+///
+/// `GetSystemState` runs `rpm-ostree status --json`, which describes *deployments*.
+/// An apt host has no deployments to snapshot, which is why it had no equivalent
+/// and why `GetSystemState` was left running on every host — failing on Ubuntu
+/// with `command not found`, *after* the operator had already approved it (#181).
+///
+/// `hostnamectl status` is the closest honest analogue: one read-only command,
+/// no root, present on every systemd Ubuntu, reporting the OS release, kernel,
+/// architecture, virtualization and machine identity. The two other facts the
+/// issue floated — pending reboot and upgradable count — already have their own
+/// actions (`CheckPendingReboot`, `AptListUpgradable`), so folding them in here
+/// would have meant a shell pipeline and a second answer to a question already
+/// answered. One action, one mechanism.
+pub fn get_host_state() -> ActionSpec {
+    ActionSpec {
+        action_name: "GetHostState",
+        mechanism: command_mechanism("hostnamectl", ["status"]),
+        risk_level: RiskLevel::Low,
+        reboot_required: false,
+        rollback_available: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::ActionMechanism;
+
+    /// Read-only and root-free: this is the action a plan reaches for before it
+    /// knows anything about the host, so it must never need privilege.
+    #[test]
+    fn get_host_state_is_a_read_only_unprivileged_query() {
+        let spec = get_host_state();
+        assert_eq!(spec.risk_level, RiskLevel::Low);
+        assert!(!spec.reboot_required);
+        match &spec.mechanism {
+            ActionMechanism::Command { program, args } => {
+                assert_eq!(*program, "hostnamectl");
+                assert_eq!(args, &["status".to_string()]);
+                assert_ne!(*program, "sudo", "a state query must not need root");
+            }
+            other => panic!("expected Command, got {other:?}"),
+        }
     }
 }

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -3922,7 +3922,7 @@ mod tests {
                 &serde_json::to_vec(&json!({
                     "type": "preview",
                     "request_id": "details-preview",
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {}
                 }))
                 .unwrap(),
@@ -3946,7 +3946,7 @@ mod tests {
         let details: Value = serde_json::from_slice(&framed.recv().await.unwrap()).unwrap();
         assert_eq!(details["type"], "approval_details_response");
         assert_eq!(details["transaction_id"], transaction_id);
-        assert_eq!(details["action_name"], "GetSystemState");
+        assert_eq!(details["action_name"], "GetMemoryInfo");
         assert_eq!(details["preview"]["risk_level"], "low");
         assert!(!details["preview"]["summary"].as_str().unwrap().is_empty());
     }
@@ -3986,7 +3986,7 @@ mod tests {
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, _) =
-            preview_and_approve(&mut framed, "GetSystemState", json!({})).await;
+            preview_and_approve(&mut framed, "GetMemoryInfo", json!({})).await;
 
         framed
             .send(
@@ -4031,7 +4031,7 @@ mod tests {
                 &serde_json::to_vec(&json!({
                     "type": "preview",
                     "request_id": "preview-forge",
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {},
                 }))
                 .unwrap(),
@@ -4091,7 +4091,7 @@ mod tests {
                 &serde_json::to_vec(&json!({
                     "type": "preview",
                     "request_id": "preview-hist",
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {},
                 }))
                 .unwrap(),
@@ -4116,7 +4116,7 @@ mod tests {
         assert_eq!(response["type"], "history_response");
         let entries = response["entries"].as_array().expect("entries array");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0]["action_name"], "GetSystemState");
+        assert_eq!(entries[0]["action_name"], "GetMemoryInfo");
         assert!(
             !entries[0]["created_at"].as_str().unwrap_or("").is_empty(),
             "created_at must be populated over the structured IPC"
@@ -4196,7 +4196,7 @@ mod tests {
                 &serde_json::to_vec(&json!({
                     "type": "preview",
                     "request_id": "preview-cancel",
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {},
                 }))
                 .unwrap(),
@@ -4249,7 +4249,7 @@ mod tests {
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, receipt) =
-            preview_and_approve(&mut framed, "GetSystemState", json!({})).await;
+            preview_and_approve(&mut framed, "GetMemoryInfo", json!({})).await;
         // Claim it (Queued -> Running) so it is in-flight from the store's view.
         assert!(state
             .audit
@@ -4324,7 +4324,7 @@ mod tests {
                 &serde_json::to_vec(&json!({
                     "type": "preview",
                     "request_id": "preview-undelivered",
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {},
                 }))
                 .unwrap(),
@@ -4380,7 +4380,7 @@ mod tests {
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, receipt) =
-            preview_and_approve(&mut framed, "GetSystemState", json!({})).await;
+            preview_and_approve(&mut framed, "GetMemoryInfo", json!({})).await;
         assert!(state
             .audit
             .claim_approved_for_execution(&transaction_id, &receipt_digest(&receipt))
@@ -4487,7 +4487,7 @@ mod tests {
             vec![json!({
                 "type": "preview",
                 "request_id": "r-principal",
-                "action_name": "GetSystemState",
+                "action_name": "GetMemoryInfo",
                 "params": {}
             })],
             1,
@@ -4520,7 +4520,7 @@ mod tests {
             vec![json!({
                 "type": "preview",
                 "request_id": "r1",
-                "action_name": "GetSystemState",
+                "action_name": "GetMemoryInfo",
                 "params": {}
             })],
             1,
@@ -4743,7 +4743,7 @@ mod tests {
             vec![json!({
                 "type": "preview",
                 "request_id": "r1",
-                "action_name": "GetSystemState",
+                "action_name": "GetMemoryInfo",
                 "params": {}
             })],
             1,
@@ -4970,7 +4970,7 @@ mod tests {
                 "type": "execute",
                 "request_id": "r1",
                 "transaction_id": "missing-transaction",
-                "action_name": "GetSystemState",
+                "action_name": "GetMemoryInfo",
                 "params": {},
                 "approval_receipt": "unissued-receipt"
             })],
@@ -5057,7 +5057,7 @@ mod tests {
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, receipt) =
-            preview_and_approve(&mut framed, "GetSystemState", json!({})).await;
+            preview_and_approve(&mut framed, "GetMemoryInfo", json!({})).await;
 
         framed
             .send(
@@ -5178,7 +5178,7 @@ mod tests {
         let preview_req = json!({
             "type": "preview",
             "request_id": "r1",
-            "action_name": "GetSystemState",
+            "action_name": "GetMemoryInfo",
             "params": {}
         });
         framed
@@ -5197,7 +5197,7 @@ mod tests {
             "type": "execute",
             "request_id": "r2",
             "transaction_id": transaction_id,
-            "action_name": "GetSystemState",
+            "action_name": "GetMemoryInfo",
             "params": {},
             "approval_receipt": receipt
         });
@@ -5393,7 +5393,7 @@ mod tests {
                 &serde_json::to_vec(&json!({
                     "type": "preview",
                     "request_id": "r1",
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {}
                 }))
                 .unwrap(),
@@ -5410,7 +5410,7 @@ mod tests {
                     "type": "execute",
                     "request_id": "r2",
                     "transaction_id": transaction_id,
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {},
                     "approval_receipt": receipt
                 }))
@@ -5483,7 +5483,7 @@ mod tests {
                 &serde_json::to_vec(&json!({
                     "type": "preview",
                     "request_id": "preview-once",
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {}
                 }))
                 .unwrap(),
@@ -5518,7 +5518,7 @@ mod tests {
                     "type": "execute",
                     "request_id": request_id,
                     "transaction_id": transaction_id,
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {},
                     "approval_receipt": approval_receipt
                 }))
@@ -5630,7 +5630,7 @@ mod tests {
                 &serde_json::to_vec(&json!({
                     "type": "preview",
                     "request_id": "r1",
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {}
                 }))
                 .unwrap(),
@@ -5651,7 +5651,7 @@ mod tests {
                     "type": "execute",
                     "request_id": "r2",
                     "transaction_id": transaction_id,
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {},
                     "approval_receipt": approval_receipt
                 }))
@@ -5680,7 +5680,7 @@ mod tests {
                     "type": "execute",
                     "request_id": "r3-replay",
                     "transaction_id": transaction_id,
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {},
                     "approval_receipt": approval_receipt
                 }))
@@ -5823,14 +5823,14 @@ mod tests {
         });
         let mut framed = FramedStream::new(client);
         let (transaction_id, receipt) =
-            preview_and_approve(&mut framed, "GetSystemState", json!({})).await;
+            preview_and_approve(&mut framed, "GetMemoryInfo", json!({})).await;
         framed
             .send(
                 &serde_json::to_vec(&json!({
                     "type": "execute",
                     "request_id": "execute-fast-progress",
                     "transaction_id": transaction_id,
-                    "action_name": "GetSystemState",
+                    "action_name": "GetMemoryInfo",
                     "params": {},
                     "approval_receipt": receipt,
                 }))

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -1309,6 +1309,7 @@ pub fn build_action_spec(action_name: &str, params: &Value) -> Result<ActionSpec
 
         // ── System info ──────────────────────────────────────────────────
         "GetMemoryInfo" => Ok(system_info::get_memory_info_spec()),
+        "GetHostState" => Ok(system_info::get_host_state()),
 
         // ── Network ───────────────────────────────────────────────────────
         "GetFirewallState" => Ok(network::get_firewall_state()),

--- a/crates/sysknife-daemon/src/preview.rs
+++ b/crates/sysknife-daemon/src/preview.rs
@@ -115,6 +115,7 @@ pub fn gate_risk(action_name: &str) -> RiskLevel {
 fn preview_profile(action_name: &str) -> PreviewProfile {
     match action_name {
         "GetSystemState"
+        | "GetHostState"
         | "CollectDiagnostics"
         | "GetDeploymentHistory"
         | "ListDeployments"

--- a/crates/sysknife-daemon/tests/action_consistency.rs
+++ b/crates/sysknife-daemon/tests/action_consistency.rs
@@ -367,17 +367,16 @@ fn mentions_tool(text: &str, tool: &str) -> bool {
         .any(|word| word == tool)
 }
 
-/// The one action whose mechanism says Fedora but which is deliberately not
-/// fenced, with the reason, so the exception is visible and cannot grow.
+/// Actions whose mechanism says one family but which are deliberately not
+/// fenced, with the reason, so every exception is visible and cannot grow.
 ///
-/// `GetSystemState` runs `rpm-ostree status --json`, so on an apt host it fails —
-/// today at execution, with `command not found`. Fencing it is the right end
-/// state, but it appears in fifteen places across the *shared* prompt blocks as
-/// the state action every worked example reaches for, and Ubuntu has no
-/// equivalent to put in those places. Restructuring empirically-validated prompt
-/// examples requires an E2E story run to confirm, so it is tracked as its own
-/// change rather than smuggled into this one.
-const UNFENCED_BY_DECISION: &[&str] = &["GetSystemState"];
+/// **Empty, and meant to stay that way.** It last held `GetSystemState`, which
+/// ran `rpm-ostree status --json` on every host and so failed on apt *after* the
+/// operator had approved it (#181). It could not simply be fenced, because it
+/// appeared throughout the shared prompt blocks as the action every worked
+/// example reaches for and Ubuntu had nothing to put in its place. Ubuntu now
+/// has `GetHostState`, so the fence covers every action with no exemptions.
+const UNFENCED_BY_DECISION: &[&str] = &[];
 
 #[test]
 fn family_fence_agrees_with_each_action_s_mechanism() {

--- a/crates/sysknife-daemon/tests/connection_deadline.rs
+++ b/crates/sysknife-daemon/tests/connection_deadline.rs
@@ -119,7 +119,7 @@ async fn a_served_connection_still_accepts_a_second_request() {
         let req = json!({
             "type": "preview",
             "request_id": request_id,
-            "action_name": "GetSystemState",
+            "action_name": "GetMemoryInfo",
             "params": {},
         });
         client

--- a/crates/sysknife-daemon/tests/lifecycle_events.rs
+++ b/crates/sysknife-daemon/tests/lifecycle_events.rs
@@ -178,13 +178,13 @@ fn progress_lines(messages: &[Value]) -> Vec<String> {
 // ---------------------------------------------------------------------------
 
 /// Verify the full sequence of lifecycle events during execution of a
-/// command-type action (`GetSystemState` runs `rpm-ostree status --json`).
+/// command-type action (`GetMemoryInfo` runs `free -h`).
 ///
 /// Expected lifecycle progress events (in order, among potentially other
 /// stdout progress lines):
-///   1. "Authorization passed for GetSystemState"
-///   2. "Executing GetSystemState..."
-///   3. "GetSystemState completed with exit code ..."
+///   1. "Authorization passed for GetMemoryInfo"
+///   2. "Executing GetMemoryInfo..."
+///   3. "GetMemoryInfo completed with exit code ..."
 ///
 /// The command may succeed or fail depending on whether rpm-ostree is
 /// installed; the test only asserts on lifecycle event presence and order.
@@ -194,10 +194,10 @@ async fn command_action_streams_lifecycle_events() {
     let state = test_state(&dir);
     let mut framed = spawn_handler(state).await;
 
-    let (transaction_id, receipt) = preview_action(&mut framed, "GetSystemState", json!({})).await;
+    let (transaction_id, receipt) = preview_action(&mut framed, "GetMemoryInfo", json!({})).await;
     execute_action(
         &mut framed,
-        "GetSystemState",
+        "GetMemoryInfo",
         json!({}),
         &transaction_id,
         &receipt,
@@ -218,13 +218,13 @@ async fn command_action_streams_lifecycle_events() {
     assert!(
         lines
             .iter()
-            .any(|l| l.contains("Authorization passed for GetSystemState")),
+            .any(|l| l.contains("Authorization passed for GetMemoryInfo")),
         "should have authorization passed event; got: {lines:?}"
     );
 
     // Verify executing event.
     assert!(
-        lines.iter().any(|l| l.contains("Executing GetSystemState")),
+        lines.iter().any(|l| l.contains("Executing GetMemoryInfo")),
         "should have executing event; got: {lines:?}"
     );
 
@@ -232,7 +232,7 @@ async fn command_action_streams_lifecycle_events() {
     assert!(
         lines
             .iter()
-            .any(|l| l.contains("GetSystemState completed with")),
+            .any(|l| l.contains("GetMemoryInfo completed with")),
         "should have completed event; got: {lines:?}"
     );
 
@@ -243,11 +243,11 @@ async fn command_action_streams_lifecycle_events() {
         .unwrap();
     let exec_idx = lines
         .iter()
-        .position(|l| l.contains("Executing GetSystemState"))
+        .position(|l| l.contains("Executing GetMemoryInfo"))
         .unwrap();
     let done_idx = lines
         .iter()
-        .position(|l| l.contains("GetSystemState completed with"))
+        .position(|l| l.contains("GetMemoryInfo completed with"))
         .unwrap();
     assert!(
         auth_idx < exec_idx,

--- a/crates/sysknife-daemon/tests/preview_approval.rs
+++ b/crates/sysknife-daemon/tests/preview_approval.rs
@@ -18,7 +18,7 @@ fn request(action_name: &str, request_id: &str, request_hash: &str) -> RequestEn
 #[test]
 fn low_risk_preview_is_read_only_and_requires_no_reboot() {
     let preview = preview_action(
-        &request("GetSystemState", "req-low", "hash-low"),
+        &request("GetMemoryInfo", "req-low", "hash-low"),
         json!({"host_name": "silverblue"}),
         json!({}),
     );

--- a/crates/sysknife-daemon/tests/preview_state_warning.rs
+++ b/crates/sysknife-daemon/tests/preview_state_warning.rs
@@ -58,7 +58,7 @@ async fn preview_warns_when_state_collection_fails() {
     let req = json!({
         "type": "preview",
         "request_id": "preview-warn-1",
-        "action_name": "GetSystemState",
+        "action_name": "GetMemoryInfo",
         "params": {},
     });
     framed

--- a/crates/sysknife-daemon/tests/rollback.rs
+++ b/crates/sysknife-daemon/tests/rollback.rs
@@ -341,7 +341,7 @@ async fn failed_rollback_leaves_status_as_failed() {
 }
 
 /// Actions without `rollback_available: true` must NOT trigger rollback,
-/// even if they fail. `GetSystemState` is a Low-risk read-only action.
+/// even if they fail. `GetMemoryInfo` is a Low-risk read-only action.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn non_rollbackable_action_does_not_trigger_rollback() {
     let dir = tempdir().unwrap();
@@ -351,11 +351,11 @@ async fn non_rollbackable_action_does_not_trigger_rollback() {
     let executor: Arc<dyn ActionExecutor> = Arc::new(FailBothExecutor);
     let mut framed = spawn_handler_with_executor(state, executor).await;
 
-    // Preview GetSystemState (Low risk, no rollback).
+    // Preview GetMemoryInfo (Low risk, no rollback).
     let preview_req = json!({
         "type": "preview",
         "request_id": "no-rollback-preview",
-        "action_name": "GetSystemState",
+        "action_name": "GetMemoryInfo",
         "params": {}
     });
     framed
@@ -385,7 +385,7 @@ async fn non_rollbackable_action_does_not_trigger_rollback() {
         "type": "execute",
         "request_id": "no-rollback-execute",
         "transaction_id": transaction_id,
-        "action_name": "GetSystemState",
+        "action_name": "GetMemoryInfo",
         "params": {},
         "approval_receipt": receipt
     });
@@ -397,9 +397,9 @@ async fn non_rollbackable_action_does_not_trigger_rollback() {
     let (_messages, completed) = drain_until_completed(&mut framed).await;
 
     let status = completed["result"]["status"].as_str().unwrap();
-    // GetSystemState uses `rpm-ostree status --json`. If rpm-ostree is not installed,
-    // the command fails. The point of this test is that rollback is NOT triggered.
-    // Accept either "succeeded" or "failed" — just not "rolled_back".
+    // GetMemoryInfo runs `free -h`, which is present on every host, so this
+    // normally succeeds. Either way the point of the test is that rollback is
+    // NOT triggered: accept "succeeded" or "failed", just not "rolled_back".
     assert_ne!(
         status, "rolled_back",
         "non-rollbackable action must never produce rolled_back status"

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -127,6 +127,7 @@ pub const KNOWN_ACTION_NAMES: &[&str] = &[
     "ListProcesses",
     "SignalProcess",
     "GetMemoryInfo",
+    "GetHostState",
     // Observability / journald (cross-distro)
     "GetJournalLog",
     "VacuumJournal",

--- a/docs/action-reference.md
+++ b/docs/action-reference.md
@@ -9,7 +9,7 @@ Every row is derived from the live code: the command from each action's `ActionS
 
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
-| `GetSystemState` | `rpm-ostree status --json` | Low | All | – | – | full rpm-ostree deployment snapshot: layered packages, pinned/staged deployments, booted/pending OSTree refs |
+| `GetSystemState` | `rpm-ostree status --json` | Low | Fedora | – | – | full rpm-ostree deployment snapshot: layered packages, pinned/staged deployments, booted/pending OSTree refs — Fedora/atomic only; on Ubuntu use GetHostState |
 | `CollectDiagnostics` | `journalctl -b -n 500 --no-pager` | Low | All | – | – | recent system journal log (last 500 lines) for error diagnosis and troubleshooting |
 | `GetDeploymentHistory` | `rpm-ostree status --json` | Low | Fedora | – | – | rpm-ostree deployment history: past and current OSTree commits with timestamps |
 | `ListDeployments` | `rpm-ostree status --json` | Low | Fedora | – | – | list all currently staged, pending, and booted deployments |
@@ -239,6 +239,7 @@ Every row is derived from the live code: the command from each action's `ActionS
 | Action | Command | Risk | Distro | Rb | Ro | Description |
 |---|---|---|---|---|---|---|
 | `GetMemoryInfo` | `free -h` | Low | All | – | – | show RAM and swap usage (free -h) — no params |
+| `GetHostState` | `hostnamectl status` | Low | Ubuntu | – | – | what this host is: OS release, kernel, architecture, virtualization, machine identity (hostnamectl) — Ubuntu/Debian counterpart to GetSystemState, which reports deployments an apt host does not have |
 
 ## Containers
 
@@ -395,4 +396,4 @@ Every row is derived from the live code: the command from each action's `ActionS
 
 ---
 
-_188 actions have an `ActionSpec` and are tabled above. The full catalogue (`KNOWN_ACTION_NAMES`) also includes `ListJobHistory`, which the dispatcher handles before the executor, for **189** total._
+_189 actions have an `ActionSpec` and are tabled above. The full catalogue (`KNOWN_ACTION_NAMES`) also includes `ListJobHistory`, which the dispatcher handles before the executor, for **190** total._

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,723 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,727 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -140,7 +140,7 @@ flow.
 
 ## Status
 
-189 typed actions · 1,723 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,727 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/e2e/cassettes/ubuntu-jammy-gpt-oss-120b.json
+++ b/tests/e2e/cassettes/ubuntu-jammy-gpt-oss-120b.json
@@ -5,894 +5,56 @@
       "groq/openai/gpt-oss-120b"
     ],
     "system_prompt_sha256": [
-      "aae976f60a093fef5c4bdc6a889da86d0284908ea05290af764b660bea55f0a4",
-      "f8c3cbc09ddbd982b1efef0423b1a6a29d94849fe6b17df470faec4c9fd41b11"
+      "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336"
     ]
   },
   "entries": {
-    "groq/openai/gpt-oss-120b:00a4a8dd62b23e9e67dfa08148bdefabf6effbc2b4450c95bb82183469a66440": {
+    "groq/openai/gpt-oss-120b:03a698fc81e1b7beab7285bbc08abeee024db4aefec4f5a9bcaa1849f57e12f3": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_c4ab3be4-6c08-47bd-9064-a731732a4fba",
+              "id": "fc_f3ed28b5-ce62-4298-a140-04e43afbfb92",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to stop the chromium snap from auto-updating. SnapHold will hold the current snap revision, preventing automatic refreshes. This is a medium‑risk action because it modifies snap refresh behavior.",
-                "steps": [
-                  {
-                    "action_name": "SnapHold",
-                    "params": "{\"name\":\"chromium\"}",
-                    "risk_level": "medium",
-                    "summary": "Hold the chromium snap at its current version to stop auto-updating"
-                  }
-                ],
-                "summary": "Pin the chromium snap to prevent automatic updates"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:04d69a90f405ce834874e6e2300c24c422a58cd5eeddd9f9ec65ad9db3b9e660": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_78fb22c0-30b1-447c-8191-27eabff62135",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to know if the ufw firewall is enabled and which ports are currently allowed. The UfwStatus action provides the firewall enabled state and the list of open ports/rules. This is a low‑risk, read‑only query.",
-                "steps": [
-                  {
-                    "action_name": "UfwStatus",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Show ufw enabled/disabled state and currently open ports"
-                  }
-                ],
-                "summary": "Check Ubuntu firewall status and list open ports"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:0544fd21858f1fdc541eed731192bd3175106dd902e386502a1b0901c03647de": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:076f16fcbd5ee2b3c1cfa394899d36b07c49cd790e2f4495175959814e2c9080": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_3ecdec76-9479-48e3-b45e-1678e5af56e0",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to bring all packages up to date. This will run AptUpgrade, which upgrades every installed package on the Ubuntu system. This operation is high risk because it may affect many services and could require a reboot.",
-                "steps": [
-                  {
-                    "action_name": "AptUpgrade",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Upgrade all installed packages to their latest versions"
-                  }
-                ],
-                "summary": "Upgrade all installed packages to the latest versions"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:0c22a802d63c754eae03dc50e2c08654f16ab7b944b9cccf0ab5abe7d66e4c97": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_433019f7-e8aa-4cc9-80ee-cd403cd45efa",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested updating all snaps. SnapRefresh without a name updates every installed snap to the newest revision. This is a medium-risk operation as it modifies installed software.",
-                "steps": [
-                  {
-                    "action_name": "SnapRefresh",
-                    "params": "{}",
-                    "risk_level": "medium",
-                    "summary": "Refresh all snaps to the latest available versions"
-                  }
-                ],
-                "summary": "Refresh all installed snap packages to their latest versions"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:0e02541d164ec66e6d2aa5b72c1677be9fa48b4e96951775c19275746d0c2d32": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_51af9b69-5a5f-401e-97de-e3093f580d2b",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested information about the lxd snap. SnapInfo provides metadata such as version, channel, description, and confinement for the specified snap. This is a read‑only low‑risk action.",
-                "steps": [
-                  {
-                    "action_name": "SnapInfo",
-                    "params": "{\"name\":\"lxd\"}",
-                    "risk_level": "low",
-                    "summary": "Retrieve detailed information for the lxd snap"
-                  }
-                ],
-                "summary": "Show details about the lxd snap"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:104a22e70b55e493d103e6a05d4d63aa337ed67e5c6431ca3ea3f9915fafa270": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_fa15b8e2-5137-4ccd-b06e-3af7bd3cb895",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to know whether the openssh-server package is present and its version. AptShow returns package details including installed version on Ubuntu systems.",
+                "explanation": "The user wants to know which version of curl is available in the apt repository. AptShow provides package details including the version without making any changes.",
                 "steps": [
                   {
                     "action_name": "AptShow",
-                    "params": "{\"package\":\"openssh-server\"}",
+                    "params": "{\"package\":\"curl\"}",
                     "risk_level": "low",
-                    "summary": "Show details of the openssh-server package, including installed version"
+                    "summary": "Show details of the curl package, including its available version"
                   }
                 ],
-                "summary": "Check if openssh-server is installed and show its version"
+                "summary": "Show available curl package version"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "36aa9a54a7d0e19e159fe4de276e8e83b1e9f7a1ea403560442edd6eae3faefe"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:12d96934367d7c03773975df00b722595334947acc02caff7cd0151bb9a835c7": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:14dc2495309ebecd0ec5160d9a0cb86e32a2c02d712d7a71c8c823669dab5172": {
+    "groq/openai/gpt-oss-120b:07928944be35b28fd820e3eae322b95687b21dec5c5c72629ac8192a25d63d53": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_7d9054b8-77c3-4d63-8630-3f5f7487e0e9",
+              "id": "fc_1177ef76-dcba-4790-9df5-17f459b1bad6",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested to revert all UFW firewall rules back to their default state. This will remove all existing rules and restore the default policy, which is a high-risk operation that may affect network access.",
-                "steps": [
-                  {
-                    "action_name": "UfwReset",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Reset all UFW firewall rules to default settings"
-                  }
-                ],
-                "summary": "Reset UFW firewall rules to defaults"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:1515064176045f3115c22ebd6c4487cbe66079a0192ff032940d9cc63abcdbbf": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_8c0b0424-1ed4-4f61-804a-00ce78d53020",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user asked to see the existing Distrobox containers. DistroboxList returns a read‑only list of containers, requiring no parameters and no approval.",
-                "steps": [
-                  {
-                    "action_name": "DistroboxList",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "List all Distrobox containers on the system"
-                  }
-                ],
-                "summary": "List all Distrobox containers"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:1a2ef89853af0a7b6f572b9806fadaa4e7d4de04814e7c84f649259d94f1e4b2": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_84ac1e45-496f-45e1-9433-cfa48a920a09",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested installing the 'code' snap using the beta release channel. SnapInstall will fetch and install that snap from the specified channel. This is a medium‑risk operation because it changes installed software.",
-                "steps": [
-                  {
-                    "action_name": "SnapInstall",
-                    "params": "{\"name\":\"code\",\"channel\":\"beta\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the 'code' snap from the beta channel"
-                  }
-                ],
-                "summary": "Install the code snap from the beta channel"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:1a99b3cdcb3e745d31d55a9f04d1691bb56625230a52a0b008531b39e8144cd3": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_c42eb05e-86db-4493-9823-422f3e26fbdd",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested installation of nginx on this Ubuntu system. AptInstall will download and install the package, handling dependencies automatically. This is a medium‑risk action as it modifies the system package set.",
-                "steps": [
-                  {
-                    "action_name": "AptInstall",
-                    "params": "{\"package\":\"nginx\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the nginx package via apt"
-                  }
-                ],
-                "summary": "Install the nginx web server package"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:1c300d4f26b968eac8079371ef910d5aa17f71f0b88e418947628d56477a0f7d": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_ca327c6d-28b4-4471-854a-ff0d9e5b2982",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to find APT packages related to Docker. AptSearch performs a read‑only search of the package database using the provided term, which satisfies the request without making any changes.",
-                "steps": [
-                  {
-                    "action_name": "AptSearch",
-                    "params": "{\"term\":\"docker\"}",
-                    "risk_level": "low",
-                    "summary": "Search APT package list for packages matching the term 'docker'"
-                  }
-                ],
-                "summary": "Search for Docker packages in APT repositories"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:1cc15e9aff77de332f802762f035cec4e860c6814b1ed4f9cf4bd94fd4b842bb": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_e4d70276-78bd-42cc-8508-779243701539",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to freeze the postgresql package so it won't be upgraded. Using AptHold will mark the package as held, preventing apt from upgrading it until the hold is removed.",
-                "steps": [
-                  {
-                    "action_name": "AptHold",
-                    "params": "{\"package\":\"postgresql\"}",
-                    "risk_level": "medium",
-                    "summary": "Mark the postgresql package as held to block upgrades"
-                  }
-                ],
-                "summary": "Hold the PostgreSQL package to prevent upgrades"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:1cd38b01faac7c1e19ceb968a136816d3c0fc8b0b44dd733e94e7c4d25a78b28": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_88fbe6e1-a00c-41b3-a21a-9937d30319a0",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested cleaning up unnecessary packages. AptAutoremove will remove any orphaned dependency packages that are no longer required by any installed package. This is a low‑risk operation that frees disk space without affecting needed software.",
-                "steps": [
-                  {
-                    "action_name": "AptAutoremove",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Automatically remove orphaned packages"
-                  }
-                ],
-                "summary": "Remove orphaned packages that are no longer needed"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:1ef10dd3d25d7fb734126e3d04e88e05e21d3b1fcc5bd093570dd9b501546554": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_a154a987-7c54-453c-9a8c-591b2fedc7a9",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to allow inbound traffic for the 'Nginx Full' profile in the UFW firewall. Adding this rule enables HTTP and HTTPS traffic as defined by the profile.",
-                "steps": [
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"Nginx Full\"}",
-                    "risk_level": "high",
-                    "summary": "Add a firewall rule to allow the Nginx Full profile"
-                  }
-                ],
-                "summary": "Allow Nginx Full profile in UFW"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:22f1201c870c08f49ecc66d2b9a655a20df9e4e63234a77c474a011de8261a71": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:245bd19be441bc206987bb408728b370adf1c3672a9e4f4b5257ca42c61afc7c": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_fc9c9a87-e43a-40a5-a94d-b31b3ef5a53b",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to find packages related to Docker using the APT package manager. AptSearch performs a read‑only query of the configured Ubuntu repositories for the given term, which satisfies the request without any system changes.",
-                "steps": [
-                  {
-                    "action_name": "AptSearch",
-                    "params": "{\"term\":\"docker\"}",
-                    "risk_level": "low",
-                    "summary": "Search the APT repositories for packages matching the term 'docker'"
-                  }
-                ],
-                "summary": "Search for Docker-related packages in the APT repository"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:26c2230d8b971af9bb5ac6fd341b4860c28dd73e1898f3a682e59a4fe2a68b3b": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_9db748cd-f3eb-4ad4-98ae-ae06a5ba8275",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to install a snap but hasn't specified which one. Providing a list of currently installed snaps is a low‑risk read‑only step that can guide the user to specify the desired snap name for installation.",
-                "steps": [
-                  {
-                    "action_name": "SnapList",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "List all snaps currently installed on the system"
-                  }
-                ],
-                "summary": "List installed snaps to help identify which snap to install"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:2e92c75e96a954e46c19b01c178c53b1aa2f35da9556c95f2aa1cd699ef15c3b": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_cbea4813-b787-4be9-9dd7-2abb75ad0077",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to fully uninstall postfix, including all its configuration files. AptPurge removes the package and any related configuration, ensuring no leftover files remain. This is a medium-risk action as it modifies the package state.",
-                "steps": [
-                  {
-                    "action_name": "AptPurge",
-                    "params": "{\"package\":\"postfix\"}",
-                    "risk_level": "medium",
-                    "summary": "Purge the postfix package and its configuration files"
-                  }
-                ],
-                "summary": "Completely remove postfix and delete its configuration"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:2e977fb570ef7ec0b09de67a60b354f2bcec27de94c1aa4c5388032cbd8b6cc1": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:2ea4c99adc7a6aa4488627177f2e507c22d4f2b0db03679ecc7d5ea590462bf1": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:2f8beba365d6d83447e2142b302fa64dd611316794ca9352ddf4cb1ef0276c82": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_318fd8b9-e492-4cfe-aafd-dc4138330a93",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to turn on the firewall. Enabling UFW will activate the firewall with the current rules. This is a high‑risk action because it changes network access and may affect remote connections.",
-                "steps": [
-                  {
-                    "action_name": "UfwEnable",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Enable the UFW firewall with existing rules"
-                  }
-                ],
-                "summary": "Enable the UFW firewall"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:304e076311e736e4d2b7f9a4cb091a4846388a19e9ee71c018459a53daeaf650": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_209c2274-7098-4370-b593-3c1aa5d0c1db",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to reset all ufw rules back to the default configuration. The UfwReset action clears all custom firewall rules and restores the default UFW state. This operation is medium risk and will require approval before execution.",
-                "steps": [
-                  {
-                    "action_name": "UfwReset",
-                    "params": "{}",
-                    "risk_level": "medium",
-                    "summary": "Reset UFW firewall to its default state, removing all custom rules"
-                  }
-                ],
-                "summary": "Reset UFW firewall rules to defaults"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:3245347279860d8d0d1265fed87fc737dfd3df7a877eee2b011a509ce408a74f": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_721624bc-635e-415a-854f-c1aac4dd1d05",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to know the status of the ufw firewall and see which network ports are currently open. UfwStatus reports whether ufw is active and its rule set, while GetListeningPorts shows the listening sockets on the system.",
-                "steps": [
-                  {
-                    "action_name": "UfwStatus",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Show ufw firewall enabled/disabled state and current rules"
-                  },
-                  {
-                    "action_name": "GetListeningPorts",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "List all listening TCP/UDP ports and the processes using them"
-                  }
-                ],
-                "summary": "Check if the Ubuntu firewall (ufw) is enabled and list open listening ports"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:365dd2f68dd8496ef870d4c48fee32d98c6695b19214cedfc2b20cccfaea659c": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:36d1e6065b82020ca7d199cfc3a90383f2c956da288b592e56e963a0df1947cc": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_776db6bf-c200-484c-993e-4e96361cf79e",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to see the active firewall configuration. GetFirewallState is a low‑risk read‑only action that returns the current firewalld zones, services, and port rules on this Ubuntu system.",
-                "steps": [
-                  {
-                    "action_name": "GetFirewallState",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Retrieve and show the current firewall rules and zones"
-                  }
-                ],
-                "summary": "Display the current firewall rules"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:3c3bd84777ff766d514e004130a11a4236a445c1b5f3744351f47a5842a75433": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_f1d7b25f-3383-476a-be77-460d66c96646",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to uninstall Postfix and purge its configuration. AptPurge removes the package along with all associated config files on Ubuntu/Debian systems. This is a medium‑risk operation because it modifies the package database and deletes files.",
-                "steps": [
-                  {
-                    "action_name": "AptPurge",
-                    "params": "{\"package\":\"postfix\"}",
-                    "risk_level": "medium",
-                    "summary": "Purge the postfix package, removing it and all configuration files"
-                  }
-                ],
-                "summary": "Completely remove Postfix and delete its configuration files"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:3cf9a1a21138e22c45aa1eca31c39afedfdc9cffc596ff79852ce7bd2a55e6f3": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:460bdee14b58bc4dd1e09f4603aef090e75a91a345ed032b28d0cbcceb04861f": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_149b10c0-638a-4638-b68a-daffe6ffdb5a",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested a new Distrobox container. DistroboxCreate will provision the container using the specified image. This is a medium‑risk action because it creates a new isolated environment.",
-                "steps": [
-                  {
-                    "action_name": "DistroboxCreate",
-                    "params": "{\"name\":\"fedora-dev\",\"image\":\"fedora:41\"}",
-                    "risk_level": "medium",
-                    "summary": "Create the distrobox container fedora-dev using the fedora:41 image"
-                  }
-                ],
-                "summary": "Create a Distrobox container named fedora-dev with the fedora:41 image"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:4716ac88d09cb6ca8d6e0fa537e09d4d01a42feea906cd9e3ac4b8474ed8e12f": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_b50a21c2-8af0-441b-9cf8-90a22b4429ac",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to install a snap but did not specify which one. Listing installed snaps first is a safe, low‑risk action that lets the user see current snap packages before choosing one to install.",
-                "steps": [
-                  {
-                    "action_name": "SnapList",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Show all installed snaps on the system"
-                  }
-                ],
-                "summary": "List available snaps"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:48bddbe8e0be42af8e95a0a0f08bc4260d7144473bfbd954b188bfcc901e9c0c": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_332af8c4-4f11-412a-b167-19f09c8f0f9f",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to prevent mysql-server from being upgraded by placing a hold (AptHold) and then view the package's information (AptShow). AptHold is a medium‑risk action because it changes package management state; AptShow is low‑risk and simply reads package metadata.",
-                "steps": [
-                  {
-                    "action_name": "AptHold",
-                    "params": "{\"package\":\"mysql-server\"}",
-                    "risk_level": "medium",
-                    "summary": "Place a hold on the mysql-server package to prevent upgrades"
-                  },
-                  {
-                    "action_name": "AptShow",
-                    "params": "{\"package\":\"mysql-server\"}",
-                    "risk_level": "low",
-                    "summary": "Show details of the mysql-server package, including version and description"
-                  }
-                ],
-                "summary": "Hold the mysql-server package and display its details"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:49919ed01370e630956df06dbc5bb282ddc18bd02de449a1d88364eb0f3da751": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_c561c5a7-0cd1-4820-85c6-33ffae5a4042",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to know which channel (e.g., stable, candidate, beta, edge) the Spotify snap is tracking. SnapInfo provides detailed snap metadata, including the current channel, without modifying the system.",
-                "steps": [
-                  {
-                    "action_name": "SnapInfo",
-                    "params": "{\"name\":\"spotify\"}",
-                    "risk_level": "low",
-                    "summary": "Retrieve metadata for the Spotify snap, including its current channel"
-                  }
-                ],
-                "summary": "Show channel information for the Spotify snap"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:4a5011c344c47eae9a085b380ad09a1f1102af97b1c634fbb91262d7a047ba6f": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_bc10042d-e39b-49b5-a06a-303b552e95c4",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to see the server's network configuration as defined by netplan. NetplanGetConfig returns the current netplan YAML configuration without making any changes. This is a low‑risk, read‑only operation.",
-                "steps": [
-                  {
-                    "action_name": "NetplanGetConfig",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Retrieve the current netplan configuration file(s)"
-                  }
-                ],
-                "summary": "Show current netplan network configuration"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:4ab31f93ed1e5fbbe0f42ed9ecb42b8515cc1c469ff96a0efbae9fb166e62d68": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:4adeb0e73abfacce4066d5ee992a30c9900de362af0f303188af686be30baa46": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_2256736f-468d-4a98-98ef-161ccd580d06",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested a new Distrobox container. DistroboxCreate will create the container with the specified name and image. This is a medium‑risk operation because it adds a new isolated environment to the system.",
-                "steps": [
-                  {
-                    "action_name": "DistroboxCreate",
-                    "params": "{\"name\":\"fedora-dev\",\"image\":\"fedora:41\"}",
-                    "risk_level": "medium",
-                    "summary": "Create the distrobox container fedora-dev using the fedora:41 image"
-                  }
-                ],
-                "summary": "Create a Distrobox container named fedora-dev with the fedora:41 image"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:4ddd9ce6dcb33e0ef5b5daa5b8c399e0911f617efbec1597e4f1a64a7c562664": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_39c66de8-86eb-42a5-93f0-cb2121a3252d",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested installing the Visual Studio Code snap from the beta release channel. This plan runs the SnapInstall action specifying the snap name and channel, which will download and install the snap in its beta version.",
+                "explanation": "The user wants to install the Visual Studio Code snap using the beta release channel. SnapInstall will fetch and install the specified snap from the requested channel. This is a medium‑risk operation as it modifies the installed snap set.",
                 "steps": [
                   {
                     "action_name": "SnapInstall",
@@ -907,46 +69,27 @@
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "43a5e9ac9f33f3daf9b19ae7ba185e0b2b48efe4abe80874e72e0f35daea3c93"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:4fe7887b1a9fa0f09cbf6d2c17f596e4650dc107962e833db5c7b6cca2c0ef26": {
+    "groq/openai/gpt-oss-120b:07bdc5a1cb0dcf18a200ead1281b6e5f07030fee6a87a12debc36c0ff62d16ae": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_9fa03a0e-707a-4c0f-9866-663292ab0fca",
+              "id": "fc_77bdc589-be07-435f-9e1e-3c53caf8603e",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to uninstall the telnet package from the system. AptRemove will remove the specified package while preserving its configuration files. This is a medium‑risk operation as it modifies the package state.",
-                "steps": [
-                  {
-                    "action_name": "AptRemove",
-                    "params": "{\"package\":\"telnet\"}",
-                    "risk_level": "medium",
-                    "summary": "Remove the telnet package using apt"
-                  }
-                ],
-                "summary": "Remove the telnet package"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:52d9aecc7a5c2089484e5ebe741b9df369b35408cb4e800f21efa6fdbeea61fa": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_b506a7fb-f5b6-4f8b-a309-5d1eebb7e3e3",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to see the current Distrobox containers. DistroboxList retrieves a list of all existing Distrobox containers without modifying the system, so it is safe and requires no approval.",
+                "explanation": "The user wants to see which development containers are running. Distrobox containers are used for development environments and can be listed without additional parameters. This read‑only action safely returns the container names and statuses.",
                 "steps": [
                   {
                     "action_name": "DistroboxList",
@@ -955,212 +98,109 @@
                     "summary": "Retrieve a list of all Distrobox containers"
                   }
                 ],
-                "summary": "List Distrobox containers"
+                "summary": "List development containers (Distrobox) currently present"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "6809a8a69524bbd52686c99bb064c220bc879b4262ec4a1da7e28024a75abe02"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:57b35f57e8c3fdf036f2021a0856f498d40be2c8cfc80e1e87484bbb751a76aa": {
+    "groq/openai/gpt-oss-120b:1223c0e163795aca43d03e724c13288d98c88bf43d8e6bfe9531455a67ae4cdc": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_f803725f-33b4-44cd-a551-a05bb57f39b3",
+              "id": "fc_5014f01e-848c-4f63-a43f-84a4c47046f6",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to prevent mysql-server from being upgraded (pin) and then see its package information. We apply an apt pin with a high priority to hold the current version, then retrieve the package details using AptShow.",
+                "explanation": "The user wants to re-enable automatic updates for the Chromium snap. Unholding the snap removes the hold that prevented auto-refresh, restoring normal update behavior.",
                 "steps": [
                   {
-                    "action_name": "SetAptPin",
-                    "params": "{\"name\":\"mysql-server-pin\",\"package\":\"mysql-server\",\"pin\":\"release *\",\"priority\":1000}",
+                    "action_name": "SnapUnhold",
+                    "params": "{\"name\":\"chromium\"}",
                     "risk_level": "medium",
-                    "summary": "Create an apt pin for mysql-server to prevent upgrades"
-                  },
-                  {
-                    "action_name": "AptShow",
-                    "params": "{\"package\":\"mysql-server\"}",
-                    "risk_level": "low",
-                    "summary": "Show detailed information about the mysql-server package"
+                    "summary": "Remove the hold on the chromium snap so it can auto-update"
                   }
                 ],
-                "summary": "Pin the mysql-server package and display its details"
+                "summary": "Allow the chromium snap to auto-update"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "6816dc4e50ad96fc96483612de1a77937b6b4799e0a59002d1ca213495145552"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:5a90f7a08c9edcfdf7d59a439b4d64f87b8c289abff5a1c767a3c1909f8e83dc": {
+    "groq/openai/gpt-oss-120b:21b69646d8664dd468e9824625c4b44eb368fff43e621c137297e672b1352e01": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_8b813041-a13c-4e48-a540-1b1401e34e93",
+              "id": "fc_5da80aa9-8f95-41ce-ac9b-1a4af2388b24",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user asked for a list of installed snaps. SnapList provides a read‑only enumeration of all snap packages currently present on the system.",
+                "explanation": "The user asked to see the server's network configuration as defined by netplan. NetplanGetConfig reads and returns the netplan YAML files without making any changes.",
                 "steps": [
                   {
-                    "action_name": "SnapList",
+                    "action_name": "NetplanGetConfig",
                     "params": "{}",
                     "risk_level": "low",
-                    "summary": "Retrieve a list of all installed snap packages"
+                    "summary": "Retrieve the netplan configuration files"
                   }
                 ],
-                "summary": "List installed snap packages"
+                "summary": "Show current netplan network configuration"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "dc0de1df9d559c76ecf64f188a32f254f8e7714b293973ca2d690a365d5c7e51"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:5ef7798d64c4b9f7cf37d72d7bf0c7a5da3c9ded02ee0f35604a4e179cd4afe6": {
+    "groq/openai/gpt-oss-120b:2bf0ba1074af6a8c02a3b449074bde3ed31385cf89ea77e36b59380514398b7a": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_9f8c4795-859f-4e55-ba33-d7ed1aafb8ba",
+              "id": "fc_878bd0be-4db8-4d34-8def-869ce4fc4114",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to freeze the PostgreSQL package to stop future upgrades. Using AptHold will mark the package as held, preventing apt from upgrading it until the hold is removed.",
-                "steps": [
-                  {
-                    "action_name": "AptHold",
-                    "params": "{\"package\":\"postgresql\"}",
-                    "risk_level": "medium",
-                    "summary": "Mark the postgresql package as held to prevent upgrades"
-                  }
-                ],
-                "summary": "Prevent PostgreSQL package from being upgraded"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:604bf8b767e0f88e9905f3da3d5841461fc3da76dda577a015259a1e08c9bf46": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_3fca4cc7-086f-42d0-a075-55a5f7598c67",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested a new Distrobox container called dev with the Ubuntu 24.04 image. This step creates the container with the specified name and image. It's a medium‑risk operation because it modifies the system by adding a container.",
-                "steps": [
-                  {
-                    "action_name": "DistroboxCreate",
-                    "params": "{\"name\":\"dev\",\"image\":\"ubuntu:24.04\"}",
-                    "risk_level": "medium",
-                    "summary": "Create the Distrobox container 'dev' based on the ubuntu:24.04 image"
-                  }
-                ],
-                "summary": "Create a Distrobox container named dev using Ubuntu 24.04"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:6255883eb8aa701a25f356a45f438d66df69b23fdc25c0ca48d0db84b1e29421": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:67147da67336f6a3f4152ffee597229394dad2ab089ef3917e87a299b29e31ac": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_f28ea47b-caaa-4a6a-bd07-cef0f319a0c8",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user asked to block port 0, but port 0 is not a valid port number for firewall rules. Providing the current firewall status helps the user see existing rules and decide on a correct port to block.",
-                "steps": [
-                  {
-                    "action_name": "UfwStatus",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Display current ufw firewall rules and status"
-                  }
-                ],
-                "summary": "Show current firewall status and note invalid port request"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:68c1e4b6cbcf1a1c3ff89b93524c8993d40bd3e301a8fd73d96283cc9bacc9c2": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_ac5f026e-b994-4e81-976b-559b35251a28",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to permit traffic defined by the UFW \"Nginx Full\" profile. This requires adding a firewall rule, which is a high‑risk operation because it modifies the system's network security settings. The plan will execute a single UfwAllow action with the appropriate service name.",
-                "steps": [
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"Nginx Full\"}",
-                    "risk_level": "high",
-                    "summary": "Add a rule to allow traffic for the \"Nginx Full\" profile in UFW"
-                  }
-                ],
-                "summary": "Allow the Nginx Full profile through the UFW firewall"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:69f8cf9744913c615314a126f98233f828045170ec81cfc725eda8f2eea0e20c": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_f48e6bf8-1ae6-442b-b04e-f195dd51a86d",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user asked to see which packages and snaps are installed. AptListInstalled lists all apt-managed packages and SnapList lists all installed snaps. Both are read‑only queries, so no approval is needed.",
+                "explanation": "The user requested to see which apt packages and snaps are currently installed. AptListInstalled lists all installed DEB packages, while SnapList lists all installed snap packages. Both are read‑only operations, so no approval is required.",
                 "steps": [
                   {
                     "action_name": "AptListInstalled",
                     "params": "{}",
                     "risk_level": "low",
-                    "summary": "List all installed apt packages"
+                    "summary": "List all installed Debian packages"
                   },
                   {
                     "action_name": "SnapList",
@@ -1175,764 +215,103 @@
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "212bd135d73c2b5008122ff9f69372a22d95a6e6df7a6b253f8e52c814f2f9cc"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:6ad7e10e0de239d1fb44db278adb1ae83fa11c19017db4ce341b060d31017e5e": {
+    "groq/openai/gpt-oss-120b:301bc0d68db22cbc87212c4967c24ebf799d1776a24edfea7bb54d7ffc371fdc": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_a723a1b9-7540-4ac5-af5c-a0c6e41a9014",
+              "id": "fc_2336f2e0-1d8b-4dcd-96b7-9cc50b5b13ca",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested to apply the netplan configuration. NetplanApply applies any pending netplan changes, which may disrupt network connectivity. This is a high‑risk read‑only‑required action.",
-                "steps": [
-                  {
-                    "action_name": "NetplanApply",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Apply the current netplan configuration to bring network interfaces up"
-                  }
-                ],
-                "summary": "Apply pending netplan network configuration"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:6b6e5bb7dd3e152a4acdb34614f215ed6944ba3ce35bb44cecad30fbcd800d99": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_f85d3dc4-4ca5-4e27-9ed6-6157bdfdba86",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to know which release channel (stable, candidate, etc.) the Spotify snap is tracking. SnapInfo provides detailed snap metadata including the current channel without making any changes.",
-                "steps": [
-                  {
-                    "action_name": "SnapInfo",
-                    "params": "{\"name\":\"spotify\"}",
-                    "risk_level": "low",
-                    "summary": "Retrieve information about the Spotify snap, including its current channel"
-                  }
-                ],
-                "summary": "Show the channel for the Spotify snap"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:6fae5bcea41f276b9640df9fae8a20091d29af691fe83c402f0ef39de222361b": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_c49b3a2f-fcc1-4672-b1ad-d0688c654c4f",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants the system's package list updated before installing the htop utility. AptUpdate refreshes the local apt cache (low risk) and AptInstall adds the htop package (medium risk). Both steps are executed in order.",
-                "steps": [
-                  {
-                    "action_name": "AptUpdate",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Refresh the apt package index"
-                  },
-                  {
-                    "action_name": "AptInstall",
-                    "params": "{\"package\":\"htop\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the htop package"
-                  }
-                ],
-                "summary": "Refresh apt package index and install htop"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:735b7a9d95f3d72935c2e61a6e4115e7ec54309150ba8fb670e9ae7e00643184": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_6c1c8b5f-111d-4a6e-ba2b-8788c05089d8",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested cleaning up packages that are no longer needed. AptAutoremove will remove automatically-installed packages that are no longer required, which satisfies this request.",
-                "steps": [
-                  {
-                    "action_name": "AptAutoremove",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Remove automatically-installed packages that are no longer needed"
-                  }
-                ],
-                "summary": "Remove unused packages"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:7694abe6fddf1099bc46da20d76081374ce8d6943db9e149e97521214cffd97e": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_3dac176c-15c0-4551-a182-5c991221ccb8",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user asked to see the current netplan configuration. NetplanGetConfig returns the YAML network config without making any changes.",
-                "steps": [
-                  {
-                    "action_name": "NetplanGetConfig",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Retrieve the netplan YAML configuration"
-                  }
-                ],
-                "summary": "Show the server's netplan network configuration"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:7c506a9bb37ab58ce4aa83fba4297cc4569fd268b1187337b729d2929cc88f7f": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_c8b8327e-8b2c-4707-81e2-73e3efa04e57",
-              "call_id": null,
-              "name": "query_current_user",
-              "input": {}
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:7cef9f79d8f0ff7e44b795424d5042a566a6eed5a792e3816821ceaf0a6df9b2": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_aef35322-dcef-4f73-bcbd-33a5be6ff5e4",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested installing the git, curl, and wget packages. These are installed using the Ubuntu apt package manager via the AptInstall action, which is a medium-risk operation requiring approval.",
-                "steps": [
-                  {
-                    "action_name": "AptInstall",
-                    "params": "{\"package\":\"git\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the git package via apt"
-                  },
-                  {
-                    "action_name": "AptInstall",
-                    "params": "{\"package\":\"curl\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the curl package via apt"
-                  },
-                  {
-                    "action_name": "AptInstall",
-                    "params": "{\"package\":\"wget\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the wget package via apt"
-                  }
-                ],
-                "summary": "Install git, curl, and wget"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:7f28d8a17d08dbbfc8e6ca3a991022624e9312cfc40eeaa9387adc5dd1924df4": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_304702b6-caeb-49c9-bcbf-3bd786ebe098",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to see the network configuration (Netplan) and then apply it. We'll first retrieve the Netplan config (low risk) and then apply the configuration (high risk) which may affect network connectivity.",
-                "steps": [
-                  {
-                    "action_name": "NetplanGetConfig",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Retrieve the current Netplan configuration files"
-                  },
-                  {
-                    "action_name": "NetplanApply",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Apply the Netplan configuration to activate any pending changes"
-                  }
-                ],
-                "summary": "Show current Netplan configuration and apply it"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:82562230bf3e1a49009565f526daf1ffd2c5e9909184e7413b63f974c582c4b2": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:86d6a7a14610b13f474e8576ff20db46b15cab14451540b2f48685cee32042bb": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_86624af9-b9c4-499a-9cab-f2baf99fdaec",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to see which apt packages and Snap packages are currently installed. Both AptListInstalled and SnapList are read‑only actions that provide this information without requiring any changes.",
-                "steps": [
-                  {
-                    "action_name": "AptListInstalled",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "List all installed apt packages"
-                  },
-                  {
-                    "action_name": "SnapList",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "List all installed Snap packages"
-                  }
-                ],
-                "summary": "List installed apt packages and Snap packages"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:89a3773824de4e5e7d9251544aca0f2c67001e3f9037fd042b3b9e35cbd022e0": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_3fddc1b9-4061-4951-b570-b0a2b28585ea",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested the telnet package be removed from the system. AptRemove will uninstall the package while preserving configuration files. This is a medium‑risk operation that modifies the system's installed packages.",
-                "steps": [
-                  {
-                    "action_name": "AptRemove",
-                    "params": "{\"package\":\"telnet\"}",
-                    "risk_level": "medium",
-                    "summary": "Remove the telnet package, keeping its configuration files"
-                  }
-                ],
-                "summary": "Remove the telnet package"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:8a04f7662636bc62f237c307183bb8d7488207ed71a439059411fcc2e2df29f9": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_a7daa697-3947-4427-bf21-41b9b2a574aa",
-              "call_id": null,
-              "name": "query_packages",
-              "input": {}
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:8a5c8981bf926ae23ef738f3279a81a83d15e373fcd6209a46e2f706872b1b15": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_ad5a2c39-d9bc-4874-8b34-33f0b6f7d525",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested that all installed snaps be refreshed. SnapRefresh without a name updates every snap to its latest revision. This is a read/write operation but poses low to medium risk, requiring no approval.",
-                "steps": [
-                  {
-                    "action_name": "SnapRefresh",
-                    "params": "{}",
-                    "risk_level": "medium",
-                    "summary": "Refresh all installed snaps to their latest versions"
-                  }
-                ],
-                "summary": "Update all snap packages to the latest versions"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:92a42034e558d5db61b307be12a073b1ba527625e58314e7a29c872e13c2e3af": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_eec77b2f-b993-4356-a844-05d34f101334",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user asked to see the Netplan network configuration. NetplanGetConfig returns the YAML configuration used by Netplan. This is a read‑only low‑risk action.",
-                "steps": [
-                  {
-                    "action_name": "NetplanGetConfig",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Retrieve the current Netplan configuration files"
-                  }
-                ],
-                "summary": "Display the current Netplan network configuration"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:95d783e6093d97c33d66933d1632fc48d60b6b7a6b1ccd7247c76a3b2cb06cac": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_6514830b-9534-4296-9250-e58b66b8ba7f",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested a list of installed packages. AptListInstalled provides a read‑only enumeration of all packages currently installed via dpkg on Ubuntu.",
-                "steps": [
-                  {
-                    "action_name": "AptListInstalled",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Retrieve the full list of installed packages"
-                  }
-                ],
-                "summary": "List all installed packages on the Ubuntu system"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:9a27db0a512c0c671800f6406efbc110bcfb5c1ecb88cea7da1324d29666968a": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:9abe5f4d90305dc12e0670ddf6d7bdbac6f58a0f5f3d4e10164e1110c193a6e8": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:9acbace9603500dc5134e26961d5427f3149de690e08ec47442938fe2c2bd374": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_becff6d7-a5bb-487d-85e6-fe06b3e994a2",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to turn on ufw and create a rule that permits inbound SSH traffic. Enabling the firewall and adding an allow rule will secure the system while ensuring remote SSH access remains possible.",
-                "steps": [
-                  {
-                    "action_name": "UfwEnable",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Enable the ufw firewall"
-                  },
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"ssh\"}",
-                    "risk_level": "high",
-                    "summary": "Allow inbound SSH connections through the firewall"
-                  }
-                ],
-                "summary": "Enable the firewall and allow SSH connections"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:9d4c5f7fb68cb04f227c0770fd99f684e246601fb23cfab9144fe8caba79ac4a": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_7ee32662-915a-4b99-8051-aad979b89908",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to know which curl version is currently available in the apt repositories. AptShow provides detailed package information, including the candidate version, without modifying the system.",
-                "steps": [
-                  {
-                    "action_name": "AptShow",
-                    "params": "{\"package\":\"curl\"}",
-                    "risk_level": "low",
-                    "summary": "Retrieve curl package details from apt"
-                  }
-                ],
-                "summary": "Show the available apt package version for curl"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:a180e137f7034afb8d95aa417ffaf9c077f64210303f4b063058e0a276fa0684": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:a1906cfab983278293aa1f241524e2e47488f1f80e09536d6b603a225d62c757": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_5cae551d-134a-40a2-b8b7-8579d16d31a4",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to know which version of curl is available from the apt package manager. AptShow retrieves detailed information, including the version, for a specified package without modifying the system.",
-                "steps": [
-                  {
-                    "action_name": "AptShow",
-                    "params": "{\"package\":\"curl\"}",
-                    "risk_level": "low",
-                    "summary": "Retrieve package details for curl, including its version"
-                  }
-                ],
-                "summary": "Show the available version of the curl package in apt"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:a1c1f8304bd8e8c5d0db4e8f61db40cbe2e26de482c7a3cd957e08d2b61f9a6f": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_c0d29aac-3214-45c6-bda7-1d98efbf32b2",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to stop the Chromium snap from automatically updating. Using SnapHold will hold the snap at its current revision, preventing future automatic refreshes.",
-                "steps": [
-                  {
-                    "action_name": "SnapHold",
-                    "params": "{\"name\":\"chromium\"}",
-                    "risk_level": "medium",
-                    "summary": "Hold the Chromium snap at its current version to stop auto-updating"
-                  }
-                ],
-                "summary": "Pin the Chromium snap to prevent auto-updates"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:a416742a93b111b0152db4c8f2326428466f844eaeb63101b009648660666904": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_68552f93-34e4-40db-a214-22317df89300",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user asked for a list of snaps currently installed on the system. SnapList provides a read‑only enumeration of all installed snap packages without making any changes.",
+                "explanation": "The user wants to install a snap but hasn't specified which one. Listing installed snaps first provides context and lets the user identify the desired snap name for installation.",
                 "steps": [
                   {
                     "action_name": "SnapList",
                     "params": "{}",
                     "risk_level": "low",
-                    "summary": "Retrieve a list of all installed snap packages"
+                    "summary": "List all snaps currently installed on the system"
                   }
                 ],
-                "summary": "List installed snap packages"
+                "summary": "Show currently installed snaps"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "104152d9261ef4530c2b5aba1b4cf47c55f6813e6f3162800e98ef6055d13bce"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:a42b173aaf7fee6c7a656eb9ed9619b86988163c2e10a969e2674b7535f383da": {
+    "groq/openai/gpt-oss-120b:3026fa4917ad2c3feb948eec5af98f979c2ef117ced410fc23f1a568e5d9f083": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_fdadafc6-3020-448f-8415-ca733223376b",
+              "id": "fc_14568d7e-8236-4068-8fcb-2065bd30f155",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to bring the system's packages up to date. This requires refreshing the APT package index (AptUpdate) and then upgrading all installed packages (AptUpgrade). AptUpdate is low risk and reads the package lists, while AptUpgrade is high risk because it modifies the system by upgrading all packages.",
+                "explanation": "The user requested a full system package upgrade. AptUpgrade will run a dist-upgrade, updating every installed package to the latest available versions. This is a high-risk operation because it may change many components and could require a reboot.",
                 "steps": [
-                  {
-                    "action_name": "AptUpdate",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Refresh the APT package index to get the latest available package information"
-                  },
                   {
                     "action_name": "AptUpgrade",
                     "params": "{}",
                     "risk_level": "high",
-                    "summary": "Upgrade all installed packages to the newest available versions"
+                    "summary": "Perform a full upgrade of all installed packages"
                   }
                 ],
-                "summary": "Update all installed packages to their latest versions"
+                "summary": "Upgrade all installed packages on the Ubuntu system"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "2919c0153420f97c794d9c24a9fa90b6d0f2e96f550075c9e696401f9d161cfc"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:a49eca48e7a94906b36b45b373cf73297e5bcdf5f4245b15f5cb375814725a4e": {
+    "groq/openai/gpt-oss-120b:3207883e66474e0be3a5b4e7692f33f48c49a6d6ba94c9191bbd6e1bd35c1a08": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_d7df59dc-7ede-4064-b2dd-9f4cdedf5956",
+              "id": "fc_8ac0438d-481a-4dc6-b8e0-33ce5dd30f1d",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested to block port 23 used by telnet. Adding a deny rule to UFW will prevent inbound connections on that port. This is a high‑risk firewall change, so it requires careful approval before execution.",
-                "steps": [
-                  {
-                    "action_name": "UfwDeny",
-                    "params": "{\"port_or_service\":\"23\"}",
-                    "risk_level": "high",
-                    "summary": "Deny inbound traffic on port 23 (telnet) using ufw"
-                  }
-                ],
-                "summary": "Block telnet (port 23) in the UFW firewall"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:ab164a0da795b6c922e4b9823307e49a5695fdc54b57ccd26d136af6a6ccdcd7": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:ab503408d8764719817cef9b7fa53d7955764f30b54efc5682e8d0a5b229c5d4": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_f9f3edf9-2512-43f7-bb2b-21e1e7fd66b8",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to view the network configuration (NetplanGetConfig) and then apply any changes (NetplanApply). The first step is a low‑risk read‑only query of the netplan YAML, and the second step applies the configuration, which is high‑risk because it may disrupt network connectivity.",
-                "steps": [
-                  {
-                    "action_name": "NetplanGetConfig",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Retrieve the current netplan network configuration files"
-                  },
-                  {
-                    "action_name": "NetplanApply",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Apply the netplan configuration to activate any changes"
-                  }
-                ],
-                "summary": "Show current netplan network configuration and then apply it"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:abd8d65fffd5bf74fcc1dd0a2da9b7823acde6cb6556f36c8eb4138b42fc657f": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_9b0a5992-e570-493d-b214-ff364f496d3f",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user asked for details about the lxd snap. SnapInfo provides metadata such as version, channel, and description for a specific snap without making any changes.",
-                "steps": [
-                  {
-                    "action_name": "SnapInfo",
-                    "params": "{\"name\":\"lxd\"}",
-                    "risk_level": "low",
-                    "summary": "Retrieve metadata for the lxd snap"
-                  }
-                ],
-                "summary": "Show detailed information about the lxd snap"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:ac1703c1f336dfb73a47b7fc160ce838e6bf1c680cee08ea694b52a09a56d14c": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_79af6c29-4733-4e6a-a841-bfa3f3648c25",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested installation of nginx. AptInstall will download and install the nginx package using the system's package manager. This is a medium-risk operation as it modifies the system's installed software.",
-                "steps": [
-                  {
-                    "action_name": "AptInstall",
-                    "params": "{\"package\":\"nginx\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the nginx package via apt"
-                  }
-                ],
-                "summary": "Install the nginx web server package"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:ac3c3b58993030f63fa07f595c413e66b336c142bead4bac60dc647276307abf": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_7e7f6f9d-9482-4dcc-82b3-239a66a284d6",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested a complete wipe of Apache2, including its config files. AptPurge will uninstall the apache2 package and purge all related configuration files from the system. This is a medium‑risk operation as it modifies the package state.",
+                "explanation": "The user requested a complete wipe of Apache2, including its config files. AptPurge removes the package and all associated configuration, fulfilling this request. This is a medium‑risk action requiring approval before execution.",
                 "steps": [
                   {
                     "action_name": "AptPurge",
                     "params": "{\"package\":\"apache2\"}",
                     "risk_level": "medium",
-                    "summary": "Purge the apache2 package and all its configuration files"
+                    "summary": "Purge the apache2 package and all related configuration files"
                   }
                 ],
                 "summary": "Fully remove Apache2 and its configuration files"
@@ -1941,477 +320,97 @@
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "2733ea5e7eb297e936f81de936f0690e3e10c403472ab7aeec81e253bec2bf83"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:aeaba02118bcf2e3fe697a66fda8f542dbc2c8557b688b30a098ff7efed4dbef": {
+    "groq/openai/gpt-oss-120b:33f8ea73bdb165d9735d81304c75142911d9584ee9fe56f06a9f994025959d10": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_6b065377-5e4d-4748-9ed4-7b749fbaf51a",
+              "id": "fc_d357130c-2cc5-4ef5-80fe-98d1dbc629d1",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested to permit HTTP and HTTPS traffic through the firewall. Adding UFW rules for ports 80/tcp and 443/tcp will open these ports. These actions are high risk because firewall changes can affect connectivity, so approval is required before execution.",
-                "steps": [
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"80/tcp\"}",
-                    "risk_level": "high",
-                    "summary": "Allow inbound traffic on TCP port 80 (HTTP)"
-                  },
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"443/tcp\"}",
-                    "risk_level": "high",
-                    "summary": "Allow inbound traffic on TCP port 443 (HTTPS)"
-                  }
-                ],
-                "summary": "Allow inbound web traffic on ports 80 and 443 via UFW"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:af8c23a651e6846ddf83a7583737f4835839872ee4f51c81a225c2dea3630275": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_e2948b13-a18a-4a55-9f5b-cf706cd2e6bf",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to turn off the firewall. This will stop UFW from filtering network traffic. It is a high‑risk operation because it removes all active firewall protection, so it should be used with caution.",
-                "steps": [
-                  {
-                    "action_name": "UfwDisable",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Disable the UFW firewall"
-                  }
-                ],
-                "summary": "Disable the Ubuntu UFW firewall"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:b39498deffc116627a4d703234baad2314b0a37b69371029b31aaa6a09fed165": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_7dd36c86-dc13-47c4-803f-44e22b839179",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested installation of three common utilities. Each AptInstall action will install one package. These actions are medium risk as they modify the system's package set.",
+                "explanation": "The user requested to install the package named vim. This action will use AptInstall to download and install the vim package via the system's package manager. No other destructive actions are performed.",
                 "steps": [
                   {
                     "action_name": "AptInstall",
-                    "params": "{\"package\":\"git\"}",
+                    "params": "{\"package\":\"vim\"}",
                     "risk_level": "medium",
-                    "summary": "Install the git version control system"
-                  },
-                  {
-                    "action_name": "AptInstall",
-                    "params": "{\"package\":\"curl\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the curl command-line tool for data transfers"
-                  },
-                  {
-                    "action_name": "AptInstall",
-                    "params": "{\"package\":\"wget\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the wget command-line tool for downloading files"
+                    "summary": "Install the vim package using apt"
                   }
                 ],
-                "summary": "Install git, curl, and wget packages"
+                "summary": "Install the Vim package"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "d4a6fad700421911fc1afafe6510c96c53783951315e94b05151f03e6e81b561"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:b7baa9d445f2ade689ee02351cc9714f7483b7d27f9c296a3640fdb28a6d8963": {
+    "groq/openai/gpt-oss-120b:3838803d7afbcd068110e659bb82fa607a2b9aa5ec07779cd71180e0e38dfc85": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_f2c89004-a2f5-4faa-8c9e-84734973bc59",
+              "id": "fc_74e4ed3f-1fb9-4056-9449-2b2b48979a38",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested an update of the APT package list. AptUpdate refreshes the local package cache without installing or removing any packages. This is a low‑risk read‑only operation.",
+                "explanation": "The user requested a list of their Distrobox containers. DistroboxList is a low‑risk, read‑only action that returns the names and status of each container.",
                 "steps": [
                   {
-                    "action_name": "AptUpdate",
+                    "action_name": "DistroboxList",
                     "params": "{}",
                     "risk_level": "low",
-                    "summary": "Run apt-get update to refresh package lists"
+                    "summary": "Retrieve a list of all Distrobox containers on the system"
                   }
                 ],
-                "summary": "Refresh the APT package index"
+                "summary": "List all Distrobox containers"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "5da0d21883d1af4cf8a83377ba73b54c938e474ba919d9a896b9cc6206a2621a"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:b8064bb64b6ec21f97fcfbe8926359a6122975f35ecd303e95edf36a33ea8125": {
+    "groq/openai/gpt-oss-120b:4801be6ab8e4381ef27e3bfe29e7682f0a50ce1fcabbd0b2836c82354e45eea0": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_7bce48f2-74bf-441e-bd75-b708c0017ec2",
+              "id": "fc_9e7fc8ec-ea7f-4c16-9dbb-3ee0f9ad931a",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested a new Distrobox container called dev using the ubuntu:24.04 image. DistroboxCreate will set up the container with the specified name and image. This is a medium-risk operation as it creates a new container environment.",
-                "steps": [
-                  {
-                    "action_name": "DistroboxCreate",
-                    "params": "{\"name\":\"dev\",\"image\":\"ubuntu:24.04\"}",
-                    "risk_level": "medium",
-                    "summary": "Create the dev container using Ubuntu 24.04"
-                  }
-                ],
-                "summary": "Create a Distrobox container named dev with Ubuntu 24.04 image"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:c24f07ca0f50f670a9ebd5031c72c606bcb27c34d17c5064096012064da47fae": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_6909dc05-bba3-4c9d-8c54-27bae10123ec",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to update the list of available packages. AptUpdate refreshes the local APT cache without installing or removing any packages.",
-                "steps": [
-                  {
-                    "action_name": "AptUpdate",
-                    "params": "{}",
-                    "risk_level": "low",
-                    "summary": "Refresh the APT package index from configured repositories"
-                  }
-                ],
-                "summary": "Refresh the APT package index"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:c415c4d30900e8b9838629ed8a596322c771720a2bae8127761ba078a49d0399": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_1b662cef-fcf2-4fbf-ab05-d90cfb075268",
-              "call_id": null,
-              "name": "query_current_user",
-              "input": {}
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:c43a2418106b102ca8d2338a767aed6d62b3d772725535dfea0cf8a03f5c7627": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_bc67a462-15c6-4cb0-a6ed-e468459890e2",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to see what Redis packages are available in the apt repositories. AptSearch performs a read‑only search of the package index using the provided term.",
-                "steps": [
-                  {
-                    "action_name": "AptSearch",
-                    "params": "{\"term\":\"redis\"}",
-                    "risk_level": "low",
-                    "summary": "Search apt repositories for packages matching 'redis'"
-                  }
-                ],
-                "summary": "Search for Redis-related packages"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:c4b4d69431a2ceba61e36087592526c12760bb8ebf5413d3aedc23aa71edc0c0": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_e7dc86bc-574c-468e-a85c-d4eb8bd0bc33",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to remove the Firefox snap package. SnapRemove will delete the installed snap, freeing the associated disk space. This is a reversible action via snap install if needed.",
-                "steps": [
-                  {
-                    "action_name": "SnapRemove",
-                    "params": "{\"name\":\"firefox\"}",
-                    "risk_level": "medium",
-                    "summary": "Remove the Firefox snap from the system"
-                  }
-                ],
-                "summary": "Uninstall the Firefox snap"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:c6c40722955d068d207d0f90eb0295a532a173d2885cbda0be02230e80de8153": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_8019d043-b17d-4e2a-a4a0-03a64fd0deb9",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants the Uncomplicated Firewall (ufw) turned on and inbound SSH traffic permitted. Enabling ufw secures the host, and adding a rule for SSH ensures remote access remains possible.",
-                "steps": [
-                  {
-                    "action_name": "UfwEnable",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Enable the ufw firewall"
-                  },
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"ssh\"}",
-                    "risk_level": "high",
-                    "summary": "Allow inbound SSH connections through the firewall"
-                  }
-                ],
-                "summary": "Enable the firewall and allow SSH connections"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:c8f43ed965d06602479105339a5a4e2095019c015ecd12313c2e2d3ca9560b73": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_ab1dd5e4-6747-4e99-a16e-373a524edde7",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to turn on the firewall. Enabling UFW will activate the firewall with its current rules. This is a high‑risk action because it modifies network access and could affect active connections.",
-                "steps": [
-                  {
-                    "action_name": "UfwEnable",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Enable the UFW firewall"
-                  }
-                ],
-                "summary": "Enable the UFW firewall"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:cd6f0ea7a5fb028d568c6a7dd85f24f119b95920b00325cbcedf481b5404d7a5": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:d02d42b307aaa044ff3f666512e073b215e0b363dc1fb072c1a258b85a9bfbce": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_6e5b5e19-ccea-4afe-bf24-c49907bfd2f5",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested removal of the distrobox container called old-dev. The DistroboxRemove action will delete that container. This is a medium-risk operation as it modifies user containers.",
-                "steps": [
-                  {
-                    "action_name": "DistroboxRemove",
-                    "params": "{\"name\":\"old-dev\"}",
-                    "risk_level": "medium",
-                    "summary": "Remove the distrobox container named old-dev"
-                  }
-                ],
-                "summary": "Delete the distrobox container named old-dev"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:d06005e10dd2240c1569d51491e7ca24b40bd79462cedbc17dbe26f67d5f1f20": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_33242810-6821-4ffd-88d2-0c8889101009",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to allow inbound SSH traffic. Adding a rule for port 22/tcp using UfwAllow will open the firewall port, enabling SSH connections. This is a high‑risk action because firewall changes can affect connectivity.",
-                "steps": [
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"22/tcp\"}",
-                    "risk_level": "high",
-                    "summary": "Allow inbound TCP traffic on port 22 via UFW"
-                  }
-                ],
-                "summary": "Open SSH port 22 in the firewall"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:d0c39e814cb9cafaf147c52d78940dfffbc077f833d52e48ab986829a98ff95f": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_be4eb20e-9305-4164-82f3-bb57ec3114e4",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants the nginx package to be eligible for upgrades again. Removing the apt hold with AptUnhold allows future apt upgrades to include nginx.",
-                "steps": [
-                  {
-                    "action_name": "AptUnhold",
-                    "params": "{\"package\":\"nginx\"}",
-                    "risk_level": "medium",
-                    "summary": "Unhold the nginx package to allow it to be upgraded"
-                  }
-                ],
-                "summary": "Remove hold from the nginx package so it can be upgraded"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:d5c66f445a5995fa2e5c7f68465386538f9eac7a41a1a20b8c66cb8d11398ec7": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_b0333e0f-5b78-4b07-aba1-438698ad4af7",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to activate any netplan changes that have been configured. NetplanApply writes the new configuration to the network interfaces, which may disrupt connectivity, so it is a high‑risk operation.",
-                "steps": [
-                  {
-                    "action_name": "NetplanApply",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Apply the current netplan configuration to network interfaces"
-                  }
-                ],
-                "summary": "Apply pending netplan network configuration"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:d72405c4dd23d1266b9ef77bcde988d46a4f546513c548c6fb636253434098a4": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_485c0c32-7816-4b7e-a958-153f259fe66c",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to block port 0. This plan adds a ufw deny rule for port 0, preventing traffic on that port. Changing firewall rules is a high‑risk operation because it can affect network connectivity.",
-                "steps": [
-                  {
-                    "action_name": "UfwDeny",
-                    "params": "{\"port_or_service\":\"0\"}",
-                    "risk_level": "high",
-                    "summary": "Deny inbound traffic on port 0 using ufw"
-                  }
-                ],
-                "summary": "Block port 0 in the firewall"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:dab22e6c0f14cef78c72996ed2d3b0411d6bcd3a57dac0102a5ac12f3ff2161c": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_76201add-e124-4c93-bb4a-6376fc064749",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user explicitly requested to disable the firewall. This plan runs the UfwDisable action, which turns off ufw, removing all active firewall rules. This is a high‑risk operation because it opens the system to network traffic.",
+                "explanation": "The user requested to turn off the firewall. The UfwDisable action disables ufw, which is a high‑risk operation because it removes the host's network protection. No additional parameters are needed.",
                 "steps": [
                   {
                     "action_name": "UfwDisable",
@@ -2426,233 +425,751 @@
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "37b779274ca5063ff67e75e2beda6a2bae3da14ed975fbff8571500d9319b1a0"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:db5a652f66c140a9dbfb19ace19880d204dcf0d4793c84e6fef3a5efaa0d9cdb": {
+    "groq/openai/gpt-oss-120b:48139092a5c97881511ccfd5520b7c9f287f6fda8ec112388852ceb50abb342f": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_c9ee2c37-2561-4cf5-abe0-09d023f224ca",
+              "id": "fc_db2d0430-e338-4339-8e61-dd43867a8d01",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested that the nginx package be upgraded. AptInstall will install the latest available version, upgrading if a newer version exists. This is a medium‑risk operation as it modifies installed packages.",
+                "explanation": "The user wants to know which channel (e.g., stable, candidate, beta, edge) the Spotify snap is tracking. SnapInfo provides detailed snap metadata, including the channel, without modifying the system.",
+                "steps": [
+                  {
+                    "action_name": "SnapInfo",
+                    "params": "{\"name\":\"spotify\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve metadata for the Spotify snap, including its channel"
+                  }
+                ],
+                "summary": "Show the current channel of the Spotify snap"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "6343b2854ae069b1938e6ca6944dadece4b09896d1f8c60dc6206d62bd38197e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:4f76a83deb094c699b9d8bc653e78cbcc5c51c255c85282e02b29fbac74cddf7": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_2b2aa721-114f-4cb2-9d15-dcc7345d432f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants Postfix uninstalled and all its configuration deleted. AptPurge removes the package and any associated config files, achieving a clean removal. This is a medium‑risk operation because it modifies the system's package state.",
+                "steps": [
+                  {
+                    "action_name": "AptPurge",
+                    "params": "{\"package\":\"postfix\"}",
+                    "risk_level": "medium",
+                    "summary": "Purge the postfix package and its configuration files"
+                  }
+                ],
+                "summary": "Completely remove Postfix and purge its configuration files"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "65ddb1730ca6ac2435fc22798b501a277d4fd69f42b8b2ed067997ac0e84a425"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:55d94c2244af0b315ebd24eb427ebca71f0886a357365930f856bc04ebb963b2": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_227f27d4-79e4-4bec-94b3-f0c0f8d5cccc",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested installation of the git, curl, and wget packages. Each AptInstall step will install one of these packages. This is a medium-risk operation as it modifies the system's installed packages.",
                 "steps": [
                   {
                     "action_name": "AptInstall",
-                    "params": "{\"package\":\"nginx\"}",
+                    "params": "{\"package\":\"git\"}",
                     "risk_level": "medium",
-                    "summary": "Upgrade nginx to the latest version available in the repositories"
+                    "summary": "Install the git package"
+                  },
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"curl\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the curl package"
+                  },
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"wget\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the wget package"
                   }
                 ],
-                "summary": "Upgrade the nginx package"
+                "summary": "Install git, curl, and wget packages"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "41ba6683ac3d45317ff8174bc6c81ff41be9d4c9aa961fdb20d4a8cf298ffe48"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:ddee74b07574a9a5ba847edf97a84c59ff9d02021092536a59752292519fb3ea": {
+    "groq/openai/gpt-oss-120b:5aa2310c6e12e7031277171bd1a33294923b2b30f52720d84e77b70f2f89cb40": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_54753d9f-e1cd-4894-8d10-c776ff0cb4ca",
+              "id": "fc_ce84f981-f73e-46de-9a51-2e053634c202",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested a list of all installed packages on this Ubuntu system. AptListInstalled provides a read‑only enumeration of every package managed by dpkg, fulfilling the request without any system changes.",
+                "explanation": "The user requested to update the apt package list. AptUpdate refreshes the local package metadata without installing or removing any packages, a low‑risk read‑only operation.",
                 "steps": [
                   {
-                    "action_name": "AptListInstalled",
+                    "action_name": "AptUpdate",
                     "params": "{}",
                     "risk_level": "low",
-                    "summary": "Retrieve a list of all packages currently installed via dpkg"
+                    "summary": "Refresh the local APT cache with the latest package information"
                   }
                 ],
-                "summary": "List all installed packages"
+                "summary": "Refresh the APT package index"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "e653dff2b00231ed7391f16d888fc0b20edae146b4c9d481959842080e59960d"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:de4e16bfabf95daf15e2578142da542f0d46a721f7f961f211e0e370f8c5de5c": {
+    "groq/openai/gpt-oss-120b:5f388b0ba7fd24b50080def1a7eb1d281dff851edd45f97239d8cd58f9861580": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_c32be37c-f9d1-465d-a401-d57ce736d141",
+              "id": "fc_5371441d-6673-4446-bcbe-7deffbc46d73",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested to see the firewall configuration. UfwStatus provides a read‑only view of the active UFW rules and overall status on Ubuntu. No system changes are made.",
+                "explanation": "The user requested the current firewall configuration. UfwStatus returns the firewall status and list of active rules on Ubuntu. This is a low-risk read-only query and requires no approval.",
                 "steps": [
                   {
                     "action_name": "UfwStatus",
                     "params": "{}",
                     "risk_level": "low",
-                    "summary": "List the current UFW firewall rules and overall status"
+                    "summary": "Retrieve the current UFW firewall status and rule set"
                   }
                 ],
-                "summary": "Display the current UFW firewall rules and status"
+                "summary": "Show current UFW firewall status and rules"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "d9aa4d5658bb3ca7945aac483cf2401fa0d8f57c0cbabd393e4f6db7fa2ac22f"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:dfa09dcef24a1002abbfba9f717badedeb29982620adea2c84b66d9767a72108": {
+    "groq/openai/gpt-oss-120b:6e99f45d09e7613101cf5b8a832e3ba02b2f7f92c022beef3a9a142d907bdfcb": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_dcb20941-5561-4d89-9321-f46a0e1f4c7c",
+              "id": "fc_5a6a0035-2169-46c0-b4b3-aa2e76f67bac",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested to remove the Firefox snap package. SnapRemove will uninstall the specified snap from the system. This is a high‑risk operation because it deletes the snap and any data it contains.",
+                "explanation": "The user wants to freeze the postgresql package so it will not be upgraded. AptHold adds an apt-mark hold on the package, which blocks future upgrades while allowing current version to remain. This is a medium‑risk action because it modifies package management state.",
                 "steps": [
                   {
-                    "action_name": "SnapRemove",
-                    "params": "{\"name\":\"firefox\"}",
-                    "risk_level": "high",
-                    "summary": "Remove the Firefox snap package"
+                    "action_name": "AptHold",
+                    "params": "{\"package\":\"postgresql\"}",
+                    "risk_level": "medium",
+                    "summary": "Place an apt hold on the postgresql package to prevent upgrades"
                   }
                 ],
-                "summary": "Uninstall the Firefox snap"
+                "summary": "Prevent the postgresql package from being upgraded"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "663c334cb291dec89fc013fb56abf0ee4e18b725d55b14e721da343cbcb4bf48"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:e056729c7e9bb1d9f3fce66bfc11390720b1909684d28bce91db75a2f56e05ce": {
+    "groq/openai/gpt-oss-120b:6f158206a5b107ee9754db977d8aa1267a1170c82266866731c3c18180bf1074": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_4986c875-02c1-46c8-a534-cfd0376453f4",
+              "id": "fc_6933ada5-bd88-4449-8392-3a2f58f50555",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to permit inbound web traffic on the standard ports 80 (HTTP) and 443 (HTTPS). Adding these rules to ufw will open the specified ports. Both actions are high risk because firewall changes can affect connectivity, but they are required to satisfy the request.",
-                "steps": [
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"80\"}",
-                    "risk_level": "high",
-                    "summary": "Allow inbound traffic on HTTP port 80"
-                  },
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"443\"}",
-                    "risk_level": "high",
-                    "summary": "Allow inbound traffic on HTTPS port 443"
-                  }
-                ],
-                "summary": "Allow HTTP and HTTPS traffic through the firewall"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:e1bbca160bbe5317ee187834c7938ec44da03aed987edcfafecef3f6e444d9c8": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_3e801534-ce8c-4843-996d-36cb02724551",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants inbound SSH traffic allowed. Adding a ufw rule for port 22 will permit SSH connections. This is a high-risk change because firewall modifications can affect remote access, so it requires approval before execution.",
-                "steps": [
-                  {
-                    "action_name": "UfwAllow",
-                    "params": "{\"port_or_service\":\"22\"}",
-                    "risk_level": "high",
-                    "summary": "Allow inbound traffic on TCP port 22 for SSH"
-                  }
-                ],
-                "summary": "Open SSH port 22 in the firewall"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:e3fef6961970b72ac358a5f1a0068daa8629c20fa551ca2952b86e96e2cc5d76": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_05226d98-9cb4-4d5e-acd4-5ea925a62b39",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested removal of the Distrobox container named 'old-dev'. This action will stop and delete the container and its associated resources. It's a medium‑risk operation because it permanently removes the container.",
+                "explanation": "The user requested removal of a specific distrobox container. DistroboxRemove will delete the container safely. This is a medium-risk operation as it permanently removes the container.",
                 "steps": [
                   {
                     "action_name": "DistroboxRemove",
                     "params": "{\"name\":\"old-dev\"}",
                     "risk_level": "medium",
-                    "summary": "Remove the Distrobox container called old-dev"
+                    "summary": "Remove the distrobox container called old-dev"
                   }
                 ],
-                "summary": "Delete the specified Distrobox container"
+                "summary": "Delete the distrobox container named old-dev"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "5396a02b28162d480e8a3a3045e3d0a2ef44e2f253a26d08f15bcc93bc5547f8"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:e4c33f027adc3374d390fd6c1639b2908208bca6dede1e75fa39c53704afcab1": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "Text": {
-              "text": "I’m sorry, but I can’t help with that."
-            }
-          }
-        ],
-        "stop_reason": "EndTurn"
-      }
-    },
-    "groq/openai/gpt-oss-120b:e630e105191d8a2fa7b08ddb9227c11ee289f7e5d20fba6856cf2363ddef2d1e": {
+    "groq/openai/gpt-oss-120b:809574fe00b340d75db0dc9702b0bea556ea37a47dc77dd927bc34c6d872bffb": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_c541e2d0-caf0-4815-8924-2259075bf9b9",
+              "id": "fc_0cf2b0bd-993c-4bf7-a9a0-499dc9261f67",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested installation of the VSCode snap. SnapInstall will download and set up the 'code' snap, which provides the Visual Studio Code editor. This is a medium‑risk action (installing software), but no further confirmation is needed for the plan.",
+                "explanation": "The user wants to know whether the openssh-server package is present and its version. AptShow retrieves package details, including installation status and version, without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "AptShow",
+                    "params": "{\"package\":\"openssh-server\"}",
+                    "risk_level": "low",
+                    "summary": "Show details for the openssh-server package, including version if installed"
+                  }
+                ],
+                "summary": "Check if openssh-server is installed and display its version"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "a07441905fac7e7823cac176d863a5582bf286684f319058854fcd9ddeb44bf2"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:80c5161265e9ae43dc92919fb504869c7e80d94871872272e53a7a3451330d34": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_ee51d360-3fae-42ee-b2ae-825d8a0e4d8d",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested updating all snaps. SnapRefresh without a name refreshes every installed snap to the newest revision. This is a medium‑risk operation because it modifies installed software.",
+                "steps": [
+                  {
+                    "action_name": "SnapRefresh",
+                    "params": "{}",
+                    "risk_level": "medium",
+                    "summary": "Refresh all installed snaps to their latest versions"
+                  }
+                ],
+                "summary": "Refresh all installed snap packages to their latest versions"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "2a8c3e89caae87c5c4e9bd67ecbc3ab54a830555cbc8b75c3f623d04667564ae"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:824627a0f809f2f4447a8e253fccdfa2bbfae4d4cc05d400f57badd2d7d7415a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a5bca1ce-b936-4075-84f8-bf64abe961b6",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a list of every package currently installed. AptListInstalled provides a read‑only enumeration of installed packages on Ubuntu without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "AptListInstalled",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve a full list of installed packages"
+                  }
+                ],
+                "summary": "List all installed packages on the Ubuntu system"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "9f136799a23967e82b0b033cb56213c66b08fa19ef571eb0b6bb8a2919d20aa7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:85afc811e59e04d9ce34f5207bca612f42f838648d417a2f0ea92937e96edcfa": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_e93d84f4-6d6f-441c-b750-f6486344a5b0",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to permit inbound traffic for the Nginx Full service using ufw. Adding this rule updates the firewall to allow connections matching the Nginx Full profile.",
+                "steps": [
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"Nginx Full\"}",
+                    "risk_level": "high",
+                    "summary": "Add a ufw rule to allow the Nginx Full service"
+                  }
+                ],
+                "summary": "Allow the Nginx Full profile through ufw"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "684cfa76030fcd8a78592b767ce69c75b948a89d9ed565d8791b331fbcc3335e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:8c98441712f8fe56ef9b7bf636abe4c726eeae6f8af413161f5504b0e7599c86": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a3a2203d-644f-4a63-b866-3b8c135580ff",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to bring all packages up to date on this Ubuntu server. AptUpgrade will update every installed package to the newest available version, which may involve significant changes, so it is classified as high risk and requires approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "AptUpgrade",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Perform a full system package upgrade"
+                  }
+                ],
+                "summary": "Upgrade all installed packages to the latest versions"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "103fa9bb3d53462fd3fdbea8d7fffcfa958eea2055ad448623fe69bdcd0451a9"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:8cdecbeb433c8387e81e51aef358f9fc7666ce57bdc3aae86b99a5d0ef221b41": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_04a33cab-5cb7-4aa7-9ae2-6b660da1d416",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a list of the snaps currently installed on the system. SnapList provides a read‑only enumeration of all snap packages, satisfying the request without any system changes.",
+                "steps": [
+                  {
+                    "action_name": "SnapList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve a list of all installed snap packages"
+                  }
+                ],
+                "summary": "List all installed snaps"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "8111f5defbb3ca46b7413c3f0011168e700b5c99986c9658b4620533494e1a69"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:8ceb750fca72271f27fbd134813d71ee6e24717bfdb758e79b77b5e5ebb1b78e": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_bff42ec4-a9e0-4c0b-a1ae-83619eb16246",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a new Distrobox container called fedora-dev based on the fedora:41 image. DistroboxCreate will create this container, which is a medium‑risk operation as it adds a new container to the system.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxCreate",
+                    "params": "{\"name\":\"fedora-dev\",\"image\":\"fedora:41\"}",
+                    "risk_level": "medium",
+                    "summary": "Create the distrobox container fedora-dev using the fedora:41 image"
+                  }
+                ],
+                "summary": "Create a Distrobox container named fedora-dev using the fedora:41 image"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "5c4e8e592b2c4f966130a7e38d507abb14e0c74bc25e720a4df3f257c5c4984e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:919789c4e3f919b70d5c163bfcd45cb092aec019cb967f18db99fcc7f29b136a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_67c81873-0cb8-4f57-939b-ed88d3986c4b",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of the telnet package. AptRemove will uninstall the package while preserving its configuration files. This is a medium‑risk operation requiring approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "AptRemove",
+                    "params": "{\"package\":\"telnet\"}",
+                    "risk_level": "medium",
+                    "summary": "Uninstall the telnet package, keeping its configuration files"
+                  }
+                ],
+                "summary": "Remove the telnet package from the server"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "73e4ad5af69e18afa1ac9c29a894e26bedced399076cc6bc20c6e971ada55a85"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:9898ae48d8f94413dddd3b567723af2d477cd0e70f3ba33c84bc446782b09c2d": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_0d8dfbb6-817c-4aed-9723-deed2338b216",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to permit inbound web traffic on standard HTTP and HTTPS ports. We will add two ufw allow rules, one for port 80/tcp and one for port 443/tcp. These actions modify the firewall configuration and are classified as high risk.",
+                "steps": [
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"80/tcp\"}",
+                    "risk_level": "high",
+                    "summary": "Allow inbound traffic on HTTP port 80/tcp"
+                  },
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"443/tcp\"}",
+                    "risk_level": "high",
+                    "summary": "Allow inbound traffic on HTTPS port 443/tcp"
+                  }
+                ],
+                "summary": "Allow web traffic on HTTP (port 80) and HTTPS (port 443) through ufw"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "e685dcd493b55ea55fb1d63bf88f9feb956b6d131096a36491b85197976b69f9"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:9a68c45bc4c2e5592ccb2d6b539801b6162d82c3906ec04db6da7c7b97ed52ee": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_298aaf35-9554-4cea-8ffb-e4956e13f25e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested installation of nginx. AptInstall will download and install the nginx package from the configured repositories. This is a medium‑risk operation because it modifies the system's package set.",
+                "steps": [
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"nginx\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the nginx package using apt"
+                  }
+                ],
+                "summary": "Install the nginx web server"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "4aabceb6b1cf59a1728c43f20273c6ea4646b4ac971487725f347a1cbe326ace"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:9beed37640755785b9992b99ee16a0c66bfd3cc983c8185852a4f0d356e0d4c2": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_77966505-5b2f-4df5-ba77-69ed577284c0",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants the firewall to permit SSH connections. Adding a rule for port 22 (or the ssh service) with UfwAllow will open the necessary port. This is a high‑risk operation because firewall changes can affect remote connectivity, so it requires approval.",
+                "steps": [
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"22\"}",
+                    "risk_level": "high",
+                    "summary": "Add a firewall rule to allow inbound traffic on port 22 (SSH)"
+                  }
+                ],
+                "summary": "Allow inbound SSH traffic on port 22 via the firewall"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "764b89917271bda5a446e7ce58122aa6c04f126a9c2e00e47f7ae414bdd57326"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:a17934bb97b1ce5aa05a0f7bed02cfcf3116fea982552ae3fe6b166ef8042d56": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f6cac187-d66c-499b-b127-bb0b8ef5e6d8",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn on the firewall. Enabling UFW will activate the firewall with its current rule set. This is a high‑risk action because it may affect network connectivity, especially on remote sessions.",
+                "steps": [
+                  {
+                    "action_name": "UfwEnable",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Enable the Uncomplicated Firewall (UFW)"
+                  }
+                ],
+                "summary": "Enable the UFW firewall"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "f5d2e0c8fe2b29140358ca6759a763c38768caaab3257c3469a2430a27b750ee"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:a6d9fb50636a47e0038551152c0eaf21f340ccd165fd172fc482dac1f4e79fbf": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_83ba87ee-53be-47c4-9e3a-5e3ad1531be6",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to stop auto-updating the Chromium snap. SnapHold will hold the snap at its current revision, which satisfies the request. This is a medium‑risk action as it modifies snap refresh behavior.",
+                "steps": [
+                  {
+                    "action_name": "SnapHold",
+                    "params": "{\"name\":\"chromium\"}",
+                    "risk_level": "medium",
+                    "summary": "Hold the Chromium snap at its current version to stop auto-updates"
+                  }
+                ],
+                "summary": "Pin the Chromium snap to prevent automatic updates"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "9f822e7fe31c9f9f385bda6a226e790eaf9f1f2f8cf510eb7478f5266accbdb4"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:a887f4d72cc77d8de8f1338d7eff0b90bd04cd6a2b8b47d78557ae56f5286505": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_75ac2380-e0db-4737-ba14-4af895b918a9",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested the VS Code snap. SnapInstall will download and install the 'code' snap, which is a medium-risk action because it modifies the system by adding a new snap package.",
                 "steps": [
                   {
                     "action_name": "SnapInstall",
                     "params": "{\"name\":\"code\"}",
                     "risk_level": "medium",
-                    "summary": "Install the Visual Studio Code snap (named 'code')"
+                    "summary": "Install the VS Code snap (code)"
                   }
                 ],
                 "summary": "Install the Visual Studio Code snap package"
@@ -2661,79 +1178,173 @@
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "469e0c877311e15d56682d4b02789b42a17407c7a3b63644dbfe7e2d94d33467"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:e9855b1d4114c33dca36d690e02199daffbd349854f23a5e24a26a06865dfda7": {
+    "groq/openai/gpt-oss-120b:a9badbc1efdbc9a68cc90d08a3705fa637ca2ba33c2195ab11cf05477180f8bb": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_853e33fc-de58-4ef6-ba16-23997983a865",
+              "id": "fc_ffbbee15-55fc-4885-8111-e980e4b7a59d",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested the current Netplan configuration. NetplanGetConfig returns the YAML configuration without modifying the system, so it's a low‑risk read‑only action.",
+                "explanation": "The user requested removal of the Firefox snap package. SnapRemove will delete the snap from the system. This is a medium‑risk operation as it modifies installed software.",
+                "steps": [
+                  {
+                    "action_name": "SnapRemove",
+                    "params": "{\"name\":\"firefox\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the Firefox snap package from the system"
+                  }
+                ],
+                "summary": "Uninstall the Firefox snap"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "8bdea8101dc3a6689ea49c58e108291e41df35aa698ec8e1139452da4e4b4ef7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:b3914868f2c80f2ab7cc67b113754b20db9a0f83b77f8a0587bbf8ea6177a2ec": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3be68e11-5278-41c6-8d91-3961077b0a66",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to view the netplan configuration, which is a read‑only operation. NetplanGetConfig returns the YAML configuration without modifying the system.",
                 "steps": [
                   {
                     "action_name": "NetplanGetConfig",
                     "params": "{}",
                     "risk_level": "low",
-                    "summary": "Retrieve the Netplan network configuration file contents"
+                    "summary": "Retrieve the netplan network configuration file(s)"
                   }
                 ],
-                "summary": "Show Netplan network configuration"
+                "summary": "Show the current netplan network configuration"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "f837cb98679e6d6a0e143e55e1bafdc0640dca07c51eef82a12c25f603d89b06"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:eac8db52e10df86faebfed099a3fb204f30136b1c0787d81ce01d26c3a2c8a1c": {
+    "groq/openai/gpt-oss-120b:b7d57859b3a88861d1ad1543a2a3c436ba8cdab27633bb8fd28eb9745311a85e": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_4d6d0a61-cb74-46df-ae6d-bdc04c84dfd8",
+              "id": "fc_cc0a4229-250d-4f75-ae7b-20522946cc94",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested installing the VS Code snap. SnapInstall will download and set up the requested snap. This is a medium‑risk action as it modifies the system by adding a new snap package.",
+                "explanation": "The user wants to apply any changes made to Netplan. NetplanApply will commit the configuration, which may restart network interfaces and could disconnect the session. This is a high‑risk action but requires no additional parameters.",
                 "steps": [
                   {
-                    "action_name": "SnapInstall",
-                    "params": "{\"name\":\"vscode\"}",
-                    "risk_level": "medium",
-                    "summary": "Install the VS Code snap package"
+                    "action_name": "NetplanApply",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Apply the Netplan configuration to bring network settings into effect"
                   }
                 ],
-                "summary": "Install the VS Code snap package"
+                "summary": "Apply the pending Netplan network configuration"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "0820d53395874b84649da23279f88c3474f9037d7a16045e913d583349b67f74"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:eb0bdfcc26f226fd06bb507e29bc406fd4e012b8cd0ad78a012076f2113d538b": {
+    "groq/openai/gpt-oss-120b:ca735e7a7468d1c75030d9c7c79d3c90bc7d5876d9bfaa38c4164169417822dc": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_5ddfcda1-0aab-4ee0-a690-f648fae08354",
+              "id": "fc_3b71d28d-a88a-49f8-b428-95913f7c91d2",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested to find all Redis-related packages available in the apt repositories. AptSearch with the term 'redis' will list matching packages without modifying the system.",
+                "explanation": "The user asked to block port 0, but port 0 is invalid for firewall rules. Instead, we will display the current ufw status so the user can review existing firewall configuration.",
+                "steps": [
+                  {
+                    "action_name": "UfwStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Display the current ufw firewall status and rules"
+                  }
+                ],
+                "summary": "Show current firewall status (port 0 is not a valid rule)"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "dbaa624779742f87f271777c499df8b6cbad3fbd1a3d28050e7247e7914da5d8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ca73bb1f0c06a6d1851f8740640e67ad905057de2ba64106921c78104e207a81": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_9da4e787-89dd-4898-9144-c224c20d0cb7",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to find all packages related to Redis. Using AptSearch with the term 'redis' will list matching packages from the APT repositories. This is a low‑risk, read‑only operation.",
                 "steps": [
                   {
                     "action_name": "AptSearch",
                     "params": "{\"term\":\"redis\"}",
                     "risk_level": "low",
-                    "summary": "Search apt repositories for packages related to Redis"
+                    "summary": "Search APT package index for packages containing 'redis'"
                   }
                 ],
                 "summary": "Search for Redis-related packages"
@@ -2742,255 +1353,464 @@
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "852831c3aa2d573ddcbbd836cb4e0b3b8d20db8a76392fd9057b55a60679d610"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:ec6cdfcda5df32e17aa241e2ea8cd463702f78fcbf8e57e60e1e661b34cdf4b1": {
+    "groq/openai/gpt-oss-120b:ca9a55f920b6e9341f1ccc80851a27f1b6a2efaeead53bf4c5d68062fb82b6a9": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_a6427cdf-cd65-4135-9c54-1c187fd0ff37",
+              "id": "fc_a05e7efa-9618-4081-8329-fa479f84773f",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to update the package list and then install the htop utility. AptUpdate refreshes the local apt cache, and AptInstall adds the requested package. The first step is low risk, the second is medium risk.",
+                "explanation": "The user requested a cleanup of unnecessary packages. AptAutoremove will remove orphaned dependencies that are not required by any installed package. This operation is low risk and does not require approval.",
+                "steps": [
+                  {
+                    "action_name": "AptAutoremove",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Run apt autoremove to purge unneeded packages"
+                  }
+                ],
+                "summary": "Remove packages that are no longer needed"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "7b521f6f4c1a4a9dad585950f74aafedbb564cff453bda7d969f1c260c2dc8d5"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:d4249604795963758153e0c2b2b6ac4ef957a79be89d396951a4153c040559fc": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3acade0d-a25c-4746-ba76-6a3cd6f30766",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants the UFW firewall turned on and SSH traffic permitted. Enabling UFW activates the firewall rules, and allowing the SSH service ensures remote access remains possible. Both actions are high risk because they modify network security settings, so they require careful execution.",
+                "steps": [
+                  {
+                    "action_name": "UfwEnable",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Enable the UFW firewall"
+                  },
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"ssh\"}",
+                    "risk_level": "high",
+                    "summary": "Allow incoming SSH connections through the firewall"
+                  }
+                ],
+                "summary": "Enable the firewall and allow incoming SSH connections"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "5b20f3a2c42a236a0773513a3b0a4b2657e310f11ac2b4e6fa8f527080102fb5"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:d599aa9642c52e3bfe22c97c67d39f0a61a84b3c665e0a84cc2f39870bc0c42d": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_bfa90613-435b-438a-b8f6-573cee739241",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to pin (hold) the mysql-server package so it won't be upgraded, then view its package information. AptHold will create an apt hold, and AptShow will retrieve the package's details. The hold is a reversible change (medium risk) and the details query is read‑only (low risk).",
+                "steps": [
+                  {
+                    "action_name": "AptHold",
+                    "params": "{\"package\":\"mysql-server\"}",
+                    "risk_level": "medium",
+                    "summary": "Place a hold on the mysql-server package to prevent future upgrades"
+                  },
+                  {
+                    "action_name": "AptShow",
+                    "params": "{\"package\":\"mysql-server\"}",
+                    "risk_level": "low",
+                    "summary": "Show detailed information about the mysql-server package"
+                  }
+                ],
+                "summary": "Hold the mysql-server package to prevent upgrades and display its package details"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "4f3af260cdad00eefc58e372e727dede9f92164bf3e4b88639e63819f6b33382"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:de0876ed8e6473af563a3a03bf01ea0c4e5d77043c870279020f52efa26fc1bb": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_eff96509-9be4-48a2-8912-2c7f412f5398",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested an update of the package list followed by installation of htop. AptUpdate refreshes the local APT cache (low risk) and AptInstall adds the specified package (medium risk). Both actions are needed to fulfill the request.",
                 "steps": [
                   {
                     "action_name": "AptUpdate",
                     "params": "{}",
                     "risk_level": "low",
-                    "summary": "Refresh the apt package index"
+                    "summary": "Refresh the APT package index to get the latest package information"
                   },
                   {
                     "action_name": "AptInstall",
                     "params": "{\"package\":\"htop\"}",
                     "risk_level": "medium",
-                    "summary": "Install the htop package"
+                    "summary": "Install the htop package after the package list has been refreshed"
                   }
                 ],
-                "summary": "Refresh apt package index and install htop"
+                "summary": "Refresh APT package index and install the htop utility"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "353bfd3462c75976a2b775ba6e3d05d5724b0d346a516b572a5956c1d7ea8a62"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:ece3b77f06bc7ddbe8fa67fb99162134164b20794119e68e6403474eee57f09a": {
+    "groq/openai/gpt-oss-120b:e0179f0d8846535d417e587086d0f6867f8b30838b45004dd66ced6bec637d28": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_879a6c7e-bafc-4d2e-85b0-fc2f0c9be33d",
+              "id": "fc_a69438ca-eb5e-4167-80e4-5266765f9284",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user requested a full system package upgrade. AptUpgrade will perform a dist-upgrade of all installed packages, which is a high‑risk operation because it may modify many components and could require a reboot. No additional checks are needed; the action will be executed directly.",
+                "explanation": "The user wants to know whether the Ubuntu firewall (ufw) is enabled and which ports are currently open for listening. UfwStatus provides the firewall state and rules, while GetListeningPorts lists active listening sockets. Both are read‑only low‑risk queries.",
                 "steps": [
                   {
-                    "action_name": "AptUpgrade",
+                    "action_name": "UfwStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Display whether ufw is active and its current rule set"
+                  },
+                  {
+                    "action_name": "GetListeningPorts",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all TCP/UDP ports currently listening and the associated processes"
+                  }
+                ],
+                "summary": "Show firewall status and list open listening ports"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "00222c4f773803d5b9eb37ddd904efbeba6227a1e9f412efe2943b5df95ab1e1"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:e209803c72e9f49c4bdabfc1254a7b4824496b2f4527687bf54b2c5c933244c4": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_0e448156-96ac-4bcc-8f5a-203268bdc90f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to view the network configuration and then apply it. GetNetworkStatus will display the interfaces, IPs, and statuses. NetplanApply will reload the netplan configuration to make any pending changes active. The first step is read‑only; the second step mutates network state and is high risk.",
+                "steps": [
+                  {
+                    "action_name": "GetNetworkStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Display current network interfaces, addresses, and connection states"
+                  },
+                  {
+                    "action_name": "NetplanApply",
                     "params": "{}",
                     "risk_level": "high",
-                    "summary": "Run a full package upgrade (dist-upgrade) on the system"
+                    "summary": "Apply the netplan configuration to activate any pending network changes"
                   }
                 ],
-                "summary": "Upgrade all installed packages on the Ubuntu system"
+                "summary": "Show current network configuration and apply netplan settings"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "c0f5ff67356cc85cdf122642a0d07573b7e8c6bdf6cc9089bf2438976fbaf1a0"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:ee934d6020390da7e16cdd9aa4f779102f95c47e884ebf55ab1da4213ab1d546": {
+    "groq/openai/gpt-oss-120b:e528bf8787e1404a8faf932a957ea3a30f5e476eec7209fe035b5c743e9c009d": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_8961e1ce-ff63-4fa0-959f-7a85795e4181",
+              "id": "fc_d688ab2a-88cd-4e4a-b931-1598cdafcc38",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to re-enable automatic updates for the Chromium snap. Using SnapUnhold removes any hold that was placed on the snap, restoring the default auto-refresh behavior.",
+                "explanation": "The user requested to reset all UFW rules back to their default state. This action will clear all existing firewall rules and restore the default configuration, which is a high‑risk operation as it changes the system's network security posture.",
                 "steps": [
                   {
-                    "action_name": "SnapUnhold",
-                    "params": "{\"name\":\"chromium\"}",
-                    "risk_level": "medium",
-                    "summary": "Remove the hold on the Chromium snap to re-enable auto-updates"
+                    "action_name": "UfwReset",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Reset UFW firewall to its default configuration, removing all custom rules"
                   }
                 ],
-                "summary": "Allow the chromium snap to auto-update again"
+                "summary": "Reset UFW firewall to default settings"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "9eda1e6a408d80b56025a68431137348baa2b3c82684a720f4373baa9560356a"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:ef0388ad516b9bd21b1b70d63876445a94a046731e8cc568542125afebb8bc56": {
+    "groq/openai/gpt-oss-120b:ea1b23cab11081f68f270f893e05c82cf0527b783eb1330351e9b23916010d84": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_17485701-a782-452b-b619-cbfe2c89ff2f",
+              "id": "fc_d4f77eea-f73b-4515-8d85-303a4823e532",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to see which development containers (toolbox containers) are running. Listing them provides the required information without any system changes.",
-                "steps": [
-                  {
-                    "action_name": "ListToolboxes",
-                    "params": "{\"username\":\"root\"}",
-                    "risk_level": "low",
-                    "summary": "List toolbox containers for the user"
-                  }
-                ],
-                "summary": "List all development toolbox containers for the current user"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:f0a2fb2fa14c6c312c483844705421ec49f5501a9ee802ef4323b692dca657fa": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_2979e1da-3cda-45ae-b185-d4d9cefcadcd",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested to block port 23 (telnet) using the UFW firewall. The UfwDeny action will add a rule to deny inbound connections on that port. This is a high‑risk change because firewall modifications can affect connectivity.",
+                "explanation": "The user wants to deny traffic on the telnet port (23). This plan adds a ufw deny rule for that port. It's a high‑risk action because firewall changes can affect connectivity, especially over remote sessions.",
                 "steps": [
                   {
                     "action_name": "UfwDeny",
                     "params": "{\"port_or_service\":\"23\"}",
                     "risk_level": "high",
-                    "summary": "Deny inbound traffic on port 23 (telnet)"
+                    "summary": "Deny inbound traffic on port 23 (telnet) via ufw"
                   }
                 ],
-                "summary": "Block inbound telnet traffic by denying port 23 in the UFW firewall"
+                "summary": "Block incoming telnet traffic on port 23 using ufw"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "bfdd970791317f4145873c38f0836dd9e774c9a75d04e14235ed9c796a536f39"
+        ]
       }
     },
-    "groq/openai/gpt-oss-120b:f42c69372bc9a7b04d201a699600cfda0b381c67b3f8c661ef8bc5ce1f1d088f": {
+    "groq/openai/gpt-oss-120b:ee8735e0e9ae51cf14643f7d6cc9d625736eb4e7dae6c3679c6ed774327aa807": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
         "content": [
           {
             "ToolUse": {
-              "id": "fc_e85e5d8f-42f2-42ad-83da-63254450bdf0",
+              "id": "fc_67703c7a-4548-4527-8f6b-dca825802eb8",
               "call_id": null,
               "name": "propose_plan",
               "input": {
-                "explanation": "The user wants to know whether the openssh-server package is present and, if so, its version. AptShow returns package details on Ubuntu/Debian without modifying the system.",
+                "explanation": "The user wants to remove the hold on the nginx package so it can be upgraded in future apt operations. This requires the AptUnhold action, which lifts the apt-mark hold flag.",
                 "steps": [
                   {
-                    "action_name": "AptShow",
-                    "params": "{\"package\":\"openssh-server\"}",
-                    "risk_level": "low",
-                    "summary": "Show details of the openssh-server package, including installation status and version"
-                  }
-                ],
-                "summary": "Check if the openssh-server package is installed and show its version"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:f42db01efcd0aacea5c146f8ef5411c30961219c9da97b984f8e78272532f485": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_4ada478f-ba49-404e-846c-b35dd0c90e93",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user requested a full package upgrade. AptUpgrade will refresh the package database and upgrade every installed package to the latest available versions. This is a high‑risk operation that may install new dependencies, restart services, and potentially require a reboot.",
-                "steps": [
-                  {
-                    "action_name": "AptUpgrade",
-                    "params": "{}",
-                    "risk_level": "high",
-                    "summary": "Upgrade all installed packages to the latest versions"
-                  }
-                ],
-                "summary": "Upgrade all installed packages on the system"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:f75f62a155818ed2b852ca4fb275732f0ac555515b49ee23dd0fcbe9fab00929": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_f5b82491-5f1c-4a87-bc47-5c95a30a8cac",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to fully wipe the Apache2 web server, including all its configuration files. This requires purging the package, which removes both the binaries and configuration directories. AptPurge is the appropriate low-level action for this on Ubuntu/Debian and is classified as high risk due to its irreversible removal of software and config.",
-                "steps": [
-                  {
-                    "action_name": "AptPurge",
-                    "params": "{\"package\":\"apache2\"}",
-                    "risk_level": "high",
-                    "summary": "Purge the apache2 package and all associated configuration files"
-                  }
-                ],
-                "summary": "Completely remove Apache2 and its configuration files"
-              }
-            }
-          }
-        ],
-        "stop_reason": "ToolUse"
-      }
-    },
-    "groq/openai/gpt-oss-120b:fabff464b27ec4e12e22fb48fa74092b665205c8910e756446beb5fb53215eaa": {
-      "surface": "groq/openai/gpt-oss-120b",
-      "output": {
-        "content": [
-          {
-            "ToolUse": {
-              "id": "fc_3197ea04-2e1b-4545-b7c8-0563464e6cdd",
-              "call_id": null,
-              "name": "propose_plan",
-              "input": {
-                "explanation": "The user wants to re-enable automatic updates for the chromium snap. Removing the hold on the snap will allow snapd to refresh it according to its normal schedule.",
-                "steps": [
-                  {
-                    "action_name": "SnapUnhold",
-                    "params": "{\"name\":\"chromium\"}",
+                    "action_name": "AptUnhold",
+                    "params": "{\"package\":\"nginx\"}",
                     "risk_level": "medium",
-                    "summary": "Remove the update hold from the chromium snap so it can auto-update"
+                    "summary": "Remove hold from nginx package to permit upgrades"
                   }
                 ],
-                "summary": "Allow the chromium snap to auto-update again"
+                "summary": "Allow nginx package to be upgraded again"
               }
             }
           }
         ],
         "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "d3c876cc7579365eaba1f033b2d9ca85351803c9467483018bc27f675884519b"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:f3c668dda8d41d53dfc8dd5de77b3b6103976343d9922c5955bc43d81035b1b0": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_5e88f879-255f-41e9-9b45-05da06f8c56a",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested information about the lxd snap. SnapInfo provides metadata such as version, channel, description, and confinement for the specified snap without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "SnapInfo",
+                    "params": "{\"name\":\"lxd\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve detailed information about the lxd snap"
+                  }
+                ],
+                "summary": "Show details about the lxd snap"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "a488530ff112b16b47517e37f05e24b71da504d6c2fb6d16629ce13d81964106"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:f4b408ae9b3fb3c8acc3711b0b3361d6a33bc5edbf4e75b67fc1a8b0a946afc0": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_13357a05-8256-412b-a224-797a2efe3c66",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to find any packages related to Docker. Using the AptSearch action with the term 'docker' will query the apt package database and list matching packages. This is a read‑only operation with low risk.",
+                "steps": [
+                  {
+                    "action_name": "AptSearch",
+                    "params": "{\"term\":\"docker\"}",
+                    "risk_level": "low",
+                    "summary": "Search apt package index for packages containing the term 'docker'"
+                  }
+                ],
+                "summary": "Search for Docker packages in the apt repositories"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "2c78ba02fabfda31bf057029dc62198d50a5299f1ef8e7cbc2216fc3f65342fc"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ff6a3f000e564091f69d113ee03e3d48dff14cf56713fedcaacb6b1fc7c89db7": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_62b983e3-e5c4-4b70-b313-86fe637fe152",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a new Distrobox container called 'dev' based on the Ubuntu 24.04 image. DistroboxCreate will provision the container with the specified name and image. This is a medium‑risk operation because it creates a new isolated environment on the system.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxCreate",
+                    "params": "{\"name\":\"dev\",\"image\":\"ubuntu:24.04\"}",
+                    "risk_level": "medium",
+                    "summary": "Create the 'dev' Distrobox container using Ubuntu 24.04"
+                  }
+                ],
+                "summary": "Create a Distrobox container named dev using the Ubuntu 24.04 image"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f377328a10a465cc34221ee3899e9fb26dd7b0a8e24ac8887ca6e179a575c336",
+        "tools": "5ccd3c47b24e71ed45ecf528ecdbca739ecfa466c15dea182e5e6a35d16bf236",
+        "max_tokens": 4096,
+        "messages": [
+          "697ef8a29b5fea0c536bf8b82845641c317ec1f900a652aa512f90cc0f8e35d7"
+        ]
       }
     }
   }

--- a/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json
+++ b/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json
@@ -5,9 +5,9 @@
     "verdict": "not-applicable"
   },
   "cassette_mode": "record",
-  "cassette_sha256": "819f72b67e5fa278c2b68a6758ffcc379ab3b529f022fdeb82f2eba3ccc8aa27",
+  "cassette_sha256": "45cdaab93d4e274319eca45c8636c663185242f477c2c41694ff108285f048ce",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-05T17:50:28+00:00",
+  "ran_at": "2026-08-08T20:12:22+00:00",
   "release": "22.04",
   "stories": {
     "100": {
@@ -16,7 +16,7 @@
     },
     "101": {
       "name": "Distrobox list alt phrasing",
-      "verdict": "FAIL"
+      "verdict": "PASS"
     },
     "102": {
       "name": "System-wide upgrade with alt phrasing",
@@ -28,7 +28,7 @@
     },
     "104": {
       "name": "Apply netplan after showing config",
-      "verdict": "PASS"
+      "verdict": "FAIL"
     },
     "55": {
       "name": "Refresh apt package index",

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "853054f5faf4f7ec463fe085696d3d9063c7eabe"
+    "tests": "c55987c8707dd4029ea4e044d94c75e9ab452f55"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-08T04:43:20-06:00"
+    "tests": "2026-08-08T13:36:56-06:00"
   },
-  "tests": 1723,
+  "tests": 1727,
   "version": 1
 }


### PR DESCRIPTION
Closes #181. Option 1 of the three the issue offered, as chosen.

## The bug

`GetSystemState` ran `rpm-ostree status --json` on **every** host, so on an
apt box it failed with `command not found` — *after* the operator had approved
it. It was the last action outside the family fence, the sole entry in
`UNFENCED_BY_DECISION`, because it appeared throughout the shared prompt blocks
as *the* action every worked example reaches for and Ubuntu had nothing to put
in its place.

## The fix

`GetHostState` — `hostnamectl status`. One read-only command, no root, present
on every systemd Ubuntu, reporting OS release, kernel, architecture and machine
identity. The issue also floated pending-reboot and upgradable-count; both
already have actions (`CheckPendingReboot`, `AptListUpgradable`), so folding
them in would have meant a shell pipeline and a second answer to an answered
question. One action, one mechanism.

`UNFENCED_BY_DECISION` is now **empty**.

## The prompt

18 references across shared blocks that are empirically validated and must keep
their wording, while naming an action that exists on the host. They now carry
`{STATE_ACTION}` / `{STATE_RETURNS}` placeholders each renderer substitutes.

Substituting the **reason** as well as the name is load-bearing: three
occurrences justify their advice with rpm-ostree specifics (*"it returns
OSTree/rpm-ostree data, not clock data"*). A name-only swap would have told the
Debian model that `GetHostState` returns OSTree data.

A new test asserts no rendered prompt leaks an unsubstituted placeholder —
every other prompt test would have passed with literal braces shipped to the
model. `prompt_with_no_distro_hint_is_unchanged_from_baseline` still passes
byte-for-byte.

## Tests that were asserting the bug

| Test | Was |
|---|---|
| `get_system_state_allowed_on_ubuntu` | asserted exactly the behaviour this issue is about |
| its Fedora twin | used `DistroId::Fedora` — plain Workstation, **no rpm-ostree**, `is_supported() == false`. Corrected to Silverblue |
| `check_plan_steps_distro_allows_generic_action` | used `GetSystemState` as its example of a generic action |
| ~35 daemon tests | used it as a stand-in for "any low-risk action"; now `GetMemoryInfo`. The one place that legitimately names it — the deployment family's member list — keeps it |

## Live validation

Real jammy VM, `groq/openai/gpt-oss-120b`, the surface every published figure
names. **49/50 — identical to the pre-change baseline**, reproduced across two
independent runs.

Which story fails does *not* reproduce: run A failed 101 (Groq
`tool_use_failed` — a correct plan under a bogus tool name, same cause as the
baseline), run B failed 104 (picked `GetNetworkStatus` over
`NetplanGetConfig`).

104 could have been mine, so it was tested rather than assumed: 1/3 here, then
the VM was rebuilt from `main` and it scored 2/3 there. n=3 cannot distinguish
those, and that isn't the claim — **104 fails on unmodified main**, so its
flakiness predates this. Worth its own issue.

Cassette re-recorded from scratch, not resumed: resuming left 176 entries under
**three** prompt hashes. Clean now — 50 entries, one hash, all fingerprinted by
the #182 work, and the artifact's `cassette_sha256` matches the committed file
byte-for-byte.

1727 tests, clippy `--all-features --all-targets` clean, `cargo doc -D warnings`
clean, action reference regenerated (190), baseline and figures re-derived.