### PR TITLE
fix(security): close the root-shell kernel-argument gap, and simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,737 Rust tests and 72 frontend tests** form the current deterministic
+**1,739 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/src/operator_text.rs
+++ b/apps/sysknife-cli/src/operator_text.rs
@@ -47,7 +47,7 @@ pub(crate) fn operator_safe(s: &str) -> String {
 
     for ch in s.chars() {
         let keep = match ch {
-            '\t' | '\n' | '\r' => {
+            '\t' | '\n' | '\r' | ' ' => {
                 pending_space = true;
                 continue;
             }
@@ -59,10 +59,6 @@ pub(crate) fn operator_safe(s: &str) -> String {
             '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}' => false,
             // Zero-width and byte-order marks — hide text in plain sight.
             '\u{200b}'..='\u{200f}' | '\u{feff}' => false,
-            ' ' => {
-                pending_space = true;
-                continue;
-            }
             _ => true,
         };
         if !keep {

--- a/apps/sysknife-cli/src/render.rs
+++ b/apps/sysknife-cli/src/render.rs
@@ -72,22 +72,20 @@ pub fn make_spinner(msg: impl Into<String>) -> ProgressBar {
 
 /// Return a colored `● low` / `● medium` / `● HIGH` badge string.
 pub fn risk_colored(risk: &PlanRiskLevel) -> String {
-    match risk {
-        PlanRiskLevel::Low => format!(
-            "● {}",
-            "low".if_supports_color(Stream::Stdout, |t| t.green())
-        ),
-        PlanRiskLevel::Medium => format!(
-            "● {}",
-            "medium".if_supports_color(Stream::Stdout, |t| t.yellow())
-        ),
-        PlanRiskLevel::High => format!(
-            "● {}",
-            // .bold() chained after .red() borrows a temporary inside the
-            // closure — materialise via .to_string() to avoid the lifetime error.
-            "HIGH".if_supports_color(Stream::Stdout, |t| t.red().bold().to_string())
-        ),
-    }
+    let label = match risk {
+        PlanRiskLevel::Low => "low"
+            .if_supports_color(Stream::Stdout, |t| t.green())
+            .to_string(),
+        PlanRiskLevel::Medium => "medium"
+            .if_supports_color(Stream::Stdout, |t| t.yellow())
+            .to_string(),
+        // .bold() chained after .red() borrows a temporary inside the
+        // closure — materialise via .to_string() to avoid the lifetime error.
+        PlanRiskLevel::High => "HIGH"
+            .if_supports_color(Stream::Stdout, |t| t.red().bold().to_string())
+            .to_string(),
+    };
+    format!("● {label}")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sysknife-brain/src/cassette.rs
+++ b/crates/sysknife-brain/src/cassette.rs
@@ -683,14 +683,18 @@ impl LlmProvider for CassetteProvider {
             .inner
             .complete(system, messages, tools, max_tokens)
             .await?;
-        let prompt_sha = sha256_hex(system.as_bytes());
+        // The fingerprint's `system` field is the same sha256 `prompt_sha` needs;
+        // compute it once and reuse it rather than hashing the (tens-of-KB)
+        // system prompt twice for one stored call.
+        let fingerprint = CallFingerprint::of(system, messages, tools, max_tokens);
+        let prompt_sha = fingerprint.system.clone();
         self.cassette
             .store(
                 key,
                 &self.surface,
                 &prompt_sha,
                 output.clone(),
-                Some(CallFingerprint::of(system, messages, tools, max_tokens)),
+                Some(fingerprint),
             )
             .map_err(|e| ProviderError::CassetteMiss(format!("cannot write cassette: {e}")))?;
         Ok(output)
@@ -770,13 +774,32 @@ mod tests {
 
     const SURFACE: &str = "groq/openai-gpt-oss-120b";
 
+    /// A `CassetteProvider` in `Record` mode against `SURFACE`. Most tests below
+    /// only vary the inner provider and the path; this and [`replayer`] collapse
+    /// that repeated four-line construction to one call.
+    fn recorder(inner: Box<dyn LlmProvider>, path: &Path) -> CassetteProvider {
+        CassetteProvider::new(
+            inner,
+            Cassette::open(path, CassetteMode::Record).unwrap(),
+            SURFACE,
+        )
+    }
+
+    /// A `CassetteProvider` in `Replay` mode against `SURFACE`. See [`recorder`].
+    fn replayer(inner: Box<dyn LlmProvider>, path: &Path) -> CassetteProvider {
+        CassetteProvider::new(
+            inner,
+            Cassette::open(path, CassetteMode::Replay).unwrap(),
+            SURFACE,
+        )
+    }
+
     #[tokio::test]
     async fn record_calls_through_and_persists() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
         let (inner, calls) = counting();
-        let cass = Cassette::open(&path, CassetteMode::Record).unwrap();
-        let p = CassetteProvider::new(inner, cass, SURFACE);
+        let p = recorder(inner, &path);
 
         let out = p.complete("sys", &msgs("hi"), &[], 100).await.unwrap();
         assert_eq!(first_text(&out), "live#1:1");
@@ -789,19 +812,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
         let (inner, _) = counting();
-        let rec = CassetteProvider::new(
-            inner,
-            Cassette::open(&path, CassetteMode::Record).unwrap(),
-            SURFACE,
-        );
+        let rec = recorder(inner, &path);
         rec.complete("sys", &msgs("hi"), &[], 100).await.unwrap();
         drop(rec);
 
-        let rep = CassetteProvider::new(
-            Box::new(Exploding),
-            Cassette::open(&path, CassetteMode::Replay).unwrap(),
-            SURFACE,
-        );
+        let rep = replayer(Box::new(Exploding), &path);
         let out = rep.complete("sys", &msgs("hi"), &[], 100).await.unwrap();
         assert_eq!(first_text(&out), "live#1:1", "must be the recorded answer");
         assert_eq!(rep.cassette().tally().hits, 1);
@@ -812,21 +827,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
         let (inner, _) = counting();
-        let rec = CassetteProvider::new(
-            inner,
-            Cassette::open(&path, CassetteMode::Record).unwrap(),
-            SURFACE,
-        );
+        let rec = recorder(inner, &path);
         rec.complete("sys", &msgs("recorded"), &[], 100)
             .await
             .unwrap();
         drop(rec);
 
-        let rep = CassetteProvider::new(
-            Box::new(Exploding),
-            Cassette::open(&path, CassetteMode::Replay).unwrap(),
-            SURFACE,
-        );
+        let rep = replayer(Box::new(Exploding), &path);
         let err = rep
             .complete("sys", &msgs("never-recorded"), &[], 100)
             .await
@@ -843,11 +850,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
         let (inner, calls) = counting();
-        let p = CassetteProvider::new(
-            inner,
-            Cassette::open(&path, CassetteMode::Record).unwrap(),
-            SURFACE,
-        );
+        let p = recorder(inner, &path);
 
         let a = p.complete("sys", &msgs("same"), &[], 100).await.unwrap();
         let b = p.complete("sys", &msgs("same"), &[], 100).await.unwrap();
@@ -887,19 +890,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
         let (inner, _) = counting();
-        let rec = CassetteProvider::new(
-            inner,
-            Cassette::open(&path, CassetteMode::Record).unwrap(),
-            SURFACE,
-        );
+        let rec = recorder(inner, &path);
         rec.complete("sys", &msgs("hi"), &[], 100).await.unwrap();
         drop(rec);
 
-        let rep = CassetteProvider::new(
-            Box::new(Exploding),
-            Cassette::open(&path, CassetteMode::Replay).unwrap(),
-            SURFACE,
-        );
+        let rep = replayer(Box::new(Exploding), &path);
         rep.complete("sys", &msgs("hi"), &[], 999)
             .await
             .expect_err("a different max_tokens is a different call");
@@ -919,19 +914,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
         let (inner, _) = counting();
-        let rec = CassetteProvider::new(
-            inner,
-            Cassette::open(&path, CassetteMode::Record).unwrap(),
-            SURFACE,
-        );
+        let rec = recorder(inner, &path);
         rec.complete("sys", &msgs("known"), &[], 100).await.unwrap();
         drop(rec);
 
-        let rep = CassetteProvider::new(
-            Box::new(Exploding),
-            Cassette::open(&path, CassetteMode::Replay).unwrap(),
-            SURFACE,
-        );
+        let rep = replayer(Box::new(Exploding), &path);
         rep.complete("sys", &msgs("known"), &[], 100).await.unwrap();
         let _ = rep.complete("sys", &msgs("unknown"), &[], 100).await; // swallowed
         let ledger = rep.cassette().ledger_path().to_path_buf();
@@ -964,21 +951,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
         let (inner, _) = counting();
-        let rec = CassetteProvider::new(
-            inner,
-            Cassette::open(&path, CassetteMode::Record).unwrap(),
-            SURFACE,
-        );
+        let rec = recorder(inner, &path);
         rec.complete("prompt version one", &msgs("hi"), &[], 100)
             .await
             .unwrap();
         drop(rec);
 
-        let rep = CassetteProvider::new(
-            Box::new(Exploding),
-            Cassette::open(&path, CassetteMode::Replay).unwrap(),
-            SURFACE,
-        );
+        let rep = replayer(Box::new(Exploding), &path);
         let err = rep
             .complete("prompt version two", &msgs("hi"), &[], 100)
             .await
@@ -994,20 +973,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
         let (inner, calls) = counting();
-        let first = CassetteProvider::new(
-            inner,
-            Cassette::open(&path, CassetteMode::Record).unwrap(),
-            SURFACE,
-        );
+        let first = recorder(inner, &path);
         first.complete("sys", &msgs("one"), &[], 100).await.unwrap();
         drop(first);
 
         let (inner2, calls2) = counting();
-        let second = CassetteProvider::new(
-            inner2,
-            Cassette::open(&path, CassetteMode::Record).unwrap(),
-            SURFACE,
-        );
+        let second = recorder(inner2, &path);
         // Already recorded: must be served from the file, not paid for again.
         second
             .complete("sys", &msgs("one"), &[], 100)
@@ -1026,11 +997,7 @@ mod tests {
             "only the new call is paid for"
         );
 
-        let rep = CassetteProvider::new(
-            Box::new(Exploding),
-            Cassette::open(&path, CassetteMode::Replay).unwrap(),
-            SURFACE,
-        );
+        let rep = replayer(Box::new(Exploding), &path);
         rep.complete("sys", &msgs("one"), &[], 100).await.unwrap();
         rep.complete("sys", &msgs("two"), &[], 100).await.unwrap();
         assert_eq!(
@@ -1096,11 +1063,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
         let (inner, _) = counting();
-        let p = CassetteProvider::new(
-            inner,
-            Cassette::open(&path, CassetteMode::Record).unwrap(),
-            SURFACE,
-        );
+        let p = recorder(inner, &path);
         p.complete("sys", &msgs("hi"), &[], 100).await.unwrap();
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;

--- a/crates/sysknife-brain/src/planner.rs
+++ b/crates/sysknife-brain/src/planner.rs
@@ -218,6 +218,12 @@ impl PlanRiskLevel {
     }
 }
 
+/// Shared by [`PlanStep::approval_required`] and [`AuthorizedStep::approval_required`]:
+/// any risk above `Low` requires approval.
+fn requires_approval(risk: &PlanRiskLevel) -> bool {
+    !matches!(risk, PlanRiskLevel::Low)
+}
+
 // ---------------------------------------------------------------------------
 // PlanStep
 // ---------------------------------------------------------------------------
@@ -280,7 +286,7 @@ impl PlanStep {
     /// Derived from the *proposed* risk level: `true` for Medium and High,
     /// `false` for Low. For gating, prefer [`AuthorizedStep::approval_required`].
     pub fn approval_required(&self) -> bool {
-        !matches!(self.risk_level, PlanRiskLevel::Low)
+        requires_approval(&self.risk_level)
     }
 
     pub fn params(&self) -> &serde_json::Value {
@@ -459,7 +465,7 @@ impl<'a> AuthorizedStep<'a> {
 
     /// Derived from the authoritative risk: `true` for Medium and High.
     pub fn approval_required(&self) -> bool {
-        !matches!(self.0.risk_level, PlanRiskLevel::Low)
+        requires_approval(&self.0.risk_level)
     }
 }
 
@@ -676,6 +682,37 @@ impl LlmPlanner {
         self
     }
 
+    /// Shared prelude for the `remember`/`forget` tool-call handlers: extract
+    /// the `fact` string and run the checks common to both — non-empty, then a
+    /// caller-supplied extra check (`remember` rejects sensitive data; `forget`
+    /// has none), then confirm preference storage is configured. Returns
+    /// `Err((message, is_error))` in the same shape both callers push into a
+    /// `ToolResultBlock` on failure, so only the differing async operation and
+    /// its success/failure formatting stay in each match arm.
+    fn prepare_pref_op<'a>(
+        &self,
+        input: &'a serde_json::Value,
+        extra_check: impl FnOnce(&str) -> Option<String>,
+    ) -> Result<(&'a str, std::path::PathBuf), (String, bool)> {
+        let fact = input.get("fact").and_then(|v| v.as_str()).unwrap_or("");
+        if fact.is_empty() {
+            return Err((
+                "Error: 'fact' parameter must not be empty.".to_string(),
+                true,
+            ));
+        }
+        if let Some(msg) = extra_check(fact) {
+            return Err((msg, true));
+        }
+        match self.prefs_path.clone() {
+            Some(p) => Ok((fact, p)),
+            None => Err((
+                "Error: preference storage is not configured.".to_string(),
+                true,
+            )),
+        }
+    }
+
     /// Send a [`PlanEvent`] to the progress channel, if one is attached.
     ///
     /// A closed or absent channel is silently ignored — progress events are
@@ -835,19 +872,19 @@ impl LlmPlanner {
         self.state_client.curated_state()
     }
 
-    /// Generate a plain-language summary of a short prompt, bypassing the
-    /// tool-use loop. Used for post-execution review.
-    ///
-    /// Returns the raw text content from the LLM. No tools are provided, so
-    /// the LLM is constrained to text-only output.
-    pub async fn summarize(&self, prompt: &str) -> Result<String, PlanningError> {
-        if prompt.len() > INTENT_MAX_BYTES {
+    /// Length, sensitive-data, and rate-limit checks shared by every entry point
+    /// that forwards free text to the LLM provider. `plan_intent` and
+    /// `summarize` used to repeat this three-step gate independently; keeping it
+    /// in one place means a future change to the sequence (e.g. an added scan)
+    /// can't be made at one call site and forgotten at the other.
+    async fn admit_request(&self, text: &str) -> Result<(), PlanningError> {
+        if text.len() > INTENT_MAX_BYTES {
             return Err(PlanningError::IntentTooLong {
-                len: prompt.len(),
+                len: text.len(),
                 max: INTENT_MAX_BYTES,
             });
         }
-        if crate::prefs::contains_sensitive(prompt) {
+        if crate::prefs::contains_sensitive(text) {
             return Err(PlanningError::IntentContainsSensitiveData);
         }
         if let Some(ref rl) = self.rate_limiter {
@@ -856,6 +893,16 @@ impl LlmPlanner {
                 return Err(PlanningError::RateLimitExceeded { retry_after_secs });
             }
         }
+        Ok(())
+    }
+
+    /// Generate a plain-language summary of a short prompt, bypassing the
+    /// tool-use loop. Used for post-execution review.
+    ///
+    /// Returns the raw text content from the LLM. No tools are provided, so
+    /// the LLM is constrained to text-only output.
+    pub async fn summarize(&self, prompt: &str) -> Result<String, PlanningError> {
+        self.admit_request(prompt).await?;
 
         let messages = vec![Message::user_text(prompt)];
         let completion = self
@@ -971,21 +1018,7 @@ impl LlmPlanner {
         if intent.is_empty() {
             return Err(PlanningError::EmptyIntent);
         }
-        if intent.len() > INTENT_MAX_BYTES {
-            return Err(PlanningError::IntentTooLong {
-                len: intent.len(),
-                max: INTENT_MAX_BYTES,
-            });
-        }
-        if crate::prefs::contains_sensitive(intent) {
-            return Err(PlanningError::IntentContainsSensitiveData);
-        }
-        if let Some(ref rl) = self.rate_limiter {
-            if let Err(retry_after_secs) = std::sync::Arc::clone(rl).check_and_consume_async().await
-            {
-                return Err(PlanningError::RateLimitExceeded { retry_after_secs });
-            }
-        }
+        self.admit_request(intent).await?;
 
         let mut messages: Vec<Message> = vec![Message::user_text(intent)];
 
@@ -1180,41 +1213,32 @@ impl LlmPlanner {
                                 }
                             }
                             "remember" => {
-                                let fact = input.get("fact").and_then(|v| v.as_str()).unwrap_or("");
-                                let (result_text, err) = if fact.is_empty() {
-                                    (
-                                        "Error: 'fact' parameter must not be empty.".to_string(),
-                                        true,
-                                    )
-                                } else if crate::prefs::contains_sensitive(fact) {
-                                    (
+                                let (result_text, err) = match self.prepare_pref_op(input, |fact| {
+                                    crate::prefs::contains_sensitive(fact).then(|| {
                                         "Error: preference rejected — it appears to contain \
                                          sensitive data (passwords, tokens, keys). Preferences \
                                          must not store secrets."
-                                            .to_string(),
-                                        true,
-                                    )
-                                } else if let Some(prefs_path) = self.prefs_path.clone() {
-                                    match crate::prefs::append_pref_async(
-                                        prefs_path.clone(),
-                                        fact.to_string(),
-                                    )
-                                    .await
-                                    {
-                                        Ok(()) => (format!("Preference saved: {fact}"), false),
-                                        Err(e) => {
-                                            eprintln!(
-                                                "[sysknife-brain] failed to save preference to {}: {e}",
-                                                prefs_path.display()
-                                            );
-                                            (format!("Error saving preference: {e}"), true)
+                                            .to_string()
+                                    })
+                                }) {
+                                    Ok((fact, prefs_path)) => {
+                                        match crate::prefs::append_pref_async(
+                                            prefs_path.clone(),
+                                            fact.to_string(),
+                                        )
+                                        .await
+                                        {
+                                            Ok(()) => (format!("Preference saved: {fact}"), false),
+                                            Err(e) => {
+                                                eprintln!(
+                                                    "[sysknife-brain] failed to save preference to {}: {e}",
+                                                    prefs_path.display()
+                                                );
+                                                (format!("Error saving preference: {e}"), true)
+                                            }
                                         }
                                     }
-                                } else {
-                                    (
-                                        "Error: preference storage is not configured.".to_string(),
-                                        true,
-                                    )
+                                    Err(pair) => pair,
                                 };
                                 tool_results.push(ToolResultBlock {
                                     tool_use_id: id.clone(),
@@ -1224,36 +1248,31 @@ impl LlmPlanner {
                                 });
                             }
                             "forget" => {
-                                let fact = input.get("fact").and_then(|v| v.as_str()).unwrap_or("");
-                                let (result_text, err) = if fact.is_empty() {
-                                    (
-                                        "Error: 'fact' parameter must not be empty.".to_string(),
-                                        true,
-                                    )
-                                } else if let Some(prefs_path) = self.prefs_path.clone() {
-                                    match crate::prefs::remove_pref_async(
-                                        prefs_path.clone(),
-                                        fact.to_string(),
-                                    )
-                                    .await
-                                    {
-                                        Ok(true) => (format!("Preference removed: {fact}"), false),
-                                        Ok(false) => {
-                                            (format!("Preference not found: {fact}"), false)
-                                        }
-                                        Err(e) => {
-                                            eprintln!(
-                                                "[sysknife-brain] failed to remove preference from {}: {e}",
-                                                prefs_path.display()
-                                            );
-                                            (format!("Error removing preference: {e}"), true)
+                                let (result_text, err) = match self.prepare_pref_op(input, |_| None)
+                                {
+                                    Ok((fact, prefs_path)) => {
+                                        match crate::prefs::remove_pref_async(
+                                            prefs_path.clone(),
+                                            fact.to_string(),
+                                        )
+                                        .await
+                                        {
+                                            Ok(true) => {
+                                                (format!("Preference removed: {fact}"), false)
+                                            }
+                                            Ok(false) => {
+                                                (format!("Preference not found: {fact}"), false)
+                                            }
+                                            Err(e) => {
+                                                eprintln!(
+                                                    "[sysknife-brain] failed to remove preference from {}: {e}",
+                                                    prefs_path.display()
+                                                );
+                                                (format!("Error removing preference: {e}"), true)
+                                            }
                                         }
                                     }
-                                } else {
-                                    (
-                                        "Error: preference storage is not configured.".to_string(),
-                                        true,
-                                    )
+                                    Err(pair) => pair,
                                 };
                                 tool_results.push(ToolResultBlock {
                                     tool_use_id: id.clone(),

--- a/crates/sysknife-brain/src/planning_tools/propose_plan.rs
+++ b/crates/sysknife-brain/src/planning_tools/propose_plan.rs
@@ -507,12 +507,17 @@ pub fn propose_plan_tool_def(family: Option<&str>) -> ToolDefinition {
         .collect();
 
     // Build a compact catalogue so the model can match intent to action by
-    // purpose.  Format: "Name — description" on its own line.
-    let action_catalogue: String = offered
-        .iter()
-        .map(|(name, desc)| format!("{name} — {desc}"))
-        .collect::<Vec<_>>()
-        .join("\n");
+    // purpose.  Format: "Name — description" on its own line. Built in one pass
+    // rather than collecting a `Vec<String>` just to join and discard it.
+    let mut action_catalogue = String::new();
+    for (i, (name, desc)) in offered.iter().enumerate() {
+        if i > 0 {
+            action_catalogue.push('\n');
+        }
+        action_catalogue.push_str(name);
+        action_catalogue.push_str(" — ");
+        action_catalogue.push_str(desc);
+    }
 
     let action_name_description = format!(
         "SysKnife action name from the approved list. \

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -1035,13 +1035,18 @@ fn push_shared(s: &mut String, block: &str, state: &StateAction) {
 
 fn render_fedora_prompt(prefs: Option<&str>, hint: &sysknife_types::DistroHint) -> String {
     let version = hint.version.as_deref().unwrap_or("(version unknown)");
-    let mut s = String::with_capacity(8192);
+    // Sized to the rendered prompt (measured ~35 KB) so the buffer doesn't have
+    // to grow-and-copy several times over on every `plan_intent()` call.
+    let mut s = String::with_capacity(36_864);
     s.push_str(PREAMBLE);
     s.push_str(SPOTLIGHTING_CLAUSE);
     push_shared(&mut s, EXAMPLES, &FEDORA_STATE_ACTION);
     push_shared(&mut s, CROSS_DISTRO_RISK_TABLES, &FEDORA_STATE_ACTION);
     s.push_str(FEDORA_RISK_TABLES);
-    push_shared(&mut s, CROSS_DISTRO_RISK_RULES, &FEDORA_STATE_ACTION);
+    // No {STATE_ACTION}/{STATE_RETURNS} placeholder appears in this block, so a
+    // plain push avoids two whole-string scans-and-allocations that `push_shared`
+    // would spend finding nothing to substitute.
+    s.push_str(CROSS_DISTRO_RISK_RULES);
     s.push_str(&FEDORA_HEADER.replacen("{}", version, 1));
     s.push_str(FEDORA_SELECTION_RULES);
     s.push_str(FEDORA_DISAMBIGUATION);
@@ -1056,13 +1061,16 @@ fn render_fedora_prompt(prefs: Option<&str>, hint: &sysknife_types::DistroHint) 
 
 fn render_debian_prompt(prefs: Option<&str>, hint: &sysknife_types::DistroHint) -> String {
     let version = hint.version.as_deref().unwrap_or("(version unknown)");
-    let mut s = String::with_capacity(8192);
+    // Sized to the rendered prompt (measured ~41 KB) — see the Fedora renderer
+    // above for why.
+    let mut s = String::with_capacity(43_008);
     s.push_str(PREAMBLE);
     s.push_str(SPOTLIGHTING_CLAUSE);
     push_shared(&mut s, EXAMPLES, &DEBIAN_STATE_ACTION);
     push_shared(&mut s, CROSS_DISTRO_RISK_TABLES, &DEBIAN_STATE_ACTION);
     s.push_str(DEBIAN_RISK_TABLES);
-    push_shared(&mut s, CROSS_DISTRO_RISK_RULES, &DEBIAN_STATE_ACTION);
+    // See the Fedora renderer above: this block has no placeholder to substitute.
+    s.push_str(CROSS_DISTRO_RISK_RULES);
     s.push_str(&DEBIAN_HEADER.replacen("{}", version, 1));
     s.push_str(DEBIAN_SELECTION_RULES);
     s.push_str(DEBIAN_COUNTERINTUITIVE);
@@ -1076,12 +1084,15 @@ fn render_debian_prompt(prefs: Option<&str>, hint: &sysknife_types::DistroHint) 
 }
 
 fn render_generic_prompt(prefs: Option<&str>) -> String {
-    let mut s = String::with_capacity(4096);
+    // Sized to the rendered prompt (measured ~29 KB) — see the Fedora renderer
+    // above for why.
+    let mut s = String::with_capacity(30_720);
     s.push_str(PREAMBLE);
     s.push_str(SPOTLIGHTING_CLAUSE);
     push_shared(&mut s, EXAMPLES, &FEDORA_STATE_ACTION);
     push_shared(&mut s, CROSS_DISTRO_RISK_TABLES, &FEDORA_STATE_ACTION);
-    push_shared(&mut s, CROSS_DISTRO_RISK_RULES, &FEDORA_STATE_ACTION);
+    // See the Fedora renderer above: this block has no placeholder to substitute.
+    s.push_str(CROSS_DISTRO_RISK_RULES);
     s.push_str(GENERIC_HEADER);
     push_shared(&mut s, CROSS_DISTRO_DISAMBIGUATION, &FEDORA_STATE_ACTION);
     push_shared(&mut s, CROSS_DISTRO_PARAMS, &FEDORA_STATE_ACTION);

--- a/crates/sysknife-brain/tests/planner.rs
+++ b/crates/sysknife-brain/tests/planner.rs
@@ -150,6 +150,43 @@ fn end_turn_text(text: &str) -> Result<Completion, ProviderError> {
     })
 }
 
+/// A single `ToolUse` completion for `name`, carrying `input` as the call's
+/// arguments. Covers everything the builders above don't: a specific tool
+/// name (`remember`, `forget`, ...) or a deliberately invalid `propose_plan`
+/// input, without hand-building the `Completion`/`ContentBlock` shape at each
+/// call site.
+fn tool_call(id: &str, name: &str, input: serde_json::Value) -> Result<Completion, ProviderError> {
+    Ok(Completion {
+        content: vec![ContentBlock::ToolUse {
+            id: id.into(),
+            call_id: None,
+            name: name.into(),
+            input,
+        }],
+        stop_reason: StopReason::ToolUse,
+    })
+}
+
+/// A `propose_plan` call naming the disallowed `RunShellCommand` action — the
+/// fixture every safety-fence-rejection test below builds, differing only in
+/// the step's `summary` text.
+fn bad_action_plan_call(step_summary: &str) -> Result<Completion, ProviderError> {
+    tool_call(
+        "tu_bad",
+        "propose_plan",
+        serde_json::json!({
+            "summary": "bad plan",
+            "explanation": "using a fake action",
+            "steps": [{
+                "action_name": "RunShellCommand",
+                "summary": step_summary,
+                "risk_level": "low",
+                "params": {}
+            }]
+        }),
+    )
+}
+
 fn make_planner(provider: MockProvider) -> LlmPlanner {
     LlmPlanner::new(Box::new(provider), Box::new(MockStateClient::default()), 5)
 }
@@ -384,24 +421,20 @@ async fn multi_step_plan_preserves_order_and_approval_flags() {
 
 #[tokio::test]
 async fn plan_step_carries_params() {
-    let planner = make_planner(MockProvider::new([Ok(Completion {
-        content: vec![ContentBlock::ToolUse {
-            id: "tu_p".into(),
-            call_id: None,
-            name: "propose_plan".into(),
-            input: serde_json::json!({
-                "summary": "Install vim",
-                "explanation": "Layers vim.",
-                "steps": [{
-                    "action_name": "InstallPackages",
-                    "summary": "Layer vim",
-                    "risk_level": "high",
-                    "params": { "packages": ["vim"] }
-                }]
-            }),
-        }],
-        stop_reason: StopReason::ToolUse,
-    })]));
+    let planner = make_planner(MockProvider::new([tool_call(
+        "tu_p",
+        "propose_plan",
+        serde_json::json!({
+            "summary": "Install vim",
+            "explanation": "Layers vim.",
+            "steps": [{
+                "action_name": "InstallPackages",
+                "summary": "Layer vim",
+                "risk_level": "high",
+                "params": { "packages": ["vim"] }
+            }]
+        }),
+    )]));
 
     let plan = planner.plan_intent("install vim").await.unwrap();
     let params = plan.steps()[0].params();
@@ -509,24 +542,9 @@ async fn invalid_plan_with_single_turn_returns_planner_stuck() {
     // turns to retry, so it returns PlannerStuck. This verifies that the KNOWN_ACTIONS
     // fence correctly rejects unknown action names.
     let planner = LlmPlanner::new(
-        Box::new(MockProvider::new([Ok(Completion {
-            content: vec![ContentBlock::ToolUse {
-                id: "tu_bad".into(),
-                call_id: None,
-                name: "propose_plan".into(),
-                input: serde_json::json!({
-                    "summary": "bad plan",
-                    "explanation": "using a fake action",
-                    "steps": [{
-                        "action_name": "RunShellCommand",
-                        "summary": "run arbitrary shell",
-                        "risk_level": "low",
-                        "params": {}
-                    }]
-                }),
-            }],
-            stop_reason: StopReason::ToolUse,
-        })])),
+        Box::new(MockProvider::new([bad_action_plan_call(
+            "run arbitrary shell",
+        )])),
         Box::new(MockStateClient::default()),
         1,
     );
@@ -545,24 +563,7 @@ async fn invalid_proposed_plan_is_retried_and_succeeds_on_second_call() {
     // This verifies symmetry with the unknown-tool retry path.
     let planner = LlmPlanner::new(
         Box::new(MockProvider::new([
-            Ok(Completion {
-                content: vec![ContentBlock::ToolUse {
-                    id: "tu_bad".into(),
-                    call_id: None,
-                    name: "propose_plan".into(),
-                    input: serde_json::json!({
-                        "summary": "bad plan",
-                        "explanation": "using a fake action",
-                        "steps": [{
-                            "action_name": "RunShellCommand",
-                            "summary": "run arbitrary shell",
-                            "risk_level": "low",
-                            "params": {}
-                        }]
-                    }),
-                }],
-                stop_reason: StopReason::ToolUse,
-            }),
+            bad_action_plan_call("run arbitrary shell"),
             propose_plan(
                 "Inspect system",
                 &[("GetSystemState", "Read current deployment", "low")],
@@ -583,19 +584,15 @@ async fn empty_steps_array_with_single_turn_returns_planner_stuck() {
     // A plan with zero steps is rejected by the safety fence and the error
     // is fed back as a tool result. With max_turns=1, no retry is possible.
     let planner = LlmPlanner::new(
-        Box::new(MockProvider::new([Ok(Completion {
-            content: vec![ContentBlock::ToolUse {
-                id: "tu_empty".into(),
-                call_id: None,
-                name: "propose_plan".into(),
-                input: serde_json::json!({
-                    "summary": "nothing to do",
-                    "explanation": "no steps",
-                    "steps": []
-                }),
-            }],
-            stop_reason: StopReason::ToolUse,
-        })])),
+        Box::new(MockProvider::new([tool_call(
+            "tu_empty",
+            "propose_plan",
+            serde_json::json!({
+                "summary": "nothing to do",
+                "explanation": "no steps",
+                "steps": []
+            }),
+        )])),
         Box::new(MockStateClient::default()),
         1,
     );
@@ -705,24 +702,7 @@ async fn rejected_plan_is_written_to_safety_audit_log() {
     // then corrects it on turn 2 (accepted). The rejection should be logged.
     let planner = LlmPlanner::new(
         Box::new(MockProvider::new([
-            Ok(Completion {
-                content: vec![ContentBlock::ToolUse {
-                    id: "tu_bad".into(),
-                    call_id: None,
-                    name: "propose_plan".into(),
-                    input: serde_json::json!({
-                        "summary": "bad plan",
-                        "explanation": "using a fake action",
-                        "steps": [{
-                            "action_name": "RunShellCommand",
-                            "summary": "run arbitrary shell",
-                            "risk_level": "low",
-                            "params": {}
-                        }]
-                    }),
-                }],
-                stop_reason: StopReason::ToolUse,
-            }),
+            bad_action_plan_call("run arbitrary shell"),
             propose_plan(
                 "Inspect system",
                 &[("GetSystemState", "Read current deployment", "low")],
@@ -771,24 +751,7 @@ async fn planner_without_audit_log_does_not_panic_on_rejection() {
     // Verify that the planner works correctly even without an audit log.
     let planner = LlmPlanner::new(
         Box::new(MockProvider::new([
-            Ok(Completion {
-                content: vec![ContentBlock::ToolUse {
-                    id: "tu_bad".into(),
-                    call_id: None,
-                    name: "propose_plan".into(),
-                    input: serde_json::json!({
-                        "summary": "bad plan",
-                        "explanation": "using a fake action",
-                        "steps": [{
-                            "action_name": "RunShellCommand",
-                            "summary": "run stuff",
-                            "risk_level": "low",
-                            "params": {}
-                        }]
-                    }),
-                }],
-                stop_reason: StopReason::ToolUse,
-            }),
+            bad_action_plan_call("run stuff"),
             propose_plan(
                 "Inspect system",
                 &[("GetSystemState", "Read deployment", "low")],
@@ -838,15 +801,11 @@ async fn remember_tool_saves_preference_and_planner_continues() {
 
     let planner = LlmPlanner::new(
         Box::new(MockProvider::new([
-            Ok(Completion {
-                content: vec![ContentBlock::ToolUse {
-                    id: "tu_rem".into(),
-                    call_id: None,
-                    name: "remember".into(),
-                    input: serde_json::json!({"fact": "prefer vim-enhanced over vim"}),
-                }],
-                stop_reason: StopReason::ToolUse,
-            }),
+            tool_call(
+                "tu_rem",
+                "remember",
+                serde_json::json!({"fact": "prefer vim-enhanced over vim"}),
+            ),
             propose_plan(
                 "Confirm preference saved",
                 &[("GetSystemState", "Confirm system is accessible", "low")],
@@ -877,15 +836,11 @@ async fn forget_tool_removes_preference() {
 
     let planner = LlmPlanner::new(
         Box::new(MockProvider::new([
-            Ok(Completion {
-                content: vec![ContentBlock::ToolUse {
-                    id: "tu_fgt".into(),
-                    call_id: None,
-                    name: "forget".into(),
-                    input: serde_json::json!({"fact": "prefer vim-enhanced over vim"}),
-                }],
-                stop_reason: StopReason::ToolUse,
-            }),
+            tool_call(
+                "tu_fgt",
+                "forget",
+                serde_json::json!({"fact": "prefer vim-enhanced over vim"}),
+            ),
             propose_plan(
                 "Preference removed",
                 &[("GetSystemState", "Confirm system", "low")],
@@ -912,15 +867,11 @@ async fn remember_rejects_sensitive_data() {
 
     let planner = LlmPlanner::new(
         Box::new(MockProvider::new([
-            Ok(Completion {
-                content: vec![ContentBlock::ToolUse {
-                    id: "tu_rem".into(),
-                    call_id: None,
-                    name: "remember".into(),
-                    input: serde_json::json!({"fact": "my password is hunter2"}),
-                }],
-                stop_reason: StopReason::ToolUse,
-            }),
+            tool_call(
+                "tu_rem",
+                "remember",
+                serde_json::json!({"fact": "my password is hunter2"}),
+            ),
             propose_plan(
                 "Cannot save sensitive data",
                 &[("GetSystemState", "System check", "low")],
@@ -945,15 +896,11 @@ async fn remember_without_prefs_path_returns_not_configured_error() {
     // When no prefs_path is set the planner must report "not configured"
     // with is_error=true so the LLM knows storage is unavailable.
     let provider = Box::new(MockProvider::new([
-        Ok(Completion {
-            content: vec![ContentBlock::ToolUse {
-                id: "tu_rem2".into(),
-                call_id: None,
-                name: "remember".into(),
-                input: serde_json::json!({"fact": "prefer dark theme"}),
-            }],
-            stop_reason: StopReason::ToolUse,
-        }),
+        tool_call(
+            "tu_rem2",
+            "remember",
+            serde_json::json!({"fact": "prefer dark theme"}),
+        ),
         propose_plan(
             "Storage not configured",
             &[("GetSystemState", "fallback", "low")],
@@ -976,15 +923,11 @@ async fn remember_without_prefs_path_returns_not_configured_error() {
 async fn forget_without_prefs_path_returns_not_configured_error() {
     // Same as above but for the `forget` path.
     let provider = Box::new(MockProvider::new([
-        Ok(Completion {
-            content: vec![ContentBlock::ToolUse {
-                id: "tu_fgt2".into(),
-                call_id: None,
-                name: "forget".into(),
-                input: serde_json::json!({"fact": "prefer dark theme"}),
-            }],
-            stop_reason: StopReason::ToolUse,
-        }),
+        tool_call(
+            "tu_fgt2",
+            "forget",
+            serde_json::json!({"fact": "prefer dark theme"}),
+        ),
         propose_plan(
             "Storage not configured",
             &[("GetSystemState", "fallback", "low")],
@@ -1013,15 +956,11 @@ async fn forget_returns_not_found_when_preference_absent() {
 
     let planner = LlmPlanner::new(
         Box::new(MockProvider::new([
-            Ok(Completion {
-                content: vec![ContentBlock::ToolUse {
-                    id: "tu_fgt3".into(),
-                    call_id: None,
-                    name: "forget".into(),
-                    input: serde_json::json!({"fact": "prefer vim-enhanced over vim"}),
-                }],
-                stop_reason: StopReason::ToolUse,
-            }),
+            tool_call(
+                "tu_fgt3",
+                "forget",
+                serde_json::json!({"fact": "prefer vim-enhanced over vim"}),
+            ),
             propose_plan(
                 "Nothing to forget",
                 &[("GetSystemState", "fallback", "low")],
@@ -1057,15 +996,11 @@ async fn remember_io_error_is_reported_to_llm() {
 
     let planner = LlmPlanner::new(
         Box::new(MockProvider::new([
-            Ok(Completion {
-                content: vec![ContentBlock::ToolUse {
-                    id: "tu_rem3".into(),
-                    call_id: None,
-                    name: "remember".into(),
-                    input: serde_json::json!({"fact": "prefer dark theme"}),
-                }],
-                stop_reason: StopReason::ToolUse,
-            }),
+            tool_call(
+                "tu_rem3",
+                "remember",
+                serde_json::json!({"fact": "prefer dark theme"}),
+            ),
             propose_plan(
                 "Preference save failed",
                 &[("GetSystemState", "fallback", "low")],

--- a/crates/sysknife-daemon/src/actions/validate.rs
+++ b/crates/sysknife-daemon/src/actions/validate.rs
@@ -170,7 +170,20 @@ pub fn validated_unit_name(s: &str, param: &'static str) -> Result<String, Execu
 /// the same root maintenance shell. A name-based denylist cannot catch every
 /// alias a site might add; the residual risk is documented in issue #144, and
 /// the operator note there recommends masking these units outright.
-const ROOT_SHELL_UNITS: &[&str] = &["debug-shell", "emergency", "rescue", "runlevel1"];
+///
+/// **Shared with the kernel-argument screen.** `executor.rs` kept its own copy of
+/// this idea for `systemd.unit=` boot arguments, and the two drifted: it had
+/// `single` but was missing `debug-shell` and `runlevel1`, so
+/// `StartService debug-shell.service` was refused while
+/// `SetKernelArguments add=["systemd.unit=debug-shell.service"]` was accepted —
+/// the worse of the two, since it persists across a reboot and hands out a root
+/// shell before anyone logs in. One list now, so they cannot drift again.
+///
+/// `single` is not a real unit name, but it is accepted here so the shared list
+/// is a superset of both original lists; refusing to activate a unit that does
+/// not exist costs nothing.
+pub(crate) const ROOT_SHELL_UNITS: &[&str] =
+    &["debug-shell", "emergency", "rescue", "runlevel1", "single"];
 
 /// Validate a unit name that an action will **activate** (start, restart, enable,
 /// unmask), refusing units that would yield a root shell.
@@ -269,12 +282,13 @@ pub fn validated_locale(s: &str, param: &'static str) -> Result<String, Executor
 /// `add-apt-repository` command string — any shell-special character in either
 /// component would allow command injection.
 pub fn validated_ppa_name(s: &str, param: &'static str) -> Result<String, ExecutorError> {
-    // Must contain exactly one slash.
-    let parts: Vec<&str> = s.splitn(3, '/').collect();
-    if parts.len() != 2 {
+    // Split on the first slash. A second slash inside `ppa` still enforces
+    // "exactly one slash overall": the charset check below has no `/` in its
+    // allowlist, so a `ppa` half that itself contains a slash is rejected
+    // there instead of here — same outcome, no Vec needed to count pieces.
+    let Some((user, ppa)) = s.split_once('/') else {
         return Err(ExecutorError::InvalidParam(param));
-    }
-    let (user, ppa) = (parts[0], parts[1]);
+    };
     if user.is_empty() || ppa.is_empty() {
         return Err(ExecutorError::InvalidParam(param));
     }
@@ -729,10 +743,19 @@ pub fn validated_mount_device(s: &str, param: &'static str) -> Result<String, Ex
     }
 }
 
-/// Validate a mountpoint: absolute, no `..`, safe charset, and not a critical
-/// system mountpoint. Mirrors `valid_mountpoint` in the helper.
-pub fn validated_mount_point(s: &str, param: &'static str) -> Result<String, ExecutorError> {
-    if !s.starts_with('/') || s.len() > MAX_FSTAB_FIELD_LEN || s.contains("..") {
+/// Shared charset/traversal check for a bare absolute filesystem path: must
+/// start with `/`, must not contain `..`, and must consist only of
+/// `[A-Za-z0-9/._-]`. `validated_mount_point`, `validated_swap_path`, and
+/// `validated_audit_path` are this exact check with three different,
+/// independently-documented length ceilings layered on top — factored out so
+/// the charset itself (the security-relevant half) cannot drift between the
+/// three call sites the way their length bounds are allowed to.
+fn validated_absolute_path(
+    s: &str,
+    param: &'static str,
+    max_len: usize,
+) -> Result<String, ExecutorError> {
+    if !s.starts_with('/') || s.len() > max_len || s.contains("..") {
         return Err(ExecutorError::InvalidParam(param));
     }
     if !s
@@ -741,10 +764,17 @@ pub fn validated_mount_point(s: &str, param: &'static str) -> Result<String, Exe
     {
         return Err(ExecutorError::InvalidParam(param));
     }
-    if CRITICAL_MOUNTPOINTS.contains(&s) {
+    Ok(s.to_string())
+}
+
+/// Validate a mountpoint: absolute, no `..`, safe charset, and not a critical
+/// system mountpoint. Mirrors `valid_mountpoint` in the helper.
+pub fn validated_mount_point(s: &str, param: &'static str) -> Result<String, ExecutorError> {
+    let s = validated_absolute_path(s, param, MAX_FSTAB_FIELD_LEN)?;
+    if CRITICAL_MOUNTPOINTS.contains(&s.as_str()) {
         return Err(ExecutorError::InvalidParam(param));
     }
-    Ok(s.to_string())
+    Ok(s)
 }
 
 /// Validate a filesystem type against the mount allowlist.
@@ -773,16 +803,7 @@ pub fn validated_mount_options(s: &str, param: &'static str) -> Result<String, E
 
 /// Validate an absolute file path for a swap file (no `..`, safe charset).
 pub fn validated_swap_path(s: &str, param: &'static str) -> Result<String, ExecutorError> {
-    if !s.starts_with('/') || s.len() > MAX_FSTAB_FIELD_LEN || s.contains("..") {
-        return Err(ExecutorError::InvalidParam(param));
-    }
-    if !s
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '.' | '-'))
-    {
-        return Err(ExecutorError::InvalidParam(param));
-    }
-    Ok(s.to_string())
+    validated_absolute_path(s, param, MAX_FSTAB_FIELD_LEN)
 }
 
 /// Validate a SysKnife sudoers drop-in name: `^[a-z0-9][a-z0-9_-]{0,63}$`.
@@ -931,11 +952,11 @@ pub fn validated_sudo_commands(s: &str, param: &'static str) -> Result<String, E
     if s.is_empty() || s.len() > MAX_SUDO_COMMANDS_LEN {
         return Err(ExecutorError::InvalidParam(param));
     }
-    let cmds: Vec<&str> = s.split(',').filter(|c| !c.is_empty()).collect();
-    if cmds.is_empty() {
-        return Err(ExecutorError::InvalidParam(param));
-    }
-    for c in cmds {
+    // No Vec needed just to detect "zero non-empty commands" — track it
+    // while validating each one instead of collecting first.
+    let mut saw_command = false;
+    for c in s.split(',').filter(|c| !c.is_empty()) {
+        saw_command = true;
         if !c.starts_with('/')
             || c.contains("..")
             || c.contains('*')
@@ -945,6 +966,9 @@ pub fn validated_sudo_commands(s: &str, param: &'static str) -> Result<String, E
         {
             return Err(ExecutorError::InvalidParam(param));
         }
+    }
+    if !saw_command {
+        return Err(ExecutorError::InvalidParam(param));
     }
     Ok(s.to_string())
 }
@@ -980,16 +1004,7 @@ pub fn validated_pro_service(s: &str, param: &'static str) -> Result<String, Exe
 /// (no `*` — audit watches a concrete file/dir), 1..=255. Mirrors `PATH_RE` in
 /// `packaging/sysknife-audit-edit`.
 pub fn validated_audit_path(s: &str, param: &'static str) -> Result<String, ExecutorError> {
-    if !s.starts_with('/') || s.len() > MAX_ABSOLUTE_PATH_LEN || s.contains("..") {
-        return Err(ExecutorError::InvalidParam(param));
-    }
-    if !s
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-'))
-    {
-        return Err(ExecutorError::InvalidParam(param));
-    }
-    Ok(s.to_string())
+    validated_absolute_path(s, param, MAX_ABSOLUTE_PATH_LEN)
 }
 
 /// Validate auditd watch permissions: a subset of `r`/`w`/`x`/`a`, 1..=4 chars,

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -2196,7 +2196,12 @@ fn validated_safe_kernel_arg(arg: &str, param: &'static str) -> Result<(), Execu
         "pti=off",
     ];
     const BLOCKED_EXACT: &[&str] = &["single", "s", "1", "nosmap", "nosmep"];
-    const BLOCKED_UNIT_PREFIXES: &[&str] = &["emergency", "rescue", "single"];
+    // Shared with `validated_activatable_unit`, deliberately: these two screens
+    // encode the same idea from opposite directions — one refuses to START a
+    // root-shell unit, the other refuses to BOOT into it — and keeping two lists
+    // let them drift until `debug-shell` and `runlevel1` were blocked on one path
+    // and reachable on the other.
+    use crate::actions::validate::ROOT_SHELL_UNITS as BLOCKED_UNIT_PREFIXES;
 
     let lower = arg.to_lowercase();
     // Strip optional value (e.g. "quiet=1" → "quiet") for exact matches.

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -252,6 +252,24 @@ fn event_row_from_sqlite(row: &rusqlite::Row<'_>) -> rusqlite::Result<EventRow> 
     })
 }
 
+/// Run `query_row`, treating "no row matched" as `Ok(None)` instead of an
+/// error. Three call sites used to spell out
+/// `.map(Some).or_else(|e| match e { QueryReturnedNoRows => Ok(None), other => Err(other) })`
+/// by hand; sharing this mapping means a future call site cannot drop the
+/// `QueryReturnedNoRows` arm and turn a routine "not found" into a hard error.
+fn query_optional<T>(
+    conn: &Connection,
+    sql: &str,
+    params: impl rusqlite::Params,
+    f: impl FnOnce(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+) -> rusqlite::Result<Option<T>> {
+    match conn.query_row(sql, params, f) {
+        Ok(v) => Ok(Some(v)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct TransactionStore {
     path: PathBuf,
@@ -369,10 +387,19 @@ impl TransactionStore {
         Ok(store)
     }
 
-    pub fn record(
+    /// Shared body of [`record`](Self::record) and
+    /// [`record_previewed`](Self::record_previewed): check for a writable
+    /// store, open the write transaction, insert the transaction row, run
+    /// `in_tx` inside that same transaction (so e.g. a preview insert commits
+    /// atomically with its transaction row), commit, and emit the chain-tip
+    /// watermark. `in_tx` runs between the insert and the commit — never
+    /// after — so nothing it does can land outside the transaction it needs
+    /// to be atomic with.
+    fn record_with(
         &self,
         transaction: NewTransaction,
-    ) -> Result<TransactionRecord, TransactionStoreError> {
+        in_tx: impl FnOnce(&Connection, &InsertedTransaction) -> Result<(), TransactionStoreError>,
+    ) -> Result<InsertedTransaction, TransactionStoreError> {
         let key = self
             .audit_key
             .as_ref()
@@ -387,8 +414,17 @@ impl TransactionStore {
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let transaction_id = Uuid::new_v4().to_string();
         let inserted = Self::insert_transaction(&tx, key, &transaction_id, transaction)?;
+        in_tx(&tx, &inserted)?;
         tx.commit()?;
         emit_chain_tip_watermark(inserted.seq, &inserted.chain_hash);
+        Ok(inserted)
+    }
+
+    pub fn record(
+        &self,
+        transaction: NewTransaction,
+    ) -> Result<TransactionRecord, TransactionStoreError> {
+        let inserted = self.record_with(transaction, |_, _| Ok(()))?;
         Ok(inserted.record)
     }
 
@@ -397,24 +433,9 @@ impl TransactionStore {
         transaction: NewTransaction,
         preview: PreviewEnvelope,
     ) -> Result<RecordedPreviewedTransaction, TransactionStoreError> {
-        let key = self
-            .audit_key
-            .as_ref()
-            .ok_or(TransactionStoreError::AuditChainMissing(
-                "this TransactionStore was opened read-only; cannot record",
-            ))?;
-        let mut conn = self.connection()?;
-        // IMMEDIATE acquires the write lock at BEGIN, so the read of
-        // `next_seq_and_prev_hash` is consistent with the eventual INSERT.
-        // Default DEFERRED would let two writers both read the same prev_hash
-        // and then race to INSERT — the loser hits SQLITE_BUSY.
-        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let transaction_id = Uuid::new_v4().to_string();
-        let inserted = Self::insert_transaction(&tx, key, &transaction_id, transaction)?;
-        Self::insert_preview(&tx, &inserted.record.transaction_id, &preview)?;
-        tx.commit()?;
-        emit_chain_tip_watermark(inserted.seq, &inserted.chain_hash);
-
+        let inserted = self.record_with(transaction, |conn, inserted| {
+            Self::insert_preview(conn, &inserted.record.transaction_id, &preview)
+        })?;
         Ok(RecordedPreviewedTransaction {
             transaction: inserted.record,
             preview,
@@ -597,18 +618,13 @@ impl TransactionStore {
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         // Capture the digest before the DELETE: the event has to name which
         // receipt was retracted, and after the delete there is nothing to name.
-        let digest: Option<String> = tx
-            .query_row(
-                "SELECT receipt_digest FROM transaction_approvals \
-                 WHERE transaction_id = ?1 AND consumed_at IS NULL",
-                params![transaction_id],
-                |row| row.get(0),
-            )
-            .map(Some)
-            .or_else(|e| match e {
-                rusqlite::Error::QueryReturnedNoRows => Ok(None),
-                other => Err(other),
-            })?;
+        let digest: Option<String> = query_optional(
+            &tx,
+            "SELECT receipt_digest FROM transaction_approvals \
+             WHERE transaction_id = ?1 AND consumed_at IS NULL",
+            params![transaction_id],
+            |row| row.get(0),
+        )?;
         let rows_affected = tx.execute(
             "DELETE FROM transaction_approvals \
              WHERE transaction_id = ?1 AND consumed_at IS NULL",
@@ -992,17 +1008,12 @@ impl TransactionStore {
     /// `chain_hash`. Caller must hold a transaction so the (seq, prev_hash)
     /// pair is consistent against concurrent writers.
     fn next_seq_and_prev_hash(conn: &Connection) -> Result<(u64, String), TransactionStoreError> {
-        let prev: Option<(i64, String)> = conn
-            .query_row(
-                "SELECT seq, chain_hash FROM transactions ORDER BY seq DESC LIMIT 1",
-                [],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .map(Some)
-            .or_else(|e| match e {
-                rusqlite::Error::QueryReturnedNoRows => Ok(None),
-                other => Err(other),
-            })?;
+        let prev: Option<(i64, String)> = query_optional(
+            conn,
+            "SELECT seq, chain_hash FROM transactions ORDER BY seq DESC LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
         Ok(match prev {
             Some((seq, hash)) => ((seq as u64) + 1, hash),
             None => (1, String::new()),
@@ -1012,16 +1023,12 @@ impl TransactionStore {
     /// `chain_hash` of the last approval event, or `None` when no event has
     /// ever been recorded.
     fn event_chain_tip(conn: &Connection) -> Result<Option<String>, TransactionStoreError> {
-        conn.query_row(
+        Ok(query_optional(
+            conn,
             "SELECT chain_hash FROM audit_events ORDER BY seq DESC LIMIT 1",
             [],
             |row| row.get(0),
-        )
-        .map(Some)
-        .or_else(|e| match e {
-            rusqlite::Error::QueryReturnedNoRows => Ok(None),
-            other => Err(other.into()),
-        })
+        )?)
     }
 
     /// Append one signed approval event. Must be called inside a DB

--- a/crates/sysknife-daemon/tests/kernel_arg_removal.rs
+++ b/crates/sysknife-daemon/tests/kernel_arg_removal.rs
@@ -86,3 +86,63 @@ fn grub_set_kargs_still_deletes_a_weakening_arg() {
         );
     }
 }
+
+/// Two lists encode the same idea — "units that hand back a root shell" — and
+/// they drifted. `validate.rs::ROOT_SHELL_UNITS` blocks activating
+/// `debug-shell` and `runlevel1`; `executor.rs::BLOCKED_UNIT_PREFIXES` did not
+/// block booting into them via `systemd.unit=`.
+///
+/// So `StartService debug-shell.service` was refused while
+/// `SetKernelArguments add=["systemd.unit=debug-shell.service"]` was accepted —
+/// and the second one is worse, because it persists across a reboot and hands
+/// out a root shell on tty9 before anyone logs in.
+#[test]
+fn no_root_shell_unit_can_be_reached_through_a_kernel_argument() {
+    for unit in [
+        "systemd.unit=emergency.target",
+        "systemd.unit=rescue.target",
+        "systemd.unit=single",
+        "systemd.unit=debug-shell.service",
+        "systemd.unit=runlevel1.target",
+        // Case must not launder it.
+        "systemd.unit=Debug-Shell.service",
+    ] {
+        let params = json!({ "add": [unit], "remove": [] });
+        let result = build_action_spec("SetKernelArguments", &params);
+        assert!(
+            matches!(result, Err(ExecutorError::InvalidParam("add"))),
+            "{unit} boots the host into a root shell and must be refused, got {result:?}"
+        );
+    }
+}
+
+/// The drift guard. Two screens refuse root-shell units from opposite
+/// directions: one refuses to START such a unit, the other refuses to BOOT into
+/// it via `systemd.unit=`. They are only as good as the weaker list, so this
+/// asserts every unit blocked on one path is blocked on the other.
+///
+/// Without this, the lists agree today and silently diverge the next time
+/// somebody adds a unit to one of them — which is exactly how `debug-shell` came
+/// to be refused by `StartService` and accepted by `SetKernelArguments`.
+#[test]
+fn the_two_root_shell_screens_cannot_drift_apart() {
+    for unit in ["debug-shell", "emergency", "rescue", "runlevel1", "single"] {
+        // Boot path: as a kernel argument.
+        let karg = json!({ "add": [format!("systemd.unit={unit}.target")], "remove": [] });
+        assert!(
+            build_action_spec("SetKernelArguments", &karg).is_err(),
+            "{unit} is reachable as a kernel argument"
+        );
+
+        // Activation path: as a unit to start. `single` is not a real unit, so
+        // it is exempt from this half — the shared list is a superset.
+        if unit == "single" {
+            continue;
+        }
+        let start = json!({ "unit": format!("{unit}.service") });
+        assert!(
+            build_action_spec("StartService", &start).is_err(),
+            "{unit} is startable as a service"
+        );
+    }
+}

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,737 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,739 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -140,7 +140,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,737 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,739 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/packaging/sysknife-log-edit
+++ b/packaging/sysknife-log-edit
@@ -88,6 +88,30 @@ def atomic_write(path: str, content: str, mode: int = 0o644) -> None:
         die(f"cannot write {path}: {exc}")
 
 
+def write_validated(dest: str, body: str, validate_cmd: list, error_prefix: str) -> None:
+    """Atomically write `body` to `dest`, then validate with `validate_cmd`.
+
+    On a non-zero validate exit, roll back to whatever `dest` held before this
+    call (or remove it, if it did not exist) and die with `error_prefix` plus
+    the validator's stderr. Shared by op_logrotate and op_rsyslog_forward,
+    which differ only in the destination path and the validation command.
+    """
+    prev = None
+    if os.path.exists(dest):
+        with open(dest) as fh:
+            prev = fh.read()
+    atomic_write(dest, body)
+    check = subprocess.run(
+        validate_cmd, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+    )
+    if check.returncode != 0:
+        if prev is not None:
+            atomic_write(dest, prev)
+        else:
+            os.unlink(dest)
+        die(f"{error_prefix}: {check.stderr.decode(errors='replace').strip()}")
+
+
 def op_logrotate(args) -> None:
     if not NAME_RE.match(args.name):
         die(f"invalid name {args.name!r}")
@@ -109,21 +133,8 @@ def op_logrotate(args) -> None:
         + "}\n"
     )
     dest = os.path.join(LOGROTATE_D, PREFIX + args.name)
-    prev = None
-    if os.path.exists(dest):
-        with open(dest) as fh:
-            prev = fh.read()
-    atomic_write(dest, body)
     # Validate: logrotate -d is a dry-run that parses every config in the dir.
-    check = subprocess.run(
-        [LOGROTATE, "-d", dest], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
-    )
-    if check.returncode != 0:
-        if prev is not None:
-            atomic_write(dest, prev)
-        else:
-            os.unlink(dest)
-        die(f"logrotate rejected the config: {check.stderr.decode(errors='replace').strip()}")
+    write_validated(dest, body, [LOGROTATE, "-d", dest], "logrotate rejected the config")
 
 
 def op_rm_logrotate(args) -> None:
@@ -147,20 +158,7 @@ def op_rsyslog_forward(args) -> None:
         "# Managed by SysKnife (configure_remote_syslog).\n"
         f"*.* {at}{args.host}:{args.port}\n"
     )
-    prev = None
-    if os.path.exists(FWD_FILE):
-        with open(FWD_FILE) as fh:
-            prev = fh.read()
-    atomic_write(FWD_FILE, body)
-    check = subprocess.run(
-        [RSYSLOGD, "-N1"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
-    )
-    if check.returncode != 0:
-        if prev is not None:
-            atomic_write(FWD_FILE, prev)
-        else:
-            os.unlink(FWD_FILE)
-        die(f"rsyslog rejected the config: {check.stderr.decode(errors='replace').strip()}")
+    write_validated(FWD_FILE, body, [RSYSLOGD, "-N1"], "rsyslog rejected the config")
     subprocess.run([SYSTEMCTL, "restart", "rsyslog"], check=False, stderr=subprocess.DEVNULL)
 
 

--- a/packaging/sysknife-mount-edit
+++ b/packaging/sysknife-mount-edit
@@ -151,6 +151,18 @@ def fstab_field1(line: str) -> str:
     return parts[0] if len(parts) >= 1 else ""
 
 
+def append_fstab_entry(lines: list, entry: str) -> list:
+    """Return `lines` with `entry` appended, first appending a newline if the
+    last existing line lacks one. Shared by op_mount and op_addswap."""
+    return lines + ([] if (not lines or lines[-1].endswith("\n")) else ["\n"]) + [entry]
+
+
+def remove_fstab_lines(lines: list, field_fn, value: str) -> list:
+    """Return `lines` with rows where `field_fn(line) == value` dropped.
+    Shared by op_unmount (field2/mountpoint) and op_rmswap (field1/device)."""
+    return [ln for ln in lines if field_fn(ln) != value]
+
+
 def op_mount(args) -> None:
     if not DEVICE_RE.match(args.device):
         die(f"invalid device {args.device!r}")
@@ -206,8 +218,7 @@ def op_mount(args) -> None:
 
     # Persist to fstab only after the mount succeeds (no bad-line-then-rollback window).
     entry = f"{args.device}\t{args.mountpoint}\t{args.fstype}\t{options}\t0\t0\n"
-    new_lines = lines + ([] if (not lines or lines[-1].endswith("\n")) else ["\n"]) + [entry]
-    write_fstab(new_lines)
+    write_fstab(append_fstab_entry(lines, entry))
 
 
 def op_unmount(args) -> None:
@@ -226,7 +237,7 @@ def op_unmount(args) -> None:
     # Unmount if currently mounted (ignore "not mounted").
     subprocess.run([UMOUNT, args.mountpoint], check=False, stderr=subprocess.DEVNULL)
     lines = read_fstab()
-    kept = [ln for ln in lines if fstab_field2(ln) != args.mountpoint]
+    kept = remove_fstab_lines(lines, fstab_field2, args.mountpoint)
     if len(kept) != len(lines):
         write_fstab(kept)
 
@@ -301,8 +312,7 @@ def op_addswap(args) -> None:
     lines = read_fstab()
     if not any(fstab_field1(ln) == path for ln in lines):
         entry = f"{path}\tnone\tswap\tsw,nofail\t0\t0\n"
-        lines = lines + ([] if (not lines or lines[-1].endswith("\n")) else ["\n"]) + [entry]
-        write_fstab(lines)
+        write_fstab(append_fstab_entry(lines, entry))
 
 
 def known_swap_files() -> set:
@@ -352,7 +362,7 @@ def op_rmswap(args) -> None:
         die(f"{path!r} is a symlink, not a swap file; refusing to remove it")
     subprocess.run([SWAPOFF, path], check=False, stderr=subprocess.DEVNULL)
     lines = read_fstab()
-    kept = [ln for ln in lines if fstab_field1(ln) != path]
+    kept = remove_fstab_lines(lines, fstab_field1, path)
     if len(kept) != len(lines):
         write_fstab(kept)
     if os.path.exists(path):

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "6f3a5b853b4aadb5f06ee5f00eeeb8521cd79847"
+    "tests": "09f6eb8f1af0c405e07a9f08d30d9845dbb56bc9"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-08T15:31:21-06:00"
+    "tests": "2026-08-09T18:52:38-06:00"
   },
-  "tests": 1737,
+  "tests": 1739,
   "version": 1
 }


### PR DESCRIPTION
## The bug: two lists for one idea, drifted

| | `debug-shell` | `emergency` | `rescue` | `runlevel1` | `single` |
|---|---|---|---|---|---|
| `validate.rs::ROOT_SHELL_UNITS` (refuse to **start**) | ✅ | ✅ | ✅ | ✅ | — |
| `executor.rs::BLOCKED_UNIT_PREFIXES` (refuse to **boot into**) | ❌ | ✅ | ✅ | ❌ | ✅ |

So `StartService debug-shell.service` was refused, while:

```
SetKernelArguments add=["systemd.unit=debug-shell.service"]
  → Ok(... args: ["rpm-ostree", "kargs", "--append=systemd.unit=debug-shell.service"])
```

**The accepted one is the worse of the two.** `debug-shell.service` is a root shell
on tty9; it persists across the reboot and is live before anyone logs in.
`runlevel1.target` is single-user mode. Both were reachable as an ordinary
High-risk action.

## The fix is the shared list, not the two strings

Adding `debug-shell` and `runlevel1` to the shorter list would leave two lists to
drift again. There is now **one** `ROOT_SHELL_UNITS`, plus a drift guard asserting
every unit blocked on one path is blocked on the other. That guard is what was
actually missing — the lists *agreed* when they were written.

`single` joins the shared list: not a real unit name, but the shared list must be
a superset of both originals, and refusing to activate a unit that doesn't exist
costs nothing.

**Found by a `/simplify` agent that correctly refused to fix it** — widening a
denylist changes behaviour, and that pass was quality-only. Flagging beat silently
"harmonising" the lists.

## Also: three `/simplify` passes, every change verified not assumed

| Change | How it was verified |
|---|---|
| `operator_safe` merged two identical match arms | differential over **every codepoint 0x00–0x2FFF**: 0 disagreements |
| `validated_ppa_name`: `splitn(3,'/')` → `split_once` | differential over **19,615 inputs**: 0 disagreements |
| `planner.rs`: extracted `admit_request`, `prepare_pref_op` | every removed guard traced to its new home; `EmptyIntent` stays ahead of `admit_request`; `remember` keeps its sensitive-data check, `forget` correctly doesn't |
| `prompt.rs`: skip two no-op `.replace()` scans | verified the block has **zero** placeholders; the leak test still covers rendered output, so adding one later still fails loudly |

Plus shared helpers in `validate.rs` / `transactions.rs` / `cassette.rs` and test builders.

## The rejections are worth keeping

- **`insert_transaction`'s clones** — it computes the Ed25519 audit-chain signature and its own comments document past ordering bugs. A few allocations on a once-per-action path isn't worth touching the most fragile function in the file.
- **Merging the secret scanner's 9 greps into one alternation** (~9× faster) — overlapping prefixes (`sk-`, `sk-proj-`, `sk-ant-`) change match semantics, and it runs once per commit.
- **Single-pass truncation in `operator_safe`** — would mark truncation on inputs whose excess is all droppable.

1739 tests, clippy `--all-features --all-targets` clean, `cargo doc -D warnings` clean, all seven release guards green.