### PR TITLE
test(e2e): validate every Ubuntu LTS on a live VM, and derive the tier from it

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 <p align="center">
   <strong>Distros</strong>&nbsp;
   <img src="https://img.shields.io/badge/Ubuntu%2020.04%2B-supported-2f855a?style=flat-square&logo=ubuntu&logoColor=white" alt="Ubuntu 20.04 and later supported">
-  <img src="https://img.shields.io/badge/Ubuntu%2024.04-VM%20validated-2f855a?style=flat-square&logo=ubuntu&logoColor=white" alt="Ubuntu 24.04 VM validated">
+  <img src="https://img.shields.io/badge/Ubuntu%2022.04%20%7C%2024.04%20%7C%2026.04-VM%20validated-2f855a?style=flat-square&logo=ubuntu&logoColor=white" alt="Ubuntu 22.04, 24.04 and 26.04 VM validated">
   <img src="https://img.shields.io/badge/Fedora%20Atomic%2041%2B-eligible%2C%20unvalidated-b7791f?style=flat-square&logo=fedora&logoColor=white" alt="Fedora Atomic 41 and later eligible but not VM validated">
 </p>
 
@@ -160,9 +160,10 @@ newgrp sysknife                       # or log out and back in
 npx sysknife-setup --no-binary --daemon-mode=skip
 ```
 
-Ubuntu 22.04 records 49/50 stories on a live VM; the run that produced that
-figure is in `tests/evidence/story-runs/`. Ubuntu 24.04 and
-26.04 have passed bootstrap and smoke tests but not the full story suite.
+All three Ubuntu LTS releases record a live-VM run of the 50-story suite, and
+each run has a replay twin that reproduces it: 22.04 at 49/50, 24.04 at 49/50,
+26.04 at 50/50. The runs are in `tests/evidence/story-runs/`. The one story
+missing from 22.04 and 24.04 is the same one, and it passed on 26.04.
 Fedora Atomic is the rpm-ostree target; record a current Silverblue 44 VM run
 before treating a release as current-validated. Plain Fedora Workstation and
 Server remain experimental until the `dnf` action family ships. See the
@@ -259,7 +260,7 @@ milestone.
 | RFC 5424 syslog forwarding (Splunk / Sentinel / QRadar) | ✅ |
 | Postgres backend (RDS / Cloud SQL / Neon / Supabase) | ✅ |
 | **Ubuntu support** — 49/50 stories on a live 22.04 VM, recorded in `tests/evidence/story-runs/` | ✅ |
-| **Ubuntu 22.04 / 26.04 VM tooling** — smoke tests pass on all three LTSes | ✅ |
+| **Every Ubuntu LTS validated** — 22.04 at 49/50, 24.04 at 49/50, 26.04 at 50/50, each with a replay twin | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
 **1,743 Rust tests and 72 frontend tests** form the current deterministic
@@ -309,7 +310,7 @@ All config files that may contain API keys are created with `chmod 0600`.
 See [ROADMAP.md](ROADMAP.md) for the full milestone breakdown.
 
 - ✅ **Ubuntu 22.04** — 49/50 stories on a live VM (recorded in `tests/evidence/story-runs/`)
-- ✅ **Ubuntu 22.04 / 26.04** — VM tooling complete; smoke tests pass on all three LTSes
+- ✅ **Ubuntu 24.04 and 26.04** — 49/50 and 50/50 on live VMs; every LTS run has a replay twin
 - 📋 Telegram inline-button approvals
 - 📋 `sysknife audit export` (CEF / NDJSON for SIEM ingest)
 - 📋 Fleet plan/execute (one plan, N targets, parallel approval)

--- a/docs/contributing/ubuntu-vm-testing.md
+++ b/docs/contributing/ubuntu-vm-testing.md
@@ -5,11 +5,16 @@ Ubuntu environments using QEMU/KVM.
 
 Supported Ubuntu LTSes:
 
-| Release | Codename | SSH port | Status |
-|---|---|---|---|
-| 22.04 | jammy | 2222 | smoke-tested |
-| 24.04 | noble | 2223 | release-validated (default) |
-| 26.04 | resolute | 2224 | smoke-tested |
+| Release | Codename | SSH port | Live suite | Status |
+|---|---|---|---|---|
+| 22.04 | jammy | 2222 | 49/50 | validated |
+| 24.04 | noble | 2223 | 49/50 | validated (default) |
+| 26.04 | resolute | 2224 | 50/50 | validated |
+
+Each release has a record run and a `.replay.json` twin in
+`tests/evidence/story-runs/`, and `tests/release/cassette-replay-parity.test.sh`
+checks every pair it finds. The one story missing from 22.04 and 24.04 is the
+same one, 101, and it passed on 26.04 — see [Story 101](#story-101-is-flaky).
 
 The Ubuntu path uses `qemu-system-x86_64` directly with a cloud-init seed
 ISO — no quickemu, no interactive installer, no GUI window. The base image
@@ -328,3 +333,27 @@ Open an issue with:
 - The failing step log
 - `UBUNTU_RELEASE=<codename> ./tests/e2e/ubuntu-vm.sh ssh 'sudo journalctl -u sysknife-daemon -n 200'`
 - `lsb_release -a` from inside the VM
+
+## Story 101 is flaky
+
+Story 101 (`DistroboxList alt phrasing`) is the one story that has failed a
+committed run, and it has failed on 22.04 and on 24.04 while passing on 26.04.
+It is not a distro difference. The failure is provider-side: the model returns a
+malformed tool call, the planner exhausts its retries, and the story gets no plan
+at all — its log contains the header line and nothing else, where a passing
+story's log contains the plan JSON.
+
+Two things follow, both worth knowing before reading a run:
+
+- **A single run is not a pass rate.** The first 24.04 record run came in at
+  46/50. Re-running the four failures individually passed three of them
+  (65, 66, 71) and failed 101 again, so those three were transient provider
+  errors rather than a 24.04 regression. The committed 24.04 run is a later
+  full-suite recording, and 101 is the only story that reproduces as a failure.
+- **A miss on replay is correct for a story that errored live.** Nothing was
+  recorded for it, so there is nothing to serve. The parity gate allows exactly
+  as many misses as there were live failures and no more, which is why the 26.04
+  pair shows zero misses and the other two show one each.
+
+If you are chasing a story that fails once, re-run that story alone before
+changing anything.

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -45,9 +45,9 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 
 | Distro | Action backend | Evidence | Launch tier |
 |---|---|---|---|
-| **Ubuntu 24.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite; the committed run in `tests/evidence/story-runs/` is 22.04, 24.04 not yet re-recorded | **Validated** |
-| **Ubuntu 22.04 LTS** | Ubuntu/apt family | VM bootstrap and smoke tests | **Smoke-tested** |
-| **Ubuntu 26.04 LTS** | Ubuntu/apt family | VM bootstrap, smoke tests, and sudo-rs sudoers verification (26.04 ships sudo-rs 0.2.x; `visudo -cf` parses the SysKnife sudoers and every grant — including the trailing-`*` wildcard grants — is honoured) | **Smoke-tested** |
+| **Ubuntu 24.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, 49/50, recorded in `ubuntu-24.04-gpt-oss-120b.json` and reproduced by its `.replay.json` twin | **Validated** |
+| **Ubuntu 22.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, 49/50, recorded in `ubuntu-22.04-gpt-oss-120b.json` and reproduced by its `.replay.json` twin | **Validated** |
+| **Ubuntu 26.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, 50/50, recorded in `ubuntu-26.04-gpt-oss-120b.json` and reproduced by its `.replay.json` twin; plus sudo-rs sudoers verification (26.04 ships sudo-rs 0.2.x; `visudo -cf` parses the SysKnife sudoers and every grant — including the trailing-`*` wildcard grants — is honoured) | **Validated** |
 | **Every other Ubuntu 20.04+ release** (20.04, 20.10, 21.x, 23.x, 25.x, 26.10, …) | Ubuntu/apt family | Eligible by release family; no per-release VM run | **Smoke-tested** |
 | **Fedora Silverblue 44** | rpm-ostree, Flatpak, toolbox, firewalld, systemd, containers | Harness and fixture coverage; no current live-VM run | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -104,12 +104,13 @@ SysKnife, not an afterthought.
 
 > **ℹ️ Distro support**
 >
-> The one committed live-VM story run is Ubuntu 22.04: 49/50 of the 50-story
-> Ubuntu suite, recorded in `tests/evidence/story-runs/`. Ubuntu 24.04 is the
-> validation target and its run has not been re-recorded yet; 26.04 is
-> smoke-tested. Fedora Atomic is supported by the rpm-ostree action family, but
-> a current Silverblue 44 VM run is a release gate. Plain Fedora remains
-> experimental until the `dnf` action family ships.
+> All three Ubuntu LTS releases have a committed live-VM run of the 50-story
+> Ubuntu suite, in `tests/evidence/story-runs/`: 22.04 at 49/50, 24.04 at 49/50,
+> 26.04 at 50/50. Each run has a replay twin that reproduces it, and the one
+> story missing from 22.04 and 24.04 is the same one, which passed on 26.04.
+> Fedora Atomic is supported by the rpm-ostree action family, but a current
+> Silverblue 44 VM run is a release gate. Plain Fedora remains experimental
+> until the `dnf` action family ships.
 > See [Distro Support](distro-support.md) for the full matrix.
 
 ```sh

