### PR TITLE
fix(plugin): close the two registry metadata gaps that cost trust points

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -3,6 +3,7 @@
   "version": "0.8.0",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
+  "homepage": "https://lacs-project.github.io/sysknife/",
   "author": {
     "name": "LACS Project",
     "url": "https://github.com/lacs-project"

--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,58 @@
+# Paths a plugin walker should skip when it reads this repository.
+#
+# Two kinds of entry live here, and the distinction matters more than the list:
+#
+#   Build output and local state, which is large, regenerated, and carries no
+#   information a reader of the plugin needs.
+#
+#   Local agent and VM artifacts, which hold absolute paths from whoever ran
+#   them last. One of them, .codex/config.toml, has reached a public commit
+#   before via an over-broad `git add -A`.
+#
+# Committed evidence stays visible on purpose. tests/e2e/cassettes/*.json are
+# the recorded provider runs that let the story suite replay offline, and
+# docs/action-reference.md is generated but tracked, because a drift guard
+# compares it against the live action catalogue. Hiding either would hide the
+# proof behind the support matrix.
+
+# Rust build output
+target/
+
+# Node
+node_modules/
+dist/
+/.pnpm-store/
+/.turbo/
+packages/setup/*.tgz
+
+# mdBook render
+book/
+
+# Python bytecode from the packaging scripts
+__pycache__/
+*.pyc
+
+# Local MCP wiring, written per machine
+.mcp.json
+.codex/
+
+# VM images and per-release runtime state for the E2E suite
+tests/e2e/vm/
+tests/e2e/ubuntu-vm/jammy/
+tests/e2e/ubuntu-vm/noble/
+tests/e2e/ubuntu-vm/resolute/
+/*.iso
+/*.qcow2
+
+# Per-run logs and replay ledgers, truncated on every run
+tests/e2e/logs/*.log
+tests/e2e/exec/logs/*.log
+tests/e2e/cassettes/*.replay-log.jsonl
+
+# Local-only docs
+docs/local/
+
+# Editor and OS scratch
+*.swp
+*.swo
+.DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Check Smithery manifest coherence
         run: bash tests/release/smithery-manifest.test.sh
 
+      - name: Check Codex plugin manifest metadata
+        run: bash tests/release/codex-plugin-manifest.test.sh
+
       - name: Check release rehearsal contract
         run: bash tests/release/release-rehearsal.test.sh
 

--- a/tests/release/codex-plugin-manifest.test.sh
+++ b/tests/release/codex-plugin-manifest.test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Guards .codex-plugin/plugin.json against the metadata gaps that cost trust
+# points in the HOL Registry listing, and a .codexignore that goes missing.
+#
+# The registry scores plugins with hashgraph-online/hol-guard, whose checks read
+# this manifest with the repository root as the plugin directory. Two of its
+# checks are all-or-nothing, so a single absent field zeroes the whole check:
+#
+#   Recommended metadata present (4 pts) wants author, homepage, repository,
+#   license and keywords. Only `homepage` was ever missing here, and its absence
+#   scored the same as a malformed manifest.
+#
+#   .codexignore found (3 pts) wants the file to exist at the repository root.
+#
+# Neither gap breaks a build, so no Rust test sees them. Both are asserted here.
+#
+# The interface URL check (websiteURL, privacyPolicyURL, termsOfServiceURL and
+# screenshots, 3 pts) is deliberately NOT asserted. It is all-or-nothing too,
+# and SysKnife publishes no privacy policy or terms of service because the
+# daemon transmits nothing. Declaring `websiteURL` alone earns zero points, so
+# the manifest states what is true instead of what scores.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+manifest="$repo_root/.codex-plugin/plugin.json"
+
+fail() {
+    printf 'codex-plugin-manifest: %s\n' "$1" >&2
+    exit 1
+}
+
+[[ -f "$manifest" ]] || fail '.codex-plugin/plugin.json is missing'
+
+field() { node -p "JSON.parse(require('fs').readFileSync('$manifest','utf8'))$1"; }
+
+# --- Recommended metadata: the scanner's RECOMMENDED_FIELDS, verbatim ---
+for key in author homepage repository license keywords; do
+    present="$(field ".$key !== undefined")"
+    [[ "$present" == "true" ]] \
+        || fail "recommended field \"$key\" is missing from the manifest"
+done
+
+# author and keywords carry a shape requirement beyond mere presence.
+[[ "$(field ".author.name ? 'yes' : 'no'")" == "yes" ]] \
+    || fail 'author.name must be a non-empty string'
+[[ "$(field ".keywords.length > 0")" == "true" ]] \
+    || fail 'keywords must be a non-empty array'
+
+# homepage and repository are read as links by the registry listing, so an
+# http:// or relative value would render as a broken destination.
+for key in homepage repository; do
+    value="$(field ".$key")"
+    [[ "$value" == https://* ]] \
+        || fail "$key is '$value', expected an https:// URL"
+done
+
+# --- Declared interface assets have to exist, or the listing renders a gap ---
+for key in composerIcon logo; do
+    value="$(field ".interface.$key")"
+    [[ -n "$value" && "$value" != undefined ]] \
+        || fail "interface.$key is not declared"
+    # Paths are relative to the repository root, which is the plugin directory
+    # the scanner passes in.
+    resolved="$repo_root/${value#./}"
+    [[ -f "$resolved" ]] \
+        || fail "interface.$key points at '$value', which does not exist"
+done
+
+# The manifest names the file that declares the MCP servers; a stale path there
+# publishes a plugin that installs and then exposes nothing.
+mcp_servers="$(field ".mcpServers")"
+[[ -f "$repo_root/${mcp_servers#./}" ]] \
+    || fail "mcpServers points at '$mcp_servers', which does not exist"
+
+# --- .codexignore ---
+[[ -f "$repo_root/.codexignore" ]] \
+    || fail '.codexignore is missing from the repository root'
+[[ -s "$repo_root/.codexignore" ]] \
+    || fail '.codexignore exists but is empty'
+
+# A .codexignore that fails to cover the build directory ships the whole target
+# tree to anything that walks the plugin, which is what the file exists to stop.
+grep -qE '^/?target/?$' "$repo_root/.codexignore" \
+    || fail '.codexignore does not exclude the Rust target directory'
+
+printf 'codex-plugin-manifest: OK\n'


### PR DESCRIPTION
The HOL Registry listing carries a Caution badge. I ran the scanner the registry
uses, [hashgraph-online/hol-guard](https://github.com/hashgraph-online/hol-guard),
against a clean export of this repository. Its 30 checks score 66/83, with four
failures:

| lost | check | detail |
|---|---|---|
| 7 | No hardcoded secrets | six findings, all false positives |
| 4 | Recommended metadata present | `homepage` missing |
| 3 | Interface links and assets valid | `websiteURL`, `privacyPolicyURL`, `termsOfServiceURL`, `screenshots` |
| 3 | `.codexignore` found | no such file |

Two of those are real gaps here, and this PR closes both. `.codex-plugin/plugin.json`
gains `homepage`, the last of the scanner's five `RECOMMENDED_FIELDS` that was
absent, and the repository root gains a `.codexignore`. Re-running the same scan
scores 73/83.

## What this PR leaves failing, and why

**The interface check.** It is all-or-nothing across four fields, so declaring
`websiteURL` alone earns zero points. The other two would be a privacy policy and
terms of service for software that transmits nothing. The manifest states what is
true rather than what scores.

**The seven-point secret check.** Six findings, every one a false positive, and
four of them are the files that prove there are no secrets:

- `scripts/check_no_secrets.sh:24`, the comment listing strings our own scanner
  must not reject
- `tests/release/no-secrets.test.sh:63`, the fixture allowlist
- `HACKING.md:600`, the example of the planner refusing `sk-proj-fake-key-for-testing`
- `crates/sysknife-brain/src/config.rs:416` (`debug_redacts_api_key`),
  `crates/sysknife-brain/src/prefs.rs:466` (`contains_sensitive_detects_new_patterns`,
  which uses AWS's own published example key), and
  `crates/sysknife-daemon/src/actions/ubuntu_pro.rs:219`
  (`pro_attach_action_name_does_not_contain_token`)

Their check has no allowlist, so it flags ours. Fixing it needs an upstream change
or a rewrite of how the fixtures are spelled, so it stays out of this PR.

Worth knowing separately: the same scan returns `install_verdict.action = "block"`
with `can_install: false`, driven entirely by those six strings, because the secret
check awards 0/7 the moment one file matches and rates each hit HIGH.

## Test

Both gaps are invisible to the Rust suite, so `tests/release/codex-plugin-manifest.test.sh`
asserts them and CI runs it beside the other manifest gates. Every assertion was
mutation-proved: dropping `target/` from `.codexignore`, removing the file,
downgrading `homepage` to `http://`, pointing `logo` at a missing asset, and
staling the `mcpServers` path each fail the test.

Local gate green from a cold worktree: fmt, clippy, doc, secret scan, and
1759/1759 nextest. `shellcheck --severity=warning` clean over the whole
`tests/e2e tests/release scripts assets/demo` set, and `yamllint -c .yamllint`
clean on the workflow.
