### PR TITLE
chore(deps): bump serde to 1.0.229

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4235,9 +4235,9 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4257,22 +4257,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Dependabot cannot do this one. Its cargo job ([run 31590033827](https://github.com/lacs-project/sysknife/actions/runs/31590033827)) ends with `Error processing toml (RuntimeError)` / `Failed to update toml` and reports both `serde` and `toml` as `unknown_error`, so the grouped PR it opens silently omits them. Left alone they stay pinned indefinitely while every other crate moves.

`toml` is deliberately **not** bumped alongside. Taking our direct dep from 1.1.3 to 1.1.4 makes cargo re-resolve `tauri-utils` (requirement `>=0.9, <=1`) off the now-unused 1.1.3 and onto the already-present 0.9.12. Both satisfy it, so the downgrade is legal rather than a bug, but it is churn in a GUI-only path for a routine patch release.

Verified locally with the full pre-commit gate: fmt, clippy `--all-features --all-targets`, `cargo doc -D warnings`, and 1,739 tests.