--- a/scripts/check_evidence_claims.py
+++ b/scripts/check_evidence_claims.py
@@ -269,6 +269,75 @@ def check_bare_story_counts(
     return problems
 
 
+def replay_verified_releases(root: Path) -> set[str]:
+    """Releases with a committed record run AND its replay twin.
+
+    That pair is what `tests/release/cassette-replay-parity.test.sh` proves
+    reproduces: the record run says what happened live, the replay says the
+    cassette reproduces it. A release with only a record run has a pass rate
+    nothing has re-derived; a release with neither has nothing at all.
+    """
+    directory = root / STORY_RUNS
+    if not directory.is_dir():
+        return set()
+
+    records: dict[str, Path] = {}
+    replays: set[str] = set()
+    for path in sorted(directory.glob("*.json")):
+        try:
+            release = str(json.loads(path.read_text()).get("release", ""))
+        except json.JSONDecodeError as exc:
+            raise Failure(f"{path.name} is not readable JSON: {exc}") from exc
+        if not release:
+            continue
+        if path.name.endswith(".replay.json"):
+            replays.add(release)
+        else:
+            records[release] = path
+    return set(records) & replays
+
+
+def check_validated_tiers(texts: dict[str, str], root: Path) -> list[str]:
+    """A release may be tiered "Validated" only where the evidence says so.
+
+    This replaced a hardcoded `reject_pattern` naming 22.04 and 26.04 as
+    "smoke-tested, not launch-validated". That was the same hand-maintained
+    blacklist the numeric guards were rewritten to remove, and it aged the same
+    way — but worse than stale: it began forbidding the truth. 22.04 accumulated
+    five live runs and a committed replay pair, so the honest tier for it became
+    unwritable, and the only ways to satisfy the guard were to understate the
+    evidence or to switch the guard off.
+
+    So the permitted set is derived. A table row whose FIRST cell names an Ubuntu
+    version may end in a "Validated" tier cell if and only if that release has a
+    replay-verified artifact pair on disk. Aspiration still cannot be published
+    as fact, which is the point of the original rule, and a release earns the
+    tier by having a run committed rather than by someone editing this file.
+    """
+    verified = replay_verified_releases(root)
+    row = re.compile(
+        r"^\|[^|]*?(?P<release>\d\d\.\d\d)[^|]*\|.*\|\s*\*{0,2}validated\*{0,2}\s*\|\s*$",
+        re.IGNORECASE,
+    )
+
+    problems = []
+    for rel, text in texts.items():
+        for line in text.splitlines():
+            match = row.match(line.strip())
+            if not match:
+                continue
+            release = match.group("release")
+            if release in verified:
+                continue
+            known = ", ".join(sorted(verified)) or "none"
+            problems.append(
+                f"{rel}: tiers Ubuntu {release} as Validated, but no replay-verified "
+                f"run is committed for it (replay-verified: {known}). Record one into "
+                f"{STORY_RUNS}/ or use a weaker tier."
+            )
+    return problems
+
+
 def main() -> int:
     root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
     try:
@@ -299,6 +368,7 @@ def main() -> int:
         story_runs = load_story_runs(root)
         problems += check_story_claims(texts, story_runs)
         problems += check_bare_story_counts(texts, story_runs, root)
+        problems += check_validated_tiers(texts, root)
 
         expected_tests = f"{baseline['tests']:,} Rust tests"
         for rel in REQUIRE_TEST_COUNT:

--- a/scripts/check_public_claims.sh
+++ b/scripts/check_public_claims.sh
@@ -51,17 +51,21 @@ reject_pattern 'plan and approve from inside (Claude|chat)|chat approval is suff
     'MCP approval must be issued by the separate terminal command' "${claim_files[@]}"
 reject_pattern 'words like "yes", "do it"|explicit approval, then execute' \
     'generated integrations must require terminal-issued receipts' "${claim_files[@]}"
-# A table row *about* 22.04/26.04 whose final tier cell is "Validated" — covers
-# both the bare `| 22.04 | … | validated |` (ubuntu-vm-testing.md) and the bolded
-# `| **Ubuntu 22.04 LTS** | … | **Validated** |` (distro-support.md) shapes.
-# grep -i makes it case-insensitive.
+# Which releases may be tiered "Validated" is decided by check_evidence_claims.py
+# (check_validated_tiers), from the replay-verified artifact pairs on disk.
 #
-# The version has to appear in the row's FIRST cell — `[^|]*` before the first
-# pipe. Matching it anywhere in the row made the 24.04 row unmentionable: citing
-# "the committed run is 22.04" in its evidence cell tripped a rule about tiering,
-# which would have pushed the honest wording out of the doc to appease the guard.
-reject_pattern '^\|[^|]*(22\.04|26\.04)[^|]*\|.*\|[[:space:]]*\*{0,2}validated\*{0,2}[[:space:]]*\|' \
-    'Ubuntu 22.04 and 26.04 are smoke-tested, not launch-validated' "${claim_files[@]}"
+# It used to be this, a literal list:
+#
+#   reject_pattern '^\|[^|]*(22\.04|26\.04)[^|]*\|.*\|…validated…\|' \
+#       'Ubuntu 22.04 and 26.04 are smoke-tested, not launch-validated'
+#
+# which is the same hand-maintained blacklist the numeric guards above were
+# rewritten to remove, and it aged worse than stale. 22.04 accumulated five live
+# runs and a committed replay pair, so the guard started forbidding the accurate
+# tier, leaving only two ways to go green: understate the evidence, or delete the
+# rule. Deriving the permitted set keeps the rule's actual purpose — aspiration
+# must not be published as fact — while letting a release earn its tier by having
+# a run committed rather than by someone remembering to edit a script.
 
 required_receipt_docs=(
     "$repo_root/README.md"

--- a/tests/e2e/cassettes/ubuntu-noble-gpt-oss-120b.json
+++ b/tests/e2e/cassettes/ubuntu-noble-gpt-oss-120b.json
@@ -1,0 +1,1776 @@
+{
+  "version": 1,
+  "meta": {
+    "surfaces": [
+      "groq/openai/gpt-oss-120b"
+    ],
+    "system_prompt_sha256": [
+      "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b"
+    ]
+  },
+  "entries": {
+    "groq/openai/gpt-oss-120b:006aec47dec5b7731b662054361be71cc08f1013449c563f70c16065377ca28d": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_94548caa-2944-4451-8c8e-c948859fae0e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to allow inbound SSH traffic. Adding a ufw rule for port 22 opens the SSH service through the firewall. This is a high-risk change because firewall modifications can affect remote access, so it requires approval.",
+                "steps": [
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"22\"}",
+                    "risk_level": "high",
+                    "summary": "Allow inbound traffic on port 22 (SSH) via ufw"
+                  }
+                ],
+                "summary": "Open firewall port 22 to allow SSH connections"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "764b89917271bda5a446e7ce58122aa6c04f126a9c2e00e47f7ae414bdd57326"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:07e1720cfe5506868f5cec96d25ca1bc5fcefc7885d7f628558d160881fb151c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_653daa49-dac5-452c-9b95-d0a6b1a84468",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to see the current network configuration and then apply it. This plan first retrieves the netplan configuration (read-only) and then applies any pending netplan changes, which may affect network connectivity.",
+                "steps": [
+                  {
+                    "action_name": "NetplanGetConfig",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the current netplan configuration files"
+                  },
+                  {
+                    "action_name": "NetplanApply",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Apply the netplan configuration, activating any changes"
+                  }
+                ],
+                "summary": "Show the netplan network configuration and then apply it"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "c0f5ff67356cc85cdf122642a0d07573b7e8c6bdf6cc9089bf2438976fbaf1a0"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:0f3039404a8304651fa7609f96b8aa200484cc87092fbcae06fa43ff6b669ad1": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_5b023e7d-53d6-493e-8feb-7a5a30aba36e",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "The request includes an unsupported destructive command 'rm -rf /', which cannot be performed via SysKnife.",
+                "suggestion": "If you only want to install the 'vim' package, please ask for that without the destructive command."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "d4a6fad700421911fc1afafe6510c96c53783951315e94b05151f03e6e81b561"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:1764bf27f467f4bc6b74a60484dbd51d03043394648dbbf768b6b293f1833f79": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_72c16be1-7118-4016-8972-257fe00019c1",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn on the firewall. Enabling UFW will activate the firewall and apply its default rules, providing network protection. This is a high-risk operation that requires approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "UfwEnable",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Enable the UFW firewall"
+                  }
+                ],
+                "summary": "Enable the UFW firewall"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "f5d2e0c8fe2b29140358ca6759a763c38768caaab3257c3469a2430a27b750ee"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:1f3b92bcadd5c51d4f5405e16e3ed3d4f6e8e71d52a6e6f771248f373fc9e0a4": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_0efb9a3a-be1a-4816-964d-105b3806b42e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to find all packages related to Redis. AptSearch with the term 'redis' will query the package index and return matching package names and descriptions.",
+                "steps": [
+                  {
+                    "action_name": "AptSearch",
+                    "params": "{\"term\":\"redis\"}",
+                    "risk_level": "low",
+                    "summary": "Search the apt package index for packages containing 'redis'"
+                  }
+                ],
+                "summary": "Search for Redis-related packages"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "852831c3aa2d573ddcbbd836cb4e0b3b8d20db8a76392fd9057b55a60679d610"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:1ff3ea67fa7984cf20c5a33489373cfb49243080f44d3297ea3b10d1eeed87a0": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_4ec54d59-d0ff-4356-9b85-cd72cc4701dc",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to uninstall Postfix and delete all related configuration. AptPurge removes the package and purges its config files on Ubuntu, fulfilling this request.",
+                "steps": [
+                  {
+                    "action_name": "AptPurge",
+                    "params": "{\"package\":\"postfix\"}",
+                    "risk_level": "medium",
+                    "summary": "Purge the Postfix package, removing binaries and configuration files"
+                  }
+                ],
+                "summary": "Completely remove Postfix and its configuration files"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "65ddb1730ca6ac2435fc22798b501a277d4fd69f42b8b2ed067997ac0e84a425"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:2137d498db0391835a2e5d1653d19f7570dbd77395f6e50a97b4f528b760ce27": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a8b7a451-68d5-4b73-9ef3-30ebeda040f9",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to stop the Chromium snap from auto-updating. SnapHold pins a snap at its current version, disabling automatic refresh. This is a medium-risk action requiring approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "SnapHold",
+                    "params": "{\"name\":\"chromium\"}",
+                    "risk_level": "medium",
+                    "summary": "Pin the Chromium snap to its current version to stop auto-updates"
+                  }
+                ],
+                "summary": "Pin the Chromium snap to prevent automatic updates"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "9f822e7fe31c9f9f385bda6a226e790eaf9f1f2f8cf510eb7478f5266accbdb4"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:23442158861186bb6f097ebe2657d61910203ad19df181f9560962575a1703d0": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_10e90b34-a05f-47d0-99fd-80a7db149f3b",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked for information about the lxd snap. SnapInfo retrieves metadata, version, channels, and description for the specified snap without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "SnapInfo",
+                    "params": "{\"name\":\"lxd\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve detailed information for the lxd snap"
+                  }
+                ],
+                "summary": "Show details about the lxd snap"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "a488530ff112b16b47517e37f05e24b71da504d6c2fb6d16629ce13d81964106"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:251498be9259a99c4fbaceaf2b0e2852b958b2752e7944b272f503d94a31b4a5": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_684994a2-9d6c-4df4-8549-24c9951ff076",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "Installing a snap requires specifying the snap name, which was not provided.",
+                "suggestion": "Please specify the name of the snap you want to install, e.g., 'install the snap \"vlc\"'."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "104152d9261ef4530c2b5aba1b4cf47c55f6813e6f3162800e98ef6055d13bce"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:283b299740a75709238892820320adf8b7ffc1f7e125f76e3e5a6effe4a7d1e6": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_c3f7c265-6b43-4e62-86ba-ce811de05444",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a full removal of the Apache2 web server, including all configuration files. AptPurge will uninstall the package and purge related config files from the system. This is a medium‑risk operation as it modifies the package state.",
+                "steps": [
+                  {
+                    "action_name": "AptPurge",
+                    "params": "{\"package\":\"apache2\"}",
+                    "risk_level": "medium",
+                    "summary": "Purge the apache2 package and delete its configuration files"
+                  }
+                ],
+                "summary": "Completely remove Apache2 and its configuration files"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "2733ea5e7eb297e936f81de936f0690e3e10c403472ab7aeec81e253bec2bf83"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:2c9d6c495ab90fd0e48dc20a09ab733af5c699ba2c9612b3994038c609de5ec9": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_dc85a303-3cad-49f4-9dc3-d6fe16d82848",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to see the existing Distrobox containers. DistroboxList returns a list of containers without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all Distrobox containers"
+                  }
+                ],
+                "summary": "List all Distrobox containers"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "5da0d21883d1af4cf8a83377ba73b54c938e474ba919d9a896b9cc6206a2621a"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:2d472ab2087affcd273bfd01861fd2790c967d089d49c8c8ba79e12a3f765b3a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_9fd7225c-c30b-4980-9704-d87547953ee1",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to uninstall the telnet package from the system. AptRemove will uninstall the named package using the system package manager. This action is medium risk and will require operator approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "AptRemove",
+                    "params": "{\"package\":\"telnet\"}",
+                    "risk_level": "medium",
+                    "summary": "Uninstall the telnet package"
+                  }
+                ],
+                "summary": "Remove the telnet package"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "73e4ad5af69e18afa1ac9c29a894e26bedced399076cc6bc20c6e971ada55a85"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:2dacecd98c90e6b5f04909f0e40103ce8790c9c26cd9f9c3a3ba1790500a007b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_49768494-cd78-4666-a9c3-e60a59f46e8d",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a view of the currently installed system packages and snaps. AptListInstalled provides a list of all installed Debian packages, and SnapList provides a list of installed snap packages. Both actions are read‑only and require no approval.",
+                "steps": [
+                  {
+                    "action_name": "AptListInstalled",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all installed Debian/Ubuntu packages"
+                  },
+                  {
+                    "action_name": "SnapList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all installed snap packages"
+                  }
+                ],
+                "summary": "List installed apt packages and snap packages"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "212bd135d73c2b5008122ff9f69372a22d95a6e6df7a6b253f8e52c814f2f9cc"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:3005375767adcc026c9c6dddc4535f9a63ccad66749ce306e0afcc94c5b0d19b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_851288a3-1f84-4e49-86ec-c4f6fb6c3a28",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to pin (hold) the mysql-server package to prevent upgrades and then view its package information. AptHold will place a hold on the package, and AptShow will retrieve its details. Both actions are safe, with AptHold being a reversible medium-risk operation and AptShow a low-risk read-only query.",
+                "steps": [
+                  {
+                    "action_name": "AptHold",
+                    "params": "{\"package\":\"mysql-server\"}",
+                    "risk_level": "medium",
+                    "summary": "Place a hold on the mysql-server package to prevent it from being upgraded or removed automatically"
+                  },
+                  {
+                    "action_name": "AptShow",
+                    "params": "{\"package\":\"mysql-server\"}",
+                    "risk_level": "low",
+                    "summary": "Show detailed information about the mysql-server package, including version, dependencies, and description"
+                  }
+                ],
+                "summary": "Hold the mysql-server package and display its package details"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "4f3af260cdad00eefc58e372e727dede9f92164bf3e4b88639e63819f6b33382"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:327b94e4db3d74bdf62e86cd4a7cb6ca3189699244f6512d6a54917b42451c0f": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f92f38aa-f116-4691-afb1-4632366c189b",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a new Distrobox container. DistroboxCreate will provision the container with the specified name and image. This is a medium‑risk operation because it modifies the user's environment by adding a new container.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxCreate",
+                    "params": "{\"name\":\"fedora-dev\",\"image\":\"fedora:41\"}",
+                    "risk_level": "medium",
+                    "summary": "Create the distrobox container fedora-dev using the fedora:41 image"
+                  }
+                ],
+                "summary": "Create a Distrobox container named fedora-dev with the fedora:41 image"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "5c4e8e592b2c4f966130a7e38d507abb14e0c74bc25e720a4df3f257c5c4984e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:34ef89aa79d9fb45cf039e6dbc91ea9fe95307e9e7a917e479b1b80b65ab99be": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f9b0d1d8-27cb-4c73-82a8-0b6a4bbfbab0",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested cleaning up unneeded packages. AptAutoremove will remove automatically installed packages that are no longer required, safely freeing space.",
+                "steps": [
+                  {
+                    "action_name": "AptAutoremove",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Run apt autoremove to clean up unnecessary packages"
+                  }
+                ],
+                "summary": "Remove orphaned packages that are no longer needed"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "7b521f6f4c1a4a9dad585950f74aafedbb564cff453bda7d969f1c260c2dc8d5"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:37a26f1c72fb8c25005a3d3b88c628551d4da06f70a9dbe56120a365984405e1": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_49c499f0-1d21-4425-ad07-1e75a2221650",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to update all snaps. SnapRefresh without a name updates every installed snap to its most recent revision, which satisfies the request.",
+                "steps": [
+                  {
+                    "action_name": "SnapRefresh",
+                    "params": "{}",
+                    "risk_level": "medium",
+                    "summary": "Refresh all snaps to their latest versions"
+                  }
+                ],
+                "summary": "Refresh all installed snaps to the latest versions"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "2a8c3e89caae87c5c4e9bd67ecbc3ab54a830555cbc8b75c3f623d04667564ae"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:3fc46652cbb9c30ae2723fd3f367e7e20d8c912a7a0200e23937ef58bf359f03": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_280b901e-d48a-4f6e-9d06-9b455dc1b94b",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn on the firewall and permit SSH traffic. Enabling UFW and adding an allow rule for the SSH service will secure the host while keeping remote access functional. Both steps are high risk because firewall changes can affect connectivity, so they will require approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "UfwEnable",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Enable the UFW firewall"
+                  },
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"ssh\"}",
+                    "risk_level": "high",
+                    "summary": "Allow incoming SSH connections through the firewall"
+                  }
+                ],
+                "summary": "Enable the UFW firewall and allow incoming SSH connections"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "5b20f3a2c42a236a0773513a3b0a4b2657e310f11ac2b4e6fa8f527080102fb5"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:49a14fd600b3e8e7ee4344c9e958e64eb28b4ec77d3fa40aee31ac7230da7951": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_d96b1c44-3a3e-4c27-8f0d-b9a41b5e5ce1",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested the firewall rule list. UfwStatus retrieves the current ufw status and rule set without modifying the system.",
+                "steps": [
+                  {
+                    "action_name": "UfwStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the current ufw firewall status and list of rules"
+                  }
+                ],
+                "summary": "Show the current firewall rules"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "d9aa4d5658bb3ca7945aac483cf2401fa0d8f57c0cbabd393e4f6db7fa2ac22f"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:4c9cf4920a67dfb23b5153e49971852c643e55d859fb0d8309ab341cf8651251": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_1fe35fbb-3fad-49a5-9130-04ea8ea6bdb1",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know which release channel (stable, candidate, beta, edge) the Spotify snap is tracking. SnapInfo returns snap metadata, including the current channel, without modifying the system.",
+                "steps": [
+                  {
+                    "action_name": "SnapInfo",
+                    "params": "{\"name\":\"spotify\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve information about the Spotify snap, including its current channel"
+                  }
+                ],
+                "summary": "Show the channel of the Spotify snap"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "6343b2854ae069b1938e6ca6944dadece4b09896d1f8c60dc6206d62bd38197e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:5153d0134674b0e16b290804416d18a7a04000c1dc6a95b1c0aacafc0bae9d9f": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_71ba0a7c-87bd-4b21-a499-a1aa8816987a",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know which version of curl can be installed via the apt package manager. AptShow returns package details, including the current candidate version, without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "AptShow",
+                    "params": "{\"package\":\"curl\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve details for the curl package, including its available version"
+                  }
+                ],
+                "summary": "Show the available version of the curl package in APT"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "36aa9a54a7d0e19e159fe4de276e8e83b1e9f7a1ea403560442edd6eae3faefe"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:571cc4919cbf38e6d2aa64b3dfab1596a942dc7a62fd4bb476414c4e17b4e873": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_fca20b93-c3c6-434f-8480-d2f6960a1d09",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to remove the hold on the nginx package so future upgrades can apply. AptUnhold will unmark the package, enabling it to be upgraded by normal apt operations.",
+                "steps": [
+                  {
+                    "action_name": "AptUnhold",
+                    "params": "{\"package\":\"nginx\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove hold on the nginx package to permit upgrades"
+                  }
+                ],
+                "summary": "Allow nginx package to be upgraded"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "d3c876cc7579365eaba1f033b2d9ca85351803c9467483018bc27f675884519b"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:577d1446c4865622264c59c3756a82bb133beba5958ede268e221d234781b859": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_bb8c102a-68cf-4b73-8640-0c6b39d63899",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested nginx to be installed on this Ubuntu system. AptInstall will download and install the package using the system's package manager. This is a medium-risk action as it modifies the system by adding new software.",
+                "steps": [
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"nginx\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the nginx package via apt"
+                  }
+                ],
+                "summary": "Install the nginx web server package"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "4aabceb6b1cf59a1728c43f20273c6ea4646b4ac971487725f347a1cbe326ace"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:605d7a14c8216b418ee3bd67512a5d8945accb5839f56d6e49322af4efc0141e": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_da65008f-e0f9-459a-820f-8cbe6aeff3a5",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether the openssh-server package is present and, if so, which version is installed. AptShow returns the package details including its installed version, fulfilling the request directly.",
+                "steps": [
+                  {
+                    "action_name": "AptShow",
+                    "params": "{\"package\":\"openssh-server\"}",
+                    "risk_level": "low",
+                    "summary": "Show details of the openssh-server package, including install status and version"
+                  }
+                ],
+                "summary": "Check if openssh-server is installed and display its version"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "a07441905fac7e7823cac176d863a5582bf286684f319058854fcd9ddeb44bf2"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:64bcf0d620c62bce653723faa86d04401c3ee54d8f78cbe5849e35adfe19b6a1": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_b92abc67-7fca-40cb-82cc-bc0a55795999",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested the VS Code snap to be installed. SnapInstall will download and install the specified snap (code). This is a medium-risk action because it adds new software to the system.",
+                "steps": [
+                  {
+                    "action_name": "SnapInstall",
+                    "params": "{\"name\":\"code\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the VS Code snap (code) from the Snap store"
+                  }
+                ],
+                "summary": "Install the Visual Studio Code snap package"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "469e0c877311e15d56682d4b02789b42a17407c7a3b63644dbfe7e2d94d33467"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:68d78dfa6d2e917bb40a2537b372a11b3c7d80930d766077cb81ac7313534c5a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_cf8ea566-994e-4ccf-b5a5-93bf2684c890",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to block port 23 (telnet) in the ufw firewall. This plan adds a deny rule for that port, preventing inbound traffic on the Telnet service.",
+                "steps": [
+                  {
+                    "action_name": "UfwDeny",
+                    "params": "{\"port_or_service\":\"23\"}",
+                    "risk_level": "high",
+                    "summary": "Deny inbound traffic on port 23 (telnet) via ufw"
+                  }
+                ],
+                "summary": "Block inbound Telnet (port 23) using ufw"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "bfdd970791317f4145873c38f0836dd9e774c9a75d04e14235ed9c796a536f39"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6be3db953bf763e07fa40df728dc0cdf451378215b3e9b04c1dcdac4b19268aa": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_5286203d-1235-4cd8-ad6b-c9c15b9acf8e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know the firewall status and which ports are allowed through it. UfwStatus provides the current enable/disable state and all configured rules, directly answering the request.",
+                "steps": [
+                  {
+                    "action_name": "UfwStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the current UFW firewall status and list of open ports"
+                  }
+                ],
+                "summary": "Show whether the UFW firewall is enabled and list open ports"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "00222c4f773803d5b9eb37ddd904efbeba6227a1e9f412efe2943b5df95ab1e1"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6e7bb3a90f2d0bf3ad0603cef39e3112a48afcbd7bf4b6427dfd670e97102810": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_6b112bba-9377-4556-bd03-fa7562f8599c",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see the server's network configuration as defined by netplan. NetplanGetConfig returns the netplan YAML configuration without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "NetplanGetConfig",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the netplan configuration files"
+                  }
+                ],
+                "summary": "Show the current netplan network configuration"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "dc0de1df9d559c76ecf64f188a32f254f8e7714b293973ca2d690a365d5c7e51"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6fba8f4723872acbeee7473c3ac9e468c511e9e100ca4fea76d3ae344ac6fba2": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_8f0bb793-9e29-43ba-a035-43c98a49ef11",
+              "call_id": null,
+              "name": "query_current_user",
+              "input": {}
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "6809a8a69524bbd52686c99bb064c220bc879b4262ec4a1da7e28024a75abe02"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:7696ee03dd58c97187d9f34e3fa57c719a876c489f1040d63033e61049ed4602": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_2d4034d2-993b-47b9-8331-49e7f5d77fae",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to set up a Distrobox container for development. DistroboxCreate will provision the container with the specified name and Ubuntu 24.04 image. This is a medium‑risk operation that requires approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxCreate",
+                    "params": "{\"name\":\"dev\",\"image\":\"ubuntu:24.04\"}",
+                    "risk_level": "medium",
+                    "summary": "Create the 'dev' Distrobox container based on Ubuntu 24.04"
+                  }
+                ],
+                "summary": "Create a Distrobox container named 'dev' using the Ubuntu 24.04 image"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "697ef8a29b5fea0c536bf8b82845641c317ec1f900a652aa512f90cc0f8e35d7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:7a044d7c4fcecf85d644c205ee4964cbdb8a4c1b1c7963e5b24a8b3a17511c10": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_47e27b0c-d868-4907-ac36-cc0d6b6952d0",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to update the apt package list, which is performed by running AptUpdate to refresh the local package cache without installing or upgrading any packages.",
+                "steps": [
+                  {
+                    "action_name": "AptUpdate",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Refresh the APT package index to get the latest package information"
+                  }
+                ],
+                "summary": "Refresh the APT package index"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "e653dff2b00231ed7391f16d888fc0b20edae146b4c9d481959842080e59960d"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:80392dfbca293c7c5ef7ebc13253ff7054be538fcabbcf9f4d8107110aa756e4": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_97955c39-d9f6-4e89-8580-0328fc55d872",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see every package currently installed. AptListInstalled provides a read‑only list of all packages from the dpkg database, which directly satisfies this request.",
+                "steps": [
+                  {
+                    "action_name": "AptListInstalled",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve a complete list of installed packages"
+                  }
+                ],
+                "summary": "List all installed packages on the Ubuntu system"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "9f136799a23967e82b0b033cb56213c66b08fa19ef571eb0b6bb8a2919d20aa7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:862f08c22fb82001d26f74d659a886c6c3229bf09fc82bdafbec574a84289180": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_66eb99c5-2c12-4617-983d-4ff7f884bcb5",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to freeze the PostgreSQL package so it will not be upgraded by future apt operations. Using AptHold will mark the package as held, preventing automatic upgrades. This is a medium‑risk action as it modifies package management state.",
+                "steps": [
+                  {
+                    "action_name": "AptHold",
+                    "params": "{\"package\":\"postgresql\"}",
+                    "risk_level": "medium",
+                    "summary": "Mark the postgresql package as held to stop automatic upgrades"
+                  }
+                ],
+                "summary": "Prevent the postgresql package from being upgraded"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "663c334cb291dec89fc013fb56abf0ee4e18b725d55b14e721da343cbcb4bf48"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:8e5c88e23d6b5149486c08175c4195e84e9d6f36129ce7a8b9ac978dd79ba41b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_412b60bc-abe4-41d7-b9ac-750b80247207",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn off the Ubuntu firewall. This plan runs the UfwDisable action, which disables ufw and removes its active rules. Disabling the firewall is a high‑risk operation because it leaves the system exposed to network traffic.",
+                "steps": [
+                  {
+                    "action_name": "UfwDisable",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Disable ufw firewall and stop enforcing its rules"
+                  }
+                ],
+                "summary": "Disable the Ubuntu firewall (ufw)"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "37b779274ca5063ff67e75e2beda6a2bae3da14ed975fbff8571500d9319b1a0"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:91b1a4ba5f87a17b5f7cb120b8dbeee4d4d8ff8c7c6a0fff77925db55dc1abae": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_48b8be2e-551c-4820-8bc6-983f22d46993",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to re-enable automatic updates for the chromium snap. Removing the hold on the snap will allow it to receive future updates.",
+                "steps": [
+                  {
+                    "action_name": "SnapUnhold",
+                    "params": "{\"name\":\"chromium\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove any hold on the chromium snap so it can auto-update"
+                  }
+                ],
+                "summary": "Allow the chromium snap to auto-update"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "6816dc4e50ad96fc96483612de1a77937b6b4799e0a59002d1ca213495145552"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:996c2bf90c5978e777077c5e7abf02c0c6e6bcb2db0bb25f4fd5e37ff72093a2": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3c43beeb-903a-4e8c-b129-5bc67d931902",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to revert the firewall configuration to its default state. UfwReset removes all custom rules and restores the default policy, which is a high‑risk operation because it changes the firewall immediately.",
+                "steps": [
+                  {
+                    "action_name": "UfwReset",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Reset UFW to its default rule set"
+                  }
+                ],
+                "summary": "Reset all UFW firewall rules to defaults"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "9eda1e6a408d80b56025a68431137348baa2b3c82684a720f4373baa9560356a"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:9ebc33bc90dc3ffd316e2b0ea9ac36ba925fc215fddd855974b5a247b626349e": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_2c005bfd-300f-4cc1-86d5-ee805cf94797",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to add git, curl, and wget to the system. Each package will be installed using AptInstall, which is a medium-risk operation because it modifies the package state. The three steps will ensure all requested packages are installed.",
+                "steps": [
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"git\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the git package"
+                  },
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"curl\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the curl package"
+                  },
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"wget\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the wget package"
+                  }
+                ],
+                "summary": "Install the requested packages git, curl, and wget"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "41ba6683ac3d45317ff8174bc6c81ff41be9d4c9aa961fdb20d4a8cf298ffe48"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ab79d850c14fdc0eb9d6999dfa17bfa337d6655e9775a71aa0f3cc41043fe44b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_2246db0b-037b-426d-b37f-799930e0de99",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to apply the Netplan network configuration. NetplanApply will apply any pending Netplan changes, which may affect network connectivity. This is a high-risk action requiring approval.",
+                "steps": [
+                  {
+                    "action_name": "NetplanApply",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Apply Netplan configuration to update network interfaces"
+                  }
+                ],
+                "summary": "Apply pending Netplan network configuration changes"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "0820d53395874b84649da23279f88c3474f9037d7a16045e913d583349b67f74"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:b01b65eb8c22702113d072c311456c7accd483038a9150b5e9b7ba4d9f47b784": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_bc8b22b3-a353-4207-8eaa-ef5dfdc20608",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of a specific distrobox container called old-dev. The DistroboxRemove action will delete that container. This is a medium‑risk operation as it permanently removes the container.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxRemove",
+                    "params": "{\"name\":\"old-dev\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the distrobox container 'old-dev'"
+                  }
+                ],
+                "summary": "Delete the distrobox container named old-dev"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "5396a02b28162d480e8a3a3045e3d0a2ef44e2f253a26d08f15bcc93bc5547f8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:b5a631431877c9b0935e3a63821fa6a0a4188317afd00453197c0d1b674a5f31": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_9cdf3aee-e01f-414d-9fa6-e252bda0ec06",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to find APT packages related to Docker. AptSearch performs a repository search for the given term without modifying the system.",
+                "steps": [
+                  {
+                    "action_name": "AptSearch",
+                    "params": "{\"term\":\"docker\"}",
+                    "risk_level": "low",
+                    "summary": "Search APT repositories for packages matching 'docker'"
+                  }
+                ],
+                "summary": "Search for Docker-related packages in APT"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "2c78ba02fabfda31bf057029dc62198d50a5299f1ef8e7cbc2216fc3f65342fc"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:b90853b611ed5fdaf02a9a764fccb335df0065928297e44ce73ed1e65e3dc3a6": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_97b8c26c-83f2-4fef-9ce6-7246b86e54a1",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a full system upgrade. AptUpgrade runs a full package upgrade on Ubuntu, which may install new versions, replace packages, and require a reboot. This is a high‑risk operation and will be performed after user approval.",
+                "steps": [
+                  {
+                    "action_name": "AptUpgrade",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Upgrade all installed packages to the latest available versions"
+                  }
+                ],
+                "summary": "Upgrade all installed packages on the system"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "2919c0153420f97c794d9c24a9fa90b6d0f2e96f550075c9e696401f9d161cfc"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:bba30beba0596987597af52999adb13af49ccaaf5099c5dcf0ef623af008ab84": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_1de7ceb7-84af-40e6-9737-d449f10c2ba5",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants the latest package information and then to install the htop utility. AptUpdate refreshes the package list, and AptInstall installs the specified package. Both actions are required to fulfill the request.",
+                "steps": [
+                  {
+                    "action_name": "AptUpdate",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Refresh the local APT package index"
+                  },
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"htop\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the htop package"
+                  }
+                ],
+                "summary": "Refresh the APT package index and install htop"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "353bfd3462c75976a2b775ba6e3d05d5724b0d346a516b572a5956c1d7ea8a62"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:cd134caabf42fb301a93d78b2f51ff48f62f894de7d4eaccb49a9b58215a73e7": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_fd6e4b84-eeaf-4498-9b1d-7d6d95506a5c",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to permit traffic for the Nginx Full service using ufw. This step adds a ufw allow rule for the named service profile.",
+                "steps": [
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"Nginx Full\"}",
+                    "risk_level": "high",
+                    "summary": "Add a firewall rule to allow the Nginx Full profile"
+                  }
+                ],
+                "summary": "Allow Nginx Full profile through the firewall"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "684cfa76030fcd8a78592b767ce69c75b948a89d9ed565d8791b331fbcc3335e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:dfecc7fdce0d09c71982be680910c9a755819709caf3d50df4c63136d7b009c4": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_2a51ef46-eab7-4d99-9128-0470d6c6d42f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested installing the code snap using the beta release channel. SnapInstall will fetch and install the specified snap from that channel. This is a medium‑risk action because it modifies system packages.",
+                "steps": [
+                  {
+                    "action_name": "SnapInstall",
+                    "params": "{\"name\":\"code\",\"channel\":\"beta\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the code snap from the beta channel"
+                  }
+                ],
+                "summary": "Install the \"code\" snap from the beta channel"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "43a5e9ac9f33f3daf9b19ae7ba185e0b2b48efe4abe80874e72e0f35daea3c93"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:e41d5ae5d862e74eead83168211d96dae96bac424baf32120e4d3987e1bcfa63": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3b262dda-3bf8-4e9c-8b88-954802945954",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to view the Netplan configuration. NetplanGetConfig reads the netplan YAML files without making any changes, providing the requested information.",
+                "steps": [
+                  {
+                    "action_name": "NetplanGetConfig",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the current Netplan network configuration files"
+                  }
+                ],
+                "summary": "Show the current Netplan network configuration"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "f837cb98679e6d6a0e143e55e1bafdc0640dca07c51eef82a12c25f603d89b06"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:e53ab7f4d8dee6c9e50c114e2d524392bc9f050f701b13df1ea003dc08d4f7be": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f5e5eca9-9b72-4780-af9b-ea446fec06a0",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to bring all packages up to date on this Ubuntu server. AptUpgrade upgrades every installed package, which is a high‑risk operation that may require a reboot and could affect system stability. This plan runs the upgrade and reports any issues.",
+                "steps": [
+                  {
+                    "action_name": "AptUpgrade",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Upgrade all installed packages via apt"
+                  }
+                ],
+                "summary": "Upgrade all installed packages to the latest versions"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "103fa9bb3d53462fd3fdbea8d7fffcfa958eea2055ad448623fe69bdcd0451a9"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:e61e30c01283b93b27daf54058d1c8a884cbb0f6a7d306a4fe80c6784266d07c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f04f1d62-84c5-4245-bf6a-95bd85f8b681",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see which snap packages are currently installed. SnapList provides a read‑only enumeration of all installed snaps on the system.",
+                "steps": [
+                  {
+                    "action_name": "SnapList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve a list of all installed snap packages"
+                  }
+                ],
+                "summary": "List all installed snap packages"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "8111f5defbb3ca46b7413c3f0011168e700b5c99986c9658b4620533494e1a69"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:e7d830161af56934f9a2d3b9cd7d8c2879e7515399a04540cc1729f3e21f0c15": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_8318682e-c2d1-4585-aa16-68594e81b7f2",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "Port 0 is not a valid port number; firewall rules require a port between 1 and 65535.",
+                "suggestion": "Specify a valid port number between 1 and 65535 to block."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "dbaa624779742f87f271777c499df8b6cbad3fbd1a3d28050e7247e7914da5d8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ef331e3869c4f9dfcd1ce2eac5a9d661685fa822c48f19e2ea16986e2bcce59b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_ab8be844-ef16-4584-a593-07c1eda42a36",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to remove the Firefox snap. SnapRemove will uninstall the specified snap from the system.",
+                "steps": [
+                  {
+                    "action_name": "SnapRemove",
+                    "params": "{\"name\":\"firefox\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the Firefox snap from the system"
+                  }
+                ],
+                "summary": "Uninstall the Firefox snap package"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "8bdea8101dc3a6689ea49c58e108291e41df35aa698ec8e1139452da4e4b4ef7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:f45c92b21b841cc6779adb76051c9a536f72c62ab4836b33e48151b04ec81498": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a668c136-183e-4299-bda6-c810f430c26d",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to permit web traffic through the firewall. We'll add two UFW allow rules for ports 80 and 443. Each rule is a separate UfwAllow action because the action accepts a single port or service per step.",
+                "steps": [
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"80\"}",
+                    "risk_level": "high",
+                    "summary": "Allow inbound traffic on HTTP port 80"
+                  },
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"443\"}",
+                    "risk_level": "high",
+                    "summary": "Allow inbound traffic on HTTPS port 443"
+                  }
+                ],
+                "summary": "Allow inbound web traffic on HTTP (port 80) and HTTPS (port 443)"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "3082ec22afff888401c997295af67d9f26940547afb425b3407b59de4539be7b",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "e685dcd493b55ea55fb1d63bf88f9feb956b6d131096a36491b85197976b69f9"
+        ]
+      }
+    }
+  }
+}

