### PR TITLE
fix(cassette): stop reporting an unrecorded intent as a mid-run divergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,736 Rust tests and 72 frontend tests** form the current deterministic
+**1,737 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/crates/sysknife-brain/src/cassette.rs
+++ b/crates/sysknife-brain/src/cassette.rs
@@ -560,12 +560,24 @@ impl Cassette {
             .max();
 
         match deepest {
+            // Message 0 is the user's intent. Diverging there means this is a
+            // different conversation, not a broken one: nothing was ever
+            // recorded for it. Reporting it as a mid-run divergence sent the
+            // reader hunting a volatile tool result that does not exist — which
+            // is exactly what it did on the first replay after this landed.
+            Some(0) => format!(
+                "no recorded output for this intent in {}. The prompt and tools match, so \
+                 the cassette is current — this particular request was never recorded \
+                 (a call that errored during recording leaves no entry). Re-record with \
+                 {}=record if it should be covered.",
+                self.path.display(),
+                ENV_CASSETTE_MODE
+            ),
             Some(index) => format!(
-                "the conversation diverged at message {index}: turns before it replay, \
-                 this one does not. The recorded and replayed messages differ at that \
-                 index, which is what a volatile tool result looks like — a timestamp, \
-                 a transaction id, or live system state folded into the call key. \
-                 See issue #182."
+                "the conversation diverged at message {index}: the intent and the turns \
+                 before it replay, this one does not. That is the signature of a volatile \
+                 tool result — a timestamp, a transaction id, or live system state folded \
+                 into the call key. See issue #182."
             ),
             None => format!(
                 "no recorded output for this call in {}; the prompt and tools match, so \
@@ -1223,6 +1235,41 @@ mod miss_diagnosis_tests {
         assert!(
             diagnosis.to_lowercase().contains("turn"),
             "must say the conversation diverged mid-run, got: {diagnosis}"
+        );
+    }
+
+    /// Diverging at message 0 means a different *intent* — a conversation that
+    /// was never recorded, not one that broke partway. The first real replay
+    /// after this landed reported "diverged at message 0" for a story whose call
+    /// simply errored during recording, which sends the reader hunting a
+    /// volatile tool result that does not exist.
+    #[test]
+    fn an_unrecorded_intent_is_not_reported_as_a_mid_run_divergence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let rec = Cassette::open(path.clone(), CassetteMode::Record).unwrap();
+        let system = "SYSTEM";
+        let recorded = vec![Message::user_text("install vim")];
+        rec.store(
+            call_key("p/m", system, &recorded, &[], 100),
+            "p/m",
+            &sha256_hex(system.as_bytes()),
+            completion("out"),
+            Some(CallFingerprint::of(system, &recorded, &[], 100)),
+        )
+        .unwrap();
+
+        let replay = Cassette::open(path, CassetteMode::Replay).unwrap();
+        // A completely different first message: never recorded.
+        let other = vec![Message::user_text("list the snaps")];
+        let d = replay.diagnose_miss("p/m", system, &other, &[], 100);
+        assert!(
+            !d.contains("diverged at message"),
+            "an unrecorded intent must not read as a mid-run divergence: {d}"
+        );
+        assert!(
+            d.contains("never recorded"),
+            "it must say the request was never recorded: {d}"
         );
     }
 

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,736 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,737 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -140,7 +140,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,736 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,737 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "5440c31f1bd8b6a3861898bfaec8bec225978706"
+    "tests": "6f3a5b853b4aadb5f06ee5f00eeeb8521cd79847"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-08T15:23:56-06:00"
+    "tests": "2026-08-08T15:31:21-06:00"
   },
-  "tests": 1736,
+  "tests": 1737,
   "version": 1
 }


### PR DESCRIPTION
Follow-up on #182, found by running the diagnostic it was built for.

## The bug I shipped

The first real replay after the #182 groundwork reported, for story 101:

> the conversation diverged at message 0: turns before it replay, this one does
> not ... which is what a volatile tool result looks like

**Message 0 is the user's intent.** Diverging there doesn't mean the conversation
broke partway — it means it's a *different* conversation and nothing was ever
recorded for it. Story 101's call errored during recording (Groq
`tool_use_failed`), so no entry exists, which is the case #182 itself calls
expected. My message sent the reader hunting a volatile tool result that isn't
there.

Split out: index 0 → never recorded. Index ≥ 1 → the volatile-tool-result
reading, which is the only case where turns genuinely replayed and then stopped.

## What the replay also showed

**The multi-turn symptom #182 is named for does not reproduce** on a clean,
single-prompt recording:

```
Cassette:  replay served 51 call(s), 1 miss(es)
```

Story 91 — the multi-turn story the issue is about — replayed with **zero**
misses. The earlier failure was most likely the stale mixed-prompt cassette
(176 entries under three prompt hashes) rather than message volatility.

**Leaving #182 open.** The replay gate is still red on story 101's expected
miss, and "should an expected miss fail the gate" is a separate question from
"does multi-turn replay work". Closing it on this evidence would overstate what
was shown.

1737 tests, clippy clean, baseline and figures re-derived.