### PR TITLE
docs: record that GUI development is paused and focus is Ubuntu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,22 @@ This repository is for SysKnife, the Linux Agent Control Standard.
 Work here must preserve the trust boundary between the planner,
 the shell, and the privileged daemon.
 
+## Current Focus — Ubuntu; GUI Paused
+
+**GUI development is temporarily paused.** Do not review, test, refactor, or
+extend `apps/sysknife-shell/**` (the Tauri desktop app). It stays in the tree
+and must keep building, so workspace-wide gates still cover it, but it is not
+where effort goes. Merging a dependency bump that only touches its lockfile is
+fine — that is maintenance, not development.
+
+**Analysis and development focus on Ubuntu**, across its versions (22.04,
+24.04, 26.04). Live-VM evidence, action coverage, and security review target
+the Debian-family path first.
+
+Fedora is deprioritized, **not** dropped. The rpm-ostree action family, the
+atomic story family, and the `FEDORA_ONLY_ACTIONS` safety fence all stay
+intact and must keep passing; nothing here licenses deleting them.
+
 ## Pre-Commit Gate
 
 **`cargo nextest run --workspace --locked` must pass with zero failures before

--- a/README.md
+++ b/README.md
@@ -191,11 +191,13 @@ SysKnife, not an afterthought. See the [CLI guide](docs/cli.md).
   <img src="assets/demo/demo.gif" alt="sysknife CLI — plan, approve, and execute in the terminal" width="900"/>
 </p>
 
-> **Also: a desktop GUI — a distant third option.** An experimental Tauri
-> desktop app (`sysknife-shell`) wraps the same plan → approve → execute loop in
-> a window. It is the least frequently maintained surface, well behind the MCP
-> integration and the CLI, so reach for it only if you specifically want a
-> graphical approval flow.
+> **Also: a desktop GUI — development paused.** An experimental Tauri desktop
+> app (`sysknife-shell`) wraps the same plan → approve → execute loop in a
+> window. **Its development is paused for now**, and effort is going to Ubuntu
+> across its supported versions instead. The code stays in the tree and still
+> builds, but it is not being reviewed, tested, or extended, so reach for it
+> only if you specifically want a graphical approval flow and can live with
+> that. The MCP integration and the CLI are the maintained surfaces.
 
 ## How it works
 


### PR DESCRIPTION
Makes a ranking into a decision. The GUI was already described as "the least frequently maintained surface"; it is now explicitly paused, with effort going to Ubuntu across 22.04, 24.04, and 26.04.

README tells users what to expect before they reach for the GUI. CLAUDE.md tells anyone working in the tree not to spend review or test effort there, while making clear the crate must keep building so workspace-wide gates still cover it, and that a dependency bump touching only its lockfile is still fine to merge.

Says "paused", not "dropped", and states the same for Fedora: deprioritized, with the rpm-ostree action family, atomic story family, and FEDORA_ONLY_ACTIONS fence all intact.