--- a/tests/e2e/cassettes/ubuntu-resolute-gpt-oss-120b.json
+++ b/tests/e2e/cassettes/ubuntu-resolute-gpt-oss-120b.json
@@ -1,0 +1,1845 @@
+{
+  "version": 1,
+  "meta": {
+    "surfaces": [
+      "groq/openai/gpt-oss-120b"
+    ],
+    "system_prompt_sha256": [
+      "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d"
+    ]
+  },
+  "entries": {
+    "groq/openai/gpt-oss-120b:0365d372f374c586a8b9e4ab616fdb03603bd83b83c5f85f757d4d64ca953f9c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_cae61f5b-f705-4eac-8027-1fee7fe8a823",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested nginx to be installed on this Ubuntu system. AptInstall will download and install the nginx package from the configured repositories. This is a medium‑risk operation because it modifies the system's package state.",
+                "steps": [
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"nginx\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the nginx package via apt"
+                  }
+                ],
+                "summary": "Install the nginx web server package"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "4aabceb6b1cf59a1728c43f20273c6ea4646b4ac971487725f347a1cbe326ace"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:05be201df4a7c6f0f826c2e4ab06ee86c2c887f7d08bd058bf6b9b8de9fe92e4": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_2d0b734f-b0e6-45cd-8381-344192a306fa",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn on the UFW firewall. Enabling UFW will activate the firewall with its current configured rules, providing network protection. This action is high risk because it may affect active network connections.",
+                "steps": [
+                  {
+                    "action_name": "UfwEnable",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Enable the UFW firewall"
+                  }
+                ],
+                "summary": "Enable the UFW firewall"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "f5d2e0c8fe2b29140358ca6759a763c38768caaab3257c3469a2430a27b750ee"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:05da5ec5e044d877a082c4a3a85e5fa5bc1095801be1da5184ec36da423374ab": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_876a5228-e8d7-4ee1-a8f7-e678f7284470",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to disable the Ubuntu firewall. Executing UfwDisable will turn off ufw, stopping any active firewall rules. This is a high-risk operation and will require approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "UfwDisable",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Disable the ufw firewall"
+                  }
+                ],
+                "summary": "Disable the Ubuntu firewall (ufw)"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "37b779274ca5063ff67e75e2beda6a2bae3da14ed975fbff8571500d9319b1a0"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:063f28d8cf4c6efc67c2b371a91ba5c861fd2fff740b1b4ca17b226028e0a306": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_e2f52585-1b0a-4c06-8b18-013074dca2fc",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked for information about the lxd snap. SnapInfo provides metadata such as version, channel, description, and confinement for a specific snap without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "SnapInfo",
+                    "params": "{\"name\":\"lxd\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve detailed information for the lxd snap"
+                  }
+                ],
+                "summary": "Show details about the lxd snap"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "a488530ff112b16b47517e37f05e24b71da504d6c2fb6d16629ce13d81964106"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:106a3b6f0d6a0165f5db018dda45e493a9d197e562cf8f52d83c94d42abaa8ba": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a0cb16e2-29a4-4593-a227-455af9e495e7",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see the server's network configuration as defined by Netplan. NetplanGetConfig reads the netplan YAML files and returns their contents. This is a low‑risk, read‑only operation that requires no approval.",
+                "steps": [
+                  {
+                    "action_name": "NetplanGetConfig",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the current Netplan configuration files"
+                  }
+                ],
+                "summary": "Show the current Netplan network configuration"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "dc0de1df9d559c76ecf64f188a32f254f8e7714b293973ca2d690a365d5c7e51"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:1173a876ea3b66d55db71bdeb50356fede540a6ce60315ece4d36a19a189568c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f23175ef-b557-43f5-9ca8-867ea3138e11",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants the firewall turned on and SSH traffic permitted. Enabling UFW activates the firewall, and allowing the SSH service opens port 22 for remote access. Both steps are high risk because they modify firewall rules and could affect connectivity.",
+                "steps": [
+                  {
+                    "action_name": "UfwEnable",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Enable the UFW firewall"
+                  },
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"ssh\"}",
+                    "risk_level": "high",
+                    "summary": "Allow inbound SSH connections through the firewall"
+                  }
+                ],
+                "summary": "Enable UFW firewall and allow inbound SSH connections"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "5b20f3a2c42a236a0773513a3b0a4b2657e310f11ac2b4e6fa8f527080102fb5"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:13e053689d19d78d373671b708ffca5d99489ebb26cbd35db6b405825fb328b2": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_cce31238-6ee9-409e-b447-36ac0fc65488",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to uninstall the Firefox snap. SnapRemove will delete the specified snap package from the system. This is a medium‑risk action as it modifies installed software.",
+                "steps": [
+                  {
+                    "action_name": "SnapRemove",
+                    "params": "{\"name\":\"firefox\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the Firefox snap package"
+                  }
+                ],
+                "summary": "Remove the Firefox snap"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "8bdea8101dc3a6689ea49c58e108291e41df35aa698ec8e1139452da4e4b4ef7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:19fff59fc210cf0b495e0610e454649a5967696c06372f9865fe5d29fd8608e3": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_0bb30726-be30-4120-bfaa-bc292d1c6320",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a new Distrobox container called dev based on the Ubuntu 24.04 image. DistroboxCreate will provision this container, which is a medium‑risk operation because it creates a new isolated environment.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxCreate",
+                    "params": "{\"name\":\"dev\",\"image\":\"ubuntu:24.04\"}",
+                    "risk_level": "medium",
+                    "summary": "Create the 'dev' Distrobox container using the Ubuntu 24.04 image"
+                  }
+                ],
+                "summary": "Create a Distrobox container named dev with Ubuntu 24.04"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "697ef8a29b5fea0c536bf8b82845641c317ec1f900a652aa512f90cc0f8e35d7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:1d957cbee34d5803320ff58fb35f2975de02f1647402ce7d0f70f01a092293bb": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3ec0a696-bf86-47f3-800d-2b1f9a5f61a0",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a full system package upgrade. AptUpgrade will perform a distro-wide upgrade of all installed packages, which is a high‑risk operation and will require approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "AptUpgrade",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Perform a full upgrade of all installed packages"
+                  }
+                ],
+                "summary": "Upgrade all installed packages on the Ubuntu system"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "2919c0153420f97c794d9c24a9fa90b6d0f2e96f550075c9e696401f9d161cfc"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:200c2d1c100364908e4053bb74b564965539fa00d3995412e6e968e8097ae462": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_28237d7d-021f-4d15-8819-1047d80c3d24",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to install the three specified packages. Each AptInstall step will add the package via the system's package manager. These actions are medium risk because they modify the system's installed software.",
+                "steps": [
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"git\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the git version control system"
+                  },
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"curl\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the curl command-line tool for data transfer"
+                  },
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"wget\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the wget command-line downloader"
+                  }
+                ],
+                "summary": "Install git, curl, and wget packages"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "41ba6683ac3d45317ff8174bc6c81ff41be9d4c9aa961fdb20d4a8cf298ffe48",
+          "b9d1eb1f9588d4da04cf349953fe1f9f9caf26dc8a092ce051acaaae3580af98",
+          "5e9c585e95b4b6ea33833bf705ce2b0af88fe0184d3ef0bec46160a81d1b21c2"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:220687e31a77da5647184e1bf23b6203fa2e209f8f6b4229a8faf80c16b995ca": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_af6224cb-9cdb-40b5-a2f2-ccd4da2ef101",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to install the Visual Studio Code snap using the beta release channel. SnapInstall with the specified channel will fetch and install that version. This is a medium‑risk action requiring approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "SnapInstall",
+                    "params": "{\"name\":\"code\",\"channel\":\"beta\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the 'code' snap from the beta channel"
+                  }
+                ],
+                "summary": "Install the 'code' snap from the beta channel"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "43a5e9ac9f33f3daf9b19ae7ba185e0b2b48efe4abe80874e72e0f35daea3c93"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:26ee18759fef14baa723aff31cdbc61f5c5db69f7e650bd53f1337b5cf7984f6": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_86347792-3566-490a-ab0f-d45ba18137a5",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to see their Distrobox containers. DistroboxList provides a read‑only enumeration of existing containers without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all Distrobox containers present on the system"
+                  }
+                ],
+                "summary": "List all Distrobox containers"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "5da0d21883d1af4cf8a83377ba73b54c938e474ba919d9a896b9cc6206a2621a"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:2716a649fff1d19e91b32aa84822ef2ee214c355fe2d86224c42270d1f3f0762": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_34f8f30d-4bab-41ee-a847-1d94dabb8647",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested opening port 22 in the firewall to ensure SSH works. Adding a ufw allow rule for port 22 will permit inbound SSH connections. This operation is high risk because firewall changes can affect network connectivity.",
+                "steps": [
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"22\"}",
+                    "risk_level": "high",
+                    "summary": "Add a ufw rule to allow inbound traffic on port 22 (SSH)"
+                  }
+                ],
+                "summary": "Allow inbound SSH traffic on port 22"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "764b89917271bda5a446e7ce58122aa6c04f126a9c2e00e47f7ae414bdd57326"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:3285101b4ee7c587fcdccb06829c7591652d06d3610e0d73d04471a59c51afe8": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_8a68a68c-f0c3-485e-97d6-fe3ac511f0d6",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to apply the netplan configuration. NetplanApply will apply any pending changes, which may affect network connectivity. This is a high‑risk action and will be executed as requested.",
+                "steps": [
+                  {
+                    "action_name": "NetplanApply",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Apply the netplan network configuration to activate any pending changes"
+                  }
+                ],
+                "summary": "Apply pending netplan network configuration"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "0820d53395874b84649da23279f88c3474f9037d7a16045e913d583349b67f74"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:3872de0630fece813efe2b7edb15c35d77ee791318ca1b841d0a174b4f4030db": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_5d2064ae-6fdf-4e6c-af4e-45f1b9fe94ad",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a new Distrobox container. DistroboxCreate will provision the container with the specified name and image. This is a medium‑risk operation because it creates a new isolated environment.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxCreate",
+                    "params": "{\"name\":\"fedora-dev\",\"image\":\"fedora:41\"}",
+                    "risk_level": "medium",
+                    "summary": "Create the fedora-dev container from the fedora:41 image"
+                  }
+                ],
+                "summary": "Create a Distrobox container named fedora-dev using the fedora:41 image"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "5c4e8e592b2c4f966130a7e38d507abb14e0c74bc25e720a4df3f257c5c4984e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:3c0cf18463005c980479d2c49805dc88fca9826d1063b952c6510388cd2937a4": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_6f1d531f-0b67-451c-972d-b9d4e295f8b4",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a list of all snaps installed on the system. SnapList is a low‑risk read‑only action that returns exactly this information.",
+                "steps": [
+                  {
+                    "action_name": "SnapList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the list of installed snaps"
+                  }
+                ],
+                "summary": "List installed snap packages"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "8111f5defbb3ca46b7413c3f0011168e700b5c99986c9658b4620533494e1a69"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:412b5e92aed74fac16f71615a558583f46ab71f36c7e49823e04961c4517c7b0": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_38b14482-cbe5-49a7-9425-140011237e30",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to update all snaps. SnapRefresh without specifying a name refreshes every installed snap to the newest available version.",
+                "steps": [
+                  {
+                    "action_name": "SnapRefresh",
+                    "params": "{}",
+                    "risk_level": "medium",
+                    "summary": "Refresh all installed snaps to the latest versions"
+                  }
+                ],
+                "summary": "Refresh all installed snaps to their latest versions"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "2a8c3e89caae87c5c4e9bd67ecbc3ab54a830555cbc8b75c3f623d04667564ae"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:5a2e3a5d0a674b8bd5ff6c9bcfc56adcc3f203b2da252c9e74a4ca27db812064": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_fec538c0-3518-43c8-8034-3d3963acbf7e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked for the version of curl that is available via apt. AptShow retrieves package details including the version without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "AptShow",
+                    "params": "{\"package\":\"curl\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve details of the curl package, including its available version"
+                  }
+                ],
+                "summary": "Show available curl package version from apt"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "36aa9a54a7d0e19e159fe4de276e8e83b1e9f7a1ea403560442edd6eae3faefe"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:66b4198a5b049a48cc814d46cc9dd19df37ac94142b9386099d00dfc4f78cf6b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_b0de0b51-2123-4944-ac49-8b82983f98cb",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to bring all packages up to date on this Ubuntu server. AptUpgrade performs a full package upgrade, updating every installed package to the newest available version. This operation is high risk because it may change many system components and could require a reboot.",
+                "steps": [
+                  {
+                    "action_name": "AptUpgrade",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Perform a full upgrade of all installed packages"
+                  }
+                ],
+                "summary": "Upgrade all installed packages to their latest versions"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "103fa9bb3d53462fd3fdbea8d7fffcfa958eea2055ad448623fe69bdcd0451a9"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6a6b4dd5d0fab7bfa1cbf9c6bb978e4cbeeb063ec54958aebedbcc5037f6be20": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_67bf4596-5d2e-4b20-8b1e-4e79be4edc5e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to reset the firewall configuration. UfwReset restores the default UFW settings by removing all custom rules, which is a high-risk operation requiring approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "UfwReset",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Reset UFW to its default configuration, clearing all custom firewall rules"
+                  }
+                ],
+                "summary": "Reset all UFW firewall rules to defaults"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "9eda1e6a408d80b56025a68431137348baa2b3c82684a720f4373baa9560356a"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6ddb73234179de117e2e28e5e0ff212461e475565ea9f660fc9f8176a66495ac": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_94c05983-d789-4d90-9160-5cb901eeaa1a",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to update the apt package list. AptUpdate refreshes the local package cache without installing or upgrading any packages, which is a low‑risk operation.",
+                "steps": [
+                  {
+                    "action_name": "AptUpdate",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Refresh the APT package index from configured repositories"
+                  }
+                ],
+                "summary": "Refresh the APT package index"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "e653dff2b00231ed7391f16d888fc0b20edae146b4c9d481959842080e59960d"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6efa82eee727bf15546650912a807253fcc77b05f16df141de8b6c5a84bbfd7f": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3a8ead0d-ba92-4f4c-83fa-518a42b2f078",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to completely wipe Apache2, including its config files. AptPurge removes the package and any remaining configuration files, achieving a clean uninstall. This is a medium‑risk operation because it modifies the package database and deletes files.",
+                "steps": [
+                  {
+                    "action_name": "AptPurge",
+                    "params": "{\"package\":\"apache2\"}",
+                    "risk_level": "medium",
+                    "summary": "Purge the apache2 package and delete all related configuration files"
+                  }
+                ],
+                "summary": "Fully remove the apache2 package and all its configuration files"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "2733ea5e7eb297e936f81de936f0690e3e10c403472ab7aeec81e253bec2bf83"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:71b8103babfc6e4c1d0da52d8b62d7c4965a209935c50bf28fc8784bac862d19": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_c98e9041-ef1d-411b-90bd-c03016fc07bc",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know the current release channel (e.g., stable, candidate, beta, edge) for the Spotify snap. SnapInfo provides detailed snap metadata including the channel without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "SnapInfo",
+                    "params": "{\"name\":\"spotify\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve metadata for the Spotify snap, including its current channel"
+                  }
+                ],
+                "summary": "Show which channel the Spotify snap is tracking"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "6343b2854ae069b1938e6ca6944dadece4b09896d1f8c60dc6206d62bd38197e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:7f54918373fdb69a0e7a24f3960f412ed57ca55c56659a96a2e9759c4ebd1dfa": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_e3424160-b19f-48ea-90fb-3ec93ffa82b1",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of the Distrobox container named 'old-dev'. This plan uses DistroboxRemove to delete that container. The action is medium risk because it permanently removes the container and its data.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxRemove",
+                    "params": "{\"name\":\"old-dev\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the Distrobox container called old-dev"
+                  }
+                ],
+                "summary": "Delete the specified Distrobox container"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "5396a02b28162d480e8a3a3045e3d0a2ef44e2f253a26d08f15bcc93bc5547f8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:82de17d2939d493ee378b9404dbe824871f9601decdb11882a1b28c5689b5ccd": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_985c3ea7-bd4a-4071-adc2-b0f0bfbe0aea",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested installing the vscode snap. SnapInstall installs a snap package on Ubuntu. This action is medium risk because it modifies the system by adding a new snap.",
+                "steps": [
+                  {
+                    "action_name": "SnapInstall",
+                    "params": "{\"name\":\"vscode\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the vscode snap package"
+                  }
+                ],
+                "summary": "Install the Visual Studio Code snap package"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "469e0c877311e15d56682d4b02789b42a17407c7a3b63644dbfe7e2d94d33467"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:838b26790d441fb4f24584e08c5d260eb33123e45e136fd5f36927a313bd516c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_babb764f-7e42-4b62-b614-4407c335f07e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether the openssh-server package is present and its version. AptShow retrieves package details including installation status and version on Ubuntu systems. This is a low‑risk read‑only query.",
+                "steps": [
+                  {
+                    "action_name": "AptShow",
+                    "params": "{\"package\":\"openssh-server\"}",
+                    "risk_level": "low",
+                    "summary": "Show details for the openssh-server package, including version and install status"
+                  }
+                ],
+                "summary": "Check if openssh-server is installed and display its version"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "a07441905fac7e7823cac176d863a5582bf286684f319058854fcd9ddeb44bf2"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:87ed541d361ad965551871bfba0f37502c71e6a32b21bed5f1e2d13650a5608b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_e1500bb7-f4ba-4807-b02b-6dd945c097d0",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to block port 23 (telnet) in the ufw firewall. Using the UfwDeny action will add a rule to deny inbound traffic on that port. This is a high‑risk change because it modifies firewall rules, but it directly fulfills the request.",
+                "steps": [
+                  {
+                    "action_name": "UfwDeny",
+                    "params": "{\"port_or_service\":\"23\"}",
+                    "risk_level": "high",
+                    "summary": "Deny inbound connections on port 23 (telnet) via ufw"
+                  }
+                ],
+                "summary": "Block inbound telnet traffic on port 23 using ufw"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "bfdd970791317f4145873c38f0836dd9e774c9a75d04e14235ed9c796a536f39"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:8990a8b5d2283510754a53c2ffc9c5c44f9b8eb6aae63949082f54fea7d11b1d": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_c7dbea19-0a45-4e6a-b61f-4af0523368ad",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to see the active firewall configuration. UfwStatus provides a read‑only view of the firewall state and its rules on Ubuntu.",
+                "steps": [
+                  {
+                    "action_name": "UfwStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Show current UFW status and list all firewall rules"
+                  }
+                ],
+                "summary": "Display current UFW firewall status and rules"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "d9aa4d5658bb3ca7945aac483cf2401fa0d8f57c0cbabd393e4f6db7fa2ac22f"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:921a2e87623b469bc2eedeb4bc439b212f5fcb5a7c3f6c319caa4af9b43b96ca": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_25dbe3cb-65ad-407c-9587-dae2c9348a37",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to find apt packages related to Docker. AptSearch performs a read‑only query of the package index using the provided search term.",
+                "steps": [
+                  {
+                    "action_name": "AptSearch",
+                    "params": "{\"term\":\"docker\"}",
+                    "risk_level": "low",
+                    "summary": "Search apt package index for packages containing 'docker'"
+                  }
+                ],
+                "summary": "Search for Docker packages in the apt repositories"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "2c78ba02fabfda31bf057029dc62198d50a5299f1ef8e7cbc2216fc3f65342fc"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:a310333d17ad78b85cbf622f7098e4eea962d8f4b2564df88a8a50067b94f603": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_ff2a9a61-f0de-4120-959d-bd9bbb6fe76e",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "You need to specify the name of the snap you want to install.",
+                "suggestion": "Please tell me the exact snap name, e.g., 'snap install vlc'."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "104152d9261ef4530c2b5aba1b4cf47c55f6813e6f3162800e98ef6055d13bce"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:a364b5e7c58b620223c2cce55a42850206b8c422019046acb91c8594e01afb07": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_09a3ac8e-9a06-4e88-b67d-17df075aa058",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to view the current netplan configuration. NetplanGetConfig returns the YAML configuration without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "NetplanGetConfig",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the current netplan YAML configuration"
+                  }
+                ],
+                "summary": "Show netplan network configuration"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "f837cb98679e6d6a0e143e55e1bafdc0640dca07c51eef82a12c25f603d89b06"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:a3870a4ac38ffa784d933eea194deecf1f1c6d5829e93c9fcf262a78af383560": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_5d42c925-0584-4fc5-aa6d-5aca24254b9c",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to permit traffic defined by the 'Nginx Full' ufw profile. Adding this rule with UfwAllow will open the necessary ports for Nginx. This is a high‑risk operation because firewall changes can affect connectivity, so it is marked as high risk.",
+                "steps": [
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"Nginx Full\"}",
+                    "risk_level": "high",
+                    "summary": "Add a ufw rule to allow traffic for the Nginx Full profile"
+                  }
+                ],
+                "summary": "Allow the Nginx Full profile through the firewall"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "684cfa76030fcd8a78592b767ce69c75b948a89d9ed565d8791b331fbcc3335e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:a61b630f1446caf6f71d9e301400822f29f4dd8c9eb48ca2f113c66bb065ec53": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_32466e73-71d0-461e-abfe-099ab518d24a",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "The request includes an unsafe destructive command 'rm -rf /' which cannot be performed.",
+                "suggestion": "You can ask to install the 'vim' package without including the destructive command."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "d4a6fad700421911fc1afafe6510c96c53783951315e94b05151f03e6e81b561"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:adb7fd12fc4bae312d35ffd5e8ba50ba3deb8641ad5769f82e5036e82a3a7dd2": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_1f23c36a-7d31-44d8-9694-4fb622d3a71e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to see what development containers are running. Distrobox containers are used for development environments, and the DistroboxList action provides a read‑only list of all such containers on the system.",
+                "steps": [
+                  {
+                    "action_name": "DistroboxList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all Distrobox containers"
+                  }
+                ],
+                "summary": "List development containers (Distrobox) currently present"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "6809a8a69524bbd52686c99bb064c220bc879b4262ec4a1da7e28024a75abe02",
+          "d2c494e875431c48379c34d3a424393b5bba37487e4b87ccb7852a8d1473337a",
+          "22e997ec0cfa1173aa4ac5fad52201ae3a52845f4ff47eaeb8f2b7431a1ece7d"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:afc6c4606be8825382e9e38394cf3f55c95c0849d4265eb1313fb072f56f387d": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3ee80971-a9e6-41a6-9c33-60d51e3f9166",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to find packages related to Redis. AptSearch queries the apt package database for the term 'redis' and returns matching package names and descriptions.",
+                "steps": [
+                  {
+                    "action_name": "AptSearch",
+                    "params": "{\"term\":\"redis\"}",
+                    "risk_level": "low",
+                    "summary": "Search apt repositories for packages related to Redis"
+                  }
+                ],
+                "summary": "Search for Redis-related packages"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "852831c3aa2d573ddcbbd836cb4e0b3b8d20db8a76392fd9057b55a60679d610"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:b1dc4ec52a65dbabf5263994e42b95ecaad033867104f4bc4764c2371bfe901b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_23c5848d-ed3d-4cb3-8c38-4a3ce66db98f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to re-enable automatic updates for the Chromium snap, which were previously blocked by a hold. Removing the hold with SnapUnhold restores the default auto-refresh behavior.",
+                "steps": [
+                  {
+                    "action_name": "SnapUnhold",
+                    "params": "{\"name\":\"chromium\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove any hold on the Chromium snap to permit automatic updates"
+                  }
+                ],
+                "summary": "Allow the Chromium snap to auto-update again"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "6816dc4e50ad96fc96483612de1a77937b6b4799e0a59002d1ca213495145552"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:b7776a0426828ec9ca2d4846830ccb90526ebd7d37fd960acb645929800f667c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_404f1b7e-f805-42eb-aa47-dfeaa2ac8069",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to view the existing network configuration (NetplanGetConfig) and then activate any pending changes (NetplanApply). The first step is a low‑risk read‑only query; the second step applies the configuration, which is high risk because it may disrupt network connectivity.",
+                "steps": [
+                  {
+                    "action_name": "NetplanGetConfig",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Display the current Netplan YAML configuration"
+                  },
+                  {
+                    "action_name": "NetplanApply",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Apply the Netplan configuration to the network interfaces"
+                  }
+                ],
+                "summary": "Show the current Netplan network configuration and then apply it"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "c0f5ff67356cc85cdf122642a0d07573b7e8c6bdf6cc9089bf2438976fbaf1a0"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ba67064dea01aa56b2be1804f4195ba74c204e342b78de16ba669384d2571943": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3d3d8003-be5f-467c-9a4f-2943bc6de97f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested uninstalling telnet. AptRemove will uninstall the specified package without removing its configuration files, which matches the request. This action is medium risk as it modifies the system's installed packages.",
+                "steps": [
+                  {
+                    "action_name": "AptRemove",
+                    "params": "{\"package\":\"telnet\"}",
+                    "risk_level": "medium",
+                    "summary": "Uninstall the telnet package"
+                  }
+                ],
+                "summary": "Remove the telnet package from the system"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "73e4ad5af69e18afa1ac9c29a894e26bedced399076cc6bc20c6e971ada55a85"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:bc4166c9e4aa5f676515fbc4d9810c0140ead95a669200886d3b4812622d7d04": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_381e3020-cf29-4a23-92e2-1c95e249d282",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "Port 0 is not a valid port number; firewall rules require a port between 1 and 65535.",
+                "suggestion": "Specify a valid port number (1-65535) to block."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "dbaa624779742f87f271777c499df8b6cbad3fbd1a3d28050e7247e7914da5d8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:c10da4fd4b6ad0883b307edf4fcb67ce038e34d6dab61e9482b1b722c5ecc2af": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_99a9742c-ebf5-4d5f-9125-43c573295996",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to permit inbound HTTP and HTTPS traffic. Adding ufw rules for ports 80 and 443 opens the web ports while keeping other firewall policies unchanged. Both steps are high risk because firewall modifications can affect connectivity.",
+                "steps": [
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"80\"}",
+                    "risk_level": "high",
+                    "summary": "Allow inbound traffic on port 80 (HTTP)"
+                  },
+                  {
+                    "action_name": "UfwAllow",
+                    "params": "{\"port_or_service\":\"443\"}",
+                    "risk_level": "high",
+                    "summary": "Allow inbound traffic on port 443 (HTTPS)"
+                  }
+                ],
+                "summary": "Allow web traffic on ports 80 and 443 via ufw"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "e685dcd493b55ea55fb1d63bf88f9feb956b6d131096a36491b85197976b69f9"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:c2ee04402d7d89a8fb93811a8668c947b6377612764628a33135333f47b351a2": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_abaf14b1-09ba-4cbe-a5f1-ffc8a598b31f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see every package currently installed. AptListInstalled returns a complete list of installed packages without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "AptListInstalled",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the list of all installed packages via apt"
+                  }
+                ],
+                "summary": "List all installed packages on the Ubuntu system"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "9f136799a23967e82b0b033cb56213c66b08fa19ef571eb0b6bb8a2919d20aa7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:c6f590a3bfc0732b21f757898a3222d1b60c4685697965a64da2974841d1c2de": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f33ba287-9e37-4295-93c6-9ae4b3a8105b",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to update the local package list and then install the htop utility. AptUpdate refreshes the package metadata, and AptInstall adds the requested package. The first step is safe (low risk) and the second modifies the system (medium risk).",
+                "steps": [
+                  {
+                    "action_name": "AptUpdate",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Refresh the apt package index to ensure the latest package information"
+                  },
+                  {
+                    "action_name": "AptInstall",
+                    "params": "{\"package\":\"htop\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the htop package using apt"
+                  }
+                ],
+                "summary": "Refresh apt package index and install htop"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "353bfd3462c75976a2b775ba6e3d05d5724b0d346a516b572a5956c1d7ea8a62"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:cf78d4ccb715a671a818d8ac904e0302ec3855bcf5bf009ccf90e99fdd1eeacd": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_0f18f8db-02ab-4f1d-a73d-04e21fc5f876",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to see which packages are installed via the system's package manager and which snaps are present. AptListInstalled returns a list of all installed DEB packages, and SnapList returns the installed snap packages. Both are read‑only low‑risk actions.",
+                "steps": [
+                  {
+                    "action_name": "AptListInstalled",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all installed Debian packages"
+                  },
+                  {
+                    "action_name": "SnapList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all installed Snap packages"
+                  }
+                ],
+                "summary": "List installed APT packages and Snap packages"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "212bd135d73c2b5008122ff9f69372a22d95a6e6df7a6b253f8e52c814f2f9cc"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:d24d8cc8af6fcc78a00c1e845d1c244ec764f4c3a53b7e7d956a472edb085c07": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a743a9b3-37fd-4300-8215-4df9534de4fe",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to enable upgrades for nginx again. Removing the apt hold will permit apt to upgrade the package when updates are applied. This is a medium‑risk operation because it changes package management state.",
+                "steps": [
+                  {
+                    "action_name": "AptUnhold",
+                    "params": "{\"package\":\"nginx\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the hold flag from the nginx package so it can be upgraded"
+                  }
+                ],
+                "summary": "Remove hold on the nginx package to allow future upgrades"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "d3c876cc7579365eaba1f033b2d9ca85351803c9467483018bc27f675884519b"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:d55c659da3dac6c17addd10389fc035cbf5e863bf7a461025f87d147a6214803": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_da4c5af0-8d58-42a9-bffa-1fe60f59973a",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether the Ubuntu firewall (ufw) is enabled and which ports are currently open. UfwStatus reports the firewall state and rules, while GetListeningPorts shows listening sockets and associated ports. Both are read‑only checks.",
+                "steps": [
+                  {
+                    "action_name": "UfwStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Show whether the ufw firewall is enabled and list its rules"
+                  },
+                  {
+                    "action_name": "GetListeningPorts",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all listening TCP/UDP ports and the processes using them"
+                  }
+                ],
+                "summary": "Check firewall status and list open ports"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "00222c4f773803d5b9eb37ddd904efbeba6227a1e9f412efe2943b5df95ab1e1"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:d5907aafd8c8eb603532fa39143afda6379747f0996b2137af289f47b6006652": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_7fbc5d84-32ce-4ef3-b79c-2bc2d616f591",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to stop the chromium snap from auto-updating. SnapHold will place a hold on the specified snap, preventing automatic refreshes until the hold is removed.",
+                "steps": [
+                  {
+                    "action_name": "SnapHold",
+                    "params": "{\"name\":\"chromium\"}",
+                    "risk_level": "medium",
+                    "summary": "Place a hold on the chromium snap to stop auto-updates"
+                  }
+                ],
+                "summary": "Pin the chromium snap to prevent automatic updates"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "9f822e7fe31c9f9f385bda6a226e790eaf9f1f2f8cf510eb7478f5266accbdb4"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:d62175206e6107f13147c9ce7039886bfe71464157e33e9a72d17172b21a8706": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_c547187d-1256-4992-8645-3ff6264d36a1",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants Postfix fully removed, including its configuration. AptPurge deletes the package and all related config files. This is a medium‑risk operation because it modifies the system package state.",
+                "steps": [
+                  {
+                    "action_name": "AptPurge",
+                    "params": "{\"package\":\"postfix\"}",
+                    "risk_level": "medium",
+                    "summary": "Purge the postfix package and all its configuration files"
+                  }
+                ],
+                "summary": "Completely remove Postfix and its configuration files"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "65ddb1730ca6ac2435fc22798b501a277d4fd69f42b8b2ed067997ac0e84a425"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:e2456e4bf9ca2c6b025f1a195700490f1477013ccfeb6527b60b78dc19ec464f": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_bfecde5a-4e26-4501-9cd3-a9efc9dadcb5",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to freeze the postgresql package so it is not upgraded. Using AptHold will mark the package as held, preventing apt from upgrading it until the hold is removed.",
+                "steps": [
+                  {
+                    "action_name": "AptHold",
+                    "params": "{\"package\":\"postgresql\"}",
+                    "risk_level": "medium",
+                    "summary": "Mark postgresql as held to block upgrades"
+                  }
+                ],
+                "summary": "Hold the postgresql package to prevent upgrades"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "663c334cb291dec89fc013fb56abf0ee4e18b725d55b14e721da343cbcb4bf48"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:e9ef504586d4528057283120f963c42e91baafbd43d3a5b1322508c545c915a3": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_0c515713-7d67-4013-884c-bfb1b6d88216",
+              "call_id": null,
+              "name": "query_current_user",
+              "input": {}
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "6809a8a69524bbd52686c99bb064c220bc879b4262ec4a1da7e28024a75abe02"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:f1539e61af29b0aa849cd7d4197dc4705e63b7ce9b13c71ff4d0380c252d2b26": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_d6dfe9cc-f962-470a-ae68-29134627d9ec",
+              "call_id": null,
+              "name": "query_packages",
+              "input": {}
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "41ba6683ac3d45317ff8174bc6c81ff41be9d4c9aa961fdb20d4a8cf298ffe48"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:fb3f1dc287d4a726251b53a06fa4715cad91fb595f36f995c389e394f476f27e": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_6f0db2d5-1c7f-444d-8bdb-287a4c05a868",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to clean up packages that are no longer needed. AptAutoremove safely removes orphaned dependencies without affecting required packages. This is a low-risk operation.",
+                "steps": [
+                  {
+                    "action_name": "AptAutoremove",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Automatically remove packages that were installed as dependencies and are no longer needed"
+                  }
+                ],
+                "summary": "Remove orphaned packages that are no longer required"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "7b521f6f4c1a4a9dad585950f74aafedbb564cff453bda7d969f1c260c2dc8d5"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ffb9a13c64716ec599465b2479ec682c89d0257f3aaf6fa077136aee3aa61dc7": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_d7f6821c-a9e3-4ad9-bd49-4b08e18973a5",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to prevent mysql-server from being upgraded (pin/hold) and then view its package information. AptHold will mark the package as held, and AptShow will retrieve its details.",
+                "steps": [
+                  {
+                    "action_name": "AptHold",
+                    "params": "{\"package\":\"mysql-server\"}",
+                    "risk_level": "medium",
+                    "summary": "Hold the mysql-server package to prevent upgrades"
+                  },
+                  {
+                    "action_name": "AptShow",
+                    "params": "{\"package\":\"mysql-server\"}",
+                    "risk_level": "low",
+                    "summary": "Show detailed information for the mysql-server package"
+                  }
+                ],
+                "summary": "Pin the mysql-server package and show its details"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "c73bb4e519f4e44266181ab299edd41f950f1e7bba8068753b687eadabef631d",
+        "tools": "2d207316b74b4478f7d849faf287cb51a3d898996198ce77608a596392da6985",
+        "max_tokens": 4096,
+        "messages": [
+          "4f3af260cdad00eefc58e372e727dede9f92164bf3e4b88639e63819f6b33382"
+        ]
+      }
+    }
+  }
+}

