### PR TITLE
fix(security): close three gaps a fresh review sweep found

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ milestone.
 | **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,739 Rust tests and 72 frontend tests** form the current deterministic
+**1,743 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/src/operator_text.rs
+++ b/apps/sysknife-cli/src/operator_text.rs
@@ -27,6 +27,48 @@ const MAX_RENDERED_LEN: usize = 512;
 /// never be mistaken for the whole one.
 const TRUNCATION_MARKER: &str = "… [truncated]";
 
+/// Most lines of a multi-line block rendered above a prompt.
+///
+/// [`MAX_RENDERED_LEN`] bounds one line; nothing bounded how many. A preview
+/// whose parameters serialise to a thousand lines scrolls the prompt — and the
+/// risk level and action name printed above it — off the screen just as
+/// effectively as one very long line.
+const MAX_RENDERED_LINES: usize = 40;
+
+/// Marker appended when [`operator_safe_block`] drops lines.
+const LINE_TRUNCATION_MARKER: &str = "… [truncated: block too long to display]";
+
+/// Return a multi-line block rendered safe to print above a prompt.
+///
+/// [`operator_safe`] collapses newlines, which is right for a one-line summary
+/// and wrong for structured text: pretty-printed JSON flattened to a single line
+/// is unreadable, and unreadable is its own approval hazard. So each line is
+/// neutralised individually and the line structure is kept, with the number of
+/// lines bounded.
+///
+/// This exists because `serde_json` is not a sanitiser. It escapes C0 controls
+/// and quotes, so raw pretty-printed JSON looks safe, but it emits U+202E and
+/// U+200B as literal UTF-8 — the two classes that reorder and hide text. A
+/// preview dumped straight from `to_string_pretty` therefore carries exactly the
+/// characters [`operator_safe`] exists to remove.
+pub(crate) fn operator_safe_block(s: &str) -> String {
+    let mut lines: Vec<String> = s
+        .lines()
+        .take(MAX_RENDERED_LINES)
+        .map(|line| {
+            // Keep leading indentation: it carries the JSON's structure, and
+            // `operator_safe` would trim it away as collapsible whitespace.
+            let indent_len = line.len() - line.trim_start().len();
+            format!("{}{}", &line[..indent_len], operator_safe(line))
+        })
+        .collect();
+
+    if s.lines().count() > MAX_RENDERED_LINES {
+        lines.push(LINE_TRUNCATION_MARKER.to_string());
+    }
+    lines.join("\n")
+}
+
 /// Return `s` rendered safe to print on one line of the operator's terminal.
 ///
 /// - `\t`, `\n`, `\r` collapse to a single space: benign in origin, but a
@@ -38,6 +80,12 @@ const TRUNCATION_MARKER: &str = "… [truncated]";
 ///   dropped. These reorder or hide text while leaving the bytes intact — the
 ///   "trojan source" class, which here would let a summary read
 ///   `remove nothing` while naming a different target.
+/// - Every other invisible formatting character goes too: U+061C (a bidi
+///   control alongside the U+200E/U+200F already covered), soft hyphen, the
+///   combining grapheme joiner, the word joiner and invisible operators, the
+///   deprecated format controls, and the TAG block used for ASCII smuggling.
+///   The set is meant to be complete; a partial one reads as neutralised
+///   without being so.
 /// - Runs of whitespace collapse and the result is trimmed, so the layout an
 ///   attacker can produce is bounded.
 /// - The result is capped at [`MAX_RENDERED_LEN`] and marked when cut.
