### PR TITLE
test(e2e): re-prove all three replays against the v0.8.0 release commit

### DIFF
--- a/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json
+++ b/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json
@@ -7,7 +7,7 @@
   "cassette_mode": "replay",
   "cassette_sha256": "0d52ba548f348817fba093c0a0801b47d07777506372f72c78bee8fa63ee312a",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-13T16:46:40+00:00",
+  "ran_at": "2026-08-16T13:52:51+00:00",
   "release": "22.04",
   "stories": {
     "100": {

--- a/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.replay.json
+++ b/tests/evidence/story-runs/ubuntu-24.04-gpt-oss-120b.replay.json
@@ -7,7 +7,7 @@
   "cassette_mode": "replay",
   "cassette_sha256": "903ec0a918fc250fbd02066494582dee90f3548d8973656beb029364f96a9450",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-13T16:59:38+00:00",
+  "ran_at": "2026-08-16T13:53:38+00:00",
   "release": "24.04",
   "stories": {
     "100": {

--- a/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.replay.json
+++ b/tests/evidence/story-runs/ubuntu-26.04-gpt-oss-120b.replay.json
@@ -7,7 +7,7 @@
   "cassette_mode": "replay",
   "cassette_sha256": "848db517c691908470867aa541badaaeb942bde1da6f2120575f48c7cff3c0ff",
   "distro_id": "ubuntu",
-  "ran_at": "2026-08-13T17:09:51+00:00",
+  "ran_at": "2026-08-16T13:53:09+00:00",
   "release": "26.04",
   "stories": {
     "100": {


### PR DESCRIPTION
Committed twins were produced at `476e68d`; the release candidate is three commits further on, and `docs/release-readiness.md` says a historical run may not back a new commit.

All three VMs re-provisioned at v0.8.0 and replayed the committed cassettes:

| Release | Stories | Cassette audit |
|---|---|---|
| 22.04 | 79/79 | 0 misses, 81 served, `ok` |
| 24.04 | 79/79 | 0 misses, 80 served, `ok` |
| 26.04 | 79/79 | 0 misses, 80 served, `ok` |

Only `ran_at` moved. Replays make no provider calls, so this cost nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f