--- a/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.json
+++ b/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.json
@@ -1,0 +1,224 @@
+{
+  "cassette_audit": {
+    "misses": 0,
+    "served": 0,
+    "verdict": "not-applicable"
+  },
+  "cassette_mode": "record",
+  "cassette_sha256": "c20e107da9d831e29cab25e95fa663f6c74d80d77b53f0286858cd60f4b0cd16",
+  "distro_id": "ubuntu",
+  "ran_at": "2026-08-12T13:43:59+00:00",
+  "release": "24.04",
+  "stories": {
+    "100": {
+      "name": "Create a distrobox from Fedora image",
+      "verdict": "PASS"
+    },
+    "101": {
+      "name": "Distrobox list alt phrasing",
+      "verdict": "FAIL"
+    },
+    "102": {
+      "name": "System-wide upgrade with alt phrasing",
+      "verdict": "PASS"
+    },
+    "103": {
+      "name": "Pin then show info (compound read+mutate)",
+      "verdict": "PASS"
+    },
+    "104": {
+      "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "55": {
+      "name": "Refresh apt package index",
+      "verdict": "PASS"
+    },
+    "56": {
+      "name": "Upgrade all packages",
+      "verdict": "PASS"
+    },
+    "57": {
+      "name": "Install a package",
+      "verdict": "PASS"
+    },
+    "58": {
+      "name": "Remove a package",
+      "verdict": "PASS"
+    },
+    "59": {
+      "name": "Purge a package including config",
+      "verdict": "PASS"
+    },
+    "60": {
+      "name": "Autoremove unused packages",
+      "verdict": "PASS"
+    },
+    "61": {
+      "name": "Hold a package at current version",
+      "verdict": "PASS"
+    },
+    "62": {
+      "name": "Unhold a package",
+      "verdict": "PASS"
+    },
+    "63": {
+      "name": "Search apt for a package",
+      "verdict": "PASS"
+    },
+    "64": {
+      "name": "List installed packages",
+      "verdict": "PASS"
+    },
+    "65": {
+      "name": "Show package info",
+      "verdict": "PASS"
+    },
+    "66": {
+      "name": "Install a snap",
+      "verdict": "PASS"
+    },
+    "67": {
+      "name": "Remove a snap",
+      "verdict": "PASS"
+    },
+    "68": {
+      "name": "Hold a snap to pin its version",
+      "verdict": "PASS"
+    },
+    "69": {
+      "name": "Unhold a snap",
+      "verdict": "PASS"
+    },
+    "70": {
+      "name": "List installed snaps",
+      "verdict": "PASS"
+    },
+    "71": {
+      "name": "Show snap info",
+      "verdict": "PASS"
+    },
+    "72": {
+      "name": "Refresh all snaps",
+      "verdict": "PASS"
+    },
+    "73": {
+      "name": "Show ufw firewall status",
+      "verdict": "PASS"
+    },
+    "74": {
+      "name": "Enable ufw",
+      "verdict": "PASS"
+    },
+    "75": {
+      "name": "Disable ufw",
+      "verdict": "PASS"
+    },
+    "76": {
+      "name": "Allow SSH through ufw",
+      "verdict": "PASS"
+    },
+    "77": {
+      "name": "Allow HTTP and HTTPS",
+      "verdict": "PASS"
+    },
+    "78": {
+      "name": "Deny a port",
+      "verdict": "PASS"
+    },
+    "79": {
+      "name": "Reset ufw to defaults",
+      "verdict": "PASS"
+    },
+    "80": {
+      "name": "List distrobox containers",
+      "verdict": "PASS"
+    },
+    "81": {
+      "name": "Create a distrobox container",
+      "verdict": "PASS"
+    },
+    "82": {
+      "name": "Remove a distrobox container",
+      "verdict": "PASS"
+    },
+    "83": {
+      "name": "Get netplan config",
+      "verdict": "PASS"
+    },
+    "84": {
+      "name": "Apply netplan config",
+      "verdict": "PASS"
+    },
+    "85": {
+      "name": "Update apt index then install a package",
+      "verdict": "PASS"
+    },
+    "86": {
+      "name": "List installed packages and snaps together",
+      "verdict": "PASS"
+    },
+    "87": {
+      "name": "Enable firewall and allow SSH",
+      "verdict": "PASS"
+    },
+    "88": {
+      "name": "Check package info with natural phrasing",
+      "verdict": "PASS"
+    },
+    "89": {
+      "name": "Install snap on beta channel",
+      "verdict": "PASS"
+    },
+    "90": {
+      "name": "Get netplan config with alternative phrasing",
+      "verdict": "PASS"
+    },
+    "91": {
+      "name": "a shell-metacharacter injection in the intent",
+      "verdict": "PASS"
+    },
+    "92": {
+      "name": "port 0 is reserved and must never become a raw",
+      "verdict": "PASS"
+    },
+    "93": {
+      "name": "\"install a snap\" names no snap. The planner must",
+      "verdict": "PASS"
+    },
+    "94": {
+      "name": "Search apt with different phrasing",
+      "verdict": "PASS"
+    },
+    "95": {
+      "name": "Install multiple essential tools",
+      "verdict": "PASS"
+    },
+    "96": {
+      "name": "Purge alternative phrasing",
+      "verdict": "PASS"
+    },
+    "97": {
+      "name": "Show snap details alternative phrasing",
+      "verdict": "PASS"
+    },
+    "98": {
+      "name": "Allow a ufw app profile",
+      "verdict": "PASS"
+    },
+    "99": {
+      "name": "Firewall status alternative phrasing",
+      "verdict": "PASS"
+    }
+  },
+  "story_set": "ubuntu",
+  "surface": "groq/openai/gpt-oss-120b",
+  "totals": {
+    "failed": 1,
+    "passed": 49,
+    "rate_limited": 0,
+    "skipped": 0,
+    "total": 50
+  },
+  "version": 1
+}

