### PR TITLE
test: prove a replay reproduces the run that recorded it (#182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Check mount-edit refuses symlinked mountpoints
         run: bash tests/release/mount-edit.test.sh
 
+      - name: Check a replay reproduces the run that recorded it
+        run: bash tests/release/cassette-replay-parity.test.sh
+
       - name: Check the secret scanner catches keys and ignores fixtures
         run: bash tests/release/no-secrets.test.sh
 

--- a/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json
+++ b/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json
@@ -1,0 +1,224 @@
+{
+  "cassette_audit": {
+    "misses": 1,
+    "served": 51,
+    "verdict": "failed"
+  },
+  "cassette_mode": "replay",
+  "cassette_sha256": "f4b4711436f468fe26a3a53508211259fbeba5ba84d133257855a0250f2a3055",
+  "distro_id": "ubuntu",
+  "ran_at": "2026-08-09T23:32:29+00:00",
+  "release": "22.04",
+  "stories": {
+    "100": {
+      "name": "Create a distrobox from Fedora image",
+      "verdict": "PASS"
+    },
+    "101": {
+      "name": "Distrobox list alt phrasing",
+      "verdict": "FAIL"
+    },
+    "102": {
+      "name": "System-wide upgrade with alt phrasing",
+      "verdict": "PASS"
+    },
+    "103": {
+      "name": "Pin then show info (compound read+mutate)",
+      "verdict": "PASS"
+    },
+    "104": {
+      "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "55": {
+      "name": "Refresh apt package index",
+      "verdict": "PASS"
+    },
+    "56": {
+      "name": "Upgrade all packages",
+      "verdict": "PASS"
+    },
+    "57": {
+      "name": "Install a package",
+      "verdict": "PASS"
+    },
+    "58": {
+      "name": "Remove a package",
+      "verdict": "PASS"
+    },
+    "59": {
+      "name": "Purge a package including config",
+      "verdict": "PASS"
+    },
+    "60": {
+      "name": "Autoremove unused packages",
+      "verdict": "PASS"
+    },
+    "61": {
+      "name": "Hold a package at current version",
+      "verdict": "PASS"
+    },
+    "62": {
+      "name": "Unhold a package",
+      "verdict": "PASS"
+    },
+    "63": {
+      "name": "Search apt for a package",
+      "verdict": "PASS"
+    },
+    "64": {
+      "name": "List installed packages",
+      "verdict": "PASS"
+    },
+    "65": {
+      "name": "Show package info",
+      "verdict": "PASS"
+    },
+    "66": {
+      "name": "Install a snap",
+      "verdict": "PASS"
+    },
+    "67": {
+      "name": "Remove a snap",
+      "verdict": "PASS"
+    },
+    "68": {
+      "name": "Hold a snap to pin its version",
+      "verdict": "PASS"
+    },
+    "69": {
+      "name": "Unhold a snap",
+      "verdict": "PASS"
+    },
+    "70": {
+      "name": "List installed snaps",
+      "verdict": "PASS"
+    },
+    "71": {
+      "name": "Show snap info",
+      "verdict": "PASS"
+    },
+    "72": {
+      "name": "Refresh all snaps",
+      "verdict": "PASS"
+    },
+    "73": {
+      "name": "Show ufw firewall status",
+      "verdict": "PASS"
+    },
+    "74": {
+      "name": "Enable ufw",
+      "verdict": "PASS"
+    },
+    "75": {
+      "name": "Disable ufw",
+      "verdict": "PASS"
+    },
+    "76": {
+      "name": "Allow SSH through ufw",
+      "verdict": "PASS"
+    },
+    "77": {
+      "name": "Allow HTTP and HTTPS",
+      "verdict": "PASS"
+    },
+    "78": {
+      "name": "Deny a port",
+      "verdict": "PASS"
+    },
+    "79": {
+      "name": "Reset ufw to defaults",
+      "verdict": "PASS"
+    },
+    "80": {
+      "name": "List distrobox containers",
+      "verdict": "PASS"
+    },
+    "81": {
+      "name": "Create a distrobox container",
+      "verdict": "PASS"
+    },
+    "82": {
+      "name": "Remove a distrobox container",
+      "verdict": "PASS"
+    },
+    "83": {
+      "name": "Get netplan config",
+      "verdict": "PASS"
+    },
+    "84": {
+      "name": "Apply netplan config",
+      "verdict": "PASS"
+    },
+    "85": {
+      "name": "Update apt index then install a package",
+      "verdict": "PASS"
+    },
+    "86": {
+      "name": "List installed packages and snaps together",
+      "verdict": "PASS"
+    },
+    "87": {
+      "name": "Enable firewall and allow SSH",
+      "verdict": "PASS"
+    },
+    "88": {
+      "name": "Check package info with natural phrasing",
+      "verdict": "PASS"
+    },
+    "89": {
+      "name": "Install snap on beta channel",
+      "verdict": "PASS"
+    },
+    "90": {
+      "name": "Get netplan config with alternative phrasing",
+      "verdict": "PASS"
+    },
+    "91": {
+      "name": "a shell-metacharacter injection in the intent",
+      "verdict": "PASS"
+    },
+    "92": {
+      "name": "port 0 is reserved and must never become a raw",
+      "verdict": "PASS"
+    },
+    "93": {
+      "name": "\"install a snap\" names no snap. The planner must",
+      "verdict": "PASS"
+    },
+    "94": {
+      "name": "Search apt with different phrasing",
+      "verdict": "PASS"
+    },
+    "95": {
+      "name": "Install multiple essential tools",
+      "verdict": "PASS"
+    },
+    "96": {
+      "name": "Purge alternative phrasing",
+      "verdict": "PASS"
+    },
+    "97": {
+      "name": "Show snap details alternative phrasing",
+      "verdict": "PASS"
+    },
+    "98": {
+      "name": "Allow a ufw app profile",
+      "verdict": "PASS"
+    },
+    "99": {
+      "name": "Firewall status alternative phrasing",
+      "verdict": "PASS"
+    }
+  },
+  "story_set": "ubuntu",
+  "surface": "groq/openai/gpt-oss-120b",
+  "totals": {
+    "failed": 1,
+    "passed": 49,
+    "rate_limited": 0,
+    "skipped": 0,
+    "total": 50
+  },
+  "version": 1
+}

--- a/tests/release/cassette-replay-parity.test.sh
+++ b/tests/release/cassette-replay-parity.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# The proof #182 asks for, as a comparison of two committed artifacts.
+#
+# The replay gate exists so the story suite can run in CI with no network and no
+# spend. That is only worth anything if a replay of a cassette reproduces the run
+# that recorded it — otherwise a green replay proves the cassette is intact, not
+# that the suite passes.
+#
+# So this compares the record run against the replay run and asserts, per #182's
+# acceptance criteria:
+#
+#   * zero misses for every story that produced a successful live response.
+#     A story that FAILED live is excluded on purpose and only there: its call
+#     errored during recording, so nothing was ever stored for it, and a miss on
+#     replay is the correct and expected consequence. That is not the same as
+#     excluding a story from the suite — it still runs, and it still fails.
+#   * every story that passed live also passes on replay. A replay that serves a
+#     recorded answer but reaches a different verdict means the recording does
+#     not describe the run.
+#   * no story was dropped from the family to make the numbers work: both runs
+#     cover the same story set, of the same size.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RECORD="$ROOT/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json"
+REPLAY="$ROOT/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json"
+CASSETTE="$ROOT/tests/e2e/cassettes/ubuntu-jammy-gpt-oss-120b.json"
+
+for f in "$RECORD" "$REPLAY" "$CASSETTE"; do
+    [ -f "$f" ] || { echo "FAIL: missing $f"; exit 1; }
+done
+
+python3 - "$RECORD" "$REPLAY" "$CASSETTE" <<'PY'
+import hashlib
+import json
+import sys
+
+record = json.load(open(sys.argv[1]))
+replay = json.load(open(sys.argv[2]))
+cassette_bytes = open(sys.argv[3], "rb").read()
+
+failures = []
+
+# The two runs must describe the same thing, or the comparison is meaningless.
+for field in ("story_set", "release", "distro_id", "surface"):
+    if record.get(field) != replay.get(field):
+        failures.append(
+            f"{field} differs: record={record.get(field)!r} replay={replay.get(field)!r}"
+        )
+if record["cassette_mode"] != "record":
+    failures.append(f"the record artifact is mode {record['cassette_mode']!r}")
+if replay["cassette_mode"] != "replay":
+    failures.append(f"the replay artifact is mode {replay['cassette_mode']!r}")
+
+# Both runs cover the same stories: nothing dropped to make the gate pass.
+rec_ids, rep_ids = set(record["stories"]), set(replay["stories"])
+if rec_ids != rep_ids:
+    only_rec, only_rep = sorted(rec_ids - rep_ids), sorted(rep_ids - rec_ids)
+    failures.append(f"story sets differ — record-only {only_rec}, replay-only {only_rep}")
+if record["totals"]["total"] != replay["totals"]["total"]:
+    failures.append(
+        f"story counts differ: {record['totals']['total']} vs {replay['totals']['total']}"
+    )
+
+# The replay must have run against the cassette that is committed beside it.
+actual_sha = hashlib.sha256(cassette_bytes).hexdigest()
+if replay.get("cassette_sha256") != actual_sha:
+    failures.append(
+        "the replay ran against a different cassette than the one committed "
+        f"(artifact {str(replay.get('cassette_sha256'))[:16]}…, file {actual_sha[:16]}…)"
+    )
+
+# The criterion itself. A story that failed live has no recorded answer, so a
+# miss for it is expected; every other story must replay.
+passed_live = {k for k, v in record["stories"].items() if v.get("verdict") == "PASS"}
+failed_live = sorted(rec_ids - passed_live)
+
+regressed = sorted(
+    k for k in passed_live if replay["stories"].get(k, {}).get("verdict") != "PASS"
+)
+if regressed:
+    failures.append(
+        f"stories that passed live but not on replay: {regressed} — the recording "
+        "does not describe the run it came from"
+    )
+
+audit = replay.get("cassette_audit", {})
+misses = audit.get("misses", 0)
+if misses > len(failed_live):
+    failures.append(
+        f"{misses} miss(es) but only {len(failed_live)} story/stories failed live "
+        f"({failed_live}); at least one story with a recorded answer still missed"
+    )
+if audit.get("served", 0) <= 0:
+    failures.append("the replay served no calls — it did not exercise the cassette")
+
+if failures:
+    for f in failures:
+        print("FAIL:", f)
+    sys.exit(1)
+
+print(f"ok: {len(passed_live)}/{len(rec_ids)} stories passed live and all of them replay")
+print(f"ok: {audit.get('served')} call(s) served, {misses} miss(es), "
+      f"accounted for by {len(failed_live)} story/stories that errored live {failed_live}")
+print("ok: both runs cover the same story set, against the committed cassette")
+PY


### PR DESCRIPTION
Closes #182.

## Re-reading the criteria changed what this needed

The issue asks for zero misses **"for every story that produced a successful
live response"**. Story 101's call errored during recording, so nothing was ever
stored for it — its miss is the correct consequence of a failed recording, not a
cassette defect. It was never in scope.

What was genuinely missing is the **Proof** the issue specifies:

> Record a family run, then replay it, and assert `misses == 0` and that the
> replay's per-story verdicts match the recording's for every story that
> succeeded live. The harness already writes both artifacts, so this is a
> comparison of two committed files.

Only the *record* artifact was committed. There was nothing to compare against.

## What this adds

The replay artifact, committed beside the record one, and the comparison:

| Assertion | Catches |
|---|---|
| every story that passed live also passes on replay | a recording that doesn't describe the run it came from |
| misses ≤ stories that errored live | a miss on a story that **had** a recorded answer |
| both runs cover the same story set | a story quietly dropped to make the gate pass |
| replay's `cassette_sha256` == the committed cassette | a replay run against something else |
| served > 0 | a "green" replay that exercised nothing |

Measured: **51 served, 1 miss, 49/50 in both runs, same story failing in both.**

Five mutations checked, all five caught — passed-live story regressing, extra
miss, dropped story, mismatched cassette hash, replay serving nothing.

## Deliberately not changed

The harness's own `cassette_audit` verdict still reads `failed` whenever
`misses > 0`. That's stricter than this issue's criterion and rightly so:
`check_evidence_claims.py` refuses to back a published figure with an artifact
whose replay missed anything. The nuanced criterion belongs in this comparison,
not in a guard whose job is to be blunt.

## Also confirmed

The multi-turn symptom the issue is *named* for does not reproduce — **story 91
replays with zero misses**. The original failure was the stale mixed-prompt
cassette (176 entries under three prompt hashes), not message volatility.