@@ -59,6 +107,23 @@ pub(crate) fn operator_safe(s: &str) -> String {
             '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}' => false,
             // Zero-width and byte-order marks — hide text in plain sight.
             '\u{200b}'..='\u{200f}' | '\u{feff}' => false,
+            // U+061C ARABIC LETTER MARK is a bidi control in exactly the way
+            // U+200E/200F above are; dropping those two and keeping this one
+            // left the set incomplete rather than strict.
+            '\u{061c}' => false,
+            // The rest of the invisible formatting characters. Each renders as
+            // nothing and can therefore split a word the operator reads as
+            // whole, or pad a summary that looks short.
+            '\u{00ad}'                  // SOFT HYPHEN
+            | '\u{034f}'                // COMBINING GRAPHEME JOINER
+            | '\u{180b}'..='\u{180e}'   // Mongolian selectors + vowel separator
+            | '\u{2060}'..='\u{2064}'   // WORD JOINER + invisible operators
+            | '\u{206a}'..='\u{206f}'   // deprecated bidi/format controls
+            | '\u{fff9}'..='\u{fffb}'   // interlinear annotation
+            // TAG characters. These mirror ASCII invisibly and are the vehicle
+            // for "ASCII smuggling": a tagged copy of a different target rides
+            // along in a summary that displays as innocuous text.
+            | '\u{e0000}'..='\u{e007f}' => false,
             _ => true,
         };
         if !keep {
@@ -82,6 +147,87 @@ pub(crate) fn operator_safe(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `sysknife approve` printed the proposed change straight from
+    /// `serde_json::to_string_pretty`, immediately above the approval prompt,
+    /// while the summary beside it went through `operator_safe`. JSON escaping
+    /// covers C0 controls and stops there, so a bidi override inside a string
+    /// value reached the terminal intact and could reorder the very target the
+    /// operator was being asked to confirm.
+    #[test]
+    fn a_json_block_cannot_smuggle_bidi_or_zero_width_past_the_prompt() {
+        let hostile = serde_json::to_string_pretty(&serde_json::json!({
+            "path": "/etc/\u{202e}gnc.d/passwd\u{202c}",
+            "note": "safe\u{200b}ish",
+        }))
+        .expect("json");
+
+        // Precondition: serde_json really does leave these in place, so the
+        // test fails for the stated reason rather than a vacuous one.
+        assert!(
+            hostile.contains('\u{202e}'),
+            "serde_json escaped the override"
+        );
+
+        let safe = operator_safe_block(&hostile);
+        assert!(
+            !safe.contains('\u{202e}'),
+            "bidi override survived: {safe:?}"
+        );
+        assert!(!safe.contains('\u{200b}'), "zero-width survived: {safe:?}");
+        // Structure must survive, or the operator cannot read what they approve.
+        assert!(safe.lines().count() > 1, "block was flattened: {safe:?}");
+        assert!(safe.contains("passwd"), "visible text was lost: {safe:?}");
+    }
+
+    /// One long line was bounded; a block of many lines was not, and scrolls the
+    /// action name and risk level off the screen just as effectively.
+    #[test]
+    fn a_tall_block_is_bounded_and_says_so() {
+        let tall = (0..500)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let safe = operator_safe_block(&tall);
+        assert_eq!(safe.lines().count(), MAX_RENDERED_LINES + 1);
+        assert!(
+            safe.ends_with(LINE_TRUNCATION_MARKER),
+            "truncation unmarked: {safe:?}"
+        );
+    }
+
+    /// The invisible-formatting set has to be complete, not merely started.
+    /// U+200E/200F were dropped and U+061C was not, though all three are bidi
+    /// controls; the zero-width block was dropped and U+2060 WORD JOINER was
+    /// not, though both render as nothing. A partial set is an operator who
+    /// believes the text was neutralised when it was not.
+    #[test]
+    fn every_invisible_formatting_character_is_dropped() {
+        for ch in [
+            '\u{061c}',  // ARABIC LETTER MARK — bidi control
+            '\u{00ad}',  // SOFT HYPHEN
+            '\u{034f}',  // COMBINING GRAPHEME JOINER
+            '\u{180e}',  // MONGOLIAN VOWEL SEPARATOR
+            '\u{2060}',  // WORD JOINER
+            '\u{2064}',  // INVISIBLE PLUS
+            '\u{206f}',  // NOMINAL DIGIT SHAPES
+            '\u{fffb}',  // INTERLINEAR ANNOTATION TERMINATOR
+            '\u{e0041}', // TAG LATIN CAPITAL LETTER A — ASCII smuggling
+        ] {
+            let hostile = format!("AptRemove{ch}Everything");
+            let safe = operator_safe(&hostile);
+            assert!(
+                !safe.chars().any(|c| c == ch),
+                "U+{:04X} survived operator_safe: {safe:?}",
+                ch as u32
+            );
+            assert_eq!(
+                safe, "AptRemoveEverything",
+                "U+{:04X} must vanish without disturbing the visible text",
+                ch as u32
+            );
+        }
+    }
 
     /// The headline case: a summary that erases and rewrites its own line.
     #[test]

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -513,8 +513,15 @@ pub async fn run_approve(
         details.action_name,
         details.preview.risk_level,
         crate::operator_text::operator_safe(&details.preview.summary),
-        serde_json::to_string_pretty(&details.preview.proposed_change)
-            .unwrap_or_else(|_| "<unavailable>".to_string())
+        // `to_string_pretty` is not a sanitiser: it escapes C0 controls but
+        // emits U+202E and U+200B literally. This is the last thing printed
+        // before the operator is asked to approve, and the proposed change is
+        // the authoritative statement of what will happen — the one string on
+        // screen that must not be able to lie about its own target.
+        crate::operator_text::operator_safe_block(
+            &serde_json::to_string_pretty(&details.preview.proposed_change)
+                .unwrap_or_else(|_| "<unavailable>".to_string())
+        )
     ));
     let approved = if details.preview.risk_level == RiskLevel::High {
         prompt_exact(

--- a/crates/sysknife-daemon/src/executor.rs
+++ b/crates/sysknife-daemon/src/executor.rs
@@ -2183,6 +2183,8 @@ fn str_array_or_empty(params: &Value, key: &'static str) -> Result<Vec<String>, 
 /// - `pti=off`         — disables Page Table Isolation (Meltdown mitigation)
 /// - `nosmap` / `nosmep` — disable SMAP/SMEP, CPU features that block a large
 ///   class of kernel-exploitation techniques
+/// - `systemd.debug_shell` — the same root shell as `systemd.unit=debug-shell`,
+///   asked for by a different name
 fn validated_safe_kernel_arg(arg: &str, param: &'static str) -> Result<(), ExecutorError> {
     const BLOCKED_PREFIXES: &[&str] = &[
         "init=",
@@ -2194,6 +2196,18 @@ fn validated_safe_kernel_arg(arg: &str, param: &'static str) -> Result<(), Execu
         "mitigations=off",
         "lockdown=",
         "pti=off",
+        // `systemd.unit=` is not the only way to ask for `debug-shell.service`.
+        // systemd-debug-generator also honours `systemd.debug_shell`, which
+        // pulls the unit into the boot transaction and spawns a root shell on
+        // tty9 before anyone logs in — the identical end state the
+        // `BLOCKED_UNIT_PREFIXES` screen below exists to prevent. Underscore is
+        // the real spelling per systemd-debug-generator(8); `rd.` is the
+        // initrd-honoured variant, and the hyphen forms are listed so a
+        // near-miss cannot creep back.
+        "systemd.debug_shell",
+        "systemd.debug-shell",
+        "rd.systemd.debug_shell",
+        "rd.systemd.debug-shell",
     ];
     const BLOCKED_EXACT: &[&str] = &["single", "s", "1", "nosmap", "nosmep"];
     // Shared with `validated_activatable_unit`, deliberately: these two screens

--- a/crates/sysknife-daemon/tests/kernel_arg_removal.rs
+++ b/crates/sysknife-daemon/tests/kernel_arg_removal.rs
@@ -116,6 +116,34 @@ fn no_root_shell_unit_can_be_reached_through_a_kernel_argument() {
     }
 }
 
+/// The same root shell, reached by a different name. `systemd.unit=` is not the
+/// only way to ask systemd for `debug-shell.service`: systemd-debug-generator
+/// also honours `systemd.debug_shell`, which pulls the unit into the boot
+/// transaction and spawns a root shell on tty9 before anyone logs in. Screening
+/// only the `systemd.unit=` spelling closed one door and left this one open.
+///
+/// Underscore is the real spelling, verified against systemd-debug-generator(8)
+/// on Ubuntu 24.04; `rd.` is the initrd-honoured variant. The hyphen forms are
+/// screened too so a near-miss cannot creep back in.
+#[test]
+fn the_debug_shell_cannot_be_reached_by_its_own_kernel_argument() {
+    for arg in [
+        "systemd.debug_shell=1",
+        "systemd.debug_shell",
+        "rd.systemd.debug_shell=1",
+        "systemd.debug-shell=1",
+        // Case must not launder it.
+        "SYSTEMD.DEBUG_SHELL=1",
+    ] {
+        let params = json!({ "add": [arg], "remove": [] });
+        let result = build_action_spec("SetKernelArguments", &params);
+        assert!(
+            matches!(result, Err(ExecutorError::InvalidParam("add"))),
+            "{arg} spawns a root shell on tty9 at boot and must be refused, got {result:?}"
+        );
+    }
+}
+
 /// The drift guard. Two screens refuse root-shell units from opposite
 /// directions: one refuses to START such a unit, the other refuses to BOOT into
 /// it via `systemd.unit=`. They are only as good as the weaker list, so this

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,739 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,743 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -140,7 +140,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,739 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,743 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/packaging/sysknife-grub-kargs-edit
+++ b/packaging/sysknife-grub-kargs-edit
@@ -52,8 +52,21 @@ KARG_PATTERN = re.compile(r"^[A-Za-z0-9_.+@:/=-]+$")
 # selinux=0, enforcing=0, security=, module_blacklist=) or drop to a single-user
 # root shell (bare single/s/1, or systemd.unit= pointing at emergency/rescue/
 # single).
-DENY_APPEND_PREFIXES = ("init=", "selinux=0", "enforcing=0", "security=", "module_blacklist=")
-DENY_APPEND_EXACT = ("single", "s", "1")
+#
+# systemd.debug_shell is the same root shell reached by a different name:
+# systemd-debug-generator pulls debug-shell.service into the boot transaction
+# and spawns a root shell on tty9 with no login, so screening only
+# systemd.unit=debug-shell.service left the front door open. Underscore is the
+# real spelling per systemd-debug-generator(8); the hyphen forms are listed so a
+# near-miss cannot creep back, and rd.* covers the initrd-honoured variant.
+DENY_APPEND_PREFIXES = (
+    "init=", "selinux=0", "enforcing=0", "security=", "module_blacklist=",
+    "systemd.debug_shell", "systemd.debug-shell",
+    "rd.systemd.debug_shell", "rd.systemd.debug-shell",
+)
+# nosmap/nosmep disable SMAP/SMEP enforcement; they are in the executor's
+# BLOCKED_EXACT and were missing here.
+DENY_APPEND_EXACT = ("single", "s", "1", "nosmap", "nosmep")
 DENY_UNIT_TARGETS = ("emergency", "rescue", "single")
 
 # --delete is screened too. "Removing an arg is always safe" was the premise for
@@ -71,14 +84,28 @@ DENY_DELETE_PREFIXES = (
     "amd_iommu=",
 )
 DENY_DELETE_EXACT = ("slab_nomerge", "nosmt", "kaslr")
-# Escape hatch: these ARE the weakening, so removing one hardens the host. Without
-# it the screen would collapse into "no deletions at all" and SysKnife could never
-# undo `mitigations=off` on a host that already boots with it.
-ALLOW_DELETE_EXACT = (
+
+# One list, read in both directions. Each of these IS the downgrade, which
+# settles both screens at once:
+#
+#   --delete X  → ALLOWED. Removing the downgrade hardens the host. Without this
+#                 escape hatch the delete screen collapses into "no deletions at
+#                 all" and SysKnife could never undo `mitigations=off` on a host
+#                 that already boots with it.
+#   --append X  → REFUSED. Adding the downgrade weakens the next boot, and it is
+#                 the exact end state the delete screen exists to protect.
+#
+# Deriving the append refusal from this set rather than retyping it is the whole
+# point. The two screens were written separately and drifted: --delete knew
+# about apparmor=, mitigations=, pti= and module.sig_enforce=, --append did not,
+# so `--append apparmor=0` silently disabled Ubuntu's MAC on the next boot while
+# `--delete apparmor=1` was correctly refused. A token added here now lands on
+# both screens or neither.
+WEAKENING_KARGS = (
     "selinux=0", "enforcing=0", "apparmor=0", "mitigations=off", "pti=off",
     "lockdown=none", "debugfs=on", "iommu=off", "intel_iommu=off",
     "module.sig_enforce=0", "init_on_alloc=0", "init_on_free=0",
-    "randomize_kstack_offset=off", "page_alloc.shuffle=0",
+    "randomize_kstack_offset=off", "page_alloc.shuffle=0", "nokaslr",
 )
 
 UPDATE_GRUB = "/usr/sbin/update-grub"
@@ -112,6 +139,9 @@ def reject_dangerous_append(tokens: list[str]) -> None:
             or lower in DENY_APPEND_EXACT
             or base in DENY_APPEND_EXACT
             or any(unit_val.startswith(u) for u in DENY_UNIT_TARGETS)
+            # Adding a known downgrade is the end state the --delete screen
+            # exists to prevent; see WEAKENING_KARGS.
+            or lower in WEAKENING_KARGS
         )
         if blocked:
             print(
@@ -126,7 +156,7 @@ def reject_dangerous_delete(tokens: list[str]) -> None:
     """Raise SystemExit(1) if removing any --delete token would weaken the boot."""
     for tok in tokens:
         lower = tok.lower()
-        if lower in ALLOW_DELETE_EXACT:
+        if lower in WEAKENING_KARGS:
             continue
         blocked = (
             any(lower.startswith(p) for p in DENY_DELETE_PREFIXES)

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "09f6eb8f1af0c405e07a9f08d30d9845dbb56bc9"
+    "tests": "961c20a5f964067c107b808960bdede1a22d5c68"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-09T18:52:38-06:00"
+    "tests": "2026-08-12T07:08:05-06:00"
   },
-  "tests": 1739,
+  "tests": 1743,
   "version": 1
 }

--- a/tests/release/grub-kargs-edit.test.sh
+++ b/tests/release/grub-kargs-edit.test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Guards sysknife-grub-kargs-edit's --delete against boot-security downgrades.
+# Guards sysknife-grub-kargs-edit against boot-security downgrades, in both
+# directions, and guards the two directions against drifting apart.
 #
 # The helper screened --append only, on the stated premise that "removing an arg
 # is always safe". The premise inverts the risk: the dangerous move is removing a
@@ -100,6 +101,60 @@ for tok in ORDINARY:
     if refused(tok):
         failures.append(f"--delete {tok!r} was refused, but it carries no security meaning")
 
+# 3b. DRIFT GUARD between the two screens. The --delete screen lets WEAKENING
+#     through on the stated grounds that each one IS the downgrade, so removing
+#     it hardens the host. That reasoning binds the other direction: if removing
+#     X hardens, then adding X weakens, and --append must refuse every one of
+#     them. The two lists were written separately and drifted -- --delete knew
+#     about apparmor=, mitigations= and module.sig_enforce=, --append did not --
+#     so `--append apparmor=0` disabled Ubuntu's MAC on the next boot while
+#     `--delete apparmor=1` was correctly refused. Deriving this list from
+#     WEAKENING rather than retyping it is the point: a token added to one
+#     screen cannot be forgotten in the other.
+append_guard = getattr(mod, "reject_dangerous_append", None)
+if append_guard is None:
+    print("FAIL: reject_dangerous_append() missing from sysknife-grub-kargs-edit")
+    sys.exit(1)
+
+
+def refused_append(tok):
+    try:
+        append_guard([tok])
+    except SystemExit as exc:
+        return exc.code != 0
+    return False
+
+
+for tok in WEAKENING:
+    if not refused_append(tok):
+        failures.append(
+            f"--append {tok!r} was accepted, but --delete treats it as a weakening; "
+            "the two screens have drifted"
+        )
+
+# 3c. The debug shell, by its own name rather than through systemd.unit=.
+#     `systemd.unit=debug-shell.service` is refused via DENY_UNIT_TARGETS, but
+#     systemd-debug-generator also honours systemd.debug_shell, which reaches
+#     the identical end state: debug-shell.service pulled into the boot
+#     transaction, root shell on tty9, no login. Underscore is the real spelling
+#     (verified against systemd-debug-generator(8) on Ubuntu 24.04); the hyphen
+#     forms are screened too so a near-miss cannot creep back.
+DEBUG_SHELL = [
+    "systemd.debug_shell=1",
+    "systemd.debug_shell",
+    "rd.systemd.debug_shell=1",
+    "systemd.debug-shell=1",
+    "SYSTEMD.DEBUG_SHELL=1",
+]
+for tok in DEBUG_SHELL:
+    if not refused_append(tok):
+        failures.append(f"--append {tok!r} was accepted; it boots into a root shell on tty9")
+
+# 3d. Ordinary appends must survive, or the screen has eaten the feature.
+for tok in ["quiet", "splash", "nomodeset", "console=ttyS0", "transparent_hugepage=madvise"]:
+    if refused_append(tok):
+        failures.append(f"--append {tok!r} was refused, but it carries no security meaning")
+
 # 4. WIRING: main() must call the screen. Drive it end to end with a protective
 #    --delete and assert it exits non-zero before reading /etc/default/grub.
 argv = sys.argv[:]
@@ -135,5 +190,8 @@ if failures:
     sys.exit(1)
 print("ok: sysknife-grub-kargs-edit refuses to delete protective kernel arguments")
 print("ok: weakening and ordinary arguments stay deletable")
+print("ok: every arg the delete screen calls a weakening is refused on --append")
+print("ok: --append refuses systemd.debug_shell in all its spellings")
+print("ok: ordinary arguments stay appendable")
 print("ok: main() screens --delete before touching /etc/default/grub")
 PY


### PR DESCRIPTION
Independent reviewers re-run over code that had already been swept surfaced three defects the earlier pass did not enumerate. Each is verified against the code. Two are the same shape as #190: a second name for something already refused.

### 1. `systemd.debug_shell` reaches the root shell `systemd.unit=` was screened for

#190 blocked booting into `debug-shell.service` via `systemd.unit=`. `systemd-debug-generator` also honours `systemd.debug_shell`, which pulls the same unit into the boot transaction and spawns a root shell on tty9 before anyone logs in. Before this change:

```
SetKernelArguments add=["systemd.debug_shell=1"]
  → Ok(... args: ["rpm-ostree", "kargs", "--append=systemd.debug_shell=1"])
```

Underscore is the real spelling, checked against `systemd-debug-generator(8)` on a live Ubuntu 24.04 guest rather than assumed. `rd.` and the hyphen forms are screened too.

### 2. The GRUB helper's two screens had drifted

`--delete` lets `apparmor=0`, `mitigations=off`, `pti=off`, `module.sig_enforce=0` and the rest through, on the grounds that each **is** the downgrade, so removing it hardens the host. That reasoning binds the other direction, and `--append` did not implement it: `--append apparmor=0` disabled Ubuntu's MAC on the next boot while `--delete apparmor=1` was correctly refused.

The helper is directly sudo-invocable (`sysknife ALL=(root) NOPASSWD: /usr/lib/sysknife/grub-kargs-edit *`), so this is a real boundary, not defence in depth. Fixed by deriving the append refusal from one shared `WEAKENING_KARGS` list, so a token added to one screen cannot be forgotten in the other. `nosmap`/`nosmep`, present in the executor's list, were missing here.

### 3. `sysknife approve` rendered the proposed change unsanitised

It printed `preview.proposed_change` straight from `serde_json::to_string_pretty` immediately above the approval prompt, while the `summary` beside it went through `operator_safe`. JSON escaping covers C0 controls and stops there, so U+202E inside a string value arrived intact and could reorder the target being confirmed. Now sanitised through `operator_safe_block`, which neutralises each line while keeping the structure (a flattened JSON blob is its own approval hazard) and bounds the line count — one long line was bounded, a tall block was not.

`operator_safe`'s invisible-character set was also completed: it dropped U+200E/U+200F but not U+061C, all three bidi controls, and dropped the zero-width block but not U+2060. Soft hyphen, combining grapheme joiner, deprecated format controls, and the TAG block used for ASCII smuggling now go too.

### Verification

Tests first, each failing for the stated reason before the fix. The GRUB gate derives its append expectations from the delete screen's own weakening list rather than retyping them — **13 tokens were accepted** before this change. The JSON test asserts `serde_json` really does leave the override in place, so it cannot pass vacuously.

Full local gate: fmt, clippy `--all-features --all-targets`, `cargo doc -D warnings`, 1,743 tests. The workspace baseline artifact and the three published figures were regenerated from the run rather than hand-edited, so `check_evidence_claims.py` passes.