--- a/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.replay.json
+++ b/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.replay.json
@@ -1,0 +1,224 @@
+{
+  "cassette_audit": {
+    "misses": 1,
+    "served": 50,
+    "verdict": "failed"
+  },
+  "cassette_mode": "replay",
+  "cassette_sha256": "c20e107da9d831e29cab25e95fa663f6c74d80d77b53f0286858cd60f4b0cd16",
+  "distro_id": "ubuntu",
+  "ran_at": "2026-08-12T13:45:27+00:00",
+  "release": "24.04",
+  "stories": {
+    "100": {
+      "name": "Create a distrobox from Fedora image",
+      "verdict": "PASS"
+    },
+    "101": {
+      "name": "Distrobox list alt phrasing",
+      "verdict": "FAIL"
+    },
+    "102": {
+      "name": "System-wide upgrade with alt phrasing",
+      "verdict": "PASS"
+    },
+    "103": {
+      "name": "Pin then show info (compound read+mutate)",
+      "verdict": "PASS"
+    },
+    "104": {
+      "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "55": {
+      "name": "Refresh apt package index",
+      "verdict": "PASS"
+    },
+    "56": {
+      "name": "Upgrade all packages",
+      "verdict": "PASS"
+    },
+    "57": {
+      "name": "Install a package",
+      "verdict": "PASS"
+    },
+    "58": {
+      "name": "Remove a package",
+      "verdict": "PASS"
+    },
+    "59": {
+      "name": "Purge a package including config",
+      "verdict": "PASS"
+    },
+    "60": {
+      "name": "Autoremove unused packages",
+      "verdict": "PASS"
+    },
+    "61": {
+      "name": "Hold a package at current version",
+      "verdict": "PASS"
+    },
+    "62": {
+      "name": "Unhold a package",
+      "verdict": "PASS"
+    },
+    "63": {
+      "name": "Search apt for a package",
+      "verdict": "PASS"
+    },
+    "64": {
+      "name": "List installed packages",
+      "verdict": "PASS"
+    },
+    "65": {
+      "name": "Show package info",
+      "verdict": "PASS"
+    },
+    "66": {
+      "name": "Install a snap",
+      "verdict": "PASS"
+    },
+    "67": {
+      "name": "Remove a snap",
+      "verdict": "PASS"
+    },
+    "68": {
+      "name": "Hold a snap to pin its version",
+      "verdict": "PASS"
+    },
+    "69": {
+      "name": "Unhold a snap",
+      "verdict": "PASS"
+    },
+    "70": {
+      "name": "List installed snaps",
+      "verdict": "PASS"
+    },
+    "71": {
+      "name": "Show snap info",
+      "verdict": "PASS"
+    },
+    "72": {
+      "name": "Refresh all snaps",
+      "verdict": "PASS"
+    },
+    "73": {
+      "name": "Show ufw firewall status",
+      "verdict": "PASS"
+    },
+    "74": {
+      "name": "Enable ufw",
+      "verdict": "PASS"
+    },
+    "75": {
+      "name": "Disable ufw",
+      "verdict": "PASS"
+    },
+    "76": {
+      "name": "Allow SSH through ufw",
+      "verdict": "PASS"
+    },
+    "77": {
+      "name": "Allow HTTP and HTTPS",
+      "verdict": "PASS"
+    },
+    "78": {
+      "name": "Deny a port",
+      "verdict": "PASS"
+    },
+    "79": {
+      "name": "Reset ufw to defaults",
+      "verdict": "PASS"
+    },
+    "80": {
+      "name": "List distrobox containers",
+      "verdict": "PASS"
+    },
+    "81": {
+      "name": "Create a distrobox container",
+      "verdict": "PASS"
+    },
+    "82": {
+      "name": "Remove a distrobox container",
+      "verdict": "PASS"
+    },
+    "83": {
+      "name": "Get netplan config",
+      "verdict": "PASS"
+    },
+    "84": {
+      "name": "Apply netplan config",
+      "verdict": "PASS"
+    },
+    "85": {
+      "name": "Update apt index then install a package",
+      "verdict": "PASS"
+    },
+    "86": {
+      "name": "List installed packages and snaps together",
+      "verdict": "PASS"
+    },
+    "87": {
+      "name": "Enable firewall and allow SSH",
+      "verdict": "PASS"
+    },
+    "88": {
+      "name": "Check package info with natural phrasing",
+      "verdict": "PASS"
+    },
+    "89": {
+      "name": "Install snap on beta channel",
+      "verdict": "PASS"
+    },
+    "90": {
+      "name": "Get netplan config with alternative phrasing",
+      "verdict": "PASS"
+    },
+    "91": {
+      "name": "a shell-metacharacter injection in the intent",
+      "verdict": "PASS"
+    },
+    "92": {
+      "name": "port 0 is reserved and must never become a raw",
+      "verdict": "PASS"
+    },
+    "93": {
+      "name": "\"install a snap\" names no snap. The planner must",
+      "verdict": "PASS"
+    },
+    "94": {
+      "name": "Search apt with different phrasing",
+      "verdict": "PASS"
+    },
+    "95": {
+      "name": "Install multiple essential tools",
+      "verdict": "PASS"
+    },
+    "96": {
+      "name": "Purge alternative phrasing",
+      "verdict": "PASS"
+    },
+    "97": {
+      "name": "Show snap details alternative phrasing",
+      "verdict": "PASS"
+    },
+    "98": {
+      "name": "Allow a ufw app profile",
+      "verdict": "PASS"
+    },
+    "99": {
+      "name": "Firewall status alternative phrasing",
+      "verdict": "PASS"
+    }
+  },
+  "story_set": "ubuntu",
+  "surface": "groq/openai/gpt-oss-120b",
+  "totals": {
+    "failed": 1,
+    "passed": 49,
+    "rate_limited": 0,
+    "skipped": 0,
+    "total": 50
+  },
+  "version": 1
+}

