### PR TITLE
feat(e2e): give every Debian-only action a story, and make a retried run replay

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ These are where contributions move the needle the most. Each links to a
 
 | Area | Why it matters | Difficulty |
 |---|---|---|
-| **Ubuntu LTS support** ([tracker](https://github.com/lacs-project/sysknife/issues?q=is%3Aopen+label%3Aubuntu)) | All three LTS releases are validated against the full story suite on a live VM, each with a committed replay twin: 22.04 at 49/50, 24.04 at 49/50, 26.04 at 50/50. `ubuntu-vm.sh` accepts `UBUNTU_RELEASE=jammy\|noble\|resolute`. Remaining: story coverage for the ~30 Debian-only actions no story touches yet, starting with `GetHostState`. | Medium |
+| **Ubuntu LTS support** ([tracker](https://github.com/lacs-project/sysknife/issues?q=is%3Aopen+label%3Aubuntu)) | All three LTS releases are validated against the full story suite on a live VM, each with a committed replay twin that reproduces it: 22.04, 24.04 and 26.04 all at 79/79. `ubuntu-vm.sh` accepts `UBUNTU_RELEASE=jammy\|noble\|resolute`. Remaining: story coverage for the cross-family actions — the Debian-only ones are all covered now. | Medium |
 | **Distro detection coverage** ([tracker](https://github.com/lacs-project/sysknife/issues?q=is%3Aopen+label%3Adistro-detection)) | Robust `/etc/os-release` parsing for every LTS we claim to support. Pure-function tests, no integration mocks. | Easy |
 | **Action catalogue gaps** | Add a typed action (e.g. `EnableFirewallZone`) — small, isolated, every PR includes the policy entry + risk level + tests. | Easy |
-| **E2E story coverage** | Real prompts, real LLM, real daemon. 104 stories exist (54 atomic + 50 Ubuntu); the gap is coverage, not count — ~30 Debian-only actions still have no story. | Medium |
+| **E2E story coverage** | Real prompts, real LLM, real daemon. The suite is 133 stories: 54 atomic + 79 Ubuntu. Every Debian-only action now has one. What is left is the cross-family middle: of the action names available on both families, 57 are still untouched by any story, plus 8 Fedora-only ones. | Medium |
 | **GUI polish (Tauri shell)** | TypeScript + React. Real OSS UX, not a thin wrapper around the daemon. | Medium |
 | **Demo recording on real hardware** | Replace the bundled demo GIF with a 30-second recording on real Silverblue / Ubuntu 26.04. | Easy (and visible) |
 | **Translations** | i18n for the shell. Spanish, German, Japanese, Mandarin in priority order. | Easy |

--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ newgrp sysknife                       # or log out and back in
 npx sysknife-setup --no-binary --daemon-mode=skip
 ```
 
-All three Ubuntu LTS releases record a live-VM run of the 50-story suite, and
-each run has a replay twin that reproduces it: 22.04 at 49/50, 24.04 at 50/50,
-26.04 at 50/50. The runs are in `tests/evidence/story-runs/`. The one story
-short on 22.04 is 101, where the provider rejected the model's call outright
-rather than the planner choosing wrongly.
+All three Ubuntu LTS releases record a live-VM run of the 79-story Ubuntu
+suite, and each run has a replay twin that reproduces it: 22.04, 24.04 and 26.04
+all at 79/79, every twin serving every call with zero misses. The runs are in
+`tests/evidence/story-runs/`. The suite grew from 50 when every Debian-only
+action got a story, `GetHostState` first.
 Fedora Atomic is the rpm-ostree target; record a current Silverblue 44 VM run
 before treating a release as current-validated. Plain Fedora Workstation and
 Server remain experimental until the `dnf` action family ships. See the
@@ -266,11 +266,11 @@ milestone.
 | Tamper-evident Ed25519-signed audit chain | ✅ |
 | RFC 5424 syslog forwarding (Splunk / Sentinel / QRadar) | ✅ |
 | Postgres backend (RDS / Cloud SQL / Neon / Supabase) | ✅ |
-| **Ubuntu support** — 49/50 stories on a live 22.04 VM, recorded in `tests/evidence/story-runs/` | ✅ |
-| **Every Ubuntu LTS validated** — 22.04 at 49/50, 24.04 at 50/50, 26.04 at 50/50, each with a replay twin | ✅ |
+| **Ubuntu support** — 79/79 stories on a live 22.04 VM, recorded in `tests/evidence/story-runs/` | ✅ |
+| **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,750 Rust tests and 72 frontend tests** form the current deterministic
+**1,758 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM
@@ -316,8 +316,8 @@ All config files that may contain API keys are created with `chmod 0600`.
 
 See [ROADMAP.md](ROADMAP.md) for the full milestone breakdown.
 
-- ✅ **Ubuntu 22.04** — 49/50 stories on a live VM (recorded in `tests/evidence/story-runs/`)
-- ✅ **Ubuntu 24.04 and 26.04** — 50/50 and 50/50 on live VMs; every LTS run has a replay twin
+- ✅ **Ubuntu 22.04** — 79/79 stories on a live VM (recorded in `tests/evidence/story-runs/`)
+- ✅ **Ubuntu 24.04 and 26.04** — 79/79 and 79/79 on live VMs; every LTS run has a replay twin that reproduces it
 - 📋 Telegram inline-button approvals
 - 📋 `sysknife audit export` (CEF / NDJSON for SIEM ingest)
 - 📋 Fleet plan/execute (one plan, N targets, parallel approval)

--- a/apps/sysknife-cli/src/render.rs
+++ b/apps/sysknife-cli/src/render.rs
@@ -266,7 +266,13 @@ pub fn print_doctor_ok(
 /// over ssh or in a log file is indistinguishable from a hung process. One line
 /// is enough to tell the two apart, and it goes to stderr so `--json` consumers
 /// reading stdout are unaffected.
+///
+/// This line is exactly the one a non-TTY run persists, so the intent goes
+/// through [`sysknife_brain::prefs::loggable_intent`]: an intent the planner is
+/// about to refuse for carrying a credential must not be written to whatever
+/// file stderr points at first.
 pub fn print_planning_notice(provider: &str, model: &str, intent: &str) {
+    let intent = sysknife_brain::prefs::loggable_intent(intent);
     eprintln!("→ planning \"{intent}\" with {provider}/{model}, this can take a minute…");
 }
 

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -1594,8 +1594,15 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
     }
 
     // Layer 1: spinner — auto-hidden by indicatif when stderr is not a TTY.
-    let spinner =
-        (!opts.json).then(|| crate::render::make_spinner(format!("Planning \"{intent}\"…")));
+    // Same redaction as the notice below: the spinner is transient on a TTY, but
+    // it is the same string and there is no reason to hold the two to different
+    // standards.
+    let spinner = (!opts.json).then(|| {
+        crate::render::make_spinner(format!(
+            "Planning \"{}\"…",
+            sysknife_brain::prefs::loggable_intent(&intent)
+        ))
+    });
 
     // …and because it is hidden there, a piped or ssh'd run would otherwise
     // print nothing at all while the provider thinks. Say it once instead.

--- a/crates/sysknife-brain/src/cassette.rs
+++ b/crates/sysknife-brain/src/cassette.rs
@@ -48,10 +48,17 @@ use sha2::{Digest, Sha256};
 
 use crate::provider::{Completion, LlmProvider, Message, ProviderError, ToolDefinition};
 
-/// On-disk format version. Bump when the entry shape changes; an unknown value
-/// is refused rather than guessed at, so a newer cassette cannot be silently
-/// half-read by an older binary.
-pub const CASSETTE_VERSION: u32 = 1;
+/// On-disk format version. Bump when the entry shape changes.
+///
+/// A *newer* file is refused rather than guessed at, so a shape this binary does
+/// not understand cannot be silently half-read. An *older* one is read: every
+/// version so far has only added optional fields, and refusing v1 would have
+/// thrown away three committed recordings to gain nothing.
+///
+/// - v1 — entries carry `output` only.
+/// - v2 — an entry may instead carry `rejection`, so a call the provider refused
+///   is reproducible. See `RecordedRejection` in this module.
+pub const CASSETTE_VERSION: u32 = 2;
 
 /// Environment variable naming the cassette file.
 pub const ENV_CASSETTE: &str = "SYSKNIFE_CASSETTE";
@@ -109,10 +116,21 @@ pub enum CassetteError {
 
 /// One recorded call. The key already carries the surface; it is repeated here
 /// so a human reading the file can tell entries apart without hashing anything.
+///
+/// Exactly one of `output` and `rejection` is present. A cassette that stored
+/// only successes could not reproduce a retry: the planner appends a correction
+/// and re-asks after a rejected tool call, so the only call recorded was the
+/// *second* one, and a replay starting from the first missed it and then missed
+/// the identical re-ask. Storing the rejection makes the whole exchange replay.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Entry {
     surface: String,
-    output: Completion,
+    /// The successful completion. Absent when the call was rejected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    output: Option<Completion>,
+    /// The refusal, when the provider rejected the request. Absent on success.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    rejection: Option<RecordedRejection>,
     /// Per-component digests of the call this entry was recorded for.
     ///
     /// The key is a single hash over `(surface, system, messages, tools,
@@ -125,6 +143,67 @@ struct Entry {
     /// against one of those simply falls back to the old, vaguer message.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     fingerprint: Option<CallFingerprint>,
+}
+
+/// A provider refusal that is a property of the request, so replaying it is
+/// honest rather than a cached flake.
+///
+/// `kind` is the variant name, kept so the replayed error is the same shape the
+/// live one had. It matters: `is_retryable` and `is_invalid_tool_call` both
+/// branch on the error, and a replay that reproduced the message but not the
+/// variant would take a different path through the retry loop than the run it
+/// claims to reproduce.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RecordedRejection {
+    kind: String,
+    message: String,
+}
+
+impl RecordedRejection {
+    fn of(error: &ProviderError) -> Option<Self> {
+        let kind = match error {
+            ProviderError::Request(_) => "request",
+            ProviderError::Parse(_) => "parse",
+            // Nothing else can carry an invalid-tool-call rejection: no adapter
+            // builds `Http`, and `Auth`/`RateLimit`/`CassetteMiss` are excluded
+            // by `is_invalid_tool_call` itself.
+            _ => return None,
+        };
+        Some(Self {
+            kind: kind.to_string(),
+            message: match error {
+                ProviderError::Request(m) | ProviderError::Parse(m) => m.clone(),
+                _ => return None,
+            },
+        })
+    }
+
+    fn to_error(&self) -> ProviderError {
+        match self.kind.as_str() {
+            "parse" => ProviderError::Parse(self.message.clone()),
+            // "request" and anything a newer writer invents. Falling back to the
+            // broader variant keeps an unknown kind replayable and retryable
+            // rather than turning it into a silent success.
+            _ => ProviderError::Request(self.message.clone()),
+        }
+    }
+}
+
+/// Whether a failure may be written to the cassette.
+///
+/// Exactly the failures the planner corrects and re-asks about — see
+/// [`ProviderError::is_invalid_tool_call`] for why the two sets are one set.
+/// Those are a deterministic function of the same bytes the key hashes, just
+/// like a success.
+///
+/// Everything else describes the moment rather than the request: a 429 is load,
+/// a timeout is timing, a 5xx is the far side having a bad day. Recording any of
+/// them would bake a flake into the file and hand it back for ever.
+fn recordable_rejection(error: &ProviderError) -> Option<RecordedRejection> {
+    if !error.is_invalid_tool_call() {
+        return None;
+    }
+    RecordedRejection::of(error)
 }
 
 /// Component digests of one call, enough to locate *where* two calls diverge
@@ -257,7 +336,7 @@ impl Cassette {
                     path: path.clone(),
                     source,
                 })?;
-            if probe.version != CASSETTE_VERSION {
+            if probe.version > CASSETTE_VERSION {
                 return Err(CassetteError::UnsupportedVersion {
                     path,
                     found: probe.version,
@@ -355,9 +434,22 @@ impl Cassette {
         Ok(tally)
     }
 
-    fn lookup(&self, key: &str) -> Option<Completion> {
+    /// The recorded outcome for `key`, which may be a refusal.
+    ///
+    /// `Some(Err(..))` is a hit, not a miss: the recording says this exact
+    /// request was rejected, and handing that back is what lets the caller's
+    /// retry take the same path it took live.
+    fn lookup(&self, key: &str) -> Option<Result<Completion, ProviderError>> {
         let state = self.state.lock().expect("cassette state poisoned");
-        state.entries.get(key).map(|e| e.output.clone())
+        let entry = state.entries.get(key)?;
+        match (&entry.output, &entry.rejection) {
+            (Some(output), _) => Some(Ok(output.clone())),
+            (None, Some(r)) => Some(Err(r.to_error())),
+            // An entry with neither is a file someone edited by hand. Treating it
+            // as a miss reports the divergence instead of serving an empty plan
+            // that would read as the model having nothing to say.
+            (None, None) => None,
+        }
     }
 
     /// True when this exact system prompt was never recorded, which is the usual
@@ -377,6 +469,30 @@ impl Cassette {
         output: Completion,
         fingerprint: Option<CallFingerprint>,
     ) -> Result<(), CassetteError> {
+        self.store_entry(key, surface, prompt_sha, Some(output), None, fingerprint)
+    }
+
+    /// Persist a provider refusal. See [`recordable_rejection`] for which ones.
+    fn store_rejection(
+        &self,
+        key: String,
+        surface: &str,
+        prompt_sha: &str,
+        rejection: RecordedRejection,
+        fingerprint: Option<CallFingerprint>,
+    ) -> Result<(), CassetteError> {
+        self.store_entry(key, surface, prompt_sha, None, Some(rejection), fingerprint)
+    }
+
+    fn store_entry(
+        &self,
+        key: String,
+        surface: &str,
+        prompt_sha: &str,
+        output: Option<Completion>,
+        rejection: Option<RecordedRejection>,
+        fingerprint: Option<CallFingerprint>,
+    ) -> Result<(), CassetteError> {
         {
             let mut state = self.state.lock().expect("cassette state poisoned");
             state.meta.surfaces.insert(surface.to_string());
@@ -384,11 +500,17 @@ impl Cassette {
                 .meta
                 .system_prompt_sha256
                 .insert(prompt_sha.to_string());
+            // A file this binary has written is a v2 file, even when it was
+            // opened from a v1 one. Leaving the stamp at 1 while writing an
+            // entry only v2 understands is the exact silent-half-read the
+            // version field exists to prevent.
+            state.version = CASSETTE_VERSION;
             state.entries.insert(
                 key.clone(),
                 Entry {
                     surface: surface.to_string(),
                     output,
+                    rejection,
                     fingerprint,
                 },
             );
@@ -567,8 +689,10 @@ impl Cassette {
             // is exactly what it did on the first replay after this landed.
             Some(0) => format!(
                 "no recorded output for this intent in {}. The prompt and tools match, so \
-                 the cassette is current — this particular request was never recorded \
-                 (a call that errored during recording leaves no entry). Re-record with \
+                 the cassette is current — this particular request was never recorded. A \
+                 recording made before cassette v2 is the usual reason: only successes \
+                 were kept, so an intent whose first call the provider rejected left the \
+                 corrected retry behind and nothing to start it from. Re-record with \
                  {}=record if it should be covered.",
                 self.path.display(),
                 ENV_CASSETTE_MODE
@@ -654,9 +778,12 @@ impl LlmProvider for CassetteProvider {
     ) -> Result<Completion, ProviderError> {
         let key = call_key(&self.surface, system, messages, tools, max_tokens);
 
-        if let Some(output) = self.cassette.lookup(&key) {
+        if let Some(outcome) = self.cassette.lookup(&key) {
+            // A recorded refusal is a hit. The caller's retry then takes the same
+            // path it took live, which is the only way an exchange that needed a
+            // retry replays at all.
             self.cassette.note("hit", &self.surface, &key);
-            return Ok(output);
+            return outcome;
         }
 
         if self.cassette.mode == CassetteMode::Replay {
@@ -679,25 +806,45 @@ impl LlmProvider for CassetteProvider {
         }
 
         // Record: pay for the call once, then keep it.
-        let output = self
+        let outcome = self
             .inner
             .complete(system, messages, tools, max_tokens)
-            .await?;
+            .await;
         // The fingerprint's `system` field is the same sha256 `prompt_sha` needs;
         // compute it once and reuse it rather than hashing the (tens-of-KB)
         // system prompt twice for one stored call.
         let fingerprint = CallFingerprint::of(system, messages, tools, max_tokens);
         let prompt_sha = fingerprint.system.clone();
-        self.cassette
-            .store(
-                key,
-                &self.surface,
-                &prompt_sha,
-                output.clone(),
-                Some(fingerprint),
-            )
-            .map_err(|e| ProviderError::CassetteMiss(format!("cannot write cassette: {e}")))?;
-        Ok(output)
+        let write_failed = |e| ProviderError::CassetteMiss(format!("cannot write cassette: {e}"));
+
+        match outcome {
+            Ok(output) => {
+                self.cassette
+                    .store(
+                        key,
+                        &self.surface,
+                        &prompt_sha,
+                        output.clone(),
+                        Some(fingerprint),
+                    )
+                    .map_err(write_failed)?;
+                Ok(output)
+            }
+            Err(error) => {
+                if let Some(rejection) = recordable_rejection(&error) {
+                    self.cassette
+                        .store_rejection(
+                            key,
+                            &self.surface,
+                            &prompt_sha,
+                            rejection,
+                            Some(fingerprint),
+                        )
+                        .map_err(write_failed)?;
+                }
+                Err(error)
+            }
+        }
     }
 }
 
@@ -947,6 +1094,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_cassette_from_an_older_format_still_replays() {
+        // v2 only added optional fields. Refusing v1 would have discarded three
+        // committed recordings — and the whole point of committing them is that
+        // they outlive the commit that made them.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let msgs = msgs("hi");
+        let key = call_key(SURFACE, "SYS", &msgs, &[], 100);
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "meta": {"surfaces": [SURFACE], "system_prompt_sha256": [sha256_hex(b"SYS")]},
+                "entries": {key: {"surface": SURFACE, "output": text_completion("v1 answer")}},
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let rep = replayer(Box::new(Exploding), &path);
+        let out = rep.complete("SYS", &msgs, &[], 100).await.unwrap();
+        assert_eq!(
+            serde_json::to_string(&out).unwrap(),
+            serde_json::to_string(&text_completion("v1 answer")).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn writing_to_a_v1_cassette_restamps_it_as_v2() {
+        // The stamp has to move with the shape. A v1 header over an entry only v2
+        // can read is precisely the silent half-read the version field prevents.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({"version": 1, "meta": {}, "entries": {}}).to_string(),
+        )
+        .unwrap();
+
+        let (inner, _) = counting();
+        let rec = recorder(inner, &path);
+        rec.complete("SYS", &msgs("hi"), &[], 100).await.unwrap();
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(doc["version"], 2, "a file this binary wrote is a v2 file");
+    }
+
+    #[tokio::test]
     async fn a_changed_system_prompt_misses_and_says_so() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.json");
@@ -1131,6 +1327,169 @@ mod tests {
         let err = Cassette::open(dir.path().join("absent.json"), CassetteMode::Replay)
             .expect_err("replay cannot invent a cassette");
         assert!(matches!(err, CassetteError::Missing(_)));
+    }
+
+    // ── Recording a rejection ────────────────────────────────────────────────
+    //
+    // The planner retries a rejected tool call with a correction appended, so a
+    // story that needs the retry records only the *second* call. A replay starts
+    // from the first, misses, and — because a `CassetteMiss` carries none of the
+    // markers that trigger a correction — retries the identical bytes and misses
+    // again. That is exactly how story 101 came back 79/79 live and 78/79 on its
+    // own twin, with two misses for one story.
+    //
+    // A cassette that stores only successes cannot reproduce any retry. These
+    // tests pin the other half.
+
+    /// Groq's rejection as it actually reaches us.
+    ///
+    /// Not `ProviderError::Http`: no adapter constructs that variant. A 400 is
+    /// classified `StatusClass::Other` and becomes `Request`. Building the test
+    /// double out of `Http` made every assertion below pass against a shape the
+    /// system cannot produce.
+    fn tool_use_failed() -> ProviderError {
+        ProviderError::Request(
+            "{\"error\":{\"message\":\"Failed to call a function. Please adjust your prompt.\",\
+             \"type\":\"invalid_request_error\",\"code\":\"tool_use_failed\"}}"
+                .into(),
+        )
+    }
+
+    /// A provider that rejects the first call the way Groq rejects a tool call
+    /// naming a tool that is not in the request, then answers.
+    struct RejectsThenAnswers {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for RejectsThenAnswers {
+        async fn complete(
+            &self,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[ToolDefinition],
+            _max_tokens: u32,
+        ) -> Result<Completion, ProviderError> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(tool_use_failed());
+            }
+            Ok(text_completion("recovered"))
+        }
+    }
+
+    #[test]
+    fn the_recorder_keeps_exactly_what_the_retry_corrects() {
+        // The two sets have to be one set. A recorder narrower than the retrier
+        // leaves a retried run unreplayable — which is the bug this fixes; a
+        // recorder wider than it serves a transient failure back for ever.
+        let cases = [
+            tool_use_failed(),
+            ProviderError::Request(
+                "attempted to call tool 'json' which was not in request.tools".into(),
+            ),
+            ProviderError::Parse("tool_use_failed in a malformed payload".into()),
+            ProviderError::Request("connection reset by peer".into()),
+            ProviderError::RateLimit("Rate limit reached".into()),
+            ProviderError::Auth("bad key".into()),
+            ProviderError::Parse("truncated json".into()),
+            ProviderError::CassetteMiss("no recording for tool_use_failed".into()),
+        ];
+        for error in cases {
+            assert_eq!(
+                recordable_rejection(&error).is_some(),
+                error.is_invalid_tool_call(),
+                "recorder and retrier disagree about {error:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_rejected_request_is_recorded_and_replayed_as_the_same_rejection() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        // Record: the provider rejects, and the rejection is kept.
+        let rec = recorder(
+            Box::new(RejectsThenAnswers {
+                calls: Arc::clone(&calls),
+            }),
+            &path,
+        );
+        let live = rec.complete("SYS", &msgs("hi"), &[], 100).await;
+        let live = live.expect_err("the double rejects the first call");
+        assert!(live.is_invalid_tool_call());
+
+        // Replay: the same rejection comes back, without touching the provider.
+        let rep = replayer(Box::new(Exploding), &path);
+        let replayed = rep
+            .complete("SYS", &msgs("hi"), &[], 100)
+            .await
+            .expect_err("the recording says this request was rejected");
+        assert!(
+            matches!(replayed, ProviderError::Request(_)),
+            "the variant must survive the round trip, not just the text: {replayed:?}"
+        );
+        assert!(
+            replayed.is_invalid_tool_call(),
+            "a replayed rejection must still trigger the correction: {replayed}"
+        );
+        assert!(
+            replayed.is_retryable(),
+            "…and must still be retryable, or the retry never happens: {replayed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn replaying_a_recorded_rejection_counts_as_a_hit_not_a_miss() {
+        // A miss fails the whole run by design. If a recorded rejection were
+        // tallied as a miss, recording it would swap one red run for another.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let rec = recorder(Box::new(RejectsThenAnswers { calls }), &path);
+        let _ = rec.complete("SYS", &msgs("hi"), &[], 100).await;
+
+        let rep = replayer(Box::new(Exploding), &path);
+        let _ = rep.complete("SYS", &msgs("hi"), &[], 100).await;
+        let tally = Cassette::read_ledger(ledger_path_for(&path)).unwrap();
+        assert_eq!(tally.hits, 1, "a recorded rejection is a hit");
+        assert_eq!(tally.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn a_transient_failure_is_not_recorded() {
+        // A 429 or a timeout says something about the moment, not about the
+        // request. Recording one would bake a flake into the file and hand it
+        // back on every replay for ever.
+        struct AlwaysRateLimited;
+        #[async_trait]
+        impl LlmProvider for AlwaysRateLimited {
+            async fn complete(
+                &self,
+                _s: &str,
+                _m: &[Message],
+                _t: &[ToolDefinition],
+                _mt: u32,
+            ) -> Result<Completion, ProviderError> {
+                Err(ProviderError::RateLimit("Rate limit reached".into()))
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let rec = recorder(Box::new(AlwaysRateLimited), &path);
+        let _ = rec.complete("SYS", &msgs("hi"), &[], 100).await;
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap_or_default())
+                .unwrap_or(serde_json::json!({"entries": {}}));
+        assert_eq!(
+            doc["entries"].as_object().map(|o| o.len()).unwrap_or(0),
+            0,
+            "a 429 must not be recorded: {doc}"
+        );
     }
 }
 

--- a/crates/sysknife-brain/src/planner.rs
+++ b/crates/sysknife-brain/src/planner.rs
@@ -87,28 +87,17 @@ const PROVIDER_RETRY_BACKOFF: Duration = Duration::from_millis(400);
 /// is how a rate limit turns into a rate-limit loop.
 const PROVIDER_RETRY_RATE_LIMIT_BACKOFF: Duration = Duration::from_millis(2_000);
 
-/// Markers that identify "the model called a tool that does not exist".
-///
-/// Groq reports this as `code: "tool_use_failed"` with a message naming the tool
-/// it refused, e.g. `attempted to call tool 'json' which was not in
-/// request.tools`. Both halves are matched because providers word it
-/// differently and neither string is one we control; matching either is enough,
-/// and a false positive costs one extra sentence in a retry that was already
-/// going to happen.
-const INVALID_TOOL_CALL_MARKERS: &[&str] = &["tool_use_failed", "was not in request.tools"];
-
 /// The sentence to add before retrying a call the provider rejected because the
 /// model named a nonexistent tool.
 ///
 /// Returns `None` for every other error, so an ordinary 502 or timeout still
 /// retries the request unchanged — resending is the correct response when the
-/// request was never the problem.
+/// request was never the problem. The classification itself lives on
+/// [`ProviderError::is_invalid_tool_call`], because the cassette has to record
+/// exactly the failures this corrects — see its doc for why the two sets must
+/// be the same one.
 fn tool_call_correction(error: &ProviderError, tools: &[ToolDefinition]) -> Option<String> {
-    let text = error.to_string().to_lowercase();
-    if !INVALID_TOOL_CALL_MARKERS
-        .iter()
-        .any(|m| text.contains(&m.to_lowercase()))
-    {
+    if !error.is_invalid_tool_call() {
         return None;
     }
 

--- a/crates/sysknife-brain/src/prefs.rs
+++ b/crates/sysknife-brain/src/prefs.rs
@@ -213,6 +213,30 @@ pub fn contains_sensitive(fact: &str) -> bool {
     SENSITIVE_PREFIXES.iter().any(|p| lower.contains(p))
 }
 
+/// The intent as it may be written somewhere that outlives the terminal.
+///
+/// `Planner::admit_request` refuses any intent [`contains_sensitive`] flags, so
+/// the credential never reaches a provider. It did still reach disk: the CLI
+/// announces `→ planning "<intent>" …` on stderr *before* calling the planner,
+/// and both CI and the story harness run with stderr redirected to a file. The
+/// notice was therefore writing the one value the fence exists to contain, on
+/// its way to reporting that it had contained it.
+///
+/// For a flagged intent there is nothing to announce anyway — the request is
+/// about to be refused — so the text is replaced wholesale rather than
+/// scrubbed. A partial scrub would need to know where the secret ends, and
+/// [`contains_sensitive`] is a shape denylist that cannot say.
+///
+/// This is not a second gate. It asks [`contains_sensitive`] the same question
+/// the planner asks, so widening the denylist widens both.
+pub fn loggable_intent(intent: &str) -> std::borrow::Cow<'_, str> {
+    if contains_sensitive(intent) {
+        std::borrow::Cow::Borrowed("<withheld: intent matched the sensitive-data fence>")
+    } else {
+        std::borrow::Cow::Borrowed(intent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -473,5 +497,31 @@ mod tests {
     fn contains_sensitive_detects_npm_and_pypi_tokens() {
         assert!(contains_sensitive("npm login with npm_abc123xyz"));
         assert!(contains_sensitive("publish with pypi-AgEIcHlwaS5vcmcAA"));
+    }
+
+    #[test]
+    fn an_intent_the_fence_will_refuse_is_not_loggable_verbatim() {
+        // The CLI announces the intent on stderr before planning. For an intent
+        // the fence is about to refuse, that line is the one thing that puts the
+        // credential on disk — `sysknife … 2>run.log` and every story harness
+        // redirect stderr to a file.
+        let leaky = "attach this machine to Ubuntu Pro using token C1aBcDeF0123456789";
+        let shown = loggable_intent(leaky);
+        assert!(
+            !shown.contains("C1aBcDeF0123456789"),
+            "the loggable form still carries the credential: {shown}"
+        );
+        assert!(
+            shown.contains("withheld"),
+            "the placeholder should say why the intent is not shown: {shown}"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_intent_is_logged_verbatim() {
+        // The notice exists so a piped or ssh'd run is distinguishable from a
+        // hung one. Redacting every intent would take that back.
+        let ordinary = "install nginx and open port 80";
+        assert_eq!(loggable_intent(ordinary), ordinary);
     }
 }

--- a/crates/sysknife-brain/src/provider.rs
+++ b/crates/sysknife-brain/src/provider.rs
@@ -159,6 +159,17 @@ pub trait LlmProvider: Send + Sync {
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ProviderError {
+    /// **No adapter constructs this.** A provider HTTP status is classified by
+    /// `providers::classify_status` into [`Auth`](Self::Auth),
+    /// [`RateLimit`](Self::RateLimit), or — for every other 4xx and 5xx —
+    /// [`Request`](Self::Request). A Groq 400 carrying `tool_use_failed`
+    /// arrives as `Request`, and a 500 does too.
+    ///
+    /// Say so here because a test double built from this variant tests a shape
+    /// the system cannot produce. That is not hypothetical: the cassette's
+    /// rejection recorder was first written to match `Http { status: 400, .. }`
+    /// and passed three new tests while recording nothing at all on a real run.
+    /// Reach for `Request` when doubling a provider failure.
     #[error("http error {status}: {body}")]
     Http { status: u16, body: String },
 
@@ -216,6 +227,39 @@ impl ProviderError {
             ProviderError::Auth(_) => false,
             ProviderError::CassetteMiss(_) => false,
         }
+    }
+
+    /// Whether the provider rejected the *request* because the model named a
+    /// tool that does not exist.
+    ///
+    /// Two callers need this same answer and must never disagree:
+    ///
+    /// - `planner::tool_call_correction` — the only failure worth re-asking
+    ///   about with a correction appended, because resending the same bytes
+    ///   reproduces the same malformed answer.
+    /// - `cassette::recordable_rejection` — the only failure worth *recording*,
+    ///   because it is a deterministic function of the same bytes the cassette
+    ///   key hashes. If the recorder kept a smaller set than the retrier, a
+    ///   run that needed a retry could never replay; if it kept a larger one, a
+    ///   transient failure would be served back for ever.
+    ///
+    /// Matched on the message, not the variant: no adapter constructs
+    /// [`Http`](Self::Http), and Groq's 400 arrives as
+    /// [`Request`](Self::Request) via `StatusClass::Other`. Groq words it
+    /// `code: "tool_use_failed"` with a message naming the tool it refused —
+    /// `attempted to call tool 'json' which was not in request.tools`. Both
+    /// halves are matched because providers word it differently and neither
+    /// string is one we control.
+    pub fn is_invalid_tool_call(&self) -> bool {
+        const MARKERS: &[&str] = &["tool_use_failed", "was not in request.tools"];
+        // Auth and CassetteMiss are about this process, not the request, and a
+        // cassette-miss diagnostic can quote a recorded message verbatim — which
+        // would otherwise make a miss look like the rejection it is reporting.
+        if matches!(self, Self::Auth(_) | Self::CassetteMiss(_)) {
+            return false;
+        }
+        let text = self.to_string().to_lowercase();
+        MARKERS.iter().any(|m| text.contains(&m.to_lowercase()))
     }
 }
 

--- a/docs/adr/0004-per-distro-prompt-dispatch.md
+++ b/docs/adr/0004-per-distro-prompt-dispatch.md
@@ -93,3 +93,24 @@ prompt isolation — is unaffected, and was independently confirmed later: the t
 Fedora actions that still reached Ubuntu plans came from the *tool schema*, which
 this ADR did not cover, not from the prompt. Published figures now derive from
 `tests/evidence/` and are enforced by `scripts/check_evidence_claims.py`.
+
+## Follow-up (2026-08-13)
+
+The "50 stories" above was the family size at the time. It is 79 now: `GetHostState`
+— the action this ADR's fence *required* somebody to introduce, because naming
+Fedora's `GetSystemState` on an apt host is what the fence forbids — had no story
+at all, and neither did 28 other Debian-only actions. Every Debian-only action now
+has one, and the family runs 79/79 on all three LTSes.
+
+Two of the new stories say something about this decision that the fence itself
+does not:
+
+- The four `Ubuntu*Flatpak` actions build **byte-identical argv** to their
+  un-prefixed twins, which `action_family.rs` deliberately leaves unfenced. So
+  the Debian prompt names only the prefixed set while the tool schema offers
+  both, and the choice has no effect on the host. Measured: the model picks the
+  un-prefixed name 3 times in 4. Those stories accept either and log which,
+  because asserting a distinction the host cannot observe is not a gate.
+- `ConfigureUnattendedUpgrades` is described in the tool schema and named in
+  **none** of the Debian prose blocks. Story 126 is therefore a measurement of
+  whether the schema description alone is enough to steer. It is.

--- a/docs/contributing/ubuntu-vm-testing.md
+++ b/docs/contributing/ubuntu-vm-testing.md
@@ -7,17 +7,20 @@ Supported Ubuntu LTSes:
 
 | Release | Codename | SSH port | Live suite | Status |
 |---|---|---|---|---|
-| 22.04 | jammy | 2222 | 49/50 | validated |
-| 24.04 | noble | 2223 | 50/50 | validated (default) |
-| 26.04 | resolute | 2224 | 50/50 | validated |
+| 22.04 | jammy | 2222 | 79/79 | validated |
+| 24.04 | noble | 2223 | 79/79 | validated (default) |
+| 26.04 | resolute | 2224 | 79/79 | validated |
 
 Each release has a record run and a `.replay.json` twin in
 `tests/evidence/story-runs/`, and `tests/release/cassette-replay-parity.test.sh`
-checks every pair it finds. The story missing from 22.04 and 24.04 is the same
-one in both, and it passed on 26.04 — but *which* story that is changes between
-rounds, because two of them are nondeterministic. See
-[Story 101 is flaky; story 104 was fixed](#story-101-is-flaky-story-104-was-fixed) before reading any single run as a
-verdict on a release.
+checks every pair it finds. All three twins currently reproduce their run with
+zero misses.
+
+Do not read a single run as a verdict on a release. Which story comes back short
+moves between rounds, because the failure is a provider-side rejection of a
+correctly-planned call and it lands wherever the sampling puts it — 101 on
+22.04, 119 on 24.04, 125 and 130 on 26.04 across successive rounds. See
+[Story 101 is flaky; story 104 was fixed](#story-101-is-flaky-story-104-was-fixed).
 
 The Ubuntu path uses `qemu-system-x86_64` directly with a cloud-init seed
 ISO — no quickemu, no interactive installer, no GUI window. The base image
@@ -127,6 +130,19 @@ every LLM call once and answering from the file afterwards.
 The wrapper sits at the provider boundary, so a replay still exercises prompt
 assembly, the tool-use loop, the safety fence, the ActionSpec risk substitution
 and the daemon IPC. Only the network hop is served from disk.
+
+Recording is paced. The provider ceiling that has actually stopped a run here is
+**tokens** per minute, not requests: one planning call carries the whole system
+prompt, ~17 kB in, against a 250 k TPM org limit — about 14 calls a minute.
+Unpaced, this suite issues one roughly every three seconds and overruns, and the
+stories past the line come back as provider 429s. `run-stories.sh` therefore
+sleeps 4 s between stories whenever it is recording (or running with no cassette
+at all), and not at all on replay. Override with `SYSKNIFE_STORY_DELAY_SECS`.
+
+Recording is also incremental: a record run serves anything already in the
+cassette from disk and pays only for the calls that miss. Adding stories to an
+existing family costs the new stories, not the whole suite. What does invalidate
+every entry is a change to `prompt.rs`, the tool schema, or the model.
 
 ```sh
 # Record. Costs one live run; the cassette lands inside the VM.
@@ -348,15 +364,34 @@ contains exactly what was wanted:
 {"name": "json", "arguments": {"steps": [{"action_name": "ListContainers", ...}]}}
 ```
 
-Measured 2 failures in 6 runs. The story then gets no plan at all: its log holds
-the header line and nothing else, where a passing story's log holds plan JSON.
+Measured 2 failures in 6 runs.
 
-Note what the retry does here. `complete_with_retry` re-sends the identical
-`(system, messages, tools)`, and the model has locked onto the wrong tool name
-*for that exact input*, so all three attempts reproduce it — the three
-`failed_generation` payloads differ only in prose wording and all three say
-`"name": "json"`. Three API calls and ~8.6 s to fail the same way. A retry that
-does not change its input is not a retry against a formatting error.
+This is not specific to story 101 — it is a property of the model and the
+phrasing, and it has since been observed on 119 (24.04) and on 125 and 130
+(26.04). Any story can land on it.
+
+Two fixes, in order, because the second only became visible once the first
+worked:
+
+1. **The retry now changes its input.** It used to re-send the identical
+   `(system, messages, tools)`, and the model had locked onto the wrong tool name
+   *for that exact input*, so all three attempts reproduced it — the three
+   `failed_generation` payloads differed only in prose wording and all three said
+   `"name": "json"`. Three API calls and ~8.6 s to fail the same way. A retry
+   that does not change its input is not a retry against a formatting error, so
+   `complete_with_retry` now appends a correction naming the real tools before
+   re-asking.
+2. **The correction is now recordable.** The cassette stored only successes, so a
+   story that needed the retry recorded only the *second* call. A replay starts
+   from the first, misses, and — a `CassetteMiss` carrying none of the markers
+   that trigger a correction — re-sends identical bytes and misses again. That
+   one gap was the entire reason all three LTS replay twins reported
+   `cassette_audit.verdict` `failed`. Cassette v2 records the rejection, and a
+   replay takes the same path the live run took.
+
+So a story short on a replay is worth reading as a cassette-vintage question
+first. Re-record and it goes away; if it does not, the diagnostic in the story
+log names the diverging message.
 
 **Story 104 (`Apply netplan after showing config`) — fixed, and worth reading as
 a worked example.** It asked for "the network config and then apply it" and
@@ -385,4 +420,12 @@ Two rules, both learned the hard way:
   concurrent suites at `SYSKNIFE_MAX_RPM=120` produced HTTP 429
   `rate_limit_exceeded`, which the harness reported as two ordinary story
   failures on 22.04. Record one release at a time; replays are free and can run
-  in parallel, because they serve from the cassette and never call out.
+  in parallel, because they serve from the cassette and never call out. One
+  release racing *itself* overruns the same ceiling, which is why a record run
+  paces — see "Record once, replay for free".
+- **Read the story log, not just the verdict.** A failing story's log now carries
+  the CLI's stderr folded in under `--- sysknife stderr ---`. It used to hold the
+  story's opening `echo` and nothing else, because every story redirects stderr
+  to `/tmp/sysknife-story-<n>-stderr.log` and nothing collected it — so
+  diagnosing a cassette miss meant re-running the whole release with a
+  hand-written `tar` of `/tmp`.

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -45,15 +45,15 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 
 | Distro | Action backend | Evidence | Launch tier |
 |---|---|---|---|
-| **Ubuntu 24.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, **50/50**, recorded in `ubuntu-24.04-gpt-oss-120b.json` and fully reproduced by its `.replay.json` twin — zero misses, `cassette_audit.verdict` `ok` | **Validated** |
-| **Ubuntu 22.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, 49/50, recorded in `ubuntu-22.04-gpt-oss-120b.json`; its `.replay.json` twin replays every story that had a recording. The one story short is 101, whose call the provider rejected, so nothing was recorded for it and the twin reports one miss and `cassette_audit.verdict` `failed` | **Validated** |
-| **Ubuntu 26.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, 50/50, recorded in `ubuntu-26.04-gpt-oss-120b.json` and fully reproduced by its `.replay.json` twin — zero misses, `cassette_audit.verdict` `ok`; plus sudo-rs sudoers verification (26.04 ships sudo-rs 0.2.x; `visudo -cf` parses the SysKnife sudoers and every grant — including the trailing-`*` wildcard grants — is honoured) | **Validated** |
+| **Ubuntu 24.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, **79/79**, recorded in `ubuntu-24.04-gpt-oss-120b.json` and fully reproduced by its `.replay.json` twin — zero misses, `cassette_audit.verdict` `ok` | **Validated** |
+| **Ubuntu 22.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, **79/79**, recorded in `ubuntu-22.04-gpt-oss-120b.json` and fully reproduced by its `.replay.json` twin — zero misses, `cassette_audit.verdict` `ok`. This is the release whose twin exercises the recorded-rejection path: story 101's first call was refused by the provider (`tool_use_failed`), and the replay serves the refusal, the correction and the answer, 81 calls for 79 stories | **Validated** |
+| **Ubuntu 26.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, **79/79**, recorded in `ubuntu-26.04-gpt-oss-120b.json` and fully reproduced by its `.replay.json` twin — zero misses, `cassette_audit.verdict` `ok`; plus sudo-rs sudoers verification (26.04 ships sudo-rs 0.2.x; `visudo -cf` parses the SysKnife sudoers and every grant — including the trailing-`*` wildcard grants — is honoured) | **Validated** |
 | **Every other Ubuntu 20.04+ release** (20.04, 20.10, 21.x, 23.x, 25.x, 26.10, …) | Ubuntu/apt family | Eligible by release family; no per-release VM run | **Smoke-tested** |
 | **Fedora Silverblue 44** | rpm-ostree, Flatpak, toolbox, firewalld, systemd, containers | Harness and fixture coverage; no current live-VM run | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,750 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,758 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -104,11 +104,10 @@ SysKnife, not an afterthought.
 
 > **ℹ️ Distro support**
 >
-> All three Ubuntu LTS releases have a committed live-VM run of the 50-story
-> Ubuntu suite, in `tests/evidence/story-runs/`: 22.04 at 49/50, 24.04 at 50/50,
-> 26.04 at 50/50. Each run has a replay twin that reproduces it. The one story
-> short on 22.04 is 101, whose call the provider rejected outright rather than a
-> planning mistake.
+> All three Ubuntu LTS releases have a committed live-VM run of the 79-story
+> Ubuntu suite, in `tests/evidence/story-runs/`: 22.04, 24.04 and 26.04 all at
+> 79/79. Each run has a replay twin that reproduces it, serving every call with
+> zero misses. Every Debian-only action has a story.
 > Fedora Atomic is supported by the rpm-ostree action family, but a current
 > Silverblue 44 VM run is a release gate. Plain Fedora remains experimental
 > until the `dnf` action family ships.
@@ -142,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,750 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,758 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/scripts/check_evidence_claims.py
+++ b/scripts/check_evidence_claims.py
@@ -325,12 +325,20 @@ def check_action_figures(texts: dict[str, str], catalogue: int) -> list[str]:
 
 
 def replay_verified_releases(root: Path) -> set[str]:
-    """Releases with a committed record run AND its replay twin.
+    """Releases with a committed record run AND a replay twin that reproduced it.
 
     That pair is what `tests/release/cassette-replay-parity.test.sh` proves
     reproduces: the record run says what happened live, the replay says the
     cassette reproduces it. A release with only a record run has a pass rate
     nothing has re-derived; a release with neither has nothing at all.
+
+    The twin has to have *worked*. Merely existing was enough here for a while,
+    and the gap was not hypothetical: all three LTSes carried a twin whose
+    `cassette_audit.verdict` was `failed`, because the cassette stored only
+    successes and so could not reproduce any story whose first call the provider
+    rejected. Each release was tiered "Validated" on the strength of a file that
+    says, in its own fields, that it did not reproduce the run. A pass-rate
+    figure was already refused on those grounds; the tier was not.
     """
     directory = root / STORY_RUNS
     if not directory.is_dir():
@@ -340,13 +348,15 @@ def replay_verified_releases(root: Path) -> set[str]:
     replays: set[str] = set()
     for path in sorted(directory.glob("*.json")):
         try:
-            release = str(json.loads(path.read_text()).get("release", ""))
+            run = json.loads(path.read_text())
         except json.JSONDecodeError as exc:
             raise Failure(f"{path.name} is not readable JSON: {exc}") from exc
+        release = str(run.get("release", ""))
         if not release:
             continue
         if path.name.endswith(".replay.json"):
-            replays.add(release)
+            if str(run.get("cassette_audit", {}).get("verdict", "")) == "ok":
+                replays.add(release)
         else:
             records[release] = path
     return set(records) & replays

--- a/tests/e2e/cassettes/ubuntu-jammy-gpt-oss-120b.json
+++ b/tests/e2e/cassettes/ubuntu-jammy-gpt-oss-120b.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "meta": {
     "surfaces": [
       "groq/openai/gpt-oss-120b"
@@ -106,6 +106,76 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:0c33ca7a80fd5088e5323fbac4dd6bead40eb4fa3d4294d6f706a135cb9aac5a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_61fc5bd6-98df-4be0-91cb-4350403f1a7d",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether the system needs a reboot. The CheckPendingReboot action reads the reboot-required flag and reports the status without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "CheckPendingReboot",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Determine whether a pending reboot is required"
+                  }
+                ],
+                "summary": "Check if a reboot is required"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "badf780f4098f9a9c08e6accc9bd78b6463864a5bc522774d1ca5824ac0c557a"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:0fa8d4ddab7222cdefbd911f5aae0c99c9236567455c26a6eaed8b1d4776b53d": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_93adbf2a-f94e-454d-b29c-0b879859a8ff",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants basic host information. GetHostState returns OS release, kernel version, and hardware architecture in a read‑only low‑risk query.",
+                "steps": [
+                  {
+                    "action_name": "GetHostState",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve OS release, kernel version, and system architecture"
+                  }
+                ],
+                "summary": "Show operating system release, kernel version, and architecture"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "36a31243b6d594e82530e21e5ba8d22bede4e185bbc97517cd12ea2562971ae1"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:14c2676eb965f9f7f0d8c3d04a2ef7fd4a83277f59189020a7fcbf233f9c0784": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -127,6 +197,76 @@
         "max_tokens": 4096,
         "messages": [
           "6809a8a69524bbd52686c99bb064c220bc879b4262ec4a1da7e28024a75abe02"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:15f2dbbd6eda7c823e231491281e35379383036ab97bff679973baab179a0200": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a073528b-4ae1-4715-aba0-2e221c51dc7a",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to roll back the Firefox snap. SnapRevert restores the snap to its prior version, which is a reversible operation. This step will execute the SnapRevert action for the Firefox snap.",
+                "steps": [
+                  {
+                    "action_name": "SnapRevert",
+                    "params": "{\"name\":\"firefox\"}",
+                    "risk_level": "medium",
+                    "summary": "Revert the Firefox snap to the previous revision"
+                  }
+                ],
+                "summary": "Revert the Firefox snap to its previous revision"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "3f1f883ed054ebaf22ba7f3327b5fb30ea657e8493ff6e540e5cd12a14936e8b"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:1c87c0f760678786846835791c0d8c73dc0025cc3ca0596628e8ee1781b64a71": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_4dc6b902-d677-4f97-b3b4-57f0c54eb48f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see which packages were installed or removed using apt in the recent past. AptHistoryList reads the apt transaction log and provides this information without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "AptHistoryList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the recent apt transaction log showing installed and removed packages"
+                  }
+                ],
+                "summary": "Show recent apt package installation and removal history"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "9650dcf7669beaf381f3c04970691f5712cabd937a398f69db03b0535271b390"
         ]
       }
     },
@@ -197,6 +337,76 @@
         "max_tokens": 4096,
         "messages": [
           "43a5e9ac9f33f3daf9b19ae7ba185e0b2b48efe4abe80874e72e0f35daea3c93"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:282f74c53ac1c3f2e9a64f478bcbc7ea884ff3bc08faec8fd3634f629f6a45e6": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_d98ca428-0610-4feb-bfbe-e51ba1ea9979",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn on automatic security updates. Configuring unattended upgrades will enable the system to automatically install security updates, keeping the machine up to date without manual intervention.",
+                "steps": [
+                  {
+                    "action_name": "ConfigureUnattendedUpgrades",
+                    "params": "{\"enabled\":true}",
+                    "risk_level": "high",
+                    "summary": "Enable unattended security updates"
+                  }
+                ],
+                "summary": "Enable automatic security updates"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "1224bb349f17ba23b876bee6423b5d16c757c0948a9cfc7d4193754e4af261c7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:29cb2d086d838ae8a2729c000f84e144745d76891acea17a7f4b534be26ff106": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_b5237bd2-6309-4787-a37b-57570bb952a1",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to view the apt pin priority for a specific package. GetAptPins returns the pin configuration and priority for the given package, fulfilling the request.",
+                "steps": [
+                  {
+                    "action_name": "GetAptPins",
+                    "params": "{\"package\":\"nginx\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve apt pin priority for the nginx package"
+                  }
+                ],
+                "summary": "Show apt pin priority for the nginx package"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "1e8ad878e47dc632d9a3d9bc95a4c7f62fff43830790de9a2b131e0c19f18cfe"
         ]
       }
     },
@@ -297,6 +507,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:3ac267e8835870a05c84bbe57ed0ef3e942bc1b7b5b714becac764f4b6b5c82e": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_bdcea997-6a23-4bc7-afc9-5d8b22882922",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of the org.mozilla.firefox Flatpak application from alice's account. UbuntuRemoveFlatpak will delete the app for that user. This is a medium‑risk operation because it modifies the user's Flatpak installations.",
+                "steps": [
+                  {
+                    "action_name": "UbuntuRemoveFlatpak",
+                    "params": "{\"username\":\"alice\",\"app_id\":\"org.mozilla.firefox\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the org.mozilla.firefox Flatpak for user alice"
+                  }
+                ],
+                "summary": "Uninstall the Firefox Flatpak for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "5c2b08f0a62952dc4ef832496a51d58f579d6f5334f420ac4cb4cf2616c07fce"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:3b553433a48a511af5b5b7aa8a89946b48838ee8f0e13780e0b36c047b2e9ad3": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -335,6 +580,41 @@
         "max_tokens": 4096,
         "messages": [
           "4f3af260cdad00eefc58e372e727dede9f92164bf3e4b88639e63819f6b33382"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:3c7501af61787108fe4f51a3e3bb32e1de394cb46569a4a35946a9957db587b1": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_92722977-5035-450b-bdd5-430cc9d53122",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants AppArmor to log violations for the nginx service without enforcing them. Changing the profile to complain mode updates its enforcement state, which is a high‑risk operation because it temporarily disables protection for nginx.",
+                "steps": [
+                  {
+                    "action_name": "AppArmorComplain",
+                    "params": "{\"profile_path\":\"/etc/apparmor.d/usr.sbin.nginx\"}",
+                    "risk_level": "high",
+                    "summary": "Put the nginx AppArmor profile into complain (logging) mode"
+                  }
+                ],
+                "summary": "Set the nginx AppArmor profile to complain mode"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "42fa9993263625d62a8ea858cf0993e2e3f6f4e0d86c3bc859d494cb31d128a4"
         ]
       }
     },
@@ -484,6 +764,68 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:45b0b6d7a5d6676c9797a8f99b57db88173fbb8c815ff92fc2f8c0933486c1b0": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_582d7deb-6c79-46be-bfa9-618ff5229ab1",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to refresh the netplan configuration files while leaving the current network interfaces untouched. NetplanGenerate rewrites the backend config without applying it, satisfying this request.",
+                "steps": [
+                  {
+                    "action_name": "NetplanGenerate",
+                    "params": "{}",
+                    "risk_level": "medium",
+                    "summary": "Regenerate netplan backend config files (dry-run) without affecting live interfaces"
+                  }
+                ],
+                "summary": "Regenerate netplan backend configuration files without applying changes"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "0b2a536f120201f7159d43fb11b17ebab393d01a0f59b9d543fde377cb157d71"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:46cd5254f43acb04366ecee2f8ee2a32d5f009c9c4325abcc4913c871132aa01": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_04a798aa-4de9-4dd3-9219-06efd91a3c86",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "Attaching to Ubuntu Pro requires a subscription token, which was not provided.",
+                "suggestion": "Please provide the Ubuntu Pro token to attach the machine."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "036e068017c7490135c5a4ddf9d0d5e070c737dba97b7a92f5b1a54e3eec2f76"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:4773d0db445084699821d08406e16788b53582eb6f13cc3a1d3c4be2d50ce3dc": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -566,6 +908,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:495306a021ada6f531e01d5437bff06bbdad55c5cecb7b98a6603dea2cf21e26": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_c9b97112-3a95-4131-b27f-f566dfc7cc4c",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to update every installed Flatpak app for the specified user. The UpdateFlatpak action performs this operation for the given user without needing any further input.",
+                "steps": [
+                  {
+                    "action_name": "UpdateFlatpak",
+                    "params": "{\"username\":\"alice\"}",
+                    "risk_level": "medium",
+                    "summary": "Refresh all Flatpak apps for user alice"
+                  }
+                ],
+                "summary": "Update all Flatpak applications for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "4d0d5a01dd80a55d1254b72fdb2d6d9b53478c80c9e876bd0ddb23d628323f9e"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:49c23057454e121ad5eff867ec6c65342b896f5c11799f33ec2d91b4c24bdd88": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -598,6 +975,41 @@
         "max_tokens": 4096,
         "messages": [
           "36aa9a54a7d0e19e159fe4de276e8e83b1e9f7a1ea403560442edd6eae3faefe"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:4b085cc9f451deb21d67fac9f82c4ac879b0daeaf00ae760defd214c90b63df8": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a12b81bf-caf5-4b1d-93da-4748d8dc283e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether cloud-init completed its provisioning without errors. CloudInitStatus provides a read‑only summary of the cloud-init run, including any errors encountered.",
+                "steps": [
+                  {
+                    "action_name": "CloudInitStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve cloud-init provisioning status and error information"
+                  }
+                ],
+                "summary": "Check cloud-init provisioning status and errors"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "16158a41b0bd4d3ef09315a655f064b8c31c88fc7c6c28f9f106ad81eefa0884"
         ]
       }
     },
@@ -899,6 +1311,174 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:61f8888d85b04e0a5ac019d21da5523285f47575dd7f9a85314902088e4a9fc9": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_5dacf145-d9e9-409e-8bd2-5e57c70c872f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of the apt pin called freeze-nginx. This action will delete the corresponding apt preferences entry.",
+                "steps": [
+                  {
+                    "action_name": "RemoveAptPin",
+                    "params": "{\"name\":\"freeze-nginx\"}",
+                    "risk_level": "medium",
+                    "summary": "Delete the apt pin named freeze-nginx"
+                  }
+                ],
+                "summary": "Remove the apt pin named freeze-nginx"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "598d6852d030a1f4fed0246e19e4904623501e30f40a7b504f2c6396fdeb369e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:62af6d9c95f492f7f80b9bf45725a83a24c6b8b60222ced54f7cbb5be0fd1085": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_d375c31a-884e-4084-8b3f-cdc1a9938c25",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to put the AppArmor profile for Firefox into enforce mode. This will activate the profile, causing any violations to be blocked. The operation is high risk because it can immediately affect Firefox functionality.",
+                "steps": [
+                  {
+                    "action_name": "AppArmorEnforce",
+                    "params": "{\"profile_path\":\"/etc/apparmor.d/usr.bin.firefox\"}",
+                    "risk_level": "high",
+                    "summary": "Set the Firefox AppArmor profile to enforce mode"
+                  }
+                ],
+                "summary": "Enable enforcement for the Firefox AppArmor profile"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "6a832dc12d26adbc61c3c7503e3b97980aa6d7b0935a09f8dd122949aa0f6bf8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:681299b903bb02f7669c4377134bd0bc74d699f986bf636b2cb23320bd38db86": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_4edd4d25-d2f5-42d8-8391-77ccbe3b9425",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "Attaching to Ubuntu Pro requires a subscription token, which was not provided.",
+                "suggestion": "Please provide the Ubuntu Pro token, e.g., \"ProAttach token: <your-token>\"."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "036e068017c7490135c5a4ddf9d0d5e070c737dba97b7a92f5b1a54e3eec2f76",
+          "4b50f28030656b9aac1a21188698ff3933fb3589d2f2879ddd4e907d315b3548"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6a73199b3d6f80e7cb85285d5ac8aff473e721cbe3f2d3a1b68fe890f9104d2a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_d911dc36-d948-4a11-8416-423995c5a6b6",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested installing the org.mozilla.firefox Flatpak from the flathub remote for the user alice. InstallFlatpak performs this installation with the specified user and remote.",
+                "steps": [
+                  {
+                    "action_name": "InstallFlatpak",
+                    "params": "{\"username\":\"alice\",\"app_id\":\"org.mozilla.firefox\",\"remote\":\"flathub\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the Firefox Flatpak from flathub for alice"
+                  }
+                ],
+                "summary": "Install Firefox Flatpak for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "d85c0e426bfd71bfcbd0aee48b95a359c63672bcb2ca7af8d91c12d07b7f973c"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6c699eba1950f6c0292548c8c8ea687da5d482cce6e502ec910dc7143b1b10eb": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_59b0e530-4ef6-4f5c-9155-258058c68b1b",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to add the deadsnakes/ppa PPA. This requires the AddPpa action, which adds a third‑party apt repository to the system. It is a medium‑risk operation because it expands the package source trust surface.",
+                "steps": [
+                  {
+                    "action_name": "AddPpa",
+                    "params": "{\"name\":\"deadsnakes/ppa\"}",
+                    "risk_level": "medium",
+                    "summary": "Add the deadsnakes/ppa Launchpad PPA to the apt sources list"
+                  }
+                ],
+                "summary": "Add the deadsnakes/ppa Launchpad PPA"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "ecd6730854bc2eaa5d921aefa68bd7a0267418a5cbd8798aa0294012e76cefdf"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:6e0ecf1842072de5860ff948eaa0019861b48a2564a986650bd28990bd89dd67": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -966,6 +1546,76 @@
         "max_tokens": 4096,
         "messages": [
           "bfdd970791317f4145873c38f0836dd9e774c9a75d04e14235ed9c796a536f39"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6f5fee97d96b2f398a76b8d59a8bf7c31cb337fd2c9ccabef07ea1cb6a5d120f": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_709c9457-bf15-43d6-969d-81f732444ba3",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether Livepatch is applying kernel patches. LivepatchStatus returns the current Livepatch service state, including whether it is active and applying patches. This is a low‑risk read‑only query.",
+                "steps": [
+                  {
+                    "action_name": "LivepatchStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the current Livepatch service status and patch application state"
+                  }
+                ],
+                "summary": "Check Canonical Livepatch status"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "dac870efbf448b09cb163a2b71dc0ff65c14a1ad5ed4db6d873460307422501a"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:6f694fb60380f7d25b665a2bfb3e83eb32f7670b6c0c88b00bdc5b75a080afc9": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f22a1a17-bd81-493f-83c9-9e57811a2d6f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a list of all Flatpak apps installed for the specified user. ListInstalledFlatpaks provides this information in a read‑only manner without requiring any changes.",
+                "steps": [
+                  {
+                    "action_name": "ListInstalledFlatpaks",
+                    "params": "{\"username\":\"alice\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the list of installed Flatpak apps for user alice"
+                  }
+                ],
+                "summary": "List Flatpak applications installed for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e8d4845c99a13c5d9c55da540c38357cc3539ce43ac1f108aece4684903a9b67"
         ]
       }
     },
@@ -1220,6 +1870,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:9a0d602dc3a8723c9b89dc0e05585df1d9855a8156ba1fd2e24e4f713801b99a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_7ec5de82-5949-45e4-b495-de79acbe072b",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to remove the Ubuntu Pro subscription from this system. Executing ProDetach will unregister the machine from the subscription service. This action is high risk because it permanently removes Pro benefits and cannot be undone without reattaching with a valid token.",
+                "steps": [
+                  {
+                    "action_name": "ProDetach",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Detach the system from the Ubuntu Pro subscription"
+                  }
+                ],
+                "summary": "Detach the machine from its Ubuntu Pro subscription"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e590d5c98f47b2db1031bb50eb29f01bf623a132124227c3824ae795af21fa16"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:9f736868a2e7a9c941c03b9e68a19e50676f1ac81242349647ebbe7715693210": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1401,6 +2086,152 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:ad7e2ef7e41268f91bd6ed8f41a08b8df0649f58a9dec4785888f23a1d675e4e": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_db96a944-2793-4918-a04c-380d6dc6ed5b",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to modify the netplan configuration to enable DHCP on eth0 but defer applying it. We set the appropriate netplan key, then run a dry‑run generation to validate the config without activating it.",
+                "steps": [
+                  {
+                    "action_name": "NetplanSet",
+                    "params": "{\"key\":\"ethernets.eth0.dhcp4\",\"value\":\"true\"}",
+                    "risk_level": "high",
+                    "summary": "Set eth0 to obtain its address via DHCP in netplan"
+                  },
+                  {
+                    "action_name": "NetplanGenerate",
+                    "params": "{}",
+                    "risk_level": "medium",
+                    "summary": "Validate the updated netplan configuration without applying it"
+                  }
+                ],
+                "summary": "Configure eth0 to use DHCP in netplan without applying the changes"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "582b5858367be4255a6f06fcb855a93abe695d3d44a10b9ece540eb018e71c13"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ae1f7158c74a4ee6b9db0493792920e7c05d62e5cbdefcab0b18368e5f9d19ae": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_10ff735a-b897-4236-9fb8-4a46fa9a4d32",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user explicitly requested an Ubuntu release upgrade. The UbuntuReleaseUpgrade action performs a distribution upgrade to the next available release, which is a high‑risk operation requiring a reboot and may take considerable time. This plan runs that action directly.",
+                "steps": [
+                  {
+                    "action_name": "UbuntuReleaseUpgrade",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Perform a distribution upgrade to the next Ubuntu version"
+                  }
+                ],
+                "summary": "Upgrade the system to the next Ubuntu release"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "7c6827883b21c104c84658845904e65c4aad9fc595efbb3729b230b51340f066"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:b5504205d6315ce76428860cecd6ea394b00568de322d49e6df7869a9ec9fff4": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_0e34b2d7-c30e-475c-b37a-b5a9a7ec277d",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know if Ubuntu Pro is active on this machine. The ProStatus action returns the current Ubuntu Pro subscription state without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "ProStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve Ubuntu Pro subscription status"
+                  }
+                ],
+                "summary": "Check Ubuntu Pro subscription status"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "a4b1a2d70753a15ee0ece91cfd980dc3fe8f0050f132a1b38702b7bfe6b3f1f6"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:b898052dbdaaf40f1fa95481f67ff52e2d566d33e0df5d14e80be5aca2ff7237": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3f7906fb-1ef2-4570-973a-f85294bd8fc7",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a list of all loaded AppArmor profiles with their current mode. AppArmorStatus provides this information as a read‑only query, so no approval is needed.",
+                "steps": [
+                  {
+                    "action_name": "AppArmorStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "List all loaded AppArmor profiles and indicate whether each is in enforce or complain mode"
+                  }
+                ],
+                "summary": "Show loaded AppArmor profiles and their enforcement mode"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "73909f9fdea175a410c1d0780939fd3654b7d2b94cc51391079ad79d8e12bd93"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:bbdeea719beabcdc38b2fa63addfec483cdaf07fb6dd0423b8358ac2a542d672": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1471,6 +2302,111 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:bf9c95cef7bb49f70d244c3f6011b5bce4b9ae90fdaa72e2a5d70a3a79fdde30": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_e275f13f-6a4e-4555-bf00-c5d69084f637",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of a specific ufw rule. The UfwDeleteRule action deletes the numbered rule from the firewall configuration. This is a high-risk operation because it modifies firewall rules and could affect network access.",
+                "steps": [
+                  {
+                    "action_name": "UfwDeleteRule",
+                    "params": "{\"rule_number\":3}",
+                    "risk_level": "high",
+                    "summary": "Delete ufw rule number 3 from the firewall"
+                  }
+                ],
+                "summary": "Delete ufw firewall rule number 3"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "dc793434faa9d16b446cccba11443c39830e53631051648dc967ae90b1dd88e8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:c1f6b0b3135bfc1e80264d3121c53a3afc44d4101b4bacd114fe908f6e4c6a0d": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_4472b474-7998-4941-9f74-208b06252e74",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to activate the esm-apps service provided by Ubuntu Pro. This requires the EnableProService action with the specified service name. Enabling a Pro service modifies the system's subscription configuration and is classified as high risk.",
+                "steps": [
+                  {
+                    "action_name": "EnableProService",
+                    "params": "{\"service\":\"esm-apps\"}",
+                    "risk_level": "high",
+                    "summary": "Enable the esm-apps Ubuntu Pro service"
+                  }
+                ],
+                "summary": "Enable the Ubuntu Pro esm-apps service"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "f64c19dd259abd4bb674841b44b5e773ced96a22da8f31b5486c06c77988831c"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ccd60ca2ffcaa57fe1efd509d0bdeb3adc8343306c19103fe77506026df798f4": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_ff66b94e-9050-4a0b-a765-8933c77c1358",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know which kernel command line arguments GRUB uses for booting. GrubGetKargs reads the current GRUB configuration and returns the kernel arguments. This is a low‑risk, read‑only operation.",
+                "steps": [
+                  {
+                    "action_name": "GrubGetKargs",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Read and display the current GRUB kernel command line arguments"
+                  }
+                ],
+                "summary": "Show the GRUB kernel command line used for boot"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "460f146ccfaf1de8ca80af93cad516ae8eb54f44997942c969c4f708f3559d88"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:d105c09f8d7b5edd365589e34a5cb79218cd9aa44a582880b7335a3aa82d6561": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1503,6 +2439,44 @@
         "max_tokens": 4096,
         "messages": [
           "684cfa76030fcd8a78592b767ce69c75b948a89d9ed565d8791b331fbcc3335e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:d22e3c08a7a11229a55372dba49323b163b4de86a00202c55894aac4c404ff31": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_06ffa677-36e4-4950-bd2e-f3f77fac0917",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to see which development containers are currently running. ListContainers returns the list of Podman containers for the specified user without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "ListContainers",
+                    "params": "{\"username\":\"root\"}",
+                    "risk_level": "low",
+                    "summary": "List all Podman containers for the current user"
+                  }
+                ],
+                "summary": "List development containers for the current user"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "6809a8a69524bbd52686c99bb064c220bc879b4262ec4a1da7e28024a75abe02",
+          "642d18c558894eef32ca9570a1a30c84d9e6a007ec8804a9f3b61c447a5ad0e0",
+          "69d24ac12c3b9d930f0a07f46a9ae07abe95b9bd899ef91f951e783a52972012",
+          "4b50f28030656b9aac1a21188698ff3933fb3589d2f2879ddd4e907d315b3548"
         ]
       }
     },
@@ -1611,6 +2585,23 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:da2797558717adaaa5ba5bd22a954c3c88024fc66f17edb93bf1bdcf9807a847": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "rejection": {
+        "kind": "request",
+        "message": "ProviderResponseError: {\"error\":{\"message\":\"Tool call validation failed: tool call validation failed: attempted to call tool 'json' which was not in request.tools\",\"type\":\"invalid_request_error\",\"code\":\"tool_use_failed\",\"failed_generation\":\"{\\\"name\\\": \\\"json\\\", \\\"arguments\\\": {\\n  \\\"summary\\\": \\\"List development containers\\\",\\n  \\\"explanation\\\": \\\"The user wants to see which development containers are currently running. ListContainers returns the user's podman containers, satisfying the request.\\\",\\n  \\\"steps\\\": [\\n    {\\n      \\\"action_name\\\": \\\"ListContainers\\\",\\n      \\\"summary\\\": \\\"List all podman containers for the current user\\\",\\n      \\\"risk_level\\\": \\\"low\\\",\\n      \\\"params\\\": \\\"{\\\\\\\"username\\\\\\\":\\\\\\\"root\\\\\\\"}\\\"\\n    }\\n  ]\\n}}\",\"status_code\":400}}"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "6809a8a69524bbd52686c99bb064c220bc879b4262ec4a1da7e28024a75abe02",
+          "642d18c558894eef32ca9570a1a30c84d9e6a007ec8804a9f3b61c447a5ad0e0",
+          "69d24ac12c3b9d930f0a07f46a9ae07abe95b9bd899ef91f951e783a52972012"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:e1740099be9f022588d7da52ebadb3489901d49e1c0dcc58290a1e2f70d622e7": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1681,6 +2672,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:e3134bfc90306615381c4127a93727a61b0ea60a0b9a7f86edf11848c2fcb18a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_6acc876c-14ec-4848-b84b-d19ae011a494",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a list of Multipass VMs and their status. MultipassList provides exactly this information in a read‑only, low‑risk operation.",
+                "steps": [
+                  {
+                    "action_name": "MultipassList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve a list of all Multipass VMs with their state"
+                  }
+                ],
+                "summary": "List Multipass virtual machines and their current state"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "23148ed87213ed1a2f619acf2aff63dced33e4e445995b1afb5df327ce134fb8"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:e57f9cb4f87b463953961c1221a0004b26f15b2a38b1333de0265387e3475502": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1716,6 +2742,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:e7b19e46429966908b40922abf1411a7ee98f4633c4b9028f591e651c7280edb": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f43d75df-3a1c-45d5-bce8-71a020994071",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn off the Livepatch service provided by Ubuntu Pro. Disabling it stops automatic kernel live patching. This action is high risk because it changes system security posture.",
+                "steps": [
+                  {
+                    "action_name": "DisableProService",
+                    "params": "{\"service\":\"livepatch\"}",
+                    "risk_level": "high",
+                    "summary": "Disable the Ubuntu Pro livepatch service"
+                  }
+                ],
+                "summary": "Disable the Ubuntu Pro Livepatch service"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e8f2462358f2f6a76406fcc44ae913e6df2f33bfcd76b8c3b7076732604f20f0"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:ebc8ab423bb22ab9131cc580db671d63b7a8b601c44c28950a9d8ba050543518": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1748,6 +2809,41 @@
         "max_tokens": 4096,
         "messages": [
           "5c4e8e592b2c4f966130a7e38d507abb14e0c74bc25e720a4df3f257c5c4984e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ee7c214ad90265c2c334f6699ab1bfc478388e56583f5e24cfa554e489c121af": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_45501d6d-695d-468d-9821-caf45b3b389f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of the deadsnakes/ppa PPA. This action will delete the PPA from the system's apt sources, which is a medium‑risk operation requiring approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "RemovePpa",
+                    "params": "{\"name\":\"deadsnakes/ppa\"}",
+                    "risk_level": "medium",
+                    "summary": "Delete the deadsnakes/ppa Launchpad PPA from the system's apt sources"
+                  }
+                ],
+                "summary": "Remove the deadsnakes/ppa Launchpad PPA"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "1b2bd41dedbda28f4b14a52317a8286f25ffea4f0998a6c016c50c6469fb642c",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e1c4eda44f192f041ee4b5c43a1efedeb7dbd3ab14490ee0783535eb60557aa3"
         ]
       }
     },

--- a/tests/e2e/cassettes/ubuntu-noble-gpt-oss-120b.json
+++ b/tests/e2e/cassettes/ubuntu-noble-gpt-oss-120b.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "meta": {
     "surfaces": [
       "groq/openai/gpt-oss-120b"
@@ -117,6 +117,181 @@
         "max_tokens": 4096,
         "messages": [
           "2a8c3e89caae87c5c4e9bd67ecbc3ab54a830555cbc8b75c3f623d04667564ae"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:06a9813d035efd8612b761ed8b189a3b66193c6cf24ff4ec8ec1d8606eb38c93": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_9393abd2-12a8-4c04-abb4-378cd0975563",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user explicitly requested an upgrade to the next Ubuntu release. The UbuntuReleaseUpgrade action performs the release upgrade, which is a high‑risk operation that may take 20–45 minutes, requires a reboot, and can affect system stability. The plan includes only this step as it fulfills the request.",
+                "steps": [
+                  {
+                    "action_name": "UbuntuReleaseUpgrade",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Perform a release upgrade to the next Ubuntu version"
+                  }
+                ],
+                "summary": "Upgrade the system to the next Ubuntu release"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "7c6827883b21c104c84658845904e65c4aad9fc595efbb3729b230b51340f066"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:0b06750dd97202a6c44e8007cc673b39c4a26d801d6a44395823ddc53f86006a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_23e19df4-1e91-4a2e-9e7e-d1c6af4ab795",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn on the 'esm-apps' service provided by Ubuntu Pro. Enabling this service will activate the Extended Security Maintenance for applications, allowing security updates for supported apps. This action requires an attached Ubuntu Pro subscription and is considered high risk because it modifies subscription state.",
+                "steps": [
+                  {
+                    "action_name": "EnableProService",
+                    "params": "{\"service\":\"esm-apps\"}",
+                    "risk_level": "high",
+                    "summary": "Activate the esm-apps service in Ubuntu Pro"
+                  }
+                ],
+                "summary": "Enable the esm-apps Ubuntu Pro service"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "f64c19dd259abd4bb674841b44b5e773ced96a22da8f31b5486c06c77988831c"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:11fcb306daa3786e01d13df4d21681b1996df48075ffff735570393b3f011bbc": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_3cefe51d-a098-417e-bd2a-b6d04de79a7f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to update the netplan configuration files on disk while leaving the currently active network interfaces untouched. NetplanGenerate rewrites the backend config files based on the saved netplan YAML but does not apply them, satisfying this request.",
+                "steps": [
+                  {
+                    "action_name": "NetplanGenerate",
+                    "params": "{}",
+                    "risk_level": "medium",
+                    "summary": "Regenerate netplan backend config files (dry-run) without applying to live interfaces"
+                  }
+                ],
+                "summary": "Regenerate netplan backend configuration files without applying changes"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "0b2a536f120201f7159d43fb11b17ebab393d01a0f59b9d543fde377cb157d71"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:18749ebad5284cb641d98c64e2fe242e5d18dbf96fdf95f6834e65684dc6baf5": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_33f69538-1815-4071-b639-8cd3480871fc",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn off the Livepatch service provided by Ubuntu Pro. Disabling it stops automatic kernel patching. This uses the DisableProService action with the service name \"livepatch\".",
+                "steps": [
+                  {
+                    "action_name": "DisableProService",
+                    "params": "{\"service\":\"livepatch\"}",
+                    "risk_level": "high",
+                    "summary": "Disable the Livepatch service in Ubuntu Pro"
+                  }
+                ],
+                "summary": "Disable the Ubuntu Livepatch Pro service"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e8f2462358f2f6a76406fcc44ae913e6df2f33bfcd76b8c3b7076732604f20f0"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:1cfde29bdeeff35dbba682bb045bdc733afd9a9c939cb90c24a05a80b1f9dc64": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_c79aefd6-8a76-40e4-a4eb-bf7977caba40",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested the org.mozilla.firefox Flatpak from flathub for the user alice. This plan runs the InstallFlatpak action to add the application for that user.",
+                "steps": [
+                  {
+                    "action_name": "InstallFlatpak",
+                    "params": "{\"username\":\"alice\",\"app_id\":\"org.mozilla.firefox\",\"remote\":\"flathub\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the Firefox Flatpak from flathub for alice"
+                  }
+                ],
+                "summary": "Install Firefox Flatpak for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "d85c0e426bfd71bfcbd0aee48b95a359c63672bcb2ca7af8d91c12d07b7f973c"
         ]
       }
     },
@@ -344,6 +519,146 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:25a3c422d1b1ec22c5939821bb77d31f5d94e661256b763fbaf11ee7c27cb3f8": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_92cd31ca-62a4-4dab-8450-c41bbfc99001",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether Livepatch is active and applying kernel patches. LivepatchStatus provides the current Livepatch status, including whether it is enabled and the kernel version being patched.",
+                "steps": [
+                  {
+                    "action_name": "LivepatchStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the Canonical Livepatch service status and patching details"
+                  }
+                ],
+                "summary": "Check if Canonical Livepatch is applying kernel patches"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "dac870efbf448b09cb163a2b71dc0ff65c14a1ad5ed4db6d873460307422501a"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:2ed599df9ebaf9bfecdd44ab69ea7968bb04df8431647d1bf329789ac37fda37": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_c816335e-f4a0-4fba-96a0-6eaca7c31822",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to remove the machine's Ubuntu Pro subscription. The ProDetach action performs this detachment without additional parameters. It is a high‑risk operation as it revokes subscription benefits.",
+                "steps": [
+                  {
+                    "action_name": "ProDetach",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Remove the Ubuntu Pro subscription from this system"
+                  }
+                ],
+                "summary": "Detach the machine from its Ubuntu Pro subscription"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e590d5c98f47b2db1031bb50eb29f01bf623a132124227c3824ae795af21fa16"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:304e2d4b79d3676761e8ac5c1ccb344d65d9d6a4c8d1e3c0fc9265705201707c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_8a981e5a-ec96-42df-88b1-f7c7f6f0580f",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether a reboot is needed. The CheckPendingReboot action reads the system's reboot-required flag and reports the status. This is a low‑risk, read‑only query.",
+                "steps": [
+                  {
+                    "action_name": "CheckPendingReboot",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Check whether a reboot is pending"
+                  }
+                ],
+                "summary": "Check if the system requires a reboot"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "badf780f4098f9a9c08e6accc9bd78b6463864a5bc522774d1ca5824ac0c557a"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:30b3f4f9e5511cc4297de51cf8aff4173025b0ce3eb8a26bb0d131d28613c0f6": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_95d2c510-12ef-4def-9e26-8c2d5e47440e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn on automatic security updates. Configuring unattended upgrades will enable the system to automatically apply security updates as they become available, which is a medium‑risk configuration change requiring approval.",
+                "steps": [
+                  {
+                    "action_name": "ConfigureUnattendedUpgrades",
+                    "params": "{\"enabled\":true}",
+                    "risk_level": "medium",
+                    "summary": "Enable unattended security updates"
+                  }
+                ],
+                "summary": "Enable automatic security updates"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "1224bb349f17ba23b876bee6423b5d16c757c0948a9cfc7d4193754e4af261c7"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:31fd005b04520652e9a70bbbae87f26f8861f15376afa685832e746f7f53e361": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -417,6 +732,41 @@
         "max_tokens": 4096,
         "messages": [
           "e685dcd493b55ea55fb1d63bf88f9feb956b6d131096a36491b85197976b69f9"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:3c11ab1598604d6f77abc895682285ea86552bd76d5c6e315301278eb76f4761": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a17b7917-8a1b-4ab8-a03d-8e5ed6159a59",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to enable DHCP for interface eth0 in the netplan configuration but defer applying the changes. This plan updates the netplan YAML by setting the dhcp4 option for eth0 to true, which is a high‑risk configuration change, and does not run NetplanApply, so the new setting will take effect only after the user later applies it.",
+                "steps": [
+                  {
+                    "action_name": "NetplanSet",
+                    "params": "{\"key\":\"ethernets.eth0.dhcp4\",\"value\":\"true\"}",
+                    "risk_level": "high",
+                    "summary": "Set eth0 to obtain its IPv4 address via DHCP in netplan"
+                  }
+                ],
+                "summary": "Configure eth0 to use DHCP in netplan without applying"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "582b5858367be4255a6f06fcb855a93abe695d3d44a10b9ece540eb018e71c13"
         ]
       }
     },
@@ -531,6 +881,111 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:4314d65a841f71004c6ff72d5bc7665ff4c802d8129c7ad4e1a3357632718118": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_e5e10218-fde6-4344-88f3-b8386fff8ffb",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of firewall rule number 3. This plan runs the UfwDeleteRule action to delete that specific rule from ufw's rule set.",
+                "steps": [
+                  {
+                    "action_name": "UfwDeleteRule",
+                    "params": "{\"rule_number\":3}",
+                    "risk_level": "high",
+                    "summary": "Delete the ufw rule with index 3"
+                  }
+                ],
+                "summary": "Delete ufw firewall rule number 3"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "dc793434faa9d16b446cccba11443c39830e53631051648dc967ae90b1dd88e8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:4bdc8dd6dc0ce984a19f74731ffbb1aa96ac8bba7ad3342a831783acb61a06ec": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_ce832618-4f76-4e81-9ae9-547671b6f484",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants AppArmor to log violations for the nginx service without enforcing them. Using AppArmorComplain changes the profile to complain (learning) mode, which is a high‑risk operation because it disables enforcement for that service.",
+                "steps": [
+                  {
+                    "action_name": "AppArmorComplain",
+                    "params": "{\"profile_path\":\"/etc/apparmor.d/usr.sbin.nginx\"}",
+                    "risk_level": "high",
+                    "summary": "Switch the nginx AppArmor profile to complain mode so violations are logged but not blocked"
+                  }
+                ],
+                "summary": "Set the nginx AppArmor profile to complain mode"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "42fa9993263625d62a8ea858cf0993e2e3f6f4e0d86c3bc859d494cb31d128a4"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:5827cbf3d82586cd4e1899bf28129c47b5ed0aa2a7a2fa1cd1daf6d4229698f9": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_2cff404b-ec26-406e-957c-fcba0df2d1f4",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see the apt pin priority (apt-cache policy) for nginx. GetAptPins with the package parameter returns this information. This is a low‑risk read‑only query.",
+                "steps": [
+                  {
+                    "action_name": "GetAptPins",
+                    "params": "{\"package\":\"nginx\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve apt pin priority for the nginx package"
+                  }
+                ],
+                "summary": "Show apt pin priority for the nginx package"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "1e8ad878e47dc632d9a3d9bc95a4c7f62fff43830790de9a2b131e0c19f18cfe"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:58d8540f8e6dec5a7998dfb9e7fc9a2f662917585c488b87be71db87a197e9a0": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -614,6 +1069,76 @@
         "max_tokens": 4096,
         "messages": [
           "6809a8a69524bbd52686c99bb064c220bc879b4262ec4a1da7e28024a75abe02"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:5a9e3706a54209dd8a2a0e4ec3d79b400c107e01b7c5438843ef570098c0e0be": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_0088fb3f-4a07-4751-858c-a07f31346054",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to add the deadsnakes/ppa PPA, which provides newer Python packages. Adding a PPA modifies the apt sources, so this is a high‑risk change requiring admin approval.",
+                "steps": [
+                  {
+                    "action_name": "AddPpa",
+                    "params": "{\"name\":\"deadsnakes/ppa\"}",
+                    "risk_level": "high",
+                    "summary": "Add the deadsnakes/ppa PPA to the apt sources"
+                  }
+                ],
+                "summary": "Add the deadsnakes/ppa Launchpad PPA"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "ecd6730854bc2eaa5d921aefa68bd7a0267418a5cbd8798aa0294012e76cefdf"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:5d58f72146c07d477212928f998a981809320f36b3005182c21f91b164300f06": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_49036b82-6338-4220-bbd8-85ea43a20f75",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to delete the apt pin identified as freeze-nginx. This action will remove the pin configuration, allowing the package to be upgraded normally.",
+                "steps": [
+                  {
+                    "action_name": "RemoveAptPin",
+                    "params": "{\"name\":\"freeze-nginx\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the apt pin named freeze-nginx"
+                  }
+                ],
+                "summary": "Remove the apt pin named freeze-nginx"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "598d6852d030a1f4fed0246e19e4904623501e30f40a7b504f2c6396fdeb369e"
         ]
       }
     },
@@ -763,6 +1288,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:703f285bebe902b22df0c7a3cd9f28217e5b8573af9fa5d679c01bc3c8b7d4b1": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_14c42cfd-03c4-4f90-aba9-872029e63c13",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see which Multipass VMs exist on the system and whether they are running, stopped, etc. MultipassList provides this information directly without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "MultipassList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve a list of Multipass VMs with their statuses"
+                  }
+                ],
+                "summary": "List all Multipass virtual machines and their current state"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "23148ed87213ed1a2f619acf2aff63dced33e4e445995b1afb5df327ce134fb8"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:7226fab6d2cb4b9456b2363b83904d4a6898fea876bc67d4d4482d9693c5b1d1": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -868,6 +1428,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:85f6e4c1b3660196014172dfbc687f11e8770988459661dd5cd70d3e0de3bb37": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_e1d8f179-c012-4ca0-a025-0558a1937538",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of the org.mozilla.firefox Flatpak application for the specified user. UbuntuRemoveFlatpak will delete the Flatpak app for that user without affecting other system components.",
+                "steps": [
+                  {
+                    "action_name": "UbuntuRemoveFlatpak",
+                    "params": "{\"username\":\"alice\",\"app_id\":\"org.mozilla.firefox\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the org.mozilla.firefox Flatpak for alice"
+                  }
+                ],
+                "summary": "Uninstall the Firefox Flatpak for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "5c2b08f0a62952dc4ef832496a51d58f579d6f5334f420ac4cb4cf2616c07fce"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:8c9a2ada85303c7a5f0cc3b158c0f4fc22982674f2a56f5adaa236d87dacb805": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -935,6 +1530,76 @@
         "max_tokens": 4096,
         "messages": [
           "dc0de1df9d559c76ecf64f188a32f254f8e7714b293973ca2d690a365d5c7e51"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:8ef06cb5a361c67cd7db06d42a79b360333ff184f307b25a76bf39fd9c1d90b3": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_ef15f5ef-3c84-4656-a3a1-680d3a09b06a",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a refresh of every installed Flatpak app for the specified user. UpdateFlatpak with the username parameter performs this operation, applying any available updates to all of alice's Flatpak installations.",
+                "steps": [
+                  {
+                    "action_name": "UpdateFlatpak",
+                    "params": "{\"username\":\"alice\"}",
+                    "risk_level": "medium",
+                    "summary": "Refresh all Flatpak apps installed for alice"
+                  }
+                ],
+                "summary": "Update all Flatpak applications for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "4d0d5a01dd80a55d1254b72fdb2d6d9b53478c80c9e876bd0ddb23d628323f9e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:94afb361c287778de64a3ccf7650ba6f68c7992ac6a64ccafefd0b46513ad0a8": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a9eb4e49-5874-40bc-a3e3-f7ddca143cbc",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to roll back the Firefox snap. Using SnapRevert will restore the snap to its prior revision, which is a reversible, medium‑risk operation.",
+                "steps": [
+                  {
+                    "action_name": "SnapRevert",
+                    "params": "{\"name\":\"firefox\"}",
+                    "risk_level": "medium",
+                    "summary": "Revert the firefox snap to its previous revision"
+                  }
+                ],
+                "summary": "Revert the firefox snap to its previous revision"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "3f1f883ed054ebaf22ba7f3327b5fb30ea657e8493ff6e540e5cd12a14936e8b"
         ]
       }
     },
@@ -1043,6 +1708,103 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:ab84a4d9c3732b32cd4bc424ba4c4460a8891a8d87b339b74981352e64c4d665": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_e02f1a19-d00d-4052-90fb-71bed5abd70c",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know if Ubuntu Pro is active on this machine. The ProStatus action returns the current subscription state and enabled services. It is a low‑risk read‑only query.",
+                "steps": [
+                  {
+                    "action_name": "ProStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve Ubuntu Pro subscription status and enabled services"
+                  }
+                ],
+                "summary": "Check Ubuntu Pro subscription status"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "a4b1a2d70753a15ee0ece91cfd980dc3fe8f0050f132a1b38702b7bfe6b3f1f6"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ae6bfe27def8e35060616ca6c45af7b90c3747b54dc963107253203f99051d88": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_1e3746cd-9204-401d-8798-3f24dc90e470",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether cloud-init completed provisioning without errors. CloudInitStatus provides a detailed status report of the cloud-init process, including any errors that occurred.",
+                "steps": [
+                  {
+                    "action_name": "CloudInitStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve cloud-init provisioning status and any error messages"
+                  }
+                ],
+                "summary": "Check cloud-init provisioning status"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "16158a41b0bd4d3ef09315a655f064b8c31c88fc7c6c28f9f106ad81eefa0884"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:aeae301845c586b96d2a2a2603507c28a2832309b3978c6679593fadbca15843": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_c29eaa1e-5fa8-44d5-8263-1c8f66862dbf",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "Attaching to Ubuntu Pro requires a subscription token, which was not provided.",
+                "suggestion": "Provide the Ubuntu Pro token using the 'token' parameter, e.g., 'ProAttach' with {\"token\":\"your-token-here\"}."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "036e068017c7490135c5a4ddf9d0d5e070c737dba97b7a92f5b1a54e3eec2f76"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:b286c2d90be47b48d08c45a075faf0576a8517f4fb76ae45e77ccc2373f5f805": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1075,6 +1837,41 @@
         "max_tokens": 4096,
         "messages": [
           "00222c4f773803d5b9eb37ddd904efbeba6227a1e9f412efe2943b5df95ab1e1"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:b44b82d1dc105438281e7f1df4323a5ef37af7d86a45ea325404909bba6c9aa9": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_2eb302e5-f380-40cf-bd28-f51f36ccc08e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to see which Flatpak applications are installed for the user alice. UbuntuListFlatpaks provides a read‑only enumeration of those apps.",
+                "steps": [
+                  {
+                    "action_name": "UbuntuListFlatpaks",
+                    "params": "{\"username\":\"alice\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the list of Flatpak applications installed for alice"
+                  }
+                ],
+                "summary": "List installed Flatpak apps for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e8d4845c99a13c5d9c55da540c38357cc3539ce43ac1f108aece4684903a9b67"
         ]
       }
     },
@@ -1434,6 +2231,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:c961b98d739470ee450900d397dbe6015922e61ae8b6431808d7acbd024ba83c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_2c11fc7d-70ee-4c5c-8cc3-8d81e03e7e61",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a view of every loaded AppArmor profile and its mode (enforce or complain). The AppArmorStatus action returns exactly this read‑only information, so we can run it directly without any prior queries.",
+                "steps": [
+                  {
+                    "action_name": "AppArmorStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve all loaded AppArmor profiles and their mode (enforce or complain)"
+                  }
+                ],
+                "summary": "List all loaded AppArmor profiles and their current mode"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "73909f9fdea175a410c1d0780939fd3654b7d2b94cc51391079ad79d8e12bd93"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:cce220e3691a7e3b8f551a46de37c2a6f9eb5d938247c175e974c84ec1ac51ec": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1466,6 +2298,41 @@
         "max_tokens": 4096,
         "messages": [
           "6816dc4e50ad96fc96483612de1a77937b6b4799e0a59002d1ca213495145552"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:d08912d4fbdb0e70b7d32ca2395a949c9609c871bb18e6d0cd5db213e806b201": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_b1b8a74d-11bc-4d8e-8297-ed1a294f56c5",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see which packages were installed or removed via apt recently. AptHistoryList provides a read‑only list of recent apt transactions, satisfying the request without any system changes.",
+                "steps": [
+                  {
+                    "action_name": "AptHistoryList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve recent apt transaction log entries"
+                  }
+                ],
+                "summary": "Show recent apt package installation and removal history"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "9650dcf7669beaf381f3c04970691f5712cabd937a398f69db03b0535271b390"
         ]
       }
     },
@@ -1542,6 +2409,41 @@
         "max_tokens": 4096,
         "messages": [
           "212bd135d73c2b5008122ff9f69372a22d95a6e6df7a6b253f8e52c814f2f9cc"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:da4855d4f7cdcf439a986582ff1ed7965424b9c6ed12a744404a59732f2c9e17": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_e81fd557-eb2b-4a69-b0ce-19de407c9960",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants the AppArmor profile at /etc/apparmor.d/usr.bin.firefox to be put into enforce mode. This action changes the profile from complain or disabled to enforce, which may cause the application to be blocked if the policy is not fully compatible, so it is classified as high risk.",
+                "steps": [
+                  {
+                    "action_name": "AppArmorEnforce",
+                    "params": "{\"profile_path\":\"/etc/apparmor.d/usr.bin.firefox\"}",
+                    "risk_level": "high",
+                    "summary": "Set the Firefox AppArmor profile to enforce mode"
+                  }
+                ],
+                "summary": "Enforce the Firefox AppArmor profile"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "6a832dc12d26adbc61c3c7503e3b97980aa6d7b0935a09f8dd122949aa0f6bf8"
         ]
       }
     },
@@ -1677,6 +2579,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:eae4330ae25daebdac4d11ab180e4616fb839afa708ac4bc88e16990b03de7e7": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_7380d0f1-6423-48cb-895e-3ce14e86aca3",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of the deadsnakes/ppa PPA. Removing a PPA modifies the system's package sources, which is a medium‑risk operation requiring approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "RemovePpa",
+                    "params": "{\"name\":\"deadsnakes/ppa\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the deadsnakes/ppa Launchpad PPA from the system"
+                  }
+                ],
+                "summary": "Remove the deadsnakes/ppa Launchpad PPA"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e1c4eda44f192f041ee4b5c43a1efedeb7dbd3ab14490ee0783535eb60557aa3"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:ef9950f5f866f5cf5517eb617ca5e3154d8c55a1424b45673e7398611aa89098": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1709,6 +2646,41 @@
         "max_tokens": 4096,
         "messages": [
           "8bdea8101dc3a6689ea49c58e108291e41df35aa698ec8e1139452da4e4b4ef7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:efc2579345b0cf6b1fadfcef174243840a81a8c637e355fc1d77a53ee224a637": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_162fbc18-e79d-4eb0-964c-58da41dff140",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants basic host information. GetHostState returns OS release, kernel version, and hardware architecture in a read‑only low‑risk action.",
+                "steps": [
+                  {
+                    "action_name": "GetHostState",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve OS release, kernel version, and system architecture"
+                  }
+                ],
+                "summary": "Show operating system release, kernel version, and architecture"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "36a31243b6d594e82530e21e5ba8d22bede4e185bbc97517cd12ea2562971ae1"
         ]
       }
     },
@@ -1747,6 +2719,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:f28540e869ec13cb34c9e141dbcd8a104ebfcb2c3958bdd0dd32411eba4178b0": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_4f358fa7-ae93-4fdd-a259-480ac54f6992",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know the kernel parameters that GRUB uses for booting. GrubGetKargs reads the GRUB configuration and returns the kernel command line without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "GrubGetKargs",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the GRUB_CMDLINE_LINUX kernel arguments from the GRUB configuration"
+                  }
+                ],
+                "summary": "Show the current GRUB kernel command line arguments"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "460f146ccfaf1de8ca80af93cad516ae8eb54f44997942c969c4f708f3559d88"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:f6fa19f2ef93a7a63e226ce0e187b8085c2aec9fe24c83c64e7fe8b725b4f375": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1771,6 +2778,42 @@
         "max_tokens": 4096,
         "messages": [
           "dbaa624779742f87f271777c499df8b6cbad3fbd1a3d28050e7247e7914da5d8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:f85e271e8705b9f77f33424156fa64b42eb58c1f1eb4f7ec9942c54da9ce5734": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_84f54bd2-e458-41d0-aaa2-0167d95e4de3",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn off the Livepatch service provided by Ubuntu Pro. This plan uses the DisableProService action with the 'livepatch' service, which will deactivate Livepatch. This is a high-risk action and will require approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "DisableProService",
+                    "params": "{\"service\":\"livepatch\"}",
+                    "risk_level": "high",
+                    "summary": "Disable the Livepatch service in Ubuntu Pro"
+                  }
+                ],
+                "summary": "Disable the Ubuntu Pro Livepatch service"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "d3714261cee8a6680137e71bb5b4a0c0f120a61f4679725675fcb9a7c36d3679",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e8f2462358f2f6a76406fcc44ae913e6df2f33bfcd76b8c3b7076732604f20f0",
+          "4b50f28030656b9aac1a21188698ff3933fb3589d2f2879ddd4e907d315b3548"
         ]
       }
     },

--- a/tests/e2e/cassettes/ubuntu-resolute-gpt-oss-120b.json
+++ b/tests/e2e/cassettes/ubuntu-resolute-gpt-oss-120b.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "meta": {
     "surfaces": [
       "groq/openai/gpt-oss-120b"
@@ -9,6 +9,76 @@
     ]
   },
   "entries": {
+    "groq/openai/gpt-oss-120b:00617aecfd0f6e036b090b57e252c4e7bdd856cabc6585b1979bba8018957591": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a57f12a1-e70f-46fe-b590-98006799ea46",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to turn on the 'esm-apps' service provided by Ubuntu Pro. This action will enable the service, allowing access to extended security maintenance for applications. It is a high-risk operation requiring approval before execution.",
+                "steps": [
+                  {
+                    "action_name": "EnableProService",
+                    "params": "{\"service\":\"esm-apps\"}",
+                    "risk_level": "high",
+                    "summary": "Enable the esm-apps service in Ubuntu Pro"
+                  }
+                ],
+                "summary": "Enable the esm-apps Ubuntu Pro service"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "f64c19dd259abd4bb674841b44b5e773ced96a22da8f31b5486c06c77988831c"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:02bc16395814e641ad6482463900313da0e4142f55ddd27738f00155e8ae35a6": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_cd7053d9-649d-4d81-95b2-a36ae4f68054",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants the AppArmor profile for nginx to be in complain mode, which logs violations without enforcing them. Using the AppArmorComplain action will change the profile's mode accordingly. This operation is high risk because it temporarily disables enforcement for the nginx service, so it should be reviewed carefully.",
+                "steps": [
+                  {
+                    "action_name": "AppArmorComplain",
+                    "params": "{\"profile_path\":\"/etc/apparmor.d/usr.sbin.nginx\"}",
+                    "risk_level": "high",
+                    "summary": "Set the nginx AppArmor profile to complain mode so violations are logged but not blocked"
+                  }
+                ],
+                "summary": "Set nginx AppArmor profile to complain mode"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "42fa9993263625d62a8ea858cf0993e2e3f6f4e0d86c3bc859d494cb31d128a4"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:0445b57c8fb65266dc4be9efa89c0f7a80c7903f2534fb17c1f2f5bbc7dee8d4": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -161,6 +231,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:0e179744ac9ff07f0d1a556062550673d31c7ab4c55f036cb6f6ed4bad2021a7": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_350fd1d6-afbf-47df-a256-8a10bb9b9289",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to roll back the Firefox snap to the earlier version. SnapRevert will revert the specified snap to its prior revision, which is a reversible operation.",
+                "steps": [
+                  {
+                    "action_name": "SnapRevert",
+                    "params": "{\"name\":\"firefox\"}",
+                    "risk_level": "medium",
+                    "summary": "Revert the Firefox snap to its previous revision"
+                  }
+                ],
+                "summary": "Revert the Firefox snap to its previous revision"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "3f1f883ed054ebaf22ba7f3327b5fb30ea657e8493ff6e540e5cd12a14936e8b"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:0ea6203f2b5ffb865bcb91fb6422307d2a6d6f61ef63b0af35d70b1405e7061f": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -182,6 +287,42 @@
         "max_tokens": 4096,
         "messages": [
           "6809a8a69524bbd52686c99bb064c220bc879b4262ec4a1da7e28024a75abe02"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:12c1e3b7d76e90c78b2c8d1194b0cb0536d1d2ec2f3670f50f3982c2b1d0cbd7": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_ab682c6a-53da-4641-871b-c2372a21cbd4",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of a specific ufw rule identified by its index. This plan will delete rule number 3 from the ufw firewall configuration.",
+                "steps": [
+                  {
+                    "action_name": "UfwDeleteRule",
+                    "params": "{\"rule_number\":3}",
+                    "risk_level": "high",
+                    "summary": "Delete ufw rule number 3"
+                  }
+                ],
+                "summary": "Delete ufw firewall rule number 3"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "dc793434faa9d16b446cccba11443c39830e53631051648dc967ae90b1dd88e8",
+          "4b50f28030656b9aac1a21188698ff3933fb3589d2f2879ddd4e907d315b3548"
         ]
       }
     },
@@ -217,6 +358,111 @@
         "max_tokens": 4096,
         "messages": [
           "5396a02b28162d480e8a3a3045e3d0a2ef44e2f253a26d08f15bcc93bc5547f8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:15574be142bf0c718b0459ee01716d4f9be56aaea250fd52b44cd501f1b0ff2e": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_d1f19e72-032a-4370-a0f0-6ff2da63b548",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to put the AppArmor profile /etc/apparmor.d/usr.bin.firefox into enforce mode. This requires the AppArmorEnforce action, which switches the profile from complain or disabled to enforcement, providing stronger security for Firefox.",
+                "steps": [
+                  {
+                    "action_name": "AppArmorEnforce",
+                    "params": "{\"profile_path\":\"/etc/apparmor.d/usr.bin.firefox\"}",
+                    "risk_level": "high",
+                    "summary": "Set the Firefox AppArmor profile to enforce mode"
+                  }
+                ],
+                "summary": "Enable enforcement for the Firefox AppArmor profile"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "6a832dc12d26adbc61c3c7503e3b97980aa6d7b0935a09f8dd122949aa0f6bf8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:1b1a14de97f3ffbda50ca7f68a4569f4c9617834c24107b2ef035e69558c8ff8": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_27320485-4c4d-4caf-8d92-7181a2aae3a9",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants unattended security updates to be turned on. Configuring unattended-upgrades will enable the system's automatic security update mechanism, ensuring future security patches are installed without manual intervention. This is a high‑risk change because it modifies system configuration and will affect future package management.",
+                "steps": [
+                  {
+                    "action_name": "ConfigureUnattendedUpgrades",
+                    "params": "{\"enabled\":true}",
+                    "risk_level": "high",
+                    "summary": "Enable unattended security updates"
+                  }
+                ],
+                "summary": "Enable automatic security updates"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "1224bb349f17ba23b876bee6423b5d16c757c0948a9cfc7d4193754e4af261c7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:1d429f09195512327298693cf41414e73cc763a6632cc5ad5a8f5e9e8a16c7d5": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_81dac638-4435-4dd2-a6ae-139c87e1bccf",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know the kernel command line that GRUB passes to the kernel. GrubGetKargs reads the current GRUB_CMDLINE_LINUX setting from /etc/default/grub without modifying anything, so it safely provides this information.",
+                "steps": [
+                  {
+                    "action_name": "GrubGetKargs",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Read the current GRUB kernel command line arguments"
+                  }
+                ],
+                "summary": "Show the GRUB kernel command line arguments used at boot"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "460f146ccfaf1de8ca80af93cad516ae8eb54f44997942c969c4f708f3559d88"
         ]
       }
     },
@@ -325,6 +571,146 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:22666e8b195a28899a5bb0720505caebb9984c8da0869751d061917c5b321bf7": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_90e07400-6823-4f8f-9cdd-06e023984317",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to delete the APT pin called 'freeze-nginx'. This action will remove the corresponding pin file from /etc/apt/preferences.d, stopping the pin from affecting future package operations. No additional steps are needed.",
+                "steps": [
+                  {
+                    "action_name": "RemoveAptPin",
+                    "params": "{\"name\":\"freeze-nginx\"}",
+                    "risk_level": "medium",
+                    "summary": "Delete the APT pin named freeze-nginx"
+                  }
+                ],
+                "summary": "Remove the APT pin named freeze-nginx"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "598d6852d030a1f4fed0246e19e4904623501e30f40a7b504f2c6396fdeb369e"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:2ad35bf887d3c48e2e766fdc988ef9326bad6c9603c0f92940b8e0819e9d463d": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_37ac6d15-30e4-4746-988c-f56b61d7dee2",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see every loaded AppArmor profile and whether it is in enforce or complain mode. The AppArmorStatus action provides a read‑only overview of all loaded profiles and their modes, satisfying the request with low risk.",
+                "steps": [
+                  {
+                    "action_name": "AppArmorStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve a list of all loaded AppArmor profiles and indicate their mode (enforce or complain)"
+                  }
+                ],
+                "summary": "List all loaded AppArmor profiles and their current mode"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "73909f9fdea175a410c1d0780939fd3654b7d2b94cc51391079ad79d8e12bd93"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:2d1917730f9b902ee0ab88aa5d6f72a96e8fcdfadd466e5bd13e8a58886786b5": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f51ca801-2926-4952-8d47-07c7e0d050a6",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to remove the Ubuntu Pro subscription from this system. The ProDetach action will delete the attached subscription, stopping any Pro services and clearing subscription data. This is a high‑risk operation because it permanently removes the subscription state.",
+                "steps": [
+                  {
+                    "action_name": "ProDetach",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Remove the attached Ubuntu Pro subscription from the system"
+                  }
+                ],
+                "summary": "Detach this machine from its Ubuntu Pro subscription"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e590d5c98f47b2db1031bb50eb29f01bf623a132124227c3824ae795af21fa16"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:2d5f7c85379a43208fe476f30bfd81ea96c4554cca5aec0cacaf1e663e8cf2a3": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_c1d821a1-3a8b-4196-994b-7bbf9280021e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested an upgrade to the next Ubuntu version. This action will perform a full distribution upgrade using Ubuntu's release upgrade tool, which may take 20–45 minutes, modify many packages, and require a reboot to complete. The operator should ensure backups are in place and be prepared for possible service interruptions.",
+                "steps": [
+                  {
+                    "action_name": "UbuntuReleaseUpgrade",
+                    "params": "{}",
+                    "risk_level": "high",
+                    "summary": "Execute the Ubuntu release upgrade to move to the next version"
+                  }
+                ],
+                "summary": "Upgrade the system to the next Ubuntu release"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "7c6827883b21c104c84658845904e65c4aad9fc595efbb3729b230b51340f066"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:333c96f35709a3bca339f4c74713b96b24f0ba92545c7fbf5043b9c9809c1f8a": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -395,6 +781,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:337932daa368ced11348e785f0d06a903df4a2ae59919098443e4d06ff9b113b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f717ea51-4c45-4776-bbc6-76f2b9030c4d",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see the apt pin priority (apt-cache policy) for nginx. GetAptPins returns pin priorities, optionally filtered by package name. This is a low‑risk read‑only query.",
+                "steps": [
+                  {
+                    "action_name": "GetAptPins",
+                    "params": "{\"package\":\"nginx\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve apt pin priorities, focusing on the nginx package"
+                  }
+                ],
+                "summary": "Show apt pin priority for the nginx package"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "1e8ad878e47dc632d9a3d9bc95a4c7f62fff43830790de9a2b131e0c19f18cfe"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:3383fd3932278026181246c496717c26cf9de0185556f6c9be2edcb955714054": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -430,6 +851,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:35864e80f842e418d5e8cfc5ec7573bc4774540f1524aa73ada3ea5a67795b5b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_647d8c6c-add3-4cb9-91c0-37ccab4ba6e7",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether Ubuntu Pro is active on this machine. The ProStatus action provides the current subscription state without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "ProStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the Ubuntu Pro subscription status"
+                  }
+                ],
+                "summary": "Check Ubuntu Pro subscription status"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "a4b1a2d70753a15ee0ece91cfd980dc3fe8f0050f132a1b38702b7bfe6b3f1f6"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:38d3e1fff1b3e4910c9c09112d2331c6992cf019159cadc8b51d04e9bdbdf768": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -462,6 +918,41 @@
         "max_tokens": 4096,
         "messages": [
           "764b89917271bda5a446e7ce58122aa6c04f126a9c2e00e47f7ae414bdd57326"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:3c91d766781d45df4db2994d775e92a671c1f8ee017e1850f31c9c7c88b202ee": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_dcf79223-5132-4df0-a14d-da992f14b026",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether the Canonical Livepatch service is applying kernel patches. Running LivepatchStatus will report the current livepatch state, including whether it is active and any recent patch activity.",
+                "steps": [
+                  {
+                    "action_name": "LivepatchStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the Livepatch service status to see if kernel patches are being applied"
+                  }
+                ],
+                "summary": "Check Canonical Livepatch status"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "dac870efbf448b09cb163a2b71dc0ff65c14a1ad5ed4db6d873460307422501a"
         ]
       }
     },
@@ -532,6 +1023,76 @@
         "max_tokens": 4096,
         "messages": [
           "103fa9bb3d53462fd3fdbea8d7fffcfa958eea2055ad448623fe69bdcd0451a9"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:50ab0cc54cc49a70ed51af29563b4bd3de1d4be5b3c3dd1ec9d427c9565122ff": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_64b4c22e-92d0-45a7-81a8-16ff20540605",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a list of Multipass VMs and their status. MultipassList provides this read‑only information without modifying the system.",
+                "steps": [
+                  {
+                    "action_name": "MultipassList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve a list of all Multipass instances and their state"
+                  }
+                ],
+                "summary": "List Multipass virtual machines and their current state"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "23148ed87213ed1a2f619acf2aff63dced33e4e445995b1afb5df327ce134fb8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:50ad61d27c0b888da28c2085a3b9bf751323de44f6ed929b3be5f94c100c811d": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_7cccffe1-ec85-424e-a155-69efd697e4d2",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to modify the netplan configuration to enable DHCP on interface eth0 but defer applying the changes. NetplanSet updates the netplan YAML accordingly; the changes will take effect when NetplanApply is run later.",
+                "steps": [
+                  {
+                    "action_name": "NetplanSet",
+                    "params": "{\"key\":\"network.ethernets.eth0.dhcp4\",\"value\":\"true\"}",
+                    "risk_level": "high",
+                    "summary": "Set eth0 to obtain its IP via DHCP in the netplan configuration"
+                  }
+                ],
+                "summary": "Configure eth0 to use DHCP via netplan without applying changes"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "582b5858367be4255a6f06fcb855a93abe695d3d44a10b9ece540eb018e71c13"
         ]
       }
     },
@@ -608,6 +1169,41 @@
         "max_tokens": 4096,
         "messages": [
           "e685dcd493b55ea55fb1d63bf88f9feb956b6d131096a36491b85197976b69f9"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:5b44aef323f4d769bb4e84d2c2487e7d2d3025b43ff5697903ba203df42d662b": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_44221d8e-2a84-4c25-85d9-a0b9183dea86",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see which packages have been installed or removed via apt recently. AptHistoryList reads the apt transaction log and provides this information without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "AptHistoryList",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve recent apt install/remove entries from the transaction log"
+                  }
+                ],
+                "summary": "Show recent apt package installation and removal history"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "9650dcf7669beaf381f3c04970691f5712cabd937a398f69db03b0535271b390"
         ]
       }
     },
@@ -728,6 +1324,41 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:6b311fe13b07bb314f2e69dd9e3a9253d0098dda971501f315cd562c3c607f5e": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_fdf38548-3669-47c0-b301-2efa291d2a06",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested updating all installed Flatpak apps for the specified user. UpdateFlatpak will refresh each Flatpak to its latest version for that user. This is a low‑risk, read‑only operation.",
+                "steps": [
+                  {
+                    "action_name": "UpdateFlatpak",
+                    "params": "{\"username\":\"alice\"}",
+                    "risk_level": "low",
+                    "summary": "Refresh all Flatpak apps for user alice"
+                  }
+                ],
+                "summary": "Update all Flatpak applications for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "4d0d5a01dd80a55d1254b72fdb2d6d9b53478c80c9e876bd0ddb23d628323f9e"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:7568b9298a97e41dd420ec7828f33f1b3ad129be721a4a54be0399702b0c277f": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -760,6 +1391,41 @@
         "max_tokens": 4096,
         "messages": [
           "65ddb1730ca6ac2435fc22798b501a277d4fd69f42b8b2ed067997ac0e84a425"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:7bf0e4ecb922ba65fbb356185e94e838eee12b361f0572b0f7484f19c71ea3c1": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_abfd53af-3605-4b4d-b3fe-1024c3751b99",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to update the netplan configuration files on disk without affecting the currently active network interfaces. NetplanGenerate rewrites the backend files based on the saved netplan YAML but does not apply them, satisfying this request safely.",
+                "steps": [
+                  {
+                    "action_name": "NetplanGenerate",
+                    "params": "{}",
+                    "risk_level": "medium",
+                    "summary": "Regenerate netplan backend configuration files"
+                  }
+                ],
+                "summary": "Regenerate netplan backend configuration files without applying changes"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "0b2a536f120201f7159d43fb11b17ebab393d01a0f59b9d543fde377cb157d71"
         ]
       }
     },
@@ -941,6 +1607,41 @@
         "max_tokens": 4096,
         "messages": [
           "2a8c3e89caae87c5c4e9bd67ecbc3ab54a830555cbc8b75c3f623d04667564ae"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:87168ccc9587aa6016fc6759347f156b1d53332850a834925fec56854a33ce07": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_f31255f8-4816-4a8c-a629-12c8d6cb62d6",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether cloud-init completed its provisioning without errors. CloudInitStatus provides a read‑only report of the cloud‑init run, including any error messages, satisfying the request.",
+                "steps": [
+                  {
+                    "action_name": "CloudInitStatus",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve cloud-init provisioning status and any error information"
+                  }
+                ],
+                "summary": "Check cloud-init provisioning status"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "16158a41b0bd4d3ef09315a655f064b8c31c88fc7c6c28f9f106ad81eefa0884"
         ]
       }
     },
@@ -1257,6 +1958,33 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:a2cf3dffa5d46081e26ae264d4fc0ffc3eb79963c5a62de681de6fb89acefe4c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_cc2ce7dd-7ad7-48dd-8e5a-bbf5b6edabca",
+              "call_id": null,
+              "name": "refuse",
+              "input": {
+                "reason": "ProAttach requires an Ubuntu Pro subscription token, which was not provided.",
+                "suggestion": "Please provide the token using the parameter 'token' to attach the subscription."
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "036e068017c7490135c5a4ddf9d0d5e070c737dba97b7a92f5b1a54e3eec2f76"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:a491313fbee48cca7c0785b78a88ca1c33b00f9ff38cf822b03ea4e33f19c7c6": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1324,6 +2052,76 @@
         "max_tokens": 4096,
         "messages": [
           "9f136799a23967e82b0b033cb56213c66b08fa19ef571eb0b6bb8a2919d20aa7"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:aa2820973553ca821dd26dc3500a41aae1e5dbe247d458d852a7a45e07a529ba": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_6af55e15-f434-43ee-843b-c30372916c25",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants basic host identification details. GetHostState returns the OS release, kernel version, and hardware architecture in a low‑risk read‑only query.",
+                "steps": [
+                  {
+                    "action_name": "GetHostState",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Retrieve OS release, kernel version, and architecture information"
+                  }
+                ],
+                "summary": "Show operating system release, kernel version, and architecture"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "36a31243b6d594e82530e21e5ba8d22bede4e185bbc97517cd12ea2562971ae1"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:aafa689f73a1e60763d18b2cc663919a74e1ac574d43de056f2227b0ae59e3b1": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_7ca38fb7-3b46-4e22-8bd7-9e5515e6ab9e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user asked to turn off the Livepatch service provided by Ubuntu Pro. Disabling this service removes automatic kernel livepatching, which may affect system security but fulfills the request. This requires the DisableProService action with the service set to livepatch, which is classified as high risk.",
+                "steps": [
+                  {
+                    "action_name": "DisableProService",
+                    "params": "{\"service\":\"livepatch\"}",
+                    "risk_level": "high",
+                    "summary": "Disable the Livepatch service in Ubuntu Pro"
+                  }
+                ],
+                "summary": "Disable the Livepatch Ubuntu Pro service"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e8f2462358f2f6a76406fcc44ae913e6df2f33bfcd76b8c3b7076732604f20f0"
         ]
       }
     },
@@ -1499,6 +2297,76 @@
         "max_tokens": 4096,
         "messages": [
           "73e4ad5af69e18afa1ac9c29a894e26bedced399076cc6bc20c6e971ada55a85"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:c294c5ede4332a6ed5fe53848fa609bcb091c740f30da0862da0fac8c92e8cbd": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_875d874b-645d-4f91-9c6d-bde0d22b7fac",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to know whether the machine requires a reboot. The CheckPendingReboot action reads the system's reboot-required flag without making any changes.",
+                "steps": [
+                  {
+                    "action_name": "CheckPendingReboot",
+                    "params": "{}",
+                    "risk_level": "low",
+                    "summary": "Read the reboot-required status flag"
+                  }
+                ],
+                "summary": "Check if a system reboot is pending"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "badf780f4098f9a9c08e6accc9bd78b6463864a5bc522774d1ca5824ac0c557a"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:c44ea3c8eaabdba732c2dd51ba178a0c027b1a7b1ec67141fbd458b050f52a36": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_b74d306c-0777-416e-8204-a52d3d83683b",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested to add the deadsnakes/ppa Launchpad PPA to the system. This action adds a third‑party apt source, which is a high‑risk change because it expands the package trust store. The plan will execute AddPpa with the specified name.",
+                "steps": [
+                  {
+                    "action_name": "AddPpa",
+                    "params": "{\"name\":\"deadsnakes/ppa\"}",
+                    "risk_level": "high",
+                    "summary": "Add the deadsnakes/ppa Launchpad PPA to the system"
+                  }
+                ],
+                "summary": "Add the deadsnakes/ppa Launchpad PPA"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "ecd6730854bc2eaa5d921aefa68bd7a0267418a5cbd8798aa0294012e76cefdf"
         ]
       }
     },
@@ -1745,6 +2613,77 @@
         ]
       }
     },
+    "groq/openai/gpt-oss-120b:dd5ea196318d71f128991c6eefa0bf77b8eb8b2d7db7c2a6e7e98a53c769a88a": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_8e2925a5-f93c-4597-ac93-e21c817d6dfc",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested installing the org.mozilla.firefox Flatpak from the flathub remote for the user alice. This can be fulfilled with the UbuntuInstallFlatpak action, which installs a Flatpak app for a specific user. The action is medium risk because it modifies the user's Flatpak installations.",
+                "steps": [
+                  {
+                    "action_name": "UbuntuInstallFlatpak",
+                    "params": "{\"username\":\"alice\",\"app_id\":\"org.mozilla.firefox\",\"remote\":\"flathub\"}",
+                    "risk_level": "medium",
+                    "summary": "Install the Firefox Flatpak from Flathub for alice"
+                  }
+                ],
+                "summary": "Install the Firefox Flatpak from Flathub for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "d85c0e426bfd71bfcbd0aee48b95a359c63672bcb2ca7af8d91c12d07b7f973c"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:ddb4bedd62153dfb0a751a197ca138a188ee5c394f863011317096ec6c46da72": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_4501f536-08bc-411c-bf1a-ac487a611729",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested a list of Flatpak applications installed for the specified user. ListInstalledFlatpaks returns exactly this information in a low-risk, read‑only operation.",
+                "steps": [
+                  {
+                    "action_name": "ListInstalledFlatpaks",
+                    "params": "{\"username\":\"alice\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the list of installed Flatpak apps for alice"
+                  }
+                ],
+                "summary": "List Flatpak apps installed for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e8d4845c99a13c5d9c55da540c38357cc3539ce43ac1f108aece4684903a9b67",
+          "4b50f28030656b9aac1a21188698ff3933fb3589d2f2879ddd4e907d315b3548"
+        ]
+      }
+    },
     "groq/openai/gpt-oss-120b:e0e9fca0780c078e50c1ab5c0132f3e1658ef13ab082d386a417abc64a112427": {
       "surface": "groq/openai/gpt-oss-120b",
       "output": {
@@ -1812,6 +2751,146 @@
         "max_tokens": 4096,
         "messages": [
           "bfdd970791317f4145873c38f0836dd9e774c9a75d04e14235ed9c796a536f39"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:f393e3d7f4d6b27bd541c08651db1338079c857b4e8e1e1234b95387ac60786c": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_30f10793-80d6-47fb-9160-7e202988d034",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of the specified PPA. The RemovePpa action deletes the PPA repository entry from the system, which is a medium‑risk change because it alters package source configuration.",
+                "steps": [
+                  {
+                    "action_name": "RemovePpa",
+                    "params": "{\"name\":\"deadsnakes/ppa\"}",
+                    "risk_level": "medium",
+                    "summary": "Delete the deadsnakes/ppa Launchpad PPA from the system's package sources"
+                  }
+                ],
+                "summary": "Remove the deadsnakes/ppa Launchpad PPA"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e1c4eda44f192f041ee4b5c43a1efedeb7dbd3ab14490ee0783535eb60557aa3"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:f4ceaf6f3a2611b780b7736722e63ed3b9850b6c6e3a02ee36fffc7ed5dd49e8": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_8a40f975-4008-42ae-b502-97d1dc3f65e0",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of a specific ufw rule identified by its rule number. This plan uses the UfwDeleteRule action to delete rule number 3 from the firewall configuration. Deleting a rule is a high‑risk operation because it modifies firewall settings and could affect connectivity, so approval is required before execution.",
+                "steps": [
+                  {
+                    "action_name": "UfwDeleteRule",
+                    "params": "{\"rule_number\":3}",
+                    "risk_level": "high",
+                    "summary": "Remove the ufw rule with index 3"
+                  }
+                ],
+                "summary": "Delete ufw firewall rule number 3"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "dc793434faa9d16b446cccba11443c39830e53631051648dc967ae90b1dd88e8"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:fac5ba8c602ef678a7caa123bb87f5b6ed832525cbdae89cd2dcd4bb506b0cf0": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_60d6657d-ef08-454e-8518-87fe9d9fea2a",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user requested removal of the Firefox Flatpak application for the specified user. UbuntuRemoveFlatpak will delete the app from alice's Flatpak installations.",
+                "steps": [
+                  {
+                    "action_name": "UbuntuRemoveFlatpak",
+                    "params": "{\"username\":\"alice\",\"app_id\":\"org.mozilla.firefox\"}",
+                    "risk_level": "medium",
+                    "summary": "Remove the org.mozilla.firefox Flatpak for user alice"
+                  }
+                ],
+                "summary": "Uninstall the org.mozilla.firefox Flatpak for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "5c2b08f0a62952dc4ef832496a51d58f579d6f5334f420ac4cb4cf2616c07fce"
+        ]
+      }
+    },
+    "groq/openai/gpt-oss-120b:fc23db9050b1ca308299502f54cb7c92138b2dba6983e4e6790333bd5e41ca79": {
+      "surface": "groq/openai/gpt-oss-120b",
+      "output": {
+        "content": [
+          {
+            "ToolUse": {
+              "id": "fc_a527ee13-45dd-449d-be29-3ebd4928640e",
+              "call_id": null,
+              "name": "propose_plan",
+              "input": {
+                "explanation": "The user wants to see which Flatpak apps are installed for the specified user. ListInstalledFlatpaks provides this information in a read‑only manner without requiring any changes.",
+                "steps": [
+                  {
+                    "action_name": "ListInstalledFlatpaks",
+                    "params": "{\"username\":\"alice\"}",
+                    "risk_level": "low",
+                    "summary": "Retrieve the list of Flatpak apps installed for alice"
+                  }
+                ],
+                "summary": "List installed Flatpak applications for user alice"
+              }
+            }
+          }
+        ],
+        "stop_reason": "ToolUse"
+      },
+      "fingerprint": {
+        "system": "f03f78d885deda96e12b4354bd1d558f8032112a58f43e89900e97e4f18cba8f",
+        "tools": "8c267cb1654abcbe95c7d70d94341a070d2864d9365500a860f9163aeb4bfb52",
+        "max_tokens": 4096,
+        "messages": [
+          "e8d4845c99a13c5d9c55da540c38357cc3539ce43ac1f108aece4684903a9b67"
         ]
       }
     }

--- a/tests/e2e/run-stories.sh
+++ b/tests/e2e/run-stories.sh
@@ -292,6 +292,11 @@ run_story() {
   local start_time
   start_time=$(date +%s.%N)
 
+  # The story's own `2>` truncates this, but only once it reaches its first
+  # `sysknife` call. A story that fails before that would otherwise have last
+  # run's stderr folded into its log and read as this run's explanation.
+  rm -f "/tmp/sysknife-story-${n}-stderr.log"
+
   if timeout "$STORY_TIMEOUT" bash "$script" > "$log" 2>&1; then
     local last_line
     last_line=$(grep -E '^(PASS|SKIP)' "$log" | tail -1 || true)
@@ -324,6 +329,18 @@ run_story() {
       echo "RATELIMIT"
       return
     fi
+    # Fold the CLI's own stderr into the story log. Every story redirects it to
+    # `/tmp/sysknife-story-<n>-stderr.log`, so a failing story's log held its
+    # opening `echo` and nothing else — while the one line that explains the
+    # failure (a cassette miss naming the diverging message, a refusal, a
+    # provider error) sat in a file nobody collects. Diagnosing a miss meant
+    # re-running the release with a hand-written tar of /tmp.
+    if [[ -s "/tmp/sysknife-story-${n}-stderr.log" ]]; then
+      {
+        printf -- '--- sysknife stderr ---\n'
+        cat "/tmp/sysknife-story-${n}-stderr.log"
+      } >> "$log"
+    fi
     RESULTS[$n]="FAIL"
     MESSAGES[$n]=$(tail -n 5 "$log" | grep -v '^$' | tail -n 1)
     if [[ $exit_code -eq 124 ]]; then
@@ -346,7 +363,36 @@ echo "Destructive: $ALLOW_DESTRUCTIVE"
 echo "Timeout:     ${STORY_TIMEOUT}s per story"
 echo ""
 
+# Pace a recording so the run does not out-run the provider's token budget.
+#
+# The ceiling that bit us is TOKENS per minute, not requests: one planning call
+# carries the whole system prompt, measured at ~17 kB in, against a 250 k TPM
+# org limit. That is ~14 calls a minute, and an unpaced record run of this suite
+# issues them roughly every three seconds — ~20 a minute — so it overruns and
+# the stories that land past the line come back as provider 429s. Serialising
+# the releases (the remedy the comment on `story_was_rate_limited` gives) fixes
+# three suites racing each other, but not one suite racing itself.
+#
+# Only recording pays for calls, so only recording waits. A replay serves from
+# disk and is left at full speed, which is the whole point of having one.
+STORY_DELAY_SECS="${SYSKNIFE_STORY_DELAY_SECS:-}"
+if [[ -z "$STORY_DELAY_SECS" ]]; then
+  if [[ "${SYSKNIFE_CASSETTE_MODE:-}" == "record" || -z "${SYSKNIFE_CASSETTE:-}" ]]; then
+    STORY_DELAY_SECS=4
+  else
+    STORY_DELAY_SECS=0
+  fi
+fi
+if [[ "$STORY_DELAY_SECS" != "0" ]]; then
+  echo "Pacing:      ${STORY_DELAY_SECS}s between stories (live calls cost tokens)"
+fi
+
+_first_story=1
 for n in "${STORIES[@]}"; do
+  if [[ $_first_story -eq 0 && "$STORY_DELAY_SECS" != "0" ]]; then
+    sleep "$STORY_DELAY_SECS"
+  fi
+  _first_story=0
   run_story "$n"
 done
 

--- a/tests/e2e/stories/story-105.sh
+++ b/tests/e2e/stories/story-105.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Story 105 (ubuntu, low-risk): Identify the host
+# Intent: "what OS release, kernel version and architecture is this machine running?"
+# Distro: ubuntu
+# The Debian counterpart to Fedora's GetSystemState, and the action the
+# per-distro prompt split (#181) was built around: naming GetSystemState on an
+# apt host is exactly what the family fence forbids, so something had to answer
+# "what is this host?" on Ubuntu. Nothing exercised it end to end until now.
+set -euo pipefail
+INTENT="what OS release, kernel version and architecture is this machine running?"
+echo "=== Story 105 (ubuntu): GetHostState ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-105-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "GetHostState")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no GetHostState step"; exit 1; fi
+echo "PASS: Story 105"

--- a/tests/e2e/stories/story-106.sh
+++ b/tests/e2e/stories/story-106.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Story 106 (ubuntu, low-risk): Recent apt transactions
+# Intent: "what packages were installed or removed with apt recently?"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="what packages were installed or removed with apt recently?"
+echo "=== Story 106 (ubuntu): AptHistoryList ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-106-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "AptHistoryList")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no AptHistoryList step"; exit 1; fi
+echo "PASS: Story 106"

--- a/tests/e2e/stories/story-107.sh
+++ b/tests/e2e/stories/story-107.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Story 107 (ubuntu, low-risk): Pending reboot check
+# Intent: "does this machine need a reboot?"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="does this machine need a reboot?"
+echo "=== Story 107 (ubuntu): CheckPendingReboot ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-107-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "CheckPendingReboot")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no CheckPendingReboot step"; exit 1; fi
+echo "PASS: Story 107"

--- a/tests/e2e/stories/story-108.sh
+++ b/tests/e2e/stories/story-108.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Story 108 (ubuntu, low-risk): cloud-init provisioning result
+# Intent: "did cloud-init finish provisioning this machine without errors?"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="did cloud-init finish provisioning this machine without errors?"
+echo "=== Story 108 (ubuntu): CloudInitStatus ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-108-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "CloudInitStatus")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no CloudInitStatus step"; exit 1; fi
+echo "PASS: Story 108"

--- a/tests/e2e/stories/story-109.sh
+++ b/tests/e2e/stories/story-109.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Story 109 (ubuntu, low-risk): GRUB kernel command line
+# Intent: "what kernel command line does grub boot this machine with?"
+# Distro: ubuntu
+# GetKernelArguments is the Fedora reading of the same question and is fenced
+# off an apt host, so on Ubuntu this is unambiguous.
+set -euo pipefail
+INTENT="what kernel command line does grub boot this machine with?"
+echo "=== Story 109 (ubuntu): GrubGetKargs ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-109-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "GrubGetKargs")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no GrubGetKargs step"; exit 1; fi
+echo "PASS: Story 109"

--- a/tests/e2e/stories/story-110.sh
+++ b/tests/e2e/stories/story-110.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Story 110 (ubuntu, low-risk): Apt pin priority for one package
+# Intent: "show me the apt pin priority for the nginx package"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="show me the apt pin priority for the nginx package"
+echo "=== Story 110 (ubuntu): GetAptPins ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-110-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "GetAptPins")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no GetAptPins step"; exit 1; fi
+PACKAGE=$(echo "$STEP" | jq -r '.params.package // ""')
+if [[ "$PACKAGE" != "nginx" ]]; then echo "FAIL: expected package=nginx, got $PACKAGE"; exit 1; fi
+echo "PASS: Story 110"

--- a/tests/e2e/stories/story-111.sh
+++ b/tests/e2e/stories/story-111.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Story 111 (ubuntu, medium-risk): Remove a named apt pin
+# Intent: "remove the apt pin named freeze-nginx"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="remove the apt pin named freeze-nginx"
+echo "=== Story 111 (ubuntu): RemoveAptPin ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-111-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "RemoveAptPin")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no RemoveAptPin step"; exit 1; fi
+NAME=$(echo "$STEP" | jq -r '.params.name // ""')
+if [[ "$NAME" != "freeze-nginx" ]]; then echo "FAIL: expected name=freeze-nginx, got $NAME"; exit 1; fi
+echo "PASS: Story 111"

--- a/tests/e2e/stories/story-112.sh
+++ b/tests/e2e/stories/story-112.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Story 112 (ubuntu, low-risk): AppArmor profile inventory
+# Intent: "show me every loaded apparmor profile and what mode it is in"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="show me every loaded apparmor profile and what mode it is in"
+echo "=== Story 112 (ubuntu): AppArmorStatus ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-112-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "AppArmorStatus")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no AppArmorStatus step"; exit 1; fi
+echo "PASS: Story 112"

--- a/tests/e2e/stories/story-113.sh
+++ b/tests/e2e/stories/story-113.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Story 113 (ubuntu, high-risk): Enforce an AppArmor profile
+# Intent: "put the apparmor profile /etc/apparmor.d/usr.bin.firefox into enforce mode"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="put the apparmor profile /etc/apparmor.d/usr.bin.firefox into enforce mode"
+echo "=== Story 113 (ubuntu): AppArmorEnforce ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-113-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "AppArmorEnforce")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no AppArmorEnforce step"; exit 1; fi
+PROFILE_PATH=$(echo "$STEP" | jq -r '.params.profile_path // ""')
+if [[ "$PROFILE_PATH" != "/etc/apparmor.d/usr.bin.firefox" ]]; then echo "FAIL: expected profile_path=/etc/apparmor.d/usr.bin.firefox, got $PROFILE_PATH"; exit 1; fi
+echo "PASS: Story 113"

--- a/tests/e2e/stories/story-114.sh
+++ b/tests/e2e/stories/story-114.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Story 114 (ubuntu, high-risk): Put an AppArmor profile in complain mode
+# Intent: "switch /etc/apparmor.d/usr.sbin.nginx to complain mode so violations are logged but not blocked"
+# Distro: ubuntu
+# High, not Medium: complain mode disables MAC enforcement for the profile.
+# The prompt taught Medium here until #205 corrected the table.
+set -euo pipefail
+INTENT="switch /etc/apparmor.d/usr.sbin.nginx to complain mode so violations are logged but not blocked"
+echo "=== Story 114 (ubuntu): AppArmorComplain ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-114-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "AppArmorComplain")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no AppArmorComplain step"; exit 1; fi
+PROFILE_PATH=$(echo "$STEP" | jq -r '.params.profile_path // ""')
+if [[ "$PROFILE_PATH" != "/etc/apparmor.d/usr.sbin.nginx" ]]; then echo "FAIL: expected profile_path=/etc/apparmor.d/usr.sbin.nginx, got $PROFILE_PATH"; exit 1; fi
+echo "PASS: Story 114"

--- a/tests/e2e/stories/story-115.sh
+++ b/tests/e2e/stories/story-115.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Story 115 (ubuntu, low-risk): Ubuntu Pro subscription state
+# Intent: "is Ubuntu Pro active on this machine?"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="is Ubuntu Pro active on this machine?"
+echo "=== Story 115 (ubuntu): ProStatus ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-115-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "ProStatus")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no ProStatus step"; exit 1; fi
+echo "PASS: Story 115"

--- a/tests/e2e/stories/story-116.sh
+++ b/tests/e2e/stories/story-116.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Story 116 (ubuntu, high-risk): A Pro token never reaches the provider
+# Intent: "attach this machine to Ubuntu Pro using token C1aBcDeF0123456789"
+# Distro: ubuntu
+#
+# `ProAttach` is the one Ubuntu action whose required param is a credential, and
+# that makes it the one action a planning story cannot assert a plan for.
+# `Planner::admit_request` runs `prefs::contains_sensitive` on the raw intent
+# before any provider call, and `SENSITIVE_PATTERNS` holds the literal substring
+# "token" — so an intent that supplies a Pro token is refused up front and the
+# token is never forwarded. That is the behaviour we want, so it is the behaviour
+# this story pins.
+#
+# The consequence is worth stating plainly: `ProAttach` is not reachable from
+# natural language. Say "token" and the request is refused; omit it and the model
+# would have to invent a credential it was never given. The second half of this
+# story checks it does not do that — a fabricated token would be handed to
+# `sudo pro attach` verbatim.
+#
+# The first half makes no provider call at all, so it neither costs a recording
+# nor can miss on replay.
+set -euo pipefail
+
+INTENT="attach this machine to Ubuntu Pro using token C1aBcDeF0123456789"
+
+echo "=== Story 116 (ubuntu): ProAttach credential fence ==="
+
+# 1. The token-bearing intent is refused before the provider sees it.
+if OUT=$(sysknife --dry-run --json "$INTENT" 2>&1); then
+  echo "FAIL: an intent carrying a Pro token was planned rather than refused"
+  echo "$OUT"
+  exit 1
+fi
+if [[ "$OUT" != *"sensitive data"* ]]; then
+  echo "FAIL: refused, but not by the sensitive-data fence: $OUT"
+  exit 1
+fi
+# The token must not appear in whatever the CLI printed on the way out.
+if [[ "$OUT" == *C1aBcDeF0123456789* ]]; then
+  echo "FAIL: the refusal echoed the token back"
+  exit 1
+fi
+echo "refused as expected: sensitive-data fence"
+
+# 2. Without the word "token" the fence admits the intent, and the model must
+#    not answer with a ProAttach step carrying a credential it was never given.
+if PLAN=$(sysknife --dry-run --json "attach this machine to my Ubuntu Pro subscription" \
+  2>/tmp/sysknife-story-116-stderr.log); then
+  echo "planned:"
+  echo "$PLAN" | jq .
+else
+  # A refusal is the outcome we hope for, and it is not a story failure. Record
+  # it so the run log shows which of the two acceptable answers came back.
+  echo "refused: $(sed -n '2p' /tmp/sysknife-story-116-stderr.log)"
+  PLAN='{"plan":{"steps":[]}}'
+fi
+TOKEN=$(echo "$PLAN" | jq -r '.plan.steps[]? | select(.action == "ProAttach") | .params.token // ""')
+if [[ -n "$TOKEN" ]]; then
+  echo "FAIL: ProAttach was planned with a fabricated token"
+  exit 1
+fi
+
+echo "PASS: Story 116"

--- a/tests/e2e/stories/story-117.sh
+++ b/tests/e2e/stories/story-117.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Story 117 (ubuntu, high-risk): Detach from Ubuntu Pro
+# Intent: "detach this machine from its Ubuntu Pro subscription"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="detach this machine from its Ubuntu Pro subscription"
+echo "=== Story 117 (ubuntu): ProDetach ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-117-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "ProDetach")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no ProDetach step"; exit 1; fi
+echo "PASS: Story 117"

--- a/tests/e2e/stories/story-118.sh
+++ b/tests/e2e/stories/story-118.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Story 118 (ubuntu, high-risk): Enable one Pro service
+# Intent: "enable the esm-apps Ubuntu Pro service"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="enable the esm-apps Ubuntu Pro service"
+echo "=== Story 118 (ubuntu): EnableProService ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-118-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "EnableProService")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no EnableProService step"; exit 1; fi
+SERVICE=$(echo "$STEP" | jq -r '.params.service // ""')
+if [[ "$SERVICE" != "esm-apps" ]]; then echo "FAIL: expected service=esm-apps, got $SERVICE"; exit 1; fi
+echo "PASS: Story 118"

--- a/tests/e2e/stories/story-119.sh
+++ b/tests/e2e/stories/story-119.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Story 119 (ubuntu, high-risk): Disable one Pro service
+# Intent: "turn off the livepatch Ubuntu Pro service"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="turn off the livepatch Ubuntu Pro service"
+echo "=== Story 119 (ubuntu): DisableProService ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-119-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "DisableProService")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no DisableProService step"; exit 1; fi
+SERVICE=$(echo "$STEP" | jq -r '.params.service // ""')
+if [[ "$SERVICE" != "livepatch" ]]; then echo "FAIL: expected service=livepatch, got $SERVICE"; exit 1; fi
+echo "PASS: Story 119"

--- a/tests/e2e/stories/story-120.sh
+++ b/tests/e2e/stories/story-120.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Story 120 (ubuntu, low-risk): Livepatch state
+# Intent: "is canonical livepatch applying kernel patches on this machine?"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="is canonical livepatch applying kernel patches on this machine?"
+echo "=== Story 120 (ubuntu): LivepatchStatus ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-120-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "LivepatchStatus")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no LivepatchStatus step"; exit 1; fi
+echo "PASS: Story 120"

--- a/tests/e2e/stories/story-121.sh
+++ b/tests/e2e/stories/story-121.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Story 121 (ubuntu, low-risk): Multipass VM inventory
+# Intent: "list the multipass VMs on this machine and their state"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="list the multipass VMs on this machine and their state"
+echo "=== Story 121 (ubuntu): MultipassList ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-121-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "MultipassList")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no MultipassList step"; exit 1; fi
+echo "PASS: Story 121"

--- a/tests/e2e/stories/story-122.sh
+++ b/tests/e2e/stories/story-122.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Story 122 (ubuntu, medium-risk): Revert a snap
+# Intent: "roll the firefox snap back to its previous revision"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="roll the firefox snap back to its previous revision"
+echo "=== Story 122 (ubuntu): SnapRevert ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-122-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "SnapRevert")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no SnapRevert step"; exit 1; fi
+NAME=$(echo "$STEP" | jq -r '.params.name // ""')
+if [[ "$NAME" != "firefox" ]]; then echo "FAIL: expected name=firefox, got $NAME"; exit 1; fi
+echo "PASS: Story 122"

--- a/tests/e2e/stories/story-123.sh
+++ b/tests/e2e/stories/story-123.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Story 123 (ubuntu, high-risk): Add a Launchpad PPA
+# Intent: "add the deadsnakes/ppa launchpad PPA to this machine"
+# Distro: ubuntu
+# High: a PPA is a third-party signing key plus package source, so everything
+# installed afterwards is trusted from it.
+set -euo pipefail
+INTENT="add the deadsnakes/ppa launchpad PPA to this machine"
+echo "=== Story 123 (ubuntu): AddPpa ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-123-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "AddPpa")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no AddPpa step"; exit 1; fi
+NAME=$(echo "$STEP" | jq -r '.params.name // ""')
+if [[ "$NAME" != "deadsnakes/ppa" ]]; then echo "FAIL: expected name=deadsnakes/ppa, got $NAME"; exit 1; fi
+echo "PASS: Story 123"

--- a/tests/e2e/stories/story-124.sh
+++ b/tests/e2e/stories/story-124.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Story 124 (ubuntu, medium-risk): Remove a Launchpad PPA
+# Intent: "remove the deadsnakes/ppa launchpad PPA from this machine"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="remove the deadsnakes/ppa launchpad PPA from this machine"
+echo "=== Story 124 (ubuntu): RemovePpa ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-124-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "RemovePpa")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no RemovePpa step"; exit 1; fi
+NAME=$(echo "$STEP" | jq -r '.params.name // ""')
+if [[ "$NAME" != "deadsnakes/ppa" ]]; then echo "FAIL: expected name=deadsnakes/ppa, got $NAME"; exit 1; fi
+echo "PASS: Story 124"

--- a/tests/e2e/stories/story-125.sh
+++ b/tests/e2e/stories/story-125.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Story 125 (ubuntu, high-risk): Delete a numbered ufw rule
+# Intent: "delete ufw rule number 3"
+# Distro: ubuntu
+set -euo pipefail
+INTENT="delete ufw rule number 3"
+echo "=== Story 125 (ubuntu): UfwDeleteRule ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-125-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "UfwDeleteRule")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no UfwDeleteRule step"; exit 1; fi
+RULE_NUMBER=$(echo "$STEP" | jq -r '.params.rule_number|tostring // ""')
+if [[ "$RULE_NUMBER" != "3" ]]; then echo "FAIL: expected rule_number=3, got $RULE_NUMBER"; exit 1; fi
+echo "PASS: Story 125"

--- a/tests/e2e/stories/story-126.sh
+++ b/tests/e2e/stories/story-126.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Story 126 (ubuntu, high-risk): Turn on automatic security updates
+# Intent: "turn on automatic security updates on this machine"
+# Distro: ubuntu
+# This action is described in the tool schema but named nowhere in the Debian
+# prose blocks, so the story measures whether the schema alone is enough.
+set -euo pipefail
+INTENT="turn on automatic security updates on this machine"
+echo "=== Story 126 (ubuntu): ConfigureUnattendedUpgrades ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-126-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "ConfigureUnattendedUpgrades")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no ConfigureUnattendedUpgrades step"; exit 1; fi
+ENABLED=$(echo "$STEP" | jq -r '.params.enabled|tostring // ""')
+if [[ "$ENABLED" != "true" ]]; then echo "FAIL: expected enabled=true, got $ENABLED"; exit 1; fi
+echo "PASS: Story 126"

--- a/tests/e2e/stories/story-127.sh
+++ b/tests/e2e/stories/story-127.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Story 127 (ubuntu, medium-risk): Regenerate netplan without applying
+# Intent: "regenerate the netplan backend config files but do not touch the running interfaces"
+# Distro: ubuntu
+# The near miss is NetplanApply, which would reconfigure live interfaces. The
+# prompt calls NetplanGenerate the dry run; this checks the model reads it that way.
+set -euo pipefail
+INTENT="regenerate the netplan backend config files but do not touch the running interfaces"
+echo "=== Story 127 (ubuntu): NetplanGenerate ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-127-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "NetplanGenerate")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no NetplanGenerate step"; exit 1; fi
+if echo "$PLAN" | jq -e '.plan.steps[] | select(.action == "NetplanApply")' >/dev/null; then
+  echo "FAIL: applied netplan when asked not to touch running interfaces"; exit 1
+fi
+echo "PASS: Story 127"

--- a/tests/e2e/stories/story-128.sh
+++ b/tests/e2e/stories/story-128.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Story 128 (ubuntu, high-risk): Set a netplan key without applying
+# Intent: "make eth0 use DHCP in netplan, but do not apply it yet"
+# Distro: ubuntu
+# The key is asserted to mention dhcp4 rather than matched exactly: 'ethernets.eth0.dhcp4'
+# and 'network.ethernets.eth0.dhcp4' are both faithful renderings of the request.
+set -euo pipefail
+INTENT="make eth0 use DHCP in netplan, but do not apply it yet"
+echo "=== Story 128 (ubuntu): NetplanSet ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-128-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "NetplanSet")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no NetplanSet step"; exit 1; fi
+KEY=$(echo "$STEP" | jq -r '.params.key // ""')
+if [[ "$KEY" != *dhcp4* ]]; then echo "FAIL: expected a dhcp4 key, got $KEY"; exit 1; fi
+echo "PASS: Story 128"

--- a/tests/e2e/stories/story-129.sh
+++ b/tests/e2e/stories/story-129.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Story 129 (ubuntu, high-risk): Distribution upgrade, not apt upgrade
+# Intent: "upgrade this machine to the next Ubuntu release"
+# Distro: ubuntu
+# AptUpgrade is the near miss and the prompt forbids it here: a release upgrade
+# is 20-45 minutes and a reboot, so confusing the two is not a cosmetic slip.
+set -euo pipefail
+INTENT="upgrade this machine to the next Ubuntu release"
+echo "=== Story 129 (ubuntu): UbuntuReleaseUpgrade ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-129-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "UbuntuReleaseUpgrade")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no UbuntuReleaseUpgrade step"; exit 1; fi
+if echo "$PLAN" | jq -e '.plan.steps[] | select(.action == "AptUpgrade")' >/dev/null; then
+  echo "FAIL: planned AptUpgrade for a release upgrade"; exit 1
+fi
+echo "PASS: Story 129"

--- a/tests/e2e/stories/story-130.sh
+++ b/tests/e2e/stories/story-130.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Story 130 (ubuntu, low-risk): List a user's flatpaks on Ubuntu
+# Intent: "list the flatpak apps installed for user alice"
+# Distro: ubuntu
+# UbuntuListFlatpaks and ListInstalledFlatpaks build byte-identical argv (both delegate to `flatpak_as`) at the
+# same risk, so which name the planner picks has no effect on the host. Either
+# passes; the run log records which one was chosen, so the Debian prompt's steer
+# toward the Ubuntu-prefixed name stays measurable without a cosmetic FAIL.
+set -euo pipefail
+INTENT="list the flatpak apps installed for user alice"
+echo "=== Story 130 (ubuntu): UbuntuListFlatpaks or ListInstalledFlatpaks ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-130-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "UbuntuListFlatpaks" or .action == "ListInstalledFlatpaks")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no UbuntuListFlatpaks or ListInstalledFlatpaks step"; exit 1; fi
+echo "chose: $(echo "$STEP" | jq -r .action)"
+USERNAME=$(echo "$STEP" | jq -r '.params.username // ""')
+if [[ "$USERNAME" != "alice" ]]; then echo "FAIL: expected username=alice, got $USERNAME"; exit 1; fi
+echo "PASS: Story 130"

--- a/tests/e2e/stories/story-131.sh
+++ b/tests/e2e/stories/story-131.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Story 131 (ubuntu, medium-risk): Install a flatpak on Ubuntu
+# Intent: "install the org.mozilla.firefox flatpak from flathub for user alice"
+# Distro: ubuntu
+# UbuntuInstallFlatpak and InstallFlatpak build byte-identical argv (both delegate to `flatpak_as`) at the
+# same risk, so which name the planner picks has no effect on the host. Either
+# passes; the run log records which one was chosen, so the Debian prompt's steer
+# toward the Ubuntu-prefixed name stays measurable without a cosmetic FAIL.
+set -euo pipefail
+INTENT="install the org.mozilla.firefox flatpak from flathub for user alice"
+echo "=== Story 131 (ubuntu): UbuntuInstallFlatpak or InstallFlatpak ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-131-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "UbuntuInstallFlatpak" or .action == "InstallFlatpak")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no UbuntuInstallFlatpak or InstallFlatpak step"; exit 1; fi
+echo "chose: $(echo "$STEP" | jq -r .action)"
+USERNAME=$(echo "$STEP" | jq -r '.params.username // ""')
+if [[ "$USERNAME" != "alice" ]]; then echo "FAIL: expected username=alice, got $USERNAME"; exit 1; fi
+APP_ID=$(echo "$STEP" | jq -r '.params.app_id // ""')
+if [[ "$APP_ID" != "org.mozilla.firefox" ]]; then echo "FAIL: expected app_id=org.mozilla.firefox, got $APP_ID"; exit 1; fi
+echo "PASS: Story 131"

--- a/tests/e2e/stories/story-132.sh
+++ b/tests/e2e/stories/story-132.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Story 132 (ubuntu, medium-risk): Remove a flatpak on Ubuntu
+# Intent: "uninstall the org.mozilla.firefox flatpak for user alice"
+# Distro: ubuntu
+# UbuntuRemoveFlatpak and RemoveFlatpak build byte-identical argv (both delegate to `flatpak_as`) at the
+# same risk, so which name the planner picks has no effect on the host. Either
+# passes; the run log records which one was chosen, so the Debian prompt's steer
+# toward the Ubuntu-prefixed name stays measurable without a cosmetic FAIL.
+set -euo pipefail
+INTENT="uninstall the org.mozilla.firefox flatpak for user alice"
+echo "=== Story 132 (ubuntu): UbuntuRemoveFlatpak or RemoveFlatpak ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-132-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "UbuntuRemoveFlatpak" or .action == "RemoveFlatpak")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no UbuntuRemoveFlatpak or RemoveFlatpak step"; exit 1; fi
+echo "chose: $(echo "$STEP" | jq -r .action)"
+USERNAME=$(echo "$STEP" | jq -r '.params.username // ""')
+if [[ "$USERNAME" != "alice" ]]; then echo "FAIL: expected username=alice, got $USERNAME"; exit 1; fi
+APP_ID=$(echo "$STEP" | jq -r '.params.app_id // ""')
+if [[ "$APP_ID" != "org.mozilla.firefox" ]]; then echo "FAIL: expected app_id=org.mozilla.firefox, got $APP_ID"; exit 1; fi
+echo "PASS: Story 132"

--- a/tests/e2e/stories/story-133.sh
+++ b/tests/e2e/stories/story-133.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Story 133 (ubuntu, medium-risk): Update every flatpak for a user on Ubuntu
+# Intent: "update all the flatpak apps for user alice"
+# Distro: ubuntu
+# UbuntuUpdateFlatpak and UpdateFlatpak build byte-identical argv (both delegate to `flatpak_as`) at the
+# same risk, so which name the planner picks has no effect on the host. Either
+# passes; the run log records which one was chosen, so the Debian prompt's steer
+# toward the Ubuntu-prefixed name stays measurable without a cosmetic FAIL.
+set -euo pipefail
+INTENT="update all the flatpak apps for user alice"
+echo "=== Story 133 (ubuntu): UbuntuUpdateFlatpak or UpdateFlatpak ==="
+PLAN=$(sysknife --dry-run --json "$INTENT" 2>/tmp/sysknife-story-133-stderr.log)
+echo "$PLAN" | jq .
+STEP=$(echo "$PLAN" | jq '.plan.steps[] | select(.action == "UbuntuUpdateFlatpak" or .action == "UpdateFlatpak")')
+if [[ -z "$STEP" || "$STEP" == "null" ]]; then echo "FAIL: no UbuntuUpdateFlatpak or UpdateFlatpak step"; exit 1; fi
+echo "chose: $(echo "$STEP" | jq -r .action)"
+USERNAME=$(echo "$STEP" | jq -r '.params.username // ""')
+if [[ "$USERNAME" != "alice" ]]; then echo "FAIL: expected username=alice, got $USERNAME"; exit 1; fi
+echo "PASS: Story 133"

--- a/tests/evidence/README.md
+++ b/tests/evidence/README.md
@@ -6,37 +6,54 @@ runs as part of `scripts/check_public_claims.sh` in CI. A number that no artifac
 produces fails the build.
 
 This exists because the README claimed "65/65 stories" validated on a live VM in
-eight places. No run ever produced that figure; no story set of that size has
-existed, and the Ubuntu family contains 50 stories. The test count had rotted the
-other way: three docs said "1,561 Rust tests" and the claims checker *required*
-that exact string while the suite had grown past 1,600.
+eight places. No run ever produced that figure; no story set of that size had
+existed, and the Ubuntu family then contained 50 stories (79 since every
+Debian-only action got one). The test count had rotted the other way: three docs
+said "1,561 Rust tests" and the claims checker *required* that exact string while
+the suite had grown past 1,600.
 
 Nothing here is filled in by hand, including by way of illustration — a number in
 this directory is a claim, and the point of the directory is that claims come from
 runs.
 
-### The committed 22.04 run
+### Why every replay twin used to fail, and what fixed it
 
-`story-runs/ubuntu-22.04-gpt-oss-120b.json` records 49/50 with
-`openai/gpt-oss-120b`. The one failure is story 101, and it is not a planning
-defect: the model produced exactly the plan the story accepts
-(`ListContainers{username:root}`) but emitted it under the tool name
-`commentary`, which the provider rejected with `tool_use_failed` (HTTP 400). It
-reproduced on retry, so it is a model/provider interaction rather than a transient
-one. See #178 for the retry gap it exposes.
+Each LTS carried a `.replay.json` whose `cassette_audit.verdict` was `failed`,
+on a different story each time — 101 on 22.04, 119 on 24.04, 125 and 130 on
+26.04. Three symptoms, one cause, and it was not the stories.
 
-The matching cassette covers 48 of the 50 stories. Two calls are not replayable,
-for different reasons, and a full-family replay therefore reports 2 misses and
-fails by design:
+The provider sometimes rejects a tool call the model emitted under a name that
+is not in `request.tools` (Groq words it `code: "tool_use_failed"`). The planner
+handles that: it appends a correction and re-asks, because re-sending identical
+bytes reproduces the identical malformed answer. The cassette, however, stored
+only *successes* — so the only entry written for such a story was the **second**
+call, the one carrying the correction. A replay starts from the first, finds no
+entry, and then, because a `CassetteMiss` carries none of the markers that
+trigger a correction, re-sends identical bytes and misses again.
 
-- **story 101** — no successful response was ever returned, so there was nothing
-  to record.
-- **story 91** — a multi-turn run whose later turns are not reproducible from the
-  recorded first turn.
+The diagnostic said so once the harness started collecting the CLI's stderr:
 
-That is the miss guard behaving correctly: it refuses to call a run reproduced
-when it was not. Closing the gap is part of the replay-gate work, not something to
-paper over by trimming the story set.
+> no recorded output for this intent. The prompt and tools match, so the
+> cassette is current — this particular request was never recorded
+
+Cassette v2 records the rejection too (`entries[].rejection`), for exactly the
+failures the planner corrects and no others — the two sets are one predicate,
+`ProviderError::is_invalid_tool_call`, so a recorder narrower than the retrier
+cannot leave a retried run unreplayable and a wider one cannot serve a transient
+failure back for ever. A replay now takes the same path the live run took: the
+recorded rejection, the correction, the recorded answer.
+
+Two things this cost, worth stating because both are easy to repeat:
+
+- The first attempt matched `ProviderError::Http { status: 400, .. }`. **No
+  adapter constructs that variant** — a 400 is classified `StatusClass::Other`
+  and arrives as `Request`. Three new tests were green against a shape the
+  system cannot produce, and the proof was a recording made with that build:
+  cassette `v2`, zero rejections.
+- `check_evidence_claims.py` let a release be tiered **Validated** on a replay
+  twin that merely *existed*. A pass-rate figure was already refused on a
+  `failed` verdict; the tier was not. It is now, so "Validated" means the twin
+  reproduced the run.
 
 ## `workspace-tests.json`
 

--- a/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json
+++ b/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json
@@ -5,9 +5,9 @@
     "verdict": "not-applicable"
   },
   "cassette_mode": "record",
-  "cassette_sha256": "2f58c611f7f4a4a321957677cb706df9475f17ac4c48f81288b5220bd7edd86d",
+  "cassette_sha256": "0d52ba548f348817fba093c0a0801b47d07777506372f72c78bee8fa63ee312a",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-13T12:06:31+00:00",
+  "ran_at": "2026-08-13T16:46:06+00:00",
   "release": "22.04",
   "stories": {
     "100": {
@@ -16,7 +16,7 @@
     },
     "101": {
       "name": "Distrobox list alt phrasing",
-      "verdict": "FAIL"
+      "verdict": "PASS"
     },
     "102": {
       "name": "System-wide upgrade with alt phrasing",
@@ -28,6 +28,122 @@
     },
     "104": {
       "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "105": {
+      "name": "Identify the host",
+      "verdict": "PASS"
+    },
+    "106": {
+      "name": "Recent apt transactions",
+      "verdict": "PASS"
+    },
+    "107": {
+      "name": "Pending reboot check",
+      "verdict": "PASS"
+    },
+    "108": {
+      "name": "cloud-init provisioning result",
+      "verdict": "PASS"
+    },
+    "109": {
+      "name": "GRUB kernel command line",
+      "verdict": "PASS"
+    },
+    "110": {
+      "name": "Apt pin priority for one package",
+      "verdict": "PASS"
+    },
+    "111": {
+      "name": "Remove a named apt pin",
+      "verdict": "PASS"
+    },
+    "112": {
+      "name": "AppArmor profile inventory",
+      "verdict": "PASS"
+    },
+    "113": {
+      "name": "Enforce an AppArmor profile",
+      "verdict": "PASS"
+    },
+    "114": {
+      "name": "Put an AppArmor profile in complain mode",
+      "verdict": "PASS"
+    },
+    "115": {
+      "name": "Ubuntu Pro subscription state",
+      "verdict": "PASS"
+    },
+    "116": {
+      "name": "A Pro token never reaches the provider",
+      "verdict": "PASS"
+    },
+    "117": {
+      "name": "Detach from Ubuntu Pro",
+      "verdict": "PASS"
+    },
+    "118": {
+      "name": "Enable one Pro service",
+      "verdict": "PASS"
+    },
+    "119": {
+      "name": "Disable one Pro service",
+      "verdict": "PASS"
+    },
+    "120": {
+      "name": "Livepatch state",
+      "verdict": "PASS"
+    },
+    "121": {
+      "name": "Multipass VM inventory",
+      "verdict": "PASS"
+    },
+    "122": {
+      "name": "Revert a snap",
+      "verdict": "PASS"
+    },
+    "123": {
+      "name": "Add a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "124": {
+      "name": "Remove a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "125": {
+      "name": "Delete a numbered ufw rule",
+      "verdict": "PASS"
+    },
+    "126": {
+      "name": "Turn on automatic security updates",
+      "verdict": "PASS"
+    },
+    "127": {
+      "name": "Regenerate netplan without applying",
+      "verdict": "PASS"
+    },
+    "128": {
+      "name": "Set a netplan key without applying",
+      "verdict": "PASS"
+    },
+    "129": {
+      "name": "Distribution upgrade, not apt upgrade",
+      "verdict": "PASS"
+    },
+    "130": {
+      "name": "List a user's flatpaks on Ubuntu",
+      "verdict": "PASS"
+    },
+    "131": {
+      "name": "Install a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "132": {
+      "name": "Remove a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "133": {
+      "name": "Update every flatpak for a user on Ubuntu",
       "verdict": "PASS"
     },
     "55": {
@@ -214,11 +330,11 @@
   "story_set": "ubuntu",
   "surface": "groq/openai/gpt-oss-120b",
   "totals": {
-    "failed": 1,
-    "passed": 49,
+    "failed": 0,
+    "passed": 79,
     "rate_limited": 0,
     "skipped": 0,
-    "total": 50
+    "total": 79
   },
   "version": 1
 }

--- a/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json
+++ b/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json
@@ -1,13 +1,13 @@
 {
   "cassette_audit": {
-    "misses": 1,
-    "served": 50,
-    "verdict": "failed"
+    "misses": 0,
+    "served": 81,
+    "verdict": "ok"
   },
   "cassette_mode": "replay",
-  "cassette_sha256": "2f58c611f7f4a4a321957677cb706df9475f17ac4c48f81288b5220bd7edd86d",
+  "cassette_sha256": "0d52ba548f348817fba093c0a0801b47d07777506372f72c78bee8fa63ee312a",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-13T12:07:42+00:00",
+  "ran_at": "2026-08-13T16:46:40+00:00",
   "release": "22.04",
   "stories": {
     "100": {
@@ -16,7 +16,7 @@
     },
     "101": {
       "name": "Distrobox list alt phrasing",
-      "verdict": "FAIL"
+      "verdict": "PASS"
     },
     "102": {
       "name": "System-wide upgrade with alt phrasing",
@@ -28,6 +28,122 @@
     },
     "104": {
       "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "105": {
+      "name": "Identify the host",
+      "verdict": "PASS"
+    },
+    "106": {
+      "name": "Recent apt transactions",
+      "verdict": "PASS"
+    },
+    "107": {
+      "name": "Pending reboot check",
+      "verdict": "PASS"
+    },
+    "108": {
+      "name": "cloud-init provisioning result",
+      "verdict": "PASS"
+    },
+    "109": {
+      "name": "GRUB kernel command line",
+      "verdict": "PASS"
+    },
+    "110": {
+      "name": "Apt pin priority for one package",
+      "verdict": "PASS"
+    },
+    "111": {
+      "name": "Remove a named apt pin",
+      "verdict": "PASS"
+    },
+    "112": {
+      "name": "AppArmor profile inventory",
+      "verdict": "PASS"
+    },
+    "113": {
+      "name": "Enforce an AppArmor profile",
+      "verdict": "PASS"
+    },
+    "114": {
+      "name": "Put an AppArmor profile in complain mode",
+      "verdict": "PASS"
+    },
+    "115": {
+      "name": "Ubuntu Pro subscription state",
+      "verdict": "PASS"
+    },
+    "116": {
+      "name": "A Pro token never reaches the provider",
+      "verdict": "PASS"
+    },
+    "117": {
+      "name": "Detach from Ubuntu Pro",
+      "verdict": "PASS"
+    },
+    "118": {
+      "name": "Enable one Pro service",
+      "verdict": "PASS"
+    },
+    "119": {
+      "name": "Disable one Pro service",
+      "verdict": "PASS"
+    },
+    "120": {
+      "name": "Livepatch state",
+      "verdict": "PASS"
+    },
+    "121": {
+      "name": "Multipass VM inventory",
+      "verdict": "PASS"
+    },
+    "122": {
+      "name": "Revert a snap",
+      "verdict": "PASS"
+    },
+    "123": {
+      "name": "Add a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "124": {
+      "name": "Remove a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "125": {
+      "name": "Delete a numbered ufw rule",
+      "verdict": "PASS"
+    },
+    "126": {
+      "name": "Turn on automatic security updates",
+      "verdict": "PASS"
+    },
+    "127": {
+      "name": "Regenerate netplan without applying",
+      "verdict": "PASS"
+    },
+    "128": {
+      "name": "Set a netplan key without applying",
+      "verdict": "PASS"
+    },
+    "129": {
+      "name": "Distribution upgrade, not apt upgrade",
+      "verdict": "PASS"
+    },
+    "130": {
+      "name": "List a user's flatpaks on Ubuntu",
+      "verdict": "PASS"
+    },
+    "131": {
+      "name": "Install a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "132": {
+      "name": "Remove a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "133": {
+      "name": "Update every flatpak for a user on Ubuntu",
       "verdict": "PASS"
     },
     "55": {
@@ -214,11 +330,11 @@
   "story_set": "ubuntu",
   "surface": "groq/openai/gpt-oss-120b",
   "totals": {
-    "failed": 1,
-    "passed": 49,
+    "failed": 0,
+    "passed": 79,
     "rate_limited": 0,
     "skipped": 0,
-    "total": 50
+    "total": 79
   },
   "version": 1
 }

--- a/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.json
+++ b/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.json
@@ -5,9 +5,9 @@
     "verdict": "not-applicable"
   },
   "cassette_mode": "record",
-  "cassette_sha256": "95d2a780bc1e3b1db966ec27fe32baf0ef3d53662815ba83b2966e1ce97dd8bd",
+  "cassette_sha256": "903ec0a918fc250fbd02066494582dee90f3548d8973656beb029364f96a9450",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-13T12:02:33+00:00",
+  "ran_at": "2026-08-13T16:59:18+00:00",
   "release": "24.04",
   "stories": {
     "100": {
@@ -28,6 +28,122 @@
     },
     "104": {
       "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "105": {
+      "name": "Identify the host",
+      "verdict": "PASS"
+    },
+    "106": {
+      "name": "Recent apt transactions",
+      "verdict": "PASS"
+    },
+    "107": {
+      "name": "Pending reboot check",
+      "verdict": "PASS"
+    },
+    "108": {
+      "name": "cloud-init provisioning result",
+      "verdict": "PASS"
+    },
+    "109": {
+      "name": "GRUB kernel command line",
+      "verdict": "PASS"
+    },
+    "110": {
+      "name": "Apt pin priority for one package",
+      "verdict": "PASS"
+    },
+    "111": {
+      "name": "Remove a named apt pin",
+      "verdict": "PASS"
+    },
+    "112": {
+      "name": "AppArmor profile inventory",
+      "verdict": "PASS"
+    },
+    "113": {
+      "name": "Enforce an AppArmor profile",
+      "verdict": "PASS"
+    },
+    "114": {
+      "name": "Put an AppArmor profile in complain mode",
+      "verdict": "PASS"
+    },
+    "115": {
+      "name": "Ubuntu Pro subscription state",
+      "verdict": "PASS"
+    },
+    "116": {
+      "name": "A Pro token never reaches the provider",
+      "verdict": "PASS"
+    },
+    "117": {
+      "name": "Detach from Ubuntu Pro",
+      "verdict": "PASS"
+    },
+    "118": {
+      "name": "Enable one Pro service",
+      "verdict": "PASS"
+    },
+    "119": {
+      "name": "Disable one Pro service",
+      "verdict": "PASS"
+    },
+    "120": {
+      "name": "Livepatch state",
+      "verdict": "PASS"
+    },
+    "121": {
+      "name": "Multipass VM inventory",
+      "verdict": "PASS"
+    },
+    "122": {
+      "name": "Revert a snap",
+      "verdict": "PASS"
+    },
+    "123": {
+      "name": "Add a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "124": {
+      "name": "Remove a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "125": {
+      "name": "Delete a numbered ufw rule",
+      "verdict": "PASS"
+    },
+    "126": {
+      "name": "Turn on automatic security updates",
+      "verdict": "PASS"
+    },
+    "127": {
+      "name": "Regenerate netplan without applying",
+      "verdict": "PASS"
+    },
+    "128": {
+      "name": "Set a netplan key without applying",
+      "verdict": "PASS"
+    },
+    "129": {
+      "name": "Distribution upgrade, not apt upgrade",
+      "verdict": "PASS"
+    },
+    "130": {
+      "name": "List a user's flatpaks on Ubuntu",
+      "verdict": "PASS"
+    },
+    "131": {
+      "name": "Install a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "132": {
+      "name": "Remove a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "133": {
+      "name": "Update every flatpak for a user on Ubuntu",
       "verdict": "PASS"
     },
     "55": {
@@ -215,10 +331,10 @@
   "surface": "groq/openai/gpt-oss-120b",
   "totals": {
     "failed": 0,
-    "passed": 50,
+    "passed": 79,
     "rate_limited": 0,
     "skipped": 0,
-    "total": 50
+    "total": 79
   },
   "version": 1
 }

--- a/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.replay.json
+++ b/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.replay.json
@@ -1,13 +1,13 @@
 {
   "cassette_audit": {
     "misses": 0,
-    "served": 51,
+    "served": 80,
     "verdict": "ok"
   },
   "cassette_mode": "replay",
-  "cassette_sha256": "95d2a780bc1e3b1db966ec27fe32baf0ef3d53662815ba83b2966e1ce97dd8bd",
+  "cassette_sha256": "903ec0a918fc250fbd02066494582dee90f3548d8973656beb029364f96a9450",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-13T12:07:29+00:00",
+  "ran_at": "2026-08-13T16:59:38+00:00",
   "release": "24.04",
   "stories": {
     "100": {
@@ -28,6 +28,122 @@
     },
     "104": {
       "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "105": {
+      "name": "Identify the host",
+      "verdict": "PASS"
+    },
+    "106": {
+      "name": "Recent apt transactions",
+      "verdict": "PASS"
+    },
+    "107": {
+      "name": "Pending reboot check",
+      "verdict": "PASS"
+    },
+    "108": {
+      "name": "cloud-init provisioning result",
+      "verdict": "PASS"
+    },
+    "109": {
+      "name": "GRUB kernel command line",
+      "verdict": "PASS"
+    },
+    "110": {
+      "name": "Apt pin priority for one package",
+      "verdict": "PASS"
+    },
+    "111": {
+      "name": "Remove a named apt pin",
+      "verdict": "PASS"
+    },
+    "112": {
+      "name": "AppArmor profile inventory",
+      "verdict": "PASS"
+    },
+    "113": {
+      "name": "Enforce an AppArmor profile",
+      "verdict": "PASS"
+    },
+    "114": {
+      "name": "Put an AppArmor profile in complain mode",
+      "verdict": "PASS"
+    },
+    "115": {
+      "name": "Ubuntu Pro subscription state",
+      "verdict": "PASS"
+    },
+    "116": {
+      "name": "A Pro token never reaches the provider",
+      "verdict": "PASS"
+    },
+    "117": {
+      "name": "Detach from Ubuntu Pro",
+      "verdict": "PASS"
+    },
+    "118": {
+      "name": "Enable one Pro service",
+      "verdict": "PASS"
+    },
+    "119": {
+      "name": "Disable one Pro service",
+      "verdict": "PASS"
+    },
+    "120": {
+      "name": "Livepatch state",
+      "verdict": "PASS"
+    },
+    "121": {
+      "name": "Multipass VM inventory",
+      "verdict": "PASS"
+    },
+    "122": {
+      "name": "Revert a snap",
+      "verdict": "PASS"
+    },
+    "123": {
+      "name": "Add a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "124": {
+      "name": "Remove a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "125": {
+      "name": "Delete a numbered ufw rule",
+      "verdict": "PASS"
+    },
+    "126": {
+      "name": "Turn on automatic security updates",
+      "verdict": "PASS"
+    },
+    "127": {
+      "name": "Regenerate netplan without applying",
+      "verdict": "PASS"
+    },
+    "128": {
+      "name": "Set a netplan key without applying",
+      "verdict": "PASS"
+    },
+    "129": {
+      "name": "Distribution upgrade, not apt upgrade",
+      "verdict": "PASS"
+    },
+    "130": {
+      "name": "List a user's flatpaks on Ubuntu",
+      "verdict": "PASS"
+    },
+    "131": {
+      "name": "Install a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "132": {
+      "name": "Remove a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "133": {
+      "name": "Update every flatpak for a user on Ubuntu",
       "verdict": "PASS"
     },
     "55": {
@@ -215,10 +331,10 @@
   "surface": "groq/openai/gpt-oss-120b",
   "totals": {
     "failed": 0,
-    "passed": 50,
+    "passed": 79,
     "rate_limited": 0,
     "skipped": 0,
-    "total": 50
+    "total": 79
   },
   "version": 1
 }

--- a/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.json
+++ b/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.json
@@ -5,9 +5,9 @@
     "verdict": "not-applicable"
   },
   "cassette_mode": "record",
-  "cassette_sha256": "25fab8bbf9f6a811485dba46cf65cc1865ea10e3fe39bc829e2f2266a2da9ab9",
+  "cassette_sha256": "848db517c691908470867aa541badaaeb942bde1da6f2120575f48c7cff3c0ff",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-13T12:02:17+00:00",
+  "ran_at": "2026-08-13T17:09:25+00:00",
   "release": "26.04",
   "stories": {
     "100": {
@@ -28,6 +28,122 @@
     },
     "104": {
       "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "105": {
+      "name": "Identify the host",
+      "verdict": "PASS"
+    },
+    "106": {
+      "name": "Recent apt transactions",
+      "verdict": "PASS"
+    },
+    "107": {
+      "name": "Pending reboot check",
+      "verdict": "PASS"
+    },
+    "108": {
+      "name": "cloud-init provisioning result",
+      "verdict": "PASS"
+    },
+    "109": {
+      "name": "GRUB kernel command line",
+      "verdict": "PASS"
+    },
+    "110": {
+      "name": "Apt pin priority for one package",
+      "verdict": "PASS"
+    },
+    "111": {
+      "name": "Remove a named apt pin",
+      "verdict": "PASS"
+    },
+    "112": {
+      "name": "AppArmor profile inventory",
+      "verdict": "PASS"
+    },
+    "113": {
+      "name": "Enforce an AppArmor profile",
+      "verdict": "PASS"
+    },
+    "114": {
+      "name": "Put an AppArmor profile in complain mode",
+      "verdict": "PASS"
+    },
+    "115": {
+      "name": "Ubuntu Pro subscription state",
+      "verdict": "PASS"
+    },
+    "116": {
+      "name": "A Pro token never reaches the provider",
+      "verdict": "PASS"
+    },
+    "117": {
+      "name": "Detach from Ubuntu Pro",
+      "verdict": "PASS"
+    },
+    "118": {
+      "name": "Enable one Pro service",
+      "verdict": "PASS"
+    },
+    "119": {
+      "name": "Disable one Pro service",
+      "verdict": "PASS"
+    },
+    "120": {
+      "name": "Livepatch state",
+      "verdict": "PASS"
+    },
+    "121": {
+      "name": "Multipass VM inventory",
+      "verdict": "PASS"
+    },
+    "122": {
+      "name": "Revert a snap",
+      "verdict": "PASS"
+    },
+    "123": {
+      "name": "Add a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "124": {
+      "name": "Remove a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "125": {
+      "name": "Delete a numbered ufw rule",
+      "verdict": "PASS"
+    },
+    "126": {
+      "name": "Turn on automatic security updates",
+      "verdict": "PASS"
+    },
+    "127": {
+      "name": "Regenerate netplan without applying",
+      "verdict": "PASS"
+    },
+    "128": {
+      "name": "Set a netplan key without applying",
+      "verdict": "PASS"
+    },
+    "129": {
+      "name": "Distribution upgrade, not apt upgrade",
+      "verdict": "PASS"
+    },
+    "130": {
+      "name": "List a user's flatpaks on Ubuntu",
+      "verdict": "PASS"
+    },
+    "131": {
+      "name": "Install a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "132": {
+      "name": "Remove a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "133": {
+      "name": "Update every flatpak for a user on Ubuntu",
       "verdict": "PASS"
     },
     "55": {
@@ -215,10 +331,10 @@
   "surface": "groq/openai/gpt-oss-120b",
   "totals": {
     "failed": 0,
-    "passed": 50,
+    "passed": 79,
     "rate_limited": 0,
     "skipped": 0,
-    "total": 50
+    "total": 79
   },
   "version": 1
 }

--- a/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.replay.json
+++ b/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.replay.json
@@ -1,13 +1,13 @@
 {
   "cassette_audit": {
     "misses": 0,
-    "served": 51,
+    "served": 80,
     "verdict": "ok"
   },
   "cassette_mode": "replay",
-  "cassette_sha256": "25fab8bbf9f6a811485dba46cf65cc1865ea10e3fe39bc829e2f2266a2da9ab9",
+  "cassette_sha256": "848db517c691908470867aa541badaaeb942bde1da6f2120575f48c7cff3c0ff",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-13T12:07:34+00:00",
+  "ran_at": "2026-08-13T17:09:51+00:00",
   "release": "26.04",
   "stories": {
     "100": {
@@ -28,6 +28,122 @@
     },
     "104": {
       "name": "Apply netplan after showing config",
+      "verdict": "PASS"
+    },
+    "105": {
+      "name": "Identify the host",
+      "verdict": "PASS"
+    },
+    "106": {
+      "name": "Recent apt transactions",
+      "verdict": "PASS"
+    },
+    "107": {
+      "name": "Pending reboot check",
+      "verdict": "PASS"
+    },
+    "108": {
+      "name": "cloud-init provisioning result",
+      "verdict": "PASS"
+    },
+    "109": {
+      "name": "GRUB kernel command line",
+      "verdict": "PASS"
+    },
+    "110": {
+      "name": "Apt pin priority for one package",
+      "verdict": "PASS"
+    },
+    "111": {
+      "name": "Remove a named apt pin",
+      "verdict": "PASS"
+    },
+    "112": {
+      "name": "AppArmor profile inventory",
+      "verdict": "PASS"
+    },
+    "113": {
+      "name": "Enforce an AppArmor profile",
+      "verdict": "PASS"
+    },
+    "114": {
+      "name": "Put an AppArmor profile in complain mode",
+      "verdict": "PASS"
+    },
+    "115": {
+      "name": "Ubuntu Pro subscription state",
+      "verdict": "PASS"
+    },
+    "116": {
+      "name": "A Pro token never reaches the provider",
+      "verdict": "PASS"
+    },
+    "117": {
+      "name": "Detach from Ubuntu Pro",
+      "verdict": "PASS"
+    },
+    "118": {
+      "name": "Enable one Pro service",
+      "verdict": "PASS"
+    },
+    "119": {
+      "name": "Disable one Pro service",
+      "verdict": "PASS"
+    },
+    "120": {
+      "name": "Livepatch state",
+      "verdict": "PASS"
+    },
+    "121": {
+      "name": "Multipass VM inventory",
+      "verdict": "PASS"
+    },
+    "122": {
+      "name": "Revert a snap",
+      "verdict": "PASS"
+    },
+    "123": {
+      "name": "Add a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "124": {
+      "name": "Remove a Launchpad PPA",
+      "verdict": "PASS"
+    },
+    "125": {
+      "name": "Delete a numbered ufw rule",
+      "verdict": "PASS"
+    },
+    "126": {
+      "name": "Turn on automatic security updates",
+      "verdict": "PASS"
+    },
+    "127": {
+      "name": "Regenerate netplan without applying",
+      "verdict": "PASS"
+    },
+    "128": {
+      "name": "Set a netplan key without applying",
+      "verdict": "PASS"
+    },
+    "129": {
+      "name": "Distribution upgrade, not apt upgrade",
+      "verdict": "PASS"
+    },
+    "130": {
+      "name": "List a user's flatpaks on Ubuntu",
+      "verdict": "PASS"
+    },
+    "131": {
+      "name": "Install a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "132": {
+      "name": "Remove a flatpak on Ubuntu",
+      "verdict": "PASS"
+    },
+    "133": {
+      "name": "Update every flatpak for a user on Ubuntu",
       "verdict": "PASS"
     },
     "55": {
@@ -215,10 +331,10 @@
   "surface": "groq/openai/gpt-oss-120b",
   "totals": {
     "failed": 0,
-    "passed": 50,
+    "passed": 79,
     "rate_limited": 0,
     "skipped": 0,
-    "total": 50
+    "total": 79
   },
   "version": 1
 }

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "af252145563cd406aa789797aa9a0dbba68f3e82"
+    "tests": "55f4b5d05eaee825dfe64dc66224f4846c0b41a5"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-13T06:53:59-06:00"
+    "tests": "2026-08-13T10:31:12-06:00"
   },
-  "tests": 1750,
+  "tests": 1758,
   "version": 1
 }

--- a/tests/release/public-claims.test.sh
+++ b/tests/release/public-claims.test.sh
@@ -235,4 +235,28 @@ rm -f "$fixture"/tests/evidence/story-runs/ubuntu-22.04-*.replay.json
 assert_rejected 'a release tiered Validated with its record run but no replay'
 cp "$repo_root"/tests/evidence/story-runs/*.json "$fixture/tests/evidence/story-runs/"
 
+# 3. A replay twin that exists but did not reproduce the run. This is the shape
+#    every LTS actually carried for a while: a `.replay.json` present and
+#    `cassette_audit.verdict` `failed`, because the cassette kept only successes
+#    and so could not reproduce a story whose first call the provider rejected.
+#    The file's own fields say it did not reproduce anything; the tier said
+#    Validated. Presence is not proof.
+python3 - "$fixture/tests/evidence/story-runs" <<'PY'
+import json, pathlib, sys
+path = next(pathlib.Path(sys.argv[1]).glob("ubuntu-22.04-*.replay.json"))
+run = json.loads(path.read_text())
+run["cassette_audit"]["verdict"] = "failed"
+run["cassette_audit"]["misses"] = 1
+path.write_text(json.dumps(run, indent=2, sort_keys=True) + "\n")
+PY
+# The mutation has to have landed. A glob that matched nothing, or a run file
+# that stopped carrying `cassette_audit`, would leave the fixture pristine and
+# the assertion below would be testing the unmutated tree.
+grep -q '"verdict": "failed"' "$fixture"/tests/evidence/story-runs/ubuntu-22.04-*.replay.json || {
+    printf 'FAIL: replay-verdict mutation did not apply; fixture would pass vacuously\n' >&2
+    exit 1
+}
+assert_rejected 'a release tiered Validated on a replay whose cassette audit failed'
+cp "$repo_root"/tests/evidence/story-runs/*.json "$fixture/tests/evidence/story-runs/"
+
 printf 'Public claims contract passed.\n'


### PR DESCRIPTION
## What

Twenty-nine stories, **105–133**, one per Debian-only action that had none. `GetHostState` first: the per-distro prompt split ([ADR 0004](docs/adr/0004-per-distro-prompt-dispatch.md), #181) exists because naming Fedora's `GetSystemState` on an apt host is what the family fence forbids, so *something* had to answer "what is this host?" on Ubuntu — and nothing exercised it end to end.

Debian-only coverage: **63/63**. Ubuntu family: 50 → **79** stories.

| Release | Record | Replay | Cassette audit |
|---|---|---|---|
| 22.04 jammy | 79/79 | 79/79 | 0 misses, 81 served, `ok` |
| 24.04 noble | 79/79 | 79/79 | 0 misses, 80 served, `ok` |
| 26.04 resolute | 79/79 | 79/79 | 0 misses, 80 served, `ok` |

## Three things the stories found

**`ProAttach` is not reachable from natural language.** `prefs::contains_sensitive` matches the literal substring `"token"`, so `admit_request` refuses before any provider call. Omit the word and the model has to invent a credential it was never given — it declines, correctly. Story 116 pins that contract rather than a plan it cannot get.

**Writing story 116 exposed a leak.** The CLI announces `→ planning "<intent>"` on stderr **before** the fence runs, and CI and the story harness both redirect stderr to a file — so the one value the fence exists to contain reached disk on its way to being refused. Both echo sites now go through `prefs::loggable_intent`, which asks `contains_sensitive` the same question the planner asks rather than keeping a second copy of it. Mutation-proven: story 116 failed before the fix with `FAIL: the refusal echoed the token back`.

**Every replay twin was failing, and it was one cause, not three.** Story 101 on 22.04, 119 on 24.04, 125 and 130 on 26.04. The provider sometimes rejects a tool call the model emitted under a name not in `request.tools`; the planner appends a correction and re-asks (#205). The cassette stored only *successes*, so the only entry written was the **second** call. A replay starts from the first, misses, and — a `CassetteMiss` carrying none of the markers that trigger a correction — re-sends identical bytes and misses again.

Cassette **v2** records the rejection. 22.04's twin now serves 81 calls for 79 stories: the refusal, the correction, and the answer.

## A vacuous guard, caught

The first attempt matched `ProviderError::Http { status: 400, .. }`. **No adapter constructs that variant** — a 400 is classified `StatusClass::Other` and arrives as `Request`. Three new tests were green against a shape the system cannot produce; the proof was a recording made with that build coming out `v2` with **zero** rejections.

The predicate now lives once, on `ProviderError::is_invalid_tool_call`, read by both the retrier and the recorder, with a test asserting the two sets are the same set — a recorder narrower than the retrier leaves a retried run unreplayable, a wider one serves a transient failure back for ever. `Http` keeps a doc note saying nothing constructs it, so the next test double does not reach for it.

## Also

- **`check_evidence_claims.py` let a release be tiered "Validated" on a replay twin that merely *existed*.** A pass-rate figure was already refused on a `failed` verdict; the tier was not — and all three LTSes were carrying that tier on twins whose own fields said they had reproduced nothing. Now requires `cassette_audit.verdict == "ok"`, mutation-proven in both directions.
- **A failing story's log now carries the CLI's stderr.** It held the story's opening `echo` and nothing else, because every story redirects stderr to `/tmp/sysknife-story-<n>-stderr.log` and nothing collected it. Diagnosing the miss above needed a hand-written `tar` of `/tmp` from inside the guest.
- **A record run paces 4 s between stories.** The ceiling that bites is *tokens* per minute: ~17 kB in per call against 250 k TPM is ~14 calls a minute, and unpaced this suite issues one every three seconds. Serialising the releases fixes three suites racing each other, not one racing itself. Replays stay at full speed.
- The four `Ubuntu*Flatpak` actions build **byte-identical argv** to their unfenced twins, so stories 130–133 accept either name and log which was chosen. Measured: the model picks the un-prefixed name 3 times in 4.
- `ConfigureUnattendedUpgrades` is in the tool schema and named in **no** Debian prose block; story 126 measures whether the schema alone steers. It does.

## Verification

- 1 758 Rust tests, `scripts/test_baseline.sh`, baseline regenerated
- `cargo fmt` / `clippy --all-targets` / `cargo doc` clean
- All 10 `tests/release/*.test.sh` pass, including the two new mutation cases
- Every published figure re-derived from `tests/evidence/`; the checker is green

Fedora is untouched — `FEDORA_ONLY_ACTIONS`, the atomic story family and the rpm-ostree actions are all intact and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f