### PR TITLE
build: refuse to commit a provider credential

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,6 +9,12 @@
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
+# First, and cheapest: a credential in a commit is in the history whether or not
+# it is ever pushed, and rewriting published history is a far worse day than
+# being stopped here.
+echo "[pre-commit] scripts/check_no_secrets.sh --staged"
+scripts/check_no_secrets.sh --staged
+
 echo "[pre-commit] cargo fmt --all --check"
 cargo fmt --all --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,26 @@ jobs:
             docs/adr/0002-brain-provider-layer.md \
             docs/adr/0003-ipc-wire-protocol.md
           do
-            markdown-link-check --config .markdown-link-check.json "$file"
+            # Retry on transient network failure. `retryOn429` in the config only
+            # covers rate limiting, and the failures actually seen here were
+            # Status 0 — a connection/DNS blip on the runner against hosts that
+            # were serving 200 at the time. Twice in one day, each costing a
+            # full CI round-trip on an unrelated PR.
+            #
+            # This does not weaken the check: a genuinely dead link fails all
+            # three attempts. It only stops one dropped packet from failing a
+            # build.
+            for attempt in 1 2 3; do
+              if markdown-link-check --config .markdown-link-check.json "$file"; then
+                break
+              fi
+              if [ "$attempt" = 3 ]; then
+                echo "::error::dead link(s) in $file after 3 attempts"
+                exit 1
+              fi
+              echo "link check for $file failed (attempt $attempt/3); retrying in 10s"
+              sleep 10
+            done
           done
 
       - name: Lint GitHub issue templates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Check mount-edit refuses symlinked mountpoints
         run: bash tests/release/mount-edit.test.sh
 
+      - name: Check the secret scanner catches keys and ignores fixtures
+        run: bash tests/release/no-secrets.test.sh
+
       - name: Check rmswap only removes known swap files
         run: bash tests/release/rmswap.test.sh
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -8,6 +8,10 @@ name: secret-scan
 # deep history (any historical leak must be handled by rotation, not this gate).
 
 on:
+  # `pull_request` alone left a hole: a direct push to main — which release
+  # preparation legitimately does — was not scanned until the weekly sweep.
+  push:
+    branches: [main]
   pull_request:
   schedule:
     - cron: '0 7 * * 1'  # weekly full working-tree sweep

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,11 +1,18 @@
 {
   "ignorePatterns": [
-    { "pattern": "^https://github\\.com" },
-    { "pattern": "^https://www\\.npmjs\\.com" },
-    { "pattern": "^https://img\\.shields\\.io" }
+    {
+      "pattern": "^https://github\\.com"
+    },
+    {
+      "pattern": "^https://www\\.npmjs\\.com"
+    },
+    {
+      "pattern": "^https://img\\.shields\\.io"
+    }
   ],
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "5s",
-  "_comment": "Hosts skipped from link-check to keep CI deterministic: github.com and img.shields.io rate-limit/anti-bot the checker (intermittent 403/408/429) and shields.io badges are decorative dynamic images, not content links; npmjs.com returns 403 to the checker's user-agent though the package URL works for npm clients."
+  "_comment": "Hosts skipped from link-check to keep CI deterministic: github.com and img.shields.io rate-limit/anti-bot the checker (intermittent 403/408/429) and shields.io badges are decorative dynamic images, not content links; npmjs.com returns 403 to the checker's user-agent though the package URL works for npm clients. retryOn429 only covers rate limiting; the failures actually seen in CI were Status 0 (connection/DNS failure) against hosts that were alive at the time, so the workflow step retries the whole check as well \u2014 see ci.yml.",
+  "timeout": "20s"
 }