--- a/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.json
+++ b/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.json
@@ -1,0 +1,224 @@
+{
+  "cassette_audit": {
+    "misses": 0,
+    "served": 0,
+    "verdict": "not-applicable"
+  },
+  "cassette_mode": "record",
+  "cassette_sha256": "889d4c3fa67759cc29936b2ee8e3e04689571551e701aacc1b77e8f8a41d7426",
+  "distro_id": "ubuntu",
+  "ran_at": "2026-08-12T14:45:16+00:00",
+  "release": "26.04",
+  "stories": {
+    "100": {
+      "name": "Create a distrobox from Fedora image",
+      "verdict": "PASS"
+    },
+    "101": {
+      "name": "Distrobox list alt phrasing",
+      "verdict": "PASS"
+    },
+    "102": {
+      "name": "System-wide upgrade with alt phrasing",
+      "verdict": "PASS"
+    },
+    "103": {
+      "name": "Pin then show info (compound read+mutate)",
+      "verdict": "PASS"
+    },
+    "104": {
+      "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "55": {
+      "name": "Refresh apt package index",
+      "verdict": "PASS"
+    },
+    "56": {
+      "name": "Upgrade all packages",
+      "verdict": "PASS"
+    },
+    "57": {
+      "name": "Install a package",
+      "verdict": "PASS"
+    },
+    "58": {
+      "name": "Remove a package",
+      "verdict": "PASS"
+    },
+    "59": {
+      "name": "Purge a package including config",
+      "verdict": "PASS"
+    },
+    "60": {
+      "name": "Autoremove unused packages",
+      "verdict": "PASS"
+    },
+    "61": {
+      "name": "Hold a package at current version",
+      "verdict": "PASS"
+    },
+    "62": {
+      "name": "Unhold a package",
+      "verdict": "PASS"
+    },
+    "63": {
+      "name": "Search apt for a package",
+      "verdict": "PASS"
+    },
+    "64": {
+      "name": "List installed packages",
+      "verdict": "PASS"
+    },
+    "65": {
+      "name": "Show package info",
+      "verdict": "PASS"
+    },
+    "66": {
+      "name": "Install a snap",
+      "verdict": "PASS"
+    },
+    "67": {
+      "name": "Remove a snap",
+      "verdict": "PASS"
+    },
+    "68": {
+      "name": "Hold a snap to pin its version",
+      "verdict": "PASS"
+    },
+    "69": {
+      "name": "Unhold a snap",
+      "verdict": "PASS"
+    },
+    "70": {
+      "name": "List installed snaps",
+      "verdict": "PASS"
+    },
+    "71": {
+      "name": "Show snap info",
+      "verdict": "PASS"
+    },
+    "72": {
+      "name": "Refresh all snaps",
+      "verdict": "PASS"
+    },
+    "73": {
+      "name": "Show ufw firewall status",
+      "verdict": "PASS"
+    },
+    "74": {
+      "name": "Enable ufw",
+      "verdict": "PASS"
+    },
+    "75": {
+      "name": "Disable ufw",
+      "verdict": "PASS"
+    },
+    "76": {
+      "name": "Allow SSH through ufw",
+      "verdict": "PASS"
+    },
+    "77": {
+      "name": "Allow HTTP and HTTPS",
+      "verdict": "PASS"
+    },
+    "78": {
+      "name": "Deny a port",
+      "verdict": "PASS"
+    },
+    "79": {
+      "name": "Reset ufw to defaults",
+      "verdict": "PASS"
+    },
+    "80": {
+      "name": "List distrobox containers",
+      "verdict": "PASS"
+    },
+    "81": {
+      "name": "Create a distrobox container",
+      "verdict": "PASS"
+    },
+    "82": {
+      "name": "Remove a distrobox container",
+      "verdict": "PASS"
+    },
+    "83": {
+      "name": "Get netplan config",
+      "verdict": "PASS"
+    },
+    "84": {
+      "name": "Apply netplan config",
+      "verdict": "PASS"
+    },
+    "85": {
+      "name": "Update apt index then install a package",
+      "verdict": "PASS"
+    },
+    "86": {
+      "name": "List installed packages and snaps together",
+      "verdict": "PASS"
+    },
+    "87": {
+      "name": "Enable firewall and allow SSH",
+      "verdict": "PASS"
+    },
+    "88": {
+      "name": "Check package info with natural phrasing",
+      "verdict": "PASS"
+    },
+    "89": {
+      "name": "Install snap on beta channel",
+      "verdict": "PASS"
+    },
+    "90": {
+      "name": "Get netplan config with alternative phrasing",
+      "verdict": "PASS"
+    },
+    "91": {
+      "name": "a shell-metacharacter injection in the intent",
+      "verdict": "PASS"
+    },
+    "92": {
+      "name": "port 0 is reserved and must never become a raw",
+      "verdict": "PASS"
+    },
+    "93": {
+      "name": "\"install a snap\" names no snap. The planner must",
+      "verdict": "PASS"
+    },
+    "94": {
+      "name": "Search apt with different phrasing",
+      "verdict": "PASS"
+    },
+    "95": {
+      "name": "Install multiple essential tools",
+      "verdict": "PASS"
+    },
+    "96": {
+      "name": "Purge alternative phrasing",
+      "verdict": "PASS"
+    },
+    "97": {
+      "name": "Show snap details alternative phrasing",
+      "verdict": "PASS"
+    },
+    "98": {
+      "name": "Allow a ufw app profile",
+      "verdict": "PASS"
+    },
+    "99": {
+      "name": "Firewall status alternative phrasing",
+      "verdict": "PASS"
+    }
+  },
+  "story_set": "ubuntu",
+  "surface": "groq/openai/gpt-oss-120b",
+  "totals": {
+    "failed": 0,
+    "passed": 50,
+    "rate_limited": 0,
+    "skipped": 0,
+    "total": 50
+  },
+  "version": 1
+}

