### PR TITLE
fix: make five comments, the retry, the fence log and the harness tell the truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04 at 49/50, 24.04 at 50/50, 26.04 at 50/50, each with a replay twin | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,746 Rust tests and 72 frontend tests** form the current deterministic
+**1,750 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04 at 49/50, 24.04 at 50/50, 26.04 at 50/50, each with a replay twin | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,745 Rust tests and 72 frontend tests** form the current deterministic
+**1,746 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/src/cli.rs
+++ b/apps/sysknife-cli/src/cli.rs
@@ -91,9 +91,12 @@ pub enum Command {
 
     /// Start an MCP server over stdio.
     ///
-    /// Exposes `sysknife_plan` and `sysknife_execute` tools so Claude Code,
-    /// Claude Desktop, Cursor, and any other MCP-capable agent can plan and
-    /// execute Linux administration tasks via the SysKnife daemon.
+    /// Exposes five tools — `sysknife_plan`, `sysknife_execute`,
+    /// `sysknife_history`, `sysknife_doctor` and `sysknife_audit_verify` — so
+    /// Claude Code, Claude Desktop, Cursor, and any other MCP-capable agent can
+    /// plan and execute Linux administration tasks via the SysKnife daemon.
+    /// `tests/mcp_stdio.rs` pins that exact set; anyone building an allowlist or
+    /// reviewing the exposed surface should read it from there, not from prose.
     ///
     /// Add to `claude_desktop_config.json`:
     ///   { "mcpServers": { "sysknife": { "command": "sysknife", "args": ["mcp-server"] } } }

--- a/crates/sysknife-brain/src/action_name.rs
+++ b/crates/sysknife-brain/src/action_name.rs
@@ -1,11 +1,18 @@
 //! `ActionName` newtype — a string that is guaranteed to be in the
 //! approved SysKnife action catalogue.
 //!
-//! The type itself lives in `sysknife-types::ActionName` so the
-//! `RequestEnvelope` deserializer can validate at the IPC boundary (and
-//! so other crates do not have to depend on `sysknife-brain` just to
-//! talk about action names). This module re-exports the type so existing
+//! The type itself lives in `sysknife-types::ActionName` so other crates do
+//! not have to depend on `sysknife-brain` just to talk about action names.
+//! This module re-exports it so existing
 //! `use sysknife_brain::action_name::ActionName` imports continue to work.
+//!
+//! It does NOT validate at the IPC boundary, which this comment used to
+//! claim. `RequestEnvelope::action_name` is a plain `String` and is not
+//! checked at deserialization time — see the note on it in
+//! `sysknife-types`. Validation happens downstream, via `ActionName::parse`,
+//! which the daemon performs before acting on a request. The distinction
+//! matters: believing malformed names are already rejected on arrival is
+//! exactly the premise under which someone would weaken that later check.
 
 pub use sysknife_types::{ActionName, UnknownActionName, KNOWN_ACTION_NAMES};
 

--- a/crates/sysknife-brain/src/audit.rs
+++ b/crates/sysknife-brain/src/audit.rs
@@ -1,9 +1,22 @@
 //! Append-only JSON-lines audit log for safety fence activations.
 //!
-//! Every time the planning safety fence rejects a plan (unknown action name,
-//! invalid risk level, etc.), the rejection is logged as a single JSON line.
-//! This provides a persistent, structured record of all fence activations
-//! for post-hoc audit and debugging.
+//! Every time the planning safety fence rejects something the model produced,
+//! the rejection is logged as a single JSON line. This provides a persistent,
+//! structured record of all fence activations for post-hoc audit and debugging.
+//!
+//! "All" is now literal. There are three paths that reject model output, and
+//! this used to record only the first:
+//!
+//! 1. `propose_plan` rejected — unknown action name, invalid risk level, a
+//!    fenced action for the wrong distro family.
+//! 2. `refuse` called with no reason — a refusal the planner will not accept.
+//! 3. an unknown tool name — the model went off-protocol entirely.
+//!
+//! Paths 2 and 3 printed to stderr and recorded nothing, which made this file
+//! misleading in the worst direction: a reviewer reading `safety-audit.jsonl`
+//! as the complete record of anomalous model behaviour saw a quieter picture
+//! than the truth, and the missing class in path 3 is precisely the one that
+//! says the model stopped following the protocol.
 //!
 //! The default log path is `$XDG_DATA_HOME/sysknife/safety-audit.jsonl`
 //! (falling back to `~/.local/share/sysknife/safety-audit.jsonl`).

--- a/crates/sysknife-brain/src/planner.rs
+++ b/crates/sysknife-brain/src/planner.rs
@@ -87,6 +87,42 @@ const PROVIDER_RETRY_BACKOFF: Duration = Duration::from_millis(400);
 /// is how a rate limit turns into a rate-limit loop.
 const PROVIDER_RETRY_RATE_LIMIT_BACKOFF: Duration = Duration::from_millis(2_000);
 
+/// Markers that identify "the model called a tool that does not exist".
+///
+/// Groq reports this as `code: "tool_use_failed"` with a message naming the tool
+/// it refused, e.g. `attempted to call tool 'json' which was not in
+/// request.tools`. Both halves are matched because providers word it
+/// differently and neither string is one we control; matching either is enough,
+/// and a false positive costs one extra sentence in a retry that was already
+/// going to happen.
+const INVALID_TOOL_CALL_MARKERS: &[&str] = &["tool_use_failed", "was not in request.tools"];
+
+/// The sentence to add before retrying a call the provider rejected because the
+/// model named a nonexistent tool.
+///
+/// Returns `None` for every other error, so an ordinary 502 or timeout still
+/// retries the request unchanged — resending is the correct response when the
+/// request was never the problem.
+fn tool_call_correction(error: &ProviderError, tools: &[ToolDefinition]) -> Option<String> {
+    let text = error.to_string().to_lowercase();
+    if !INVALID_TOOL_CALL_MARKERS
+        .iter()
+        .any(|m| text.contains(&m.to_lowercase()))
+    {
+        return None;
+    }
+
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    Some(format!(
+        "Your previous response was rejected: it called a tool that does not exist. \
+         Call one of these tools by its exact name: {}. \
+         Emit a real tool call, not a JSON object describing one, and do not wrap \
+         the call in another name. If the plan you had in mind was correct, send \
+         the same plan through `propose_plan`.",
+        names.join(", ")
+    ))
+}
+
 /// Maximum byte length accepted for a natural-language intent.
 ///
 /// 2 KB covers any realistic user request. Values larger than this are
@@ -960,10 +996,13 @@ impl LlmPlanner {
         tools: &[ToolDefinition],
     ) -> Result<Completion, ProviderError> {
         let mut attempt: u32 = 0;
+        // Owned, because a retry may need to say something the first attempt did
+        // not. See `tool_call_correction` below.
+        let mut messages: Vec<Message> = messages.to_vec();
         loop {
             let error = match self
                 .provider
-                .complete(system, messages, tools, PLANNING_MAX_TOKENS)
+                .complete(system, &messages, tools, PLANNING_MAX_TOKENS)
                 .await
             {
                 Ok(completion) => return Ok(completion),
@@ -972,6 +1011,18 @@ impl LlmPlanner {
 
             if !error.is_retryable() || attempt >= PROVIDER_RETRY_LIMIT {
                 return Err(error);
+            }
+
+            // Some failures are the model's output being malformed rather than
+            // our request being wrong, and for those a plain retry is not a
+            // retry at all: the request is byte-identical, so the model
+            // reproduces the same malformed answer. Observed live on Groq, three
+            // attempts in a row naming a tool called `json` whose arguments were
+            // a perfectly good plan — the three `failed_generation` payloads
+            // differed only in prose wording. Changing the input is the whole
+            // point, so say what went wrong before asking again.
+            if let Some(correction) = tool_call_correction(&error, tools) {
+                messages.push(Message::user_text(correction));
             }
 
             if let Some(ref rl) = self.rate_limiter {
@@ -1199,6 +1250,20 @@ impl LlmPlanner {
                                             turn + 1,
                                             max = self.max_turns
                                         );
+                                        // audit.rs promises a record of ALL fence
+                                        // activations. This path printed and did not
+                                        // record, so a reviewer treating
+                                        // safety-audit.jsonl as complete silently
+                                        // missed every reasonless refusal.
+                                        if let Some(audit) = self.audit_log.clone() {
+                                            audit
+                                                .log_rejection_async(
+                                                    intent.to_string(),
+                                                    reason.clone(),
+                                                    input.to_string(),
+                                                )
+                                                .await;
+                                        }
                                         tool_results.push(ToolResultBlock {
                                             tool_use_id: id.clone(),
                                             call_id: call_id.clone(),
@@ -1346,7 +1411,10 @@ impl LlmPlanner {
                                         // An unknown tool call is a protocol violation — log
                                         // it as a safety event and feed the error back so the
                                         // LLM has a chance to recover within the remaining
-                                        // turns.
+                                        // turns. The logging half of that sentence was missing:
+                                        // this printed to stderr only, so the one fence event
+                                        // that says "the model went off-protocol" was the one
+                                        // absent from the audit trail.
                                         eprintln!(
                                             "[SYSKNIFE WARNING] LLM called unknown tool \
                                              '{other_name}' (turn {}/{max}); sending error \
@@ -1354,6 +1422,15 @@ impl LlmPlanner {
                                             turn + 1,
                                             max = self.max_turns
                                         );
+                                        if let Some(audit) = self.audit_log.clone() {
+                                            audit
+                                                .log_rejection_async(
+                                                    intent.to_string(),
+                                                    format!("unknown tool: {other_name}"),
+                                                    input.to_string(),
+                                                )
+                                                .await;
+                                        }
                                         tool_results.push(ToolResultBlock {
                                             tool_use_id: id.clone(),
                                             call_id: call_id.clone(),

--- a/crates/sysknife-brain/tests/planner.rs
+++ b/crates/sysknife-brain/tests/planner.rs
@@ -2066,3 +2066,209 @@ async fn a_reasonless_refusal_is_retried_rather_than_accepted() {
         .expect("the model must get another turn after an invalid refusal");
     assert_eq!(plan.summary(), "install vim");
 }
+
+// ---------------------------------------------------------------------------
+// Provider retry: recovering from a rejected tool call
+// ---------------------------------------------------------------------------
+
+/// Records the messages of every call, so a test can assert what the retry
+/// actually sent rather than only that a retry happened.
+struct MessageRecordingProvider {
+    turns: Mutex<VecDeque<Result<Completion, ProviderError>>>,
+    seen: Arc<Mutex<Vec<Vec<String>>>>,
+}
+
+impl MessageRecordingProvider {
+    fn new(
+        turns: impl IntoIterator<Item = Result<Completion, ProviderError>>,
+    ) -> (Self, Arc<Mutex<Vec<Vec<String>>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let p = Self {
+            turns: Mutex::new(turns.into_iter().collect()),
+            seen: Arc::clone(&seen),
+        };
+        (p, seen)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for MessageRecordingProvider {
+    async fn complete(
+        &self,
+        _system: &str,
+        messages: &[Message],
+        _tools: &[ToolDefinition],
+        _max_tokens: u32,
+    ) -> Result<Completion, ProviderError> {
+        let rendered: Vec<String> = messages
+            .iter()
+            .flat_map(|m| m.content.iter())
+            .filter_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
+        self.seen.lock().unwrap().push(rendered);
+        self.turns
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| Err(ProviderError::Parse("provider exhausted".into())))
+    }
+}
+
+/// The Groq rejection that motivated this: the model emitted a tool call named
+/// `json` whose arguments were a perfectly good plan, and the provider refused
+/// it. Retrying the identical request reproduced it three times.
+fn tool_use_failed_error() -> ProviderError {
+    ProviderError::Request(
+        "ProviderResponseError: {\"error\":{\"message\":\"Tool call validation failed: \
+         attempted to call tool 'json' which was not in request.tools\",\
+         \"code\":\"tool_use_failed\",\"status_code\":400}}"
+            .into(),
+    )
+}
+
+#[tokio::test]
+async fn a_rejected_tool_call_is_retried_with_a_correction_not_the_same_bytes() {
+    let (provider, seen) = MessageRecordingProvider::new([
+        Err(tool_use_failed_error()),
+        propose_plan(
+            "Inspect system",
+            &[("GetSystemState", "Read current deployment", "low")],
+        ),
+    ]);
+    let planner = LlmPlanner::new(Box::new(provider), Box::new(MockStateClient::default()), 3);
+
+    let plan = planner.plan_intent("inspect the system").await.unwrap();
+    assert_eq!(plan.steps()[0].action_name(), "GetSystemState");
+
+    let calls = seen.lock().unwrap().clone();
+    assert_eq!(
+        calls.len(),
+        2,
+        "expected one retry, got {} call(s)",
+        calls.len()
+    );
+
+    // The whole point: the second request differs from the first.
+    assert_ne!(
+        calls[0], calls[1],
+        "the retry sent byte-identical messages, so the model has no reason to \
+         answer differently — this is the bug, not the fix"
+    );
+    let correction = calls[1].last().expect("retry carried no message");
+    assert!(
+        correction.contains("called a tool that does not exist"),
+        "retry did not explain the rejection: {correction}"
+    );
+    assert!(
+        correction.contains("propose_plan"),
+        "the correction must name the tools that DO exist: {correction}"
+    );
+}
+
+#[tokio::test]
+async fn an_ordinary_transport_failure_is_retried_unchanged() {
+    // A 502 says nothing about the request, so resending it verbatim is right.
+    // Appending a correction there would be noise in the conversation and would
+    // teach the model that a network blip was its fault.
+    let (provider, seen) = MessageRecordingProvider::new([
+        Err(ProviderError::Http {
+            status: 502,
+            body: "bad gateway".into(),
+        }),
+        propose_plan(
+            "Inspect system",
+            &[("GetSystemState", "Read current deployment", "low")],
+        ),
+    ]);
+    let planner = LlmPlanner::new(Box::new(provider), Box::new(MockStateClient::default()), 3);
+
+    planner.plan_intent("inspect the system").await.unwrap();
+
+    let calls = seen.lock().unwrap().clone();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(
+        calls[0], calls[1],
+        "a transport failure must be retried unchanged; only a rejected tool call \
+         earns a correction"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Safety audit log — the two paths that used to print without recording
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_reasonless_refusal_is_written_to_the_safety_audit_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("safety-audit.jsonl");
+
+    // `refuse` with no reason is a fence activation. It printed to stderr and
+    // recorded nothing, so a reviewer treating safety-audit.jsonl as the
+    // complete record of fence activations — which audit.rs promises — missed
+    // every one of them.
+    let planner = LlmPlanner::new(
+        Box::new(MockProvider::new([
+            tool_call("tu_refuse", "refuse", serde_json::json!({})),
+            propose_plan(
+                "Inspect system",
+                &[("GetSystemState", "Read current deployment", "low")],
+            ),
+        ])),
+        Box::new(MockStateClient::default()),
+        3,
+    )
+    .with_audit_log(SafetyAuditLog::new(&log_path));
+
+    planner.plan_intent("inspect the system").await.unwrap();
+
+    let content = std::fs::read_to_string(&log_path).unwrap_or_default();
+    assert_eq!(
+        content.lines().count(),
+        1,
+        "the reasonless refusal was not recorded; log was: {content:?}"
+    );
+    let entry: serde_json::Value = serde_json::from_str(content.lines().next().unwrap()).unwrap();
+    assert_eq!(entry["event"], "safety_fence_rejection");
+    assert_eq!(entry["intent"], "inspect the system");
+}
+
+#[tokio::test]
+async fn an_unknown_tool_call_is_written_to_the_safety_audit_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("safety-audit.jsonl");
+
+    // The comment on this path already said "log it as a safety event". It did
+    // not. Of all the fence events, the one saying the model went off-protocol
+    // entirely was the one missing from the trail.
+    let planner = LlmPlanner::new(
+        Box::new(MockProvider::new([
+            tool_call("tu_x", "definitely_not_a_tool", serde_json::json!({})),
+            propose_plan(
+                "Inspect system",
+                &[("GetSystemState", "Read current deployment", "low")],
+            ),
+        ])),
+        Box::new(MockStateClient::default()),
+        3,
+    )
+    .with_audit_log(SafetyAuditLog::new(&log_path));
+
+    planner.plan_intent("inspect the system").await.unwrap();
+
+    let content = std::fs::read_to_string(&log_path).unwrap_or_default();
+    assert_eq!(
+        content.lines().count(),
+        1,
+        "the unknown tool call was not recorded; log was: {content:?}"
+    );
+    let entry: serde_json::Value = serde_json::from_str(content.lines().next().unwrap()).unwrap();
+    assert!(
+        entry["reason"]
+            .as_str()
+            .is_some_and(|r| r.contains("definitely_not_a_tool")),
+        "the record must name the tool that was called: {entry}"
+    );
+}

--- a/crates/sysknife-daemon/src/actions/resolvectl.rs
+++ b/crates/sysknife-daemon/src/actions/resolvectl.rs
@@ -48,8 +48,10 @@ pub fn resolvectl_status() -> ActionSpec {
 
 /// Set DNS servers for a network interface (`sudo resolvectl dns <iface> <server>…`).
 ///
-/// Risk: Medium. Changes DNS resolution for the named interface; affects all
+/// Risk: High. Changes DNS resolution for the named interface; affects all
 /// processes resolving names through systemd-resolved on that interface.
+/// Redirecting DNS is a MitM primitive, which is why the spec below gates it at
+/// High and Admin, matching `SetDnsServers`.
 /// Cross-distro: works on any systemd-resolved host.
 ///
 /// `interface` is the network interface name (e.g. `"eth0"`, `"wlp1s0"`).

--- a/crates/sysknife-daemon/src/audit_chain.rs
+++ b/crates/sysknife-daemon/src/audit_chain.rs
@@ -46,8 +46,13 @@
 //! - **Status mutations are not in the chain.** The mutable `status` field
 //!   is intentionally excluded — the chain protects the *authorisation
 //!   decision* (immutable fields captured at insert time), not the live
-//!   execution state. A future append-only `audit_events` table will
-//!   chain status transitions if the threat model demands it.
+//!   execution state. Status transitions ARE chained, separately: the
+//!   append-only `audit_events` table exists (created by migration v2 in
+//!   `transactions.rs`) and `verify_event_chain` / `verify_event_binding`
+//!   below verify it. This paragraph described that as future work long
+//!   after it shipped, which is worse than saying nothing — a reader would
+//!   conclude the capability is missing and either duplicate it or assume
+//!   status history is unprotected.
 //!
 //! ## Key management
 //!

--- a/crates/sysknife-daemon/src/store.rs
+++ b/crates/sysknife-daemon/src/store.rs
@@ -19,14 +19,23 @@
 //!
 //! See `docs/storage-cloud.md` for the full table. Summary:
 //!
+//! These three rows said `require` until they were checked against the code.
+//! `pg_tls::require_tls_for_remote` REFUSES `sslmode=require` on any connection
+//! that crosses the network, because `require` completes TLS against any
+//! certificate and so authenticates nothing. An operator following the old table
+//! got a hard startup refusal, and the obvious way to "fix" that is to loosen the
+//! check — which reopens the MITM hole the check exists to close. Supabase and
+//! Neon both publish CA chains, so `verify-full` is what they support and what
+//! this daemon accepts.
+//!
 //! | Provider             | URL hint                                        | TLS mode      | Statement cache |
 //! |----------------------|-------------------------------------------------|---------------|-----------------|
 //! | AWS RDS / Aurora     | `*.rds.amazonaws.com:5432`                      | `verify-full` | default         |
 //! | GCP Cloud SQL        | via Cloud SQL Auth Proxy on `127.0.0.1`         | `disable`     | default         |
 //! | Azure Flexible       | `*.postgres.database.azure.com:5432`            | `verify-full` | default         |
-//! | Supabase (5432)      | `db.<ref>.supabase.co:5432`                     | `require`     | default         |
-//! | Supabase (pooler)    | `*.pooler.supabase.com:6543`                    | `require`     | **0**           |
-//! | Neon                 | `ep-*.neon.tech`                                | `require`     | default         |
+//! | Supabase (5432)      | `db.<ref>.supabase.co:5432`                     | `verify-full` | default         |
+//! | Supabase (pooler)    | `*.pooler.supabase.com:6543`                    | `verify-full` | **0**           |
+//! | Neon                 | `ep-*.neon.tech`                                | `verify-full` | default         |
 //! | Self-hosted          | (operator chooses)                              | as needed     | default         |
 
 use async_trait::async_trait;

--- a/crates/sysknife-daemon/tests/prompt_risk_labels.rs
+++ b/crates/sysknife-daemon/tests/prompt_risk_labels.rs
@@ -134,6 +134,88 @@ fn prompt_risk_tables_match_the_action_specs() {
     );
 }
 
+/// The other place a risk level is written in prose: the doc comment above each
+/// action's spec.
+///
+/// `resolvectl.rs` said `/// Risk: Medium.` two lines above
+/// `risk_level: RiskLevel::High`, and the surrounding comment even justified
+/// High. Citing that doc line — the natural thing to do when writing a table or
+/// answering "how risky is this?" — understated a DNS-hijack primitive as
+/// Dev-accessible.
+///
+/// Each `Risk: <level>` doc line is paired with the next `risk_level:` in the
+/// same file. That pairing is what the convention already implies (the doc sits
+/// directly above the spec it describes) and it holds for all 68 of them, so a
+/// failure here means either the level is wrong or the doc line has drifted away
+/// from the spec it belongs to. Both are worth a human look.
+#[test]
+fn doc_comment_risk_levels_match_the_spec_below_them() {
+    const NEEDLE: &str = "Risk: ";
+    const SPEC: &str = "risk_level: RiskLevel::";
+
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/actions");
+    let mut wrong = Vec::new();
+    let mut checked = 0usize;
+
+    let mut files: Vec<_> = std::fs::read_dir(&dir)
+        .expect("actions dir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "rs"))
+        .collect();
+    files.sort();
+
+    for path in files {
+        let src = std::fs::read_to_string(&path).expect("read action module");
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let lines: Vec<&str> = src.lines().collect();
+
+        for (i, line) in lines.iter().enumerate() {
+            if !line.trim_start().starts_with("///") {
+                continue;
+            }
+            let Some(rest) = line.split(NEEDLE).nth(1) else {
+                continue;
+            };
+            let claimed = ["Low", "Medium", "High"]
+                .into_iter()
+                .find(|lvl| rest.starts_with(lvl));
+            let Some(claimed) = claimed else { continue };
+            checked += 1;
+
+            // The spec this doc line sits above.
+            let actual = lines[i + 1..].iter().find_map(|l| {
+                l.split(SPEC).nth(1).and_then(|r| {
+                    ["Low", "Medium", "High"]
+                        .into_iter()
+                        .find(|l| r.starts_with(l))
+                })
+            });
+            if let Some(actual) = actual {
+                if actual != claimed {
+                    wrong.push(format!(
+                        "  {name}:{}: doc says Risk: {claimed}, the spec below says {actual}",
+                        i + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        checked > 50,
+        "only {checked} doc risk lines were found; the comment convention must have \
+         changed and this guard is no longer looking at anything"
+    );
+    assert!(
+        wrong.is_empty(),
+        "{} doc comment(s) state a risk their own spec contradicts:\n{}\n\
+         The ActionSpec is the authority. If the pairing itself is wrong, move the \
+         doc line back above the spec it describes.",
+        wrong.len(),
+        wrong.join("\n")
+    );
+}
+
 /// The parse has to actually find the tables. Without this, a heading rename
 /// would silently reduce the guard above to asserting nothing — the failure mode
 /// where a green test proves only that it looked at an empty set.

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,745 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,746 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,746 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,750 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -142,7 +142,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,745 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,746 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -142,7 +142,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,746 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,750 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/e2e/run-stories.sh
+++ b/tests/e2e/run-stories.sh
@@ -242,10 +242,36 @@ fi
 # (91 to 93) accept an empty plan, so a rate-limited run makes them pass while
 # proving nothing. Reporting that as PASS is how a throttled suite reads as a
 # healthy one.
+#
+# Two different limiters can stop a story, and only one of them was detected.
+# The pattern below used to be `rate limit exceeded` alone, which is SysKnife's
+# OWN limiter talking. The provider has its own ceiling and words it nothing
+# like that: Groq returns `429 Too Many Requests` with
+# `"code":"rate_limit_exceeded"` and a message beginning `Rate limit reached`.
+# So a provider 429 fell through as an ordinary story failure, and the summary
+# still printed `0 rate-limited` — which is how three suites recorded in
+# parallel produced a believable, wrong 48/50 on 22.04. The binding ceiling
+# there was TOKENS per minute, not requests, so no amount of SYSKNIFE_MAX_RPM
+# tuning would have avoided it; running one release at a time does.
 story_was_rate_limited() {
   local n="$1" log="$2"
-  grep -qi 'rate limit exceeded' "$log" 2>/dev/null && return 0
-  grep -qi 'rate limit exceeded' "/tmp/sysknife-story-${n}-stderr.log" 2>/dev/null
+  local pattern='rate limit exceeded|rate_limit_exceeded|rate limit reached|429 too many requests'
+  grep -qiE "$pattern" "$log" 2>/dev/null && return 0
+  grep -qiE "$pattern" "/tmp/sysknife-story-${n}-stderr.log" 2>/dev/null
+}
+
+# Which limiter it was, so the report names a remedy that exists. SysKnife's own
+# limiter is raised with SYSKNIFE_MAX_RPM; the provider's is not raisable from
+# here at all.
+story_rate_limit_source() {
+  local n="$1" log="$2"
+  local provider='rate_limit_exceeded|rate limit reached|429 too many requests'
+  if grep -qiE "$provider" "$log" 2>/dev/null ||
+    grep -qiE "$provider" "/tmp/sysknife-story-${n}-stderr.log" 2>/dev/null; then
+    printf 'provider'
+  else
+    printf 'planner'
+  fi
 }
 
 run_story() {
@@ -272,7 +298,7 @@ run_story() {
     if story_was_rate_limited "$n" "$log"; then
       # Overrides the story's own verdict on purpose. It never saw a plan.
       RESULTS[$n]="RATELIMIT"
-      MESSAGES[$n]="planner rate limit hit; this result is not evidence"
+      MESSAGES[$n]="$(story_rate_limit_source "$n" "$log") rate limit hit; this result is not evidence"
       DURATIONS[$n]="0.0"
       echo "RATELIMIT"
     elif [[ "$last_line" == SKIP* ]]; then
@@ -294,7 +320,7 @@ run_story() {
     DURATIONS[$n]=$(echo "$end_time - $start_time" | bc 2>/dev/null || echo "?")
     if story_was_rate_limited "$n" "$log"; then
       RESULTS[$n]="RATELIMIT"
-      MESSAGES[$n]="planner rate limit hit; this result is not evidence"
+      MESSAGES[$n]="$(story_rate_limit_source "$n" "$log") rate limit hit; this result is not evidence"
       echo "RATELIMIT"
       return
     fi
@@ -371,10 +397,17 @@ echo ""
 echo "Summary: $pass_count/$total passed, $fail_count failed, $skip_count skipped, $ratelimit_count rate-limited"
 if [[ $ratelimit_count -gt 0 ]]; then
   echo ""
-  echo "  $ratelimit_count story/stories never reached the model: the planner's own"
-  echo "  rate limit (DEFAULT_MAX_RPM, 20 requests/minute) rejected them. Those"
-  echo "  results say nothing about the model and must not be counted either way."
-  echo "  Raise it for a full-suite run, e.g. SYSKNIFE_MAX_RPM=120."
+  echo "  $ratelimit_count story/stories never reached the model, so those results"
+  echo "  say nothing about it and must not be counted either way. Each is labelled"
+  echo "  with which limiter stopped it:"
+  echo ""
+  echo "    planner  — SysKnife's own limiter (DEFAULT_MAX_RPM, 20/minute)."
+  echo "               Raise it for a full-suite run: SYSKNIFE_MAX_RPM=120."
+  echo "    provider — the API's ceiling, which SYSKNIFE_MAX_RPM cannot raise."
+  echo "               Groq's binding limit is TOKENS per minute, and one planning"
+  echo "               call carries the whole prompt plus the action catalogue, so"
+  echo "               concurrent suites exceed it long before the request rate"
+  echo "               looks high. Record one release at a time; replays are free."
 fi
 echo "Logs:    $LOG_DIR/"
 echo ""

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "c57232956e6aa3b6332402b3c54e26ab65ca83ee"
+    "tests": "86771d0786a0c169eab4adf3a270925b84bd973c"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-13T04:59:40-06:00"
+    "tests": "2026-08-13T06:38:30-06:00"
   },
-  "tests": 1745,
+  "tests": 1746,
   "version": 1
 }

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "86771d0786a0c169eab4adf3a270925b84bd973c"
+    "tests": "af252145563cd406aa789797aa9a0dbba68f3e82"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-13T06:38:30-06:00"
+    "tests": "2026-08-13T06:53:59-06:00"
   },
-  "tests": 1746,
+  "tests": 1750,
   "version": 1
 }


### PR DESCRIPTION
Everything the earlier sweeps found and I had verified but not acted on. Three commits, each self-contained.

### 1. Five comments that contradicted their own code

- **`store.rs`** recommended `sslmode=require` for Supabase and Neon. Not a suboptimal suggestion — an instruction that *fails*: `pg_tls::require_tls_for_remote` **refuses** `require` on any connection crossing the network, because `require` completes TLS against any certificate and authenticates nothing. An operator following it got a hard startup refusal, and the obvious way to make that go away is to loosen the check, reopening the MITM hole it exists to close. `docs/storage-cloud.md` said `verify-full` all along; only the summary drifted.
- **`cli.rs`** said the MCP server exposes 2 tools. It exposes 5. Anyone building an allowlist from that comment missed three live tools.
- **`audit_chain.rs`** called chained status transitions "a future append-only `audit_events` table". That table shipped in migration v2, and its verifiers sit in the same file as the paragraph calling them hypothetical.
- **`action_name.rs`** claimed the `RequestEnvelope` deserializer "can validate at the IPC boundary". `sysknife-types` says the opposite: it's a plain `String`, validated downstream via `ActionName::parse`. That inversion is the premise under which someone weakens the real check.
- **`resolvectl.rs`** said `Risk: Medium` two lines above `RiskLevel::High`.

That last one is **guarded**, not just fixed: 68 `Risk:` doc lines exist across the action modules and exactly one contradicted its spec, so the convention is worth keeping and checking. `doc_comment_risk_levels_match_the_spec_below_them` pairs each with the next `risk_level:` and compares, and asserts it found >50 so a style change can't reduce it to asserting nothing. Mutation-checked.

### 2. The retry could not recover the failure it most often faced

`complete_with_retry` re-sent byte-identical requests. Right for a 502; useless for the live Groq failure where the model emits a tool call named `json` — arguments a perfectly good plan — and re-sending makes it reproduce the same malformed answer. Three attempts, three `failed_generation` payloads differing only in prose wording, all `"name": "json"`. ~8.6 s and 3 API calls to fail identically, and it's what makes story 101 flap.

`is_retryable`'s own comment states the principle: *"Every 4xx is a defect in the request just built, and building it again produces the same bytes."* Correct — so when the defect is in the **response**, change the input. A rejected tool call now appends one corrective message naming the tools that exist, the same repair loop `refuse.rs` already uses. Every other error still retries unchanged, pinned by its own test.

**No cassette impact:** the correction is appended only on a retry, retries happen only on live failures, and those are never recorded. First-attempt requests are unchanged, so every committed cassette key still matches.

### 3. Two of three fence paths printed without recording

`audit.rs` promises "a record of all fence activations". Only `propose_plan` rejections were written; a reasonless `refuse` and an unknown tool name went to stderr alone — and the unknown-tool branch's own comment said "log it as a safety event". That third one is the event saying the model stopped following the protocol at all. Both now log, and the module doc enumerates all three so the claim is checkable.

### 4. The harness could not see the provider's rate limit

`story_was_rate_limited` grepped `rate limit exceeded` — our limiter's wording. Groq says `429 Too Many Requests` / `"code":"rate_limit_exceeded"` / `Rate limit reached`. So a provider 429 fell through as an ordinary failure while the summary printed `0 rate-limited`. That produced a believable, wrong **48/50** on 22.04 when three suites recorded concurrently; both "failures" passed standalone. It now detects all four shapes and reports *which* limiter, because the remedies differ: `SYSKNIFE_MAX_RPM` raises ours and cannot touch Groq's, whose binding ceiling is **tokens** per minute.

Verified against captured text, not regex shape: the real 429 body → `provider`, our limiter → `planner`, an ordinary `FAIL:` → not rate-limited.

Full gate: fmt, clippy `--all-features --all-targets`, `cargo doc -D warnings`, 1,750 tests (was 1,746; baseline and published figures regenerated from the run).