### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [0.8.0] — 2026-08-16
+
+Every Debian-only action now has a live-VM story, and the recording that proves
+a run can be reproduced finally reproduces the runs that needed a retry.
+
+### Security
+
+- **A credential in an intent reached disk before the fence refused it.**
+  ([#206](https://github.com/lacs-project/sysknife/pull/206))
+  `Planner::admit_request` refuses any intent `prefs::contains_sensitive` flags,
+  so a Pro token or API key never reaches a provider. The CLI, however, printed
+  `→ planning "<intent>"` to stderr *before* calling the planner, and both CI and
+  the story harness run with stderr redirected to a file. The one value the fence
+  exists to contain was therefore written to disk on its way to being refused.
+  Both echo sites now go through `prefs::loggable_intent`, which asks
+  `contains_sensitive` the same question rather than keeping a second copy of it.
+
+### Added
+
+- **Twenty-nine user stories, 105 to 133, one per Debian-only action that had
+  none.** ([#206](https://github.com/lacs-project/sysknife/pull/206))
+  `GetHostState` first: the per-distro prompt split exists because naming
+  Fedora's `GetSystemState` on an apt host is what the family fence forbids, so
+  something had to answer "what is this host?" on Ubuntu, and nothing exercised
+  it end to end. Debian-only coverage is 63 of 63. The Ubuntu family runs 79/79
+  on 22.04, 24.04 and 26.04, each with a committed replay twin that reproduces
+  the run with zero misses.
+
+- **`ProviderError::is_invalid_tool_call`**, the single classification read by
+  both the planner's corrective retry and the cassette's rejection recorder. A
+  recorder narrower than the retrier leaves a retried run unreplayable; a wider
+  one serves a transient failure back for ever.
+
+### Fixed
+
+- **Cassette v2 records provider rejections, so a retried exchange replays.**
+  ([#206](https://github.com/lacs-project/sysknife/pull/206))
+  The planner appends a correction and re-asks when a provider rejects a tool
+  call, but the cassette stored only successes, so the only entry written was the
+  *second* call. A replay started from the first, missed, and re-sent identical
+  bytes. That single gap was why all three LTS replay twins reported
+  `cassette_audit.verdict` `failed`. v1 files are still read; new writes are v2.
+
+- **A failing story's log now carries the CLI's stderr.** It held the story's
+  opening line and nothing else, because every story redirects stderr to
+  `/tmp/sysknife-story-<n>-stderr.log` and nothing collected it.
+
+- **A record run paces itself.** The provider ceiling that bites is tokens per
+  minute, not requests: roughly 17 kB in per call against 250 k TPM is about 14
+  calls a minute, and unpaced the suite issues one every three seconds.
+
+### Changed
+
+- **"Validated" now requires a replay twin that actually reproduced the run.**
+  `check_evidence_claims.py` accepted any committed twin, including one whose own
+  `cassette_audit.verdict` said `failed`. A pass-rate figure was already refused
+  on those grounds; the tier was not.
+
 ## [0.7.0] — 2026-08-08
 
 A security release. Five privileged paths that a bounded action could ride into

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4875,7 +4875,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,11 +15,11 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.7.0" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.7.0" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.7.0" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.8.0" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.8.0" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.8.0" }
 chrono = "0.4"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.7.0" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.8.0" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -39,11 +39,11 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.7.0", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.8.0", features = ["test-support"] }
 # and `AttributionCensus::from_counts_for_tests`, so the verify renderers can be
 # tested without building signed chain rows. Dev-only: production builds of this
 # bin do not compile dev-dependencies, so the constructor stays unreachable there.
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.7.0", features = ["test-support"] }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.8.0", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "react": "^19.2.8",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.7.0" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.7.0" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.8.0" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.8.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.7.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.7.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.8.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.8.0" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.7.0"
+version = "0.8.0"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.7.0" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.8.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,8 +17,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 test-support = []
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.7.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.7.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.8.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.8.0" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -61,7 +61,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.7.0" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.8.0" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.7.0" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.8.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Twenty-four commits have landed since v0.7.0, including two `fix(security)` commits and, in #206, a credential that reached disk before the fence refused it. `npx sysknife-setup` and `cargo install sysknife-cli` hand out **v0.7.0**, so anyone installing today gets a build we have already patched. That is the reason to cut this now rather than after a launch.

## Every version moves together

This is the part that has broken before. A bump that misses the internal dependency requirements passes `check_release_versions.sh`, which only reads package versions, and then dies mid-publish on crates.io with some crates already pushed and unrepeatable.

- 8 Cargo package versions
- **15 internal `sysknife-*` dependency pins**
- `Cargo.lock`
- 5 JSON manifests (shell package.json, package-lock.json, tauri.conf.json, setup package.json, .codex-plugin/plugin.json)
- `server.json`, in two places (top-level and `packages[0]`)

## Verification

- `scripts/check_release_versions.sh v0.8.0` → all match
- `scripts/release_rehearsal.sh --check` → preflight passed, both artifacts built
- 1 758 tests, fmt, clippy `--all-targets`, `cargo doc` all clean
- Evidence checker and public-claims contract green

The tag is not pushed by this PR. `release.yml` publishes on tag, and both registries are immutable, so that stays a deliberate separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f