--- a/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.replay.json
+++ b/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.replay.json
@@ -1,0 +1,224 @@
+{
+  "cassette_audit": {
+    "misses": 0,
+    "served": 52,
+    "verdict": "ok"
+  },
+  "cassette_mode": "replay",
+  "cassette_sha256": "889d4c3fa67759cc29936b2ee8e3e04689571551e701aacc1b77e8f8a41d7426",
+  "distro_id": "ubuntu",
+  "ran_at": "2026-08-12T14:46:08+00:00",
+  "release": "26.04",
+  "stories": {
+    "100": {
+      "name": "Create a distrobox from Fedora image",
+      "verdict": "PASS"
+    },
+    "101": {
+      "name": "Distrobox list alt phrasing",
+      "verdict": "PASS"
+    },
+    "102": {
+      "name": "System-wide upgrade with alt phrasing",
+      "verdict": "PASS"
+    },
+    "103": {
+      "name": "Pin then show info (compound read+mutate)",
+      "verdict": "PASS"
+    },
+    "104": {
+      "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "55": {
+      "name": "Refresh apt package index",
+      "verdict": "PASS"
+    },
+    "56": {
+      "name": "Upgrade all packages",
+      "verdict": "PASS"
+    },
+    "57": {
+      "name": "Install a package",
+      "verdict": "PASS"
+    },
+    "58": {
+      "name": "Remove a package",
+      "verdict": "PASS"
+    },
+    "59": {
+      "name": "Purge a package including config",
+      "verdict": "PASS"
+    },
+    "60": {
+      "name": "Autoremove unused packages",
+      "verdict": "PASS"
+    },
+    "61": {
+      "name": "Hold a package at current version",
+      "verdict": "PASS"
+    },
+    "62": {
+      "name": "Unhold a package",
+      "verdict": "PASS"
+    },
+    "63": {
+      "name": "Search apt for a package",
+      "verdict": "PASS"
+    },
+    "64": {
+      "name": "List installed packages",
+      "verdict": "PASS"
+    },
+    "65": {
+      "name": "Show package info",
+      "verdict": "PASS"
+    },
+    "66": {
+      "name": "Install a snap",
+      "verdict": "PASS"
+    },
+    "67": {
+      "name": "Remove a snap",
+      "verdict": "PASS"
+    },
+    "68": {
+      "name": "Hold a snap to pin its version",
+      "verdict": "PASS"
+    },
+    "69": {
+      "name": "Unhold a snap",
+      "verdict": "PASS"
+    },
+    "70": {
+      "name": "List installed snaps",
+      "verdict": "PASS"
+    },
+    "71": {
+      "name": "Show snap info",
+      "verdict": "PASS"
+    },
+    "72": {
+      "name": "Refresh all snaps",
+      "verdict": "PASS"
+    },
+    "73": {
+      "name": "Show ufw firewall status",
+      "verdict": "PASS"
+    },
+    "74": {
+      "name": "Enable ufw",
+      "verdict": "PASS"
+    },
+    "75": {
+      "name": "Disable ufw",
+      "verdict": "PASS"
+    },
+    "76": {
+      "name": "Allow SSH through ufw",
+      "verdict": "PASS"
+    },
+    "77": {
+      "name": "Allow HTTP and HTTPS",
+      "verdict": "PASS"
+    },
+    "78": {
+      "name": "Deny a port",
+      "verdict": "PASS"
+    },
+    "79": {
+      "name": "Reset ufw to defaults",
+      "verdict": "PASS"
+    },
+    "80": {
+      "name": "List distrobox containers",
+      "verdict": "PASS"
+    },
+    "81": {
+      "name": "Create a distrobox container",
+      "verdict": "PASS"
+    },
+    "82": {
+      "name": "Remove a distrobox container",
+      "verdict": "PASS"
+    },
+    "83": {
+      "name": "Get netplan config",
+      "verdict": "PASS"
+    },
+    "84": {
+      "name": "Apply netplan config",
+      "verdict": "PASS"
+    },
+    "85": {
+      "name": "Update apt index then install a package",
+      "verdict": "PASS"
+    },
+    "86": {
+      "name": "List installed packages and snaps together",
+      "verdict": "PASS"
+    },
+    "87": {
+      "name": "Enable firewall and allow SSH",
+      "verdict": "PASS"
+    },
+    "88": {
+      "name": "Check package info with natural phrasing",
+      "verdict": "PASS"
+    },
+    "89": {
+      "name": "Install snap on beta channel",
+      "verdict": "PASS"
+    },
+    "90": {
+      "name": "Get netplan config with alternative phrasing",
+      "verdict": "PASS"
+    },
+    "91": {
+      "name": "a shell-metacharacter injection in the intent",
+      "verdict": "PASS"
+    },
+    "92": {
+      "name": "port 0 is reserved and must never become a raw",
+      "verdict": "PASS"
+    },
+    "93": {
+      "name": "\"install a snap\" names no snap. The planner must",
+      "verdict": "PASS"
+    },
+    "94": {
+      "name": "Search apt with different phrasing",
+      "verdict": "PASS"
+    },
+    "95": {
+      "name": "Install multiple essential tools",
+      "verdict": "PASS"
+    },
+    "96": {
+      "name": "Purge alternative phrasing",
+      "verdict": "PASS"
+    },
+    "97": {
+      "name": "Show snap details alternative phrasing",
+      "verdict": "PASS"
+    },
+    "98": {
+      "name": "Allow a ufw app profile",
+      "verdict": "PASS"
+    },
+    "99": {
+      "name": "Firewall status alternative phrasing",
+      "verdict": "PASS"
+    }
+  },
+  "story_set": "ubuntu",
+  "surface": "groq/openai/gpt-oss-120b",
+  "totals": {
+    "failed": 0,
+    "passed": 50,
+    "rate_limited": 0,
+    "skipped": 0,
+    "total": 50
+  },
+  "version": 1
+}

--- a/tests/release/cassette-replay-parity.test.sh
+++ b/tests/release/cassette-replay-parity.test.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# The proof #182 asks for, as a comparison of two committed artifacts.
+# The proof #182 asks for, as a comparison of committed artifacts — for every
+# release that has a committed run, not just the first one.
 #
 # The replay gate exists so the story suite can run in CI with no network and no
 # spend. That is only worth anything if a replay of a cassette reproduces the run
 # that recorded it — otherwise a green replay proves the cassette is intact, not
 # that the suite passes.
 #
