### PR TITLE
docs: correct five figures that drifted past the guards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,10 @@ table below.
 
 | Area | Why it matters | Difficulty |
 |---|---|---|
-| **Ubuntu LTS support** | All three LTS releases are validated against the full story suite on a live VM, each with a committed replay twin that reproduces it: 22.04, 24.04 and 26.04 all at 79/79. `ubuntu-vm.sh` accepts `UBUNTU_RELEASE=jammy\|noble\|resolute`. Remaining: story coverage for the cross-family actions. The Debian-only ones are all covered now. | medium |
+| **Ubuntu LTS support** | All three LTS releases are validated against the full story suite on a live VM, each with a committed replay twin that reproduces it: 22.04, 24.04 and 26.04 all at 79/79. `ubuntu-vm.sh` accepts `UBUNTU_RELEASE=jammy\|noble\|resolute`. Remaining: story coverage for the cross-family actions, and five Debian-only ones that still have none: the four fail2ban actions and `GrubSetKargs`. | medium |
 | **Distro detection coverage** | Robust `/etc/os-release` parsing for every release we claim to support. Pure-function tests against real fixture files, no integration mocks. The existing fixtures at the bottom of `crates/sysknife-core/src/distro.rs` show the shape. | easy |
 | **Action catalogue gaps** | Add a typed action (for example `EnableFirewallZone`). Small and isolated, and every PR carries the policy entry, the risk level and the tests. | easy |
-| **E2E story coverage** | Real prompts, real LLM, real daemon. The suite is 133 stories: 54 atomic + 79 Ubuntu. Every Debian-only action now has one. What is left is the cross-family middle: of the action names available on both families, 57 are still untouched by any story, plus 8 Fedora-only ones. | medium |
+| **E2E story coverage** | Real prompts, real LLM, real daemon. The suite is 133 stories: 54 atomic + 79 Ubuntu. Every Debian-only action now has one. What is left is the cross-family middle: of the action names available on both families, 59 are still untouched by any story, plus 10 Fedora-only and 5 Ubuntu-only ones. See #233 for the clustered map. | medium |
 | **Fedora Atomic validation** | The action families exist and `DistroId::is_supported()` returns true for Atomic 41 and up. Nobody has run `tests/e2e/atomic-vm.sh` against a current release. Needs Fedora Atomic hardware or a VM host. | tedious |
 | **Demo recording on real hardware** | Replace the bundled demo GIF with a 30-second recording on real Ubuntu 26.04 with rollback visible. | easy |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ rpm-ostree action families work, it just needs a fresh validation run. See
 ## Phase 9: Launch
 
 - record a demo video on real hardware with rollback visible (#32)
-- extend MCP server with direct read-only tools — expose all ~59 Observer-level
+- extend MCP server with direct read-only tools — expose all 63 Observer-level
   actions (`get_disk_usage`, `list_services`, `get_authorized_keys`, …) as
   individual MCP tools so Claude Desktop can read live system state in-context;
   mutating actions remain plan-only to preserve the approval gate

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ Privileged. The only component that touches the system. Provides:
 
 - 190 typed actions (rpm-ostree, systemd, firewall, users, containers,
   flatpak, toolbox, SSH, kernel args, …)
-- Role-based authorization (`Observer` → `Dev` → `Admin`)
+- Role-based authorization (`Observer` → `Dev` → `Admin`, plus `Boot`)
 - Policy enforcement: stale-approval detection, request hash validation
 - Preview generation: risk level, side effects, reboot flag, rollback
   metadata, content hash
@@ -119,7 +119,7 @@ component the other passes through.
 
 The daemon owns:
 
-- authorization (role-based: Observer → Dev → Admin)
+- authorization (role-based: Observer → Dev → Admin, plus Boot)
 - policy (stale-approval detection, request validation)
 - previews (risk level, side effects, rollback metadata)
 - jobs (execution, live output streaming)

--- a/docs/testing/user-stories.md
+++ b/docs/testing/user-stories.md
@@ -6,7 +6,7 @@ COSMIC Atomic). Run inside a QEMU/KVM VM via `tests/e2e/atomic-vm.sh`, or on
 real hardware.
 
 These twenty are a readable subset, not the suite: the atomic family is 54
-stories and the Ubuntu family a further 50, all in `tests/e2e/stories/`. The
+stories and the Ubuntu family a further 79, all in `tests/e2e/stories/`. The
 harness runs the family; this file explains twenty of them in prose.
 
 Each story has:


### PR DESCRIPTION
Every number below was re-derived from the catalogue and the story files, twice,
and both claim guards still pass afterwards.

CONTRIBUTING.md said the cross-family story gap was "57 ... plus 8 Fedora-only".
It is 59 All, 10 Fedora-only, and 5 Ubuntu-only that the sentence never
mentioned. The same table said "The Debian-only ones are all covered now", which
is false: the four fail2ban actions and GrubSetKargs have no story, and #219
exists because of the fail2ban half. This matters more than the other three
because CONTRIBUTING.md is the first file a contributor reads, and a wrong figure
there is the worst place to keep one.

ROADMAP.md said "~59 Observer-level" actions. There are 63: 62 Low-risk rows in
the generated reference plus ListJobHistory, which has no ActionSpec of its own
and is lifted in by a monotonic exception.

docs/testing/user-stories.md said the Ubuntu family is "a further 50". It is 79.

docs/architecture.md listed four CallerRole values at line 58 and then three at
lines 76 and 122, dropping Boot from both. Boot is real: CallerRole::Boot, wire
number 4, and policy.rs says it can call everything.

Why the guards missed all five. check_bare_story_counts matches
`\b([0-9]{2,})[-\s]stor(?:y|ies)\b`, so "57 are still untouched by any story"
carries no number next to the word it looks for, and it iterates splitlines() so
the wrapped "54\nstories" in user-stories.md never matches either. The prose
claim had no number at all. The role lists are not numeric. CONTRIBUTING.md and
ROADMAP.md are both in CLAIM_FILES, so this is unguarded claim shapes rather than
unguarded files.

Deriving these rather than restating them is the obvious follow-up, and #229
stays open for it.