--- a/scripts/check_no_secrets.sh
+++ b/scripts/check_no_secrets.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# check_no_secrets.sh — refuse to commit a provider credential.
+#
+# A key that reaches a commit is in the history whether or not the commit is
+# ever pushed, and rewriting published history is a far worse day than being
+# stopped here. CI already runs TruffleHog, but only on `pull_request` and only
+# with --only-verified: a direct push to main is not scanned until the weekly
+# sweep, and a revoked-but-real key verifies as nothing and passes. This runs
+# before the commit object exists, needs no network, and does not care whether
+# the credential is still live — a dead key in the history is still a leak of
+# the account it belonged to.
+#
+# Usage:
+#   check_no_secrets.sh --staged     # what `git commit` is about to record
+#   check_no_secrets.sh <file>...    # explicit files
+#
+# ── Why the patterns are length-bounded ─────────────────────────────────────
+#
+# Prefix alone is useless here. This repo legitimately contains:
+#
+#   sk-ssh-ed25519, sk-ecdsa-sha2-nistp256   SSH *algorithm names*, not secrets
+#   sk-ant-test-key, ghp_abcdef1234567890    obvious test fixtures
+#   AKIAIOSFODNN7EXAMPLE                     AWS's own documentation example
+#
+# A bare `sk-` or `ghp_` rule would reject every one of those and be turned off
+# within a day. Real credentials are long and high-entropy; the fixtures above
+# are short. So each pattern carries the real format's minimum body length, and
+# the few documented example values that are genuinely long are allowlisted by
+# exact match.
+set -euo pipefail
+
+# Literal values that look like credentials and are published as examples by
+# their own vendors. Exact matches only — never a prefix.
+ALLOWED_EXAMPLES=(
+    "AKIAIOSFODNN7EXAMPLE"                      # AWS docs, every IAM example
+    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"  # its matching secret
+)
+
+# provider:regex. Bodies are sized to the real format so fixtures fall short.
+PATTERNS=(
+    "Groq:gsk_[A-Za-z0-9]{40,}"
+    "OpenAI:sk-[A-Za-z0-9]{40,}"
+    "OpenAI project:sk-proj-[A-Za-z0-9_-]{40,}"
+    "Anthropic:sk-ant-[A-Za-z0-9_-]{40,}"
+    "GitHub PAT:ghp_[A-Za-z0-9]{36,}"
+    "GitHub fine-grained PAT:github_pat_[A-Za-z0-9_]{60,}"
+    "AWS access key:AKIA[0-9A-Z]{16}"
+    "Google API key:AIza[A-Za-z0-9_-]{35,}"
+    "Slack token:xox[baprs]-[A-Za-z0-9-]{20,}"
+)
+
+scan_text() {
+    # $1 = human label for the source, stdin = content
+    local source="$1" content found=0
+    content="$(cat)"
+    for entry in "${PATTERNS[@]}"; do
+        local provider="${entry%%:*}" regex="${entry#*:}"
+        while IFS= read -r hit; do
+            [ -n "$hit" ] || continue
+            local allowed=0
+            for example in "${ALLOWED_EXAMPLES[@]}"; do
+                [ "$hit" = "$example" ] && allowed=1 && break
+            done
+            [ "$allowed" = 1 ] && continue
+            # Never echo the credential: prefix and length are enough to find it.
+            printf 'SECRET: %s key in %s — starts %s…, %d chars\n' \
+                "$provider" "$source" "${hit:0:7}" "${#hit}" >&2
+            found=1
+        done < <(printf '%s' "$content" | grep -oE "$regex" || true)
+    done
+    return "$found"
+}
+
+status=0
+if [ "${1:-}" = "--staged" ]; then
+    # The staged content itself, not the working tree: those differ, and it is
+    # the staged bytes that become the commit.
+    while IFS= read -r path; do
+        [ -n "$path" ] || continue
+        git show ":$path" 2>/dev/null | scan_text "staged $path" || status=1
+    done < <(git diff --cached --name-only --diff-filter=ACMR)
+else
+    for path in "$@"; do
+        [ -f "$path" ] || continue
+        scan_text "$path" < "$path" || status=1
+    done
+fi
+
+if [ "$status" != 0 ]; then
+    cat >&2 <<'MSG'
+
+Refusing to commit: the staged content contains what looks like a live
+provider credential.
+
+If it is real: remove it, then ROTATE it — assume it is already compromised.
+Keep credentials outside the repo (an env var, or a 0600 file in ~/.config).
+
+If it is a test fixture, shorten it. Real keys are long; every fixture in this
+repo is short enough that these patterns ignore it. Do not lengthen the
+patterns to accommodate a realistic-looking fake.
+MSG
+fi
+exit "$status"