-# So this compares the record run against the replay run and asserts, per #182's
+# So this compares each record run against its replay run and asserts, per #182's
 # acceptance criteria:
 #
 #   * zero misses for every story that produced a successful live response.
@@ -19,88 +20,139 @@
 #     not describe the run.
 #   * no story was dropped from the family to make the numbers work: both runs
 #     cover the same story set, of the same size.
+#
+# Discovery, rather than a hardcoded release. The gate used to name
+# ubuntu-22.04 and ubuntu-jammy explicitly, so a second release could be
+# recorded, committed, and never checked. Now every `*.json` in story-runs/ is
+# required to have a `.replay.json` twin and is checked: committing a record run
+# without its replay is itself a failure, because it publishes a pass rate
+# nothing has reproduced.
+#
+# The cassette is located by CONTENT, not by name. Artifacts are named by version
+# (22.04) and cassettes by codename (jammy), and the only machine-readable link
+# between them was a prose comment in ubuntu-vm.conf. Since the gate already has
+# to prove the replay ran against the committed cassette, it identifies the
+# cassette by the sha256 the replay recorded — which is that proof, and needs no
+# name map to drift.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-RECORD="$ROOT/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json"
-REPLAY="$ROOT/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json"
-CASSETTE="$ROOT/tests/e2e/cassettes/ubuntu-jammy-gpt-oss-120b.json"
+RUNS="$ROOT/tests/evidence/story-runs"
+CASSETTES="$ROOT/tests/e2e/cassettes"
 
-for f in "$RECORD" "$REPLAY" "$CASSETTE"; do
-    [ -f "$f" ] || { echo "FAIL: missing $f"; exit 1; }
-done
+[ -d "$RUNS" ] || { echo "FAIL: missing $RUNS"; exit 1; }
+[ -d "$CASSETTES" ] || { echo "FAIL: missing $CASSETTES"; exit 1; }
 
-python3 - "$RECORD" "$REPLAY" "$CASSETTE" <<'PY'
+python3 - "$RUNS" "$CASSETTES" <<'PY'
 import hashlib
 import json
 import sys
+from pathlib import Path
 
-record = json.load(open(sys.argv[1]))
-replay = json.load(open(sys.argv[2]))
-cassette_bytes = open(sys.argv[3], "rb").read()
+runs = Path(sys.argv[1])
+cassettes = Path(sys.argv[2])
+
+# Index the committed cassettes by content, so a replay artifact can name its
+# cassette by hash instead of by a filename convention.
+by_sha = {}
+for path in sorted(cassettes.glob("*.json")):
+    by_sha[hashlib.sha256(path.read_bytes()).hexdigest()] = path
+
+records = sorted(p for p in runs.glob("*.json") if not p.name.endswith(".replay.json"))
+if not records:
+    print("FAIL: no record artifacts in tests/evidence/story-runs/ — nothing is proven")
+    sys.exit(1)
 
 failures = []
+checked = []
 
-# The two runs must describe the same thing, or the comparison is meaningless.
-for field in ("story_set", "release", "distro_id", "surface"):
-    if record.get(field) != replay.get(field):
+for rec_path in records:
+    label = rec_path.stem
+    rep_path = rec_path.with_name(f"{rec_path.stem}.replay.json")
+    if not rep_path.exists():
         failures.append(
-            f"{field} differs: record={record.get(field)!r} replay={replay.get(field)!r}"
+            f"[{label}] no {rep_path.name}: this run publishes a pass rate that no "
+            "replay has reproduced"
         )
-if record["cassette_mode"] != "record":
-    failures.append(f"the record artifact is mode {record['cassette_mode']!r}")
-if replay["cassette_mode"] != "replay":
-    failures.append(f"the replay artifact is mode {replay['cassette_mode']!r}")
+        continue
 
-# Both runs cover the same stories: nothing dropped to make the gate pass.
-rec_ids, rep_ids = set(record["stories"]), set(replay["stories"])
-if rec_ids != rep_ids:
-    only_rec, only_rep = sorted(rec_ids - rep_ids), sorted(rep_ids - rec_ids)
-    failures.append(f"story sets differ — record-only {only_rec}, replay-only {only_rep}")
-if record["totals"]["total"] != replay["totals"]["total"]:
-    failures.append(
-        f"story counts differ: {record['totals']['total']} vs {replay['totals']['total']}"
+    record = json.loads(rec_path.read_text())
+    replay = json.loads(rep_path.read_text())
+
+    # The two runs must describe the same thing, or the comparison is meaningless.
+    for field in ("story_set", "release", "distro_id", "surface"):
+        if record.get(field) != replay.get(field):
+            failures.append(
+                f"[{label}] {field} differs: record={record.get(field)!r} "
+                f"replay={replay.get(field)!r}"
+            )
+    if record["cassette_mode"] != "record":
+        failures.append(f"[{label}] the record artifact is mode {record['cassette_mode']!r}")
+    if replay["cassette_mode"] != "replay":
+        failures.append(f"[{label}] the replay artifact is mode {replay['cassette_mode']!r}")
+
+    # Both runs cover the same stories: nothing dropped to make the gate pass.
+    rec_ids, rep_ids = set(record["stories"]), set(replay["stories"])
+    if rec_ids != rep_ids:
+        only_rec, only_rep = sorted(rec_ids - rep_ids), sorted(rep_ids - rec_ids)
+        failures.append(
+            f"[{label}] story sets differ — record-only {only_rec}, replay-only {only_rep}"
+        )
+    if record["totals"]["total"] != replay["totals"]["total"]:
+        failures.append(
+            f"[{label}] story counts differ: {record['totals']['total']} vs "
+            f"{replay['totals']['total']}"
+        )
+
+    # The replay must have run against a cassette that is committed beside it.
+    claimed = replay.get("cassette_sha256")
+    cassette = by_sha.get(claimed)
+    if cassette is None:
+        failures.append(
+            f"[{label}] the replay ran against a cassette that is not committed "
+            f"(sha {str(claimed)[:16]}…; committed: "
+            f"{sorted(p.name for p in by_sha.values())})"
+        )
+
+    # The criterion itself. A story that failed live has no recorded answer, so a
+    # miss for it is expected; every other story must replay.
+    passed_live = {k for k, v in record["stories"].items() if v.get("verdict") == "PASS"}
+    failed_live = sorted(rec_ids - passed_live)
+
+    regressed = sorted(
+        k for k in passed_live if replay["stories"].get(k, {}).get("verdict") != "PASS"
     )
+    if regressed:
+        failures.append(
+            f"[{label}] stories that passed live but not on replay: {regressed} — the "
+            "recording does not describe the run it came from"
+        )
 
-# The replay must have run against the cassette that is committed beside it.
-actual_sha = hashlib.sha256(cassette_bytes).hexdigest()
-if replay.get("cassette_sha256") != actual_sha:
-    failures.append(
-        "the replay ran against a different cassette than the one committed "
-        f"(artifact {str(replay.get('cassette_sha256'))[:16]}…, file {actual_sha[:16]}…)"
+    audit = replay.get("cassette_audit", {})
+    misses = audit.get("misses", 0)
+    if misses > len(failed_live):
+        failures.append(
+            f"[{label}] {misses} miss(es) but only {len(failed_live)} story/stories "
+            f"failed live ({failed_live}); at least one story with a recorded answer "
+            "still missed"
+        )
+    if audit.get("served", 0) <= 0:
+        failures.append(f"[{label}] the replay served no calls — it did not exercise the cassette")
+
+    checked.append(
+        (label, len(passed_live), len(rec_ids), audit.get("served"), misses, failed_live,
+         cassette.name if cassette else "<uncommitted>")
     )
-
-# The criterion itself. A story that failed live has no recorded answer, so a
-# miss for it is expected; every other story must replay.
-passed_live = {k for k, v in record["stories"].items() if v.get("verdict") == "PASS"}
-failed_live = sorted(rec_ids - passed_live)
-
-regressed = sorted(
-    k for k in passed_live if replay["stories"].get(k, {}).get("verdict") != "PASS"
-)
-if regressed:
-    failures.append(
-        f"stories that passed live but not on replay: {regressed} — the recording "
-        "does not describe the run it came from"
-    )
-
-audit = replay.get("cassette_audit", {})
-misses = audit.get("misses", 0)
-if misses > len(failed_live):
-    failures.append(
-        f"{misses} miss(es) but only {len(failed_live)} story/stories failed live "
-        f"({failed_live}); at least one story with a recorded answer still missed"
-    )
-if audit.get("served", 0) <= 0:
-    failures.append("the replay served no calls — it did not exercise the cassette")
 
 if failures:
     for f in failures:
         print("FAIL:", f)
     sys.exit(1)
 
-print(f"ok: {len(passed_live)}/{len(rec_ids)} stories passed live and all of them replay")
-print(f"ok: {audit.get('served')} call(s) served, {misses} miss(es), "
-      f"accounted for by {len(failed_live)} story/stories that errored live {failed_live}")
-print("ok: both runs cover the same story set, against the committed cassette")
+for label, passed, total, served, misses, failed_live, cassette in checked:
+    print(f"ok: [{label}] {passed}/{total} stories passed live and all of them replay")
+    print(f"ok: [{label}] {served} call(s) served, {misses} miss(es), accounted for by "
+          f"{len(failed_live)} story/stories that errored live {failed_live}, "
+          f"against committed {cassette}")
+print(f"ok: {len(checked)} release run(s) checked, each against the cassette it recorded")
 PY

--- a/tests/release/public-claims.test.sh
+++ b/tests/release/public-claims.test.sh
@@ -33,11 +33,16 @@ fixture_files=(
     # every assert_rejected below would pass for the wrong reason.
     "tests/evidence/workspace-tests.json"
     "crates/sysknife-brain/src/planning_tools/propose_plan.rs"
-    # The committed story run that backs the published pass rate. Without it the
-    # pristine fixture fails, because README's figure would have no evidence — the
-    # guard working, but on the fixture rather than on a real claim.
-    "tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json"
 )
+
+# The committed story runs that back the published pass rates and decide which
+# releases may be tiered "Validated". Copied as a set rather than named one by
+# one: naming them meant the fixture held 22.04's record run and not its replay,
+# so the tier rule — which requires a record AND a replay — saw no verified
+# release at all, and a doc stating the accurate tier would have failed the
+# pristine check for a reason that had nothing to do with the doc.
+mkdir -p "$fixture/tests/evidence/story-runs"
+cp "$repo_root"/tests/evidence/story-runs/*.json "$fixture/tests/evidence/story-runs/"
 for rel in "${fixture_files[@]}"; do
     mkdir -p "$fixture/$(dirname "$rel")"
     cp "$repo_root/$rel" "$fixture/$rel"
@@ -199,11 +204,26 @@ if ! "$checker" "$fixture" >/dev/null 2>&1; then
 fi
 cp "$repo_root/docs/introduction.md" "$fixture/docs/introduction.md"
 
-# Flip the bolded 22.04 launch-matrix tier to Validated — the guard must reject
-# it even in distro-support.md's `**Ubuntu 22.04 LTS** … **Validated**` shape.
-sed -i '/Ubuntu 22\.04 LTS/ s/\*\*Smoke-tested\*\*/**Validated**/' \
-    "$fixture/docs/distro-support.md"
-assert_rejected 'Ubuntu 22.04 marked validated in bolded launch matrix'
+# The tier rule, in both directions. Which releases may be called "Validated" is
+# derived from the replay-verified pairs on disk, so the mutations have to attack
+# the derivation rather than a hardcoded release name.
+#
+# 1. A release with no committed run at all. 20.04 is named in the install docs
+#    as supported, which is exactly the kind of release someone would promote to
+#    Validated by hand.
+printf '\n| **Ubuntu 20.04 LTS** | apt family | full | **Validated** |\n' \
+    >> "$fixture/docs/distro-support.md"
+assert_rejected 'a release with no committed run tiered Validated'
 cp "$repo_root/docs/distro-support.md" "$fixture/docs/distro-support.md"
+
+# 2. A release whose record run is committed but whose replay is not. The pass
+#    rate exists, nothing has reproduced it, and the parity gate never sees it —
+#    so the tier is not earned. Deleting the replay twin must take the tier away
+#    from a release the pristine fixture accepts, which also proves the rule is
+#    reading the replay and not merely the presence of a file named for the
+#    release.
+rm -f "$fixture"/tests/evidence/story-runs/ubuntu-22.04-*.replay.json
+assert_rejected 'a release tiered Validated with its record run but no replay'
+cp "$repo_root"/tests/evidence/story-runs/*.json "$fixture/tests/evidence/story-runs/"
 
 printf 'Public claims contract passed.\n'


### PR DESCRIPTION
Only 22.04 had ever run the live story suite. The matrix said otherwise, and inverted: 24.04 was tiered **Validated** while its own evidence cell admitted *"the committed run is 22.04, 24.04 not yet re-recorded"*, and 22.04 — the release with the actual run — was tiered Smoke-tested.

So the suite ran on the two releases that never had it, recording both halves for each:

| Release | Codename | Live | Replay | Cassette misses |
|---|---|---|---|---|
| 22.04 | jammy | 49/50 | 49/50 | 1 (story 101 errored live) |
| 24.04 | noble | **49/50** | 49/50 | 1 (story 101 errored live) |
| 26.04 | resolute | **50/50** | 50/50 | **0** |

Every release now has a record run and a replay twin that reproduces it.

### Story 101 is provider-side, not a distro difference

The one story missing from 22.04 and 24.04 is the same one, and it **passed on 26.04**. The model returns a malformed tool call, the planner exhausts its retries, and the story gets no plan at all — its log holds the header line and nothing else, where a passing story's log holds the plan JSON.

This is documented in `docs/contributing/ubuntu-vm-testing.md`, because it changes how a run should be read. The first 24.04 recording came in at 46/50; re-running those four stories individually passed three (65, 66, 71) and failed 101 again. Those three were transient provider errors. **A single run is not a pass rate**, and both runs are reported rather than only the better one.

### Both gates were pinned to the one release that existed when they were written

- **`cassette-replay-parity`** now discovers every record/replay pair in `story-runs/` instead of naming `ubuntu-22.04`, so a second release can no longer be recorded, committed, and never checked. It also requires every record run to *have* a replay twin — committing one without the other publishes a pass rate nothing has reproduced. The cassette is located by **content hash**, not filename: artifacts are named by version and cassettes by codename, and the only link between them was a prose comment in `ubuntu-vm.conf`.

- **Which releases may be tiered Validated is now derived** from those pairs. It used to be a hardcoded `reject_pattern` naming 22.04 and 26.04 as "smoke-tested, not launch-validated" — the same hand-maintained blacklist the numeric guards were rewritten to remove, aged into something worse than stale: **it forbade the truth.** With five live runs behind 22.04 the accurate tier was unwritable, and the only ways to go green were to understate the evidence or delete the rule. A release now earns its tier by having a run committed.

### Mutation tests move with the rule

Marking a release with no committed run as Validated must be rejected, and so must marking one whose record run is committed but whose replay is not. The fixture now copies `story-runs/` as a set rather than naming one file — that omission is why the tier rule initially saw no verified release at all.

Verified: full pre-commit gate (fmt, clippy `--all-features --all-targets`, `cargo doc -D warnings`, 1,743 tests), plus the parity gate across all three pairs and the public-claims contract including both new mutations. New artifacts were scanned for credentials before commit; none present.