### PR TITLE
fix(provider): stop telling people to rotate a working key on a 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,758 Rust tests and 72 frontend tests** form the current deterministic
+**1,759 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/crates/sysknife-brain/src/providers/mod.rs
+++ b/crates/sysknife-brain/src/providers/mod.rs
@@ -5,8 +5,16 @@ pub mod rig_adapter;
 /// adapter that maps SDK errors onto [`crate::provider::ProviderError`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum StatusClass {
-    /// 401 Unauthorized / 403 Forbidden — credentials are missing or invalid.
+    /// 401 Unauthorized — the credential itself was rejected.
     Auth,
+    /// 403 Forbidden — the request was refused. Kept separate from
+    /// [`Auth`](Self::Auth) because "check your API key" is the wrong advice
+    /// about half the time: a 403 is just as often a blocked IP or region, or
+    /// an account without access to the requested model. Observed live, Groq
+    /// answering a planning call from a VPN exit with
+    /// `{"error":{"message":"Access denied. Please check your network
+    /// settings."}}` while SysKnife told the operator to check their key.
+    Forbidden,
     /// 429 Too Many Requests.
     RateLimit,
     /// Any other 4xx/5xx status — a generic request error.
@@ -20,7 +28,8 @@ pub(super) enum StatusClass {
 /// is available (e.g. a transport-level failure with no HTTP response).
 pub(super) fn classify_status(status: http::StatusCode) -> StatusClass {
     match status {
-        http::StatusCode::UNAUTHORIZED | http::StatusCode::FORBIDDEN => StatusClass::Auth,
+        http::StatusCode::UNAUTHORIZED => StatusClass::Auth,
+        http::StatusCode::FORBIDDEN => StatusClass::Forbidden,
         http::StatusCode::TOO_MANY_REQUESTS => StatusClass::RateLimit,
         _ => StatusClass::Other,
     }
@@ -123,7 +132,7 @@ pub(crate) const LOG_PREVIEW_CHARS: usize = 200;
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_error_msg;
+    use super::{classify_status, sanitize_error_msg, StatusClass};
 
     #[test]
     fn sanitize_error_msg_strips_key_param() {
@@ -212,5 +221,34 @@ mod tests {
         let input = "connection refused: https://api.example.com/v1";
         let result = sanitize_error_msg(input);
         assert_eq!(result, input);
+    }
+
+    #[test]
+    fn a_401_and_a_403_are_not_the_same_diagnosis() {
+        // 401 means the credential was rejected. 403 means the request was
+        // refused, which is just as often a blocked IP, a blocked region, or an
+        // account without access to the model.
+        //
+        // Folding both into "check your API key" sends someone with a perfectly
+        // good key to rotate it. Observed live: Groq answered a planning call
+        // from a VPN exit with `403 {"error":{"message":"Access denied. Please
+        // check your network settings."}}`, and SysKnife reported
+        // "provider authentication failed — check your API key".
+        assert_eq!(
+            classify_status(http::StatusCode::UNAUTHORIZED),
+            StatusClass::Auth
+        );
+        assert_eq!(
+            classify_status(http::StatusCode::FORBIDDEN),
+            StatusClass::Forbidden
+        );
+        assert_eq!(
+            classify_status(http::StatusCode::TOO_MANY_REQUESTS),
+            StatusClass::RateLimit
+        );
+        assert_eq!(
+            classify_status(http::StatusCode::INTERNAL_SERVER_ERROR),
+            StatusClass::Other
+        );
     }
 }

--- a/crates/sysknife-brain/src/providers/openai_adapter.rs
+++ b/crates/sysknife-brain/src/providers/openai_adapter.rs
@@ -389,6 +389,27 @@ fn map_openai_error(err: async_openai::error::OpenAIError) -> ProviderError {
                     "OpenAI authentication failed — check OPENAI_API_KEY".to_string(),
                 )
             }
+            // A 403 is refused-request, not rejected-credential: a blocked IP or
+            // region, an account without access to the model, or an org policy
+            // are all as likely as a bad key. Sending the reader to rotate a
+            // working key is the wrong advice, and it is the advice they got —
+            // observed live, Groq answering from a VPN exit with "Access denied.
+            // Please check your network settings." The provider's own text stays
+            // withheld for the same reason the Auth arm withholds it, and stays
+            // logged.
+            super::StatusClass::Forbidden => {
+                tracing::error!(
+                    target: "sysknife_brain::openai_adapter",
+                    "OpenAI refused the request (403): {}",
+                    msg
+                );
+                ProviderError::Auth(
+                    "provider refused the request (HTTP 403) — this is a rejected key, a blocked \
+                     IP or region, or an account without access to that model; the provider's \
+                     reason is in the log line above"
+                        .to_string(),
+                )
+            }
             super::StatusClass::RateLimit => {
                 tracing::warn!(
                     target: "sysknife_brain::openai_adapter",

--- a/crates/sysknife-brain/src/providers/rig_adapter.rs
+++ b/crates/sysknife-brain/src/providers/rig_adapter.rs
@@ -386,6 +386,17 @@ fn from_rig_response(choice: OneOrMany<AssistantContent>) -> Result<Completion, 
 /// still logged for operator diagnostics. Mirrors `openai_adapter`.
 const AUTH_FAILURE_MSG: &str = "provider authentication failed — check your API key";
 
+/// What a 403 means, which is deliberately not "your key is wrong".
+///
+/// A 403 is refused-request, not rejected-credential: a blocked IP or region,
+/// an account without access to the model, or an org policy are all as likely
+/// as a bad key. Naming all of them costs one line and saves the reader from
+/// rotating a working key. The provider's own text is still withheld for the
+/// same reason [`AUTH_FAILURE_MSG`] withholds it, and still logged.
+const FORBIDDEN_MSG: &str = "provider refused the request (HTTP 403) — this is a rejected key, \
+     a blocked IP or region, or an account without access to that model; the provider's reason \
+     is in the log line above";
+
 fn map_rig_error(err: rig::completion::CompletionError) -> ProviderError {
     let msg = sanitize_error_msg(&err.to_string());
     // "Rig" is the name of a dependency, which means nothing to a user
@@ -399,6 +410,7 @@ fn map_rig_error(err: rig::completion::CompletionError) -> ProviderError {
     if let Some(status) = err.provider_response_status() {
         return match super::classify_status(status) {
             super::StatusClass::Auth => ProviderError::Auth(AUTH_FAILURE_MSG.to_string()),
+            super::StatusClass::Forbidden => ProviderError::Auth(FORBIDDEN_MSG.to_string()),
             super::StatusClass::RateLimit => ProviderError::RateLimit(msg),
             super::StatusClass::Other => ProviderError::Request(msg),
         };

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,758 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,759 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,758 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,759 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "55f4b5d05eaee825dfe64dc66224f4846c0b41a5"
+    "tests": "1585e9ec798db17e81c879ad44040e8c6ff2e6e5"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-13T10:31:12-06:00"
+    "tests": "2026-08-16T08:31:24-06:00"
   },
-  "tests": 1758,
+  "tests": 1759,
   "version": 1
 }


### PR DESCRIPTION
Found by running the release-readiness install exercise on a clean Ubuntu 24.04 VM.

`classify_status` folded 401 and 403 into one class, and the Auth arm emits a fixed "check your API key" while withholding the provider's own text. The withholding is correct: auth-error text can echo key-adjacent context. The folding is not.

Groq answered a planning call from a VPN exit with:

```
403 {"error":{"message":"Access denied. Please check your network settings."}}
```

and SysKnife reported `provider authentication failed — check your API key`. The key was fine. Anyone behind a VPN, a corporate proxy, or in a blocked region is sent to rotate a working credential, and the single line that says otherwise is a `tracing::error!` they are not reading.

A 403 is refused-request, not rejected-credential. It now has its own `StatusClass::Forbidden` and a message naming the real possibilities, in both adapters. Provider text stays withheld and stays logged.

`a_401_and_a_403_are_not_the_same_diagnosis` pins the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9dpzc8CXrPDksbHmndT8f