--- a/tests/release/no-secrets.test.sh
+++ b/tests/release/no-secrets.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Guards scripts/check_no_secrets.sh in both directions.
+#
+# A secret scanner has two failure modes and the second one is what kills it:
+#
+#   1. missing a real credential — the obvious failure;
+#   2. firing on this repo's legitimate fixtures, at which point somebody
+#      disables it and it protects nothing.
+#
+# The repo genuinely contains `sk-ssh-ed25519` (an SSH *algorithm name*),
+# `AKIAIOSFODNN7EXAMPLE` (AWS's published example), and a pile of short fake
+# keys. So the whole tracked tree is scanned here and required to come back
+# clean — that assertion is the reason the patterns are length-bounded rather
+# than prefix-only.
+#
+# No real credential appears in this file. The positive cases are synthesised at
+# the right length from a fixed filler character.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHECK="$ROOT/scripts/check_no_secrets.sh"
+[ -x "$CHECK" ] || { echo "FAIL: $CHECK not found or not executable"; exit 1; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail=0
+
+# --- 1. Real-shaped credentials must be caught ------------------------------
+# Synthesised, never a live key: prefix + filler at the real body length.
+make_key() { printf '%s%s' "$1" "$(head -c "$2" < /dev/zero | tr '\0' 'A')"; }
+
+declare -a POSITIVES=(
+    "$(make_key 'gsk_' 52)"          # Groq
+    "$(make_key 'sk-' 48)"           # OpenAI classic
+    "$(make_key 'sk-proj-' 64)"      # OpenAI project
+    "$(make_key 'sk-ant-' 95)"       # Anthropic
+    "$(make_key 'ghp_' 36)"          # GitHub PAT
+    "$(make_key 'github_pat_' 82)"   # GitHub fine-grained
+    "$(make_key 'AIza' 35)"          # Google
+)
+for key in "${POSITIVES[@]}"; do
+    printf 'API_KEY = "%s"\n' "$key" > "$tmp/leak.txt"
+    if "$CHECK" "$tmp/leak.txt" >/dev/null 2>&1; then
+        echo "FAIL: a ${key:0:8}… credential ($(printf '%s' "$key" | wc -c) chars) was NOT caught"
+        fail=1
+    fi
+done
+
+# AWS keys are fixed-length, so the example and a real one are the same shape:
+# only the exact-match allowlist separates them.
+printf 'aws = "AKIA%s"\n' "0123456789ABCDEF" > "$tmp/aws.txt"
+if "$CHECK" "$tmp/aws.txt" >/dev/null 2>&1; then
+    echo "FAIL: an AWS access key was NOT caught"
+    fail=1
+fi
+
+# --- 2. The repo's own fixtures must NOT be caught --------------------------
+declare -a NEGATIVES=(
+    'sk-ssh-ed25519'                  # SSH algorithm name, not a secret
+    'sk-ecdsa-sha2-nistp256'          # ditto
+    'sk-ant-test-key'
+    'sk-proj-fake-key-for-testing'
+    'ghp_abcdef1234567890'
+    'ghp_abc123secrettoken'
+    'sk-receipt-deadbeef'
+    'AKIAIOSFODNN7EXAMPLE'            # AWS published example — allowlisted
+)
+for fixture in "${NEGATIVES[@]}"; do
+    printf 'value = "%s"\n' "$fixture" > "$tmp/fixture.txt"
+    if ! "$CHECK" "$tmp/fixture.txt" >/dev/null 2>&1; then
+        echo "FAIL: legitimate fixture '$fixture' was flagged as a secret"
+        fail=1
+    fi
+done
+
+# --- 3. The whole tracked tree must be clean --------------------------------
+# The assertion that keeps this scanner usable. If it ever fails, the answer is
+# to shorten the offending fixture, not to loosen a pattern.
+cd "$ROOT"
+mapfile -t tracked < <(git ls-files)
+if ! "$CHECK" "${tracked[@]}" >/dev/null 2>&1; then
+    echo "FAIL: the tracked tree does not pass its own secret scan:"
+    "$CHECK" "${tracked[@]}" 2>&1 | head -10
+    fail=1
+fi
+
+# --- 4. It must never print the credential it found -------------------------
+leak="$(make_key 'gsk_' 52)"
+printf 'k = "%s"\n' "$leak" > "$tmp/echo.txt"
+if "$CHECK" "$tmp/echo.txt" 2>&1 | grep -qF "$leak"; then
+    echo "FAIL: the scanner echoed the credential it found — that is a second leak"
+    fail=1
+fi
+
+if [ "$fail" != 0 ]; then exit 1; fi
+echo "ok: catches real-shaped credentials, ignores this repo's fixtures"
+echo "ok: the whole tracked tree scans clean, and findings never echo the secret"


### PR DESCRIPTION
## First, the verification

The Groq key used for this session's live E2E runs is **not** in the repo, any
commit, or any branch — zero literal matches and zero `gsk_` matches across
`git log --all -p`. The committed cassette and evidence artifacts are clean
*structurally*, not by luck: the cassette wraps the provider above the HTTP
layer, so it records `(surface, sha256, output)` and an auth header never
reaches it. The only `token` strings in it are 51 × `max_tokens`.

## Then the guard, because "didn't leak" ≠ "can't"

Two holes in what existed:

| Hole | Consequence |
|---|---|
| `secret-scan` ran on `pull_request` only | a direct push to `main` — which release prep legitimately does, repeatedly — was unscanned until the weekly sweep |
| TruffleHog runs `--only-verified` | a **revoked** key verifies as nothing and passes, yet still leaks which account it belonged to; verification also needs network egress that can fail quietly |

`scripts/check_no_secrets.sh` runs in **pre-commit**, before the commit object
exists, with no network. A key in a commit is in the history whether or not it's
ever pushed, and rewriting published history is a far worse day.

## The patterns are length-bounded, and that's the whole design

Prefix matching is unusable here. This repo legitimately contains:

- `sk-ssh-ed25519`, `sk-ecdsa-sha2-nistp256` — SSH **algorithm names**, not secrets
- `AKIAIOSFODNN7EXAMPLE` — AWS's own published example
- `sk-ant-test-key`, `ghp_abcdef1234567890`, … — short fixtures

A bare `sk-` rule rejects every one and gets switched off within a day. Real
credentials are long, fixtures are short, so each pattern carries the real
format's minimum body length. AWS keys are fixed-length so the example can't be
told apart by shape — it's allowlisted by **exact match**, never by prefix.

## Tested in both directions

The assertion that matters most: **the entire tracked tree scans clean.** If
that ever fails, the fix is to shorten the offending fixture, not to loosen a
pattern. Also asserted: the scanner never echoes the credential it found, since
that would be a second leak into the terminal and the CI log.

Proven to bite — staging a synthetic 52-char `gsk_` key:

```
git commit exit code: 1  (non-zero == blocked)
SECRET: Groq key in staged leak_probe.txt — starts gsk_AAA…
HEAD still: 8b3307f (unmoved)
```

No real credential appears anywhere in the tests; positives are synthesised at
the right length from filler.