### PR TITLE
fix(setup): make the audit-database move all-or-nothing, and let --purge see it

### DIFF
--- a/packages/setup/install-daemon.js
+++ b/packages/setup/install-daemon.js
@@ -110,8 +110,14 @@ function databasePath() {
  *
  * Returns a human-readable note, or null when there was nothing to do.
  */
+function legacyDatabasePath() {
+  return path.join(os.homedir(), '.local', 'share', 'sysknife', 'daemon.sqlite');
+}
+
+const DB_SIDECARS = ['', '-wal', '-shm'];
+
 function migrateLegacyDatabase() {
-  const legacy = path.join(os.homedir(), '.local', 'share', 'sysknife', 'daemon.sqlite');
+  const legacy = legacyDatabasePath();
   const current = databasePath();
   if (!fs.existsSync(legacy)) return null;
   if (fs.existsSync(current)) {
@@ -119,9 +125,41 @@ function migrateLegacyDatabase() {
       + 'Neither was touched. Keep whichever history you need and delete the other.';
   }
   fs.mkdirSync(path.dirname(current), { recursive: true });
-  for (const suffix of ['', '-wal', '-shm']) {
-    if (fs.existsSync(legacy + suffix)) fs.renameSync(legacy + suffix, current + suffix);
+
+  // All three move or none does. The loop used to rename them in sequence with
+  // no handling, so a failure on `-wal` left the database already moved and its
+  // write-ahead log behind: the daemon then opens a chain whose WAL is in
+  // another directory, which is the one state this function exists to avoid.
+  // EXDEV across a bind-mounted XDG_STATE_HOME, a read-only destination and a
+  // stale lock all produce it.
+  const moved = [];
+  try {
+    for (const suffix of DB_SIDECARS) {
+      if (fs.existsSync(legacy + suffix)) {
+        fs.renameSync(legacy + suffix, current + suffix);
+        moved.push(suffix);
+      }
+    }
+  } catch (err) {
+    const stranded = [];
+    for (const suffix of moved.reverse()) {
+      try {
+        fs.renameSync(current + suffix, legacy + suffix);
+      } catch {
+        stranded.push(current + suffix);
+      }
+    }
+    if (stranded.length > 0) {
+      return `could not move the audit database from ${legacy} to ${current}: ${err.message}. `
+        + `Rolling back also failed, so parts of one chain are now split across both `
+        + `locations: ${stranded.join(', ')}. Move them back beside ${legacy} before `
+        + 'starting the daemon, or it will open an incomplete chain.';
+    }
+    return `could not move the audit database from ${legacy} to ${current}: ${err.message}. `
+      + `Nothing was moved, so the old history is intact at ${legacy}. The daemon reads `
+      + `${current} and will start a new chain, so move it yourself to keep the old one.`;
   }
+
   return `moved the audit database from ${legacy} to ${current} (the path the daemon reads by default).`;
 }
 
@@ -408,6 +446,8 @@ async function _installSystemService(daemonBinPath) {
 module.exports = {
   installDaemonService,
   databasePath,
+  legacyDatabasePath,
+  DB_SIDECARS,
   migrateLegacyDatabase,
   userUnitContent,
   runtimeSocketPath,

--- a/packages/setup/tests/install-daemon.test.mjs
+++ b/packages/setup/tests/install-daemon.test.mjs
@@ -13,11 +13,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import os from 'node:os';
+import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { userUnitContent, runtimeSocketPath, runtimeDir } = require('../install-daemon.js');
+const {
+  userUnitContent, runtimeSocketPath, runtimeDir,
+  databasePath, migrateLegacyDatabase, legacyDatabasePath,
+} = require('../install-daemon.js');
 
 // ---------------------------------------------------------------------------
 // runtimeDir / runtimeSocketPath — the socket-mismatch regression guard
@@ -111,4 +115,89 @@ test('userUnitContent points the database at the path the daemon reads by defaul
 test('userUnitContent wires the given daemon binary path as ExecStart', () => {
   const unit = userUnitContent('/opt/sysknife/sysknife-daemon');
   assert.match(unit, /ExecStart=\/opt\/sysknife\/sysknife-daemon/);
+});
+
+// ---------------------------------------------------------------------------
+// migrateLegacyDatabase — the audit chain is the one thing that cannot be
+// re-derived, so a move that half-succeeds is worse than one that never starts
+// ---------------------------------------------------------------------------
+
+/** Run `fn` with $HOME pointed at a fresh tmpdir and XDG_STATE_HOME cleared. */
+function withFakeHome(fn) {
+  const prevHome = process.env.HOME;
+  const prevState = process.env.XDG_STATE_HOME;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-migrate-'));
+  process.env.HOME = home;
+  delete process.env.XDG_STATE_HOME;
+  try {
+    return fn(home);
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+    if (prevState === undefined) delete process.env.XDG_STATE_HOME; else process.env.XDG_STATE_HOME = prevState;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+function seedLegacy(home, suffixes = ['', '-wal', '-shm']) {
+  const legacy = path.join(home, '.local', 'share', 'sysknife', 'daemon.sqlite');
+  fs.mkdirSync(path.dirname(legacy), { recursive: true });
+  for (const s of suffixes) fs.writeFileSync(legacy + s, `contents${s}`);
+  return legacy;
+}
+
+test('migrateLegacyDatabase moves the database with both sidecars', () => {
+  withFakeHome((home) => {
+    const legacy = seedLegacy(home);
+    const note = migrateLegacyDatabase();
+    assert.match(note, /moved the audit database/);
+    for (const s of ['', '-wal', '-shm']) {
+      assert.equal(fs.existsSync(legacy + s), false, `legacy${s} should be gone`);
+      assert.equal(fs.readFileSync(databasePath() + s, 'utf8'), `contents${s}`);
+    }
+  });
+});
+
+test('a sidecar that cannot be moved leaves the whole chain where it was', () => {
+  withFakeHome((home) => {
+    const legacy = seedLegacy(home);
+    // Make the -wal destination un-renameable-onto by putting a directory there.
+    // Any mid-loop failure has the same shape: EXDEV across a bind mount, a
+    // read-only destination, a stale lock. The main file has already moved by
+    // then, so without a rollback the chain is split across two directories and
+    // the daemon opens a database whose write-ahead log is somewhere else.
+    fs.mkdirSync(path.dirname(databasePath()), { recursive: true });
+    fs.mkdirSync(`${databasePath()}-wal`, { recursive: true });
+
+    const note = migrateLegacyDatabase();
+
+    assert.match(note, /could not move/i, 'the operator has to be told it failed');
+    for (const s of ['', '-wal', '-shm']) {
+      assert.equal(
+        fs.existsSync(legacy + s), true,
+        `legacy${s} must still be there: a half-moved audit chain is unreadable`,
+      );
+    }
+    assert.equal(fs.existsSync(databasePath()), false, 'no orphan at the destination');
+  });
+});
+
+test('migrateLegacyDatabase touches neither database when both exist', () => {
+  withFakeHome((home) => {
+    const legacy = seedLegacy(home, ['']);
+    fs.mkdirSync(path.dirname(databasePath()), { recursive: true });
+    fs.writeFileSync(databasePath(), 'newer');
+    const note = migrateLegacyDatabase();
+    assert.match(note, /two audit databases exist/);
+    assert.equal(fs.readFileSync(legacy, 'utf8'), 'contents');
+    assert.equal(fs.readFileSync(databasePath(), 'utf8'), 'newer');
+  });
+});
+
+test('the legacy path is exported, so uninstall cannot restate it wrongly', () => {
+  withFakeHome((home) => {
+    assert.equal(
+      legacyDatabasePath(),
+      path.join(home, '.local', 'share', 'sysknife', 'daemon.sqlite'),
+    );
+  });
 });

--- a/packages/setup/tests/uninstall.test.mjs
+++ b/packages/setup/tests/uninstall.test.mjs
@@ -18,7 +18,7 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const { footprint } = require('../uninstall.js');
-const { databasePath } = require('../install-daemon.js');
+const { databasePath, legacyDatabasePath } = require('../install-daemon.js');
 
 test('the footprint separates software from data, and the audit chain is data', () => {
   const fp = footprint('/tmp/project');
@@ -75,4 +75,28 @@ test('a dry run reports what exists and changes nothing on disk', async () => {
   assert.ok(result.removed.includes(mcp), 'dry run should report the file it found');
   assert.ok(fs.existsSync(mcp), 'dry run must not delete anything');
   fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('--purge can see a database the migration never moved', () => {
+  // The installer moves ~/.local/share/sysknife/daemon.sqlite to the XDG state
+  // path, but only in user mode and only when it runs. A system-mode install
+  // returns before the migration, and anyone who installed once and never
+  // re-ran the wizard still has the old file. footprint() derived the audit
+  // chain from databasePath() alone, so on those hosts `--purge` printed that it
+  // had removed "the signed audit chain of every action SysKnife executed" and
+  // left it on disk.
+  const legacy = legacyDatabasePath();
+  const paths = footprint('/tmp/project').data.map((e) => e.path);
+  for (const suffix of ['', '-wal', '-shm']) {
+    assert.ok(
+      paths.includes(legacy + suffix),
+      `footprint must list the legacy database${suffix}`,
+    );
+  }
+});
+
+test('the legacy entries are derived from install-daemon, not restated', () => {
+  const entry = footprint('/tmp/project').data.find((e) => e.path === legacyDatabasePath());
+  assert.ok(entry, 'legacy database is listed');
+  assert.match(entry.what, /audit chain/i, 'and it says what it is');
 });

--- a/packages/setup/uninstall.js
+++ b/packages/setup/uninstall.js
@@ -29,7 +29,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
-const { databasePath } = require('./install-daemon.js');
+const { databasePath, legacyDatabasePath, DB_SIDECARS } = require('./install-daemon.js');
 
 const SYSTEM_UNIT_PATH = '/etc/systemd/system/sysknife-daemon.service';
 
@@ -63,6 +63,21 @@ function footprint(cwd = process.cwd()) {
       { path: db, what: 'the signed audit chain of every action SysKnife executed' },
       { path: `${db}-wal`, what: 'its write-ahead log' },
       { path: `${db}-shm`, what: 'its shared-memory index' },
+      // The installer moves this to the XDG state path, but only in user mode
+      // and only when it runs. A system-mode install returns before the
+      // migration, and anyone who installed once and never re-ran the wizard
+      // still has it. Listing only `databasePath()` meant `--purge` claimed to
+      // have removed the audit chain and left this file behind. Absent paths are
+      // skipped when the footprint is reported, so naming it costs nothing on a
+      // host that has already migrated.
+      {
+        path: legacyDatabasePath(),
+        what: 'the signed audit chain from the older layout, if the installer never moved it',
+      },
+      ...DB_SIDECARS.filter((s) => s !== '').map((s) => ({
+        path: legacyDatabasePath() + s,
+        what: `the older layout's ${s === '-wal' ? 'write-ahead log' : 'shared-memory index'}`,
+      })),
       {
         path: path.join(home, '.local', 'share', 'sysknife', 'safety-audit.jsonl'),
         what: 'the record of every plan the safety fence rejected',


### PR DESCRIPTION
Closes #240. Both defects shipped in v0.8.0.

`migrateLegacyDatabase` renamed the database and its `-wal` and `-shm` sidecars
in sequence with no handling, so a failure on the second left the database
already moved and its write-ahead log behind. The daemon then opens a chain
whose WAL is in another directory, which is the state the function's own doc
comment says it exists to prevent: "the SQLite sidecars move with it or the
chain is unreadable". EXDEV across a bind-mounted XDG_STATE_HOME, a read-only
destination and a stale lock all reach it, and the throw escaped into
installDaemonService, which calls it without a try, aborting the install
mid-move.

The move now records what it moved and rolls back on failure, returning a
message instead of throwing. When the rollback also fails it names the stranded
files, because that is the one state an operator has to repair by hand before
starting the daemon, and silence there is worse than a long warning.

Separately, `footprint()` derived the audit chain from `databasePath()` alone
while printing "the signed audit chain of every action SysKnife executed" for
it. The migration runs only in user mode and only when the installer runs, so a
system-mode install or an install that was never re-run still has the old file,
and `--purge` claimed to have removed the chain and left it there. The legacy
path is now `legacyDatabasePath()`, exported alongside `DB_SIDECARS` and derived
by `footprint()` rather than restated. Absent paths are already skipped when the
footprint is reported, so a migrated host sees no change.

`uninstall.js` already reached into the same legacy directory for
`safety-audit.jsonl`, so it knew the directory and not the database.

Four tests, written failing first: the happy path with both sidecars, a sidecar
that cannot be moved leaving the whole chain in place, the both-databases-exist
refusal, and the footprint listing the legacy database. The partial-failure case
puts a directory at the `-wal` destination, which fails one rename in the loop
after the first has already succeeded. Both fixes are mutation-proved: restoring
the unguarded loop fails the rollback test, and removing the legacy entries
fails the footprint tests. 80/80 in the setup suite.