### PR TITLE
docs(readme): say plainly that both demo GIFs are scripted reproductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@
 </p>
 
 <p align="center">
-  <em>Illustrative reproduction of the Claude Code MCP flow — same flow works in Cursor and Codex CLI.</em><br/>
+  <em>A deterministic reproduction of the Claude Code MCP flow, rendered offline by
+  <a href="assets/demo/mcp-flow-mock.sh">mcp-flow-mock.sh</a> so it replays identically from a
+  fresh checkout. The same flow works in Cursor and Codex CLI.</em><br/>
   <em>Looking for the standalone CLI? See <a href="docs/cli.md">the CLI guide</a>.</em>
 </p>
 
@@ -191,6 +193,13 @@ SysKnife, not an afterthought. See the [CLI guide](docs/cli.md).
 
 <p align="center">
   <img src="assets/demo/demo.gif" alt="sysknife CLI — plan, approve, and execute in the terminal" width="900"/>
+</p>
+
+<p align="center">
+  <em>A deterministic reproduction of a real planning and execution session, rendered offline by
+  <a href="assets/demo/demo-mock.sh">demo-mock.sh</a>. Live LLM calls are nondeterministic and the
+  tape has to render with no daemon or provider configured, so the recording is scripted rather
+  than captured; the output styling is generated from the same code paths as the real CLI.</em>
 </p>
 
 > **Also: a desktop GUI — development paused.** An experimental Tauri desktop


### PR DESCRIPTION
`demo.gif` had no caption, and `demo-mock.sh` sits in the same directory. A reader who finds the script before the disclosure concludes the demo was faked, which is a fair reading of an undisclosed reconstruction in the hero position.

The reasons for scripting it are good and now stated: live LLM calls are nondeterministic, and the VHS tape has to render with no daemon, socket or provider configured, so a captured session could not be reproduced from a fresh checkout. Both captions now say so and link the generating script.

`mcp-flow.gif` said "Illustrative reproduction", which is true but vague enough to read as hedging. It now says the same thing as its sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f