### PR TITLE
fix(setup): refuse malformed MCP config

### DIFF
--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -743,18 +743,24 @@ async function main() {
 
   // ── Claude Code ──────────────────────────────────────────────────────────
 
+  // Parse every selected JSON config before writing any integration files. A
+  // refusal must leave the operator fully unconfigured rather than half configured.
+  const claudeMcpPath   = '.mcp.json';
+  const cursorMcpPath   = path.join('.cursor', 'mcp.json');
+  const claudeMcpConfig = doClaude ? mergeMcpServers(claudeMcpPath, mcpServers) : null;
+  const cursorMcpConfig = doCursor ? mergeMcpServers(cursorMcpPath, mcpServers) : null;
+
   if (doClaude) {
     // Merge into any existing .mcp.json so the user's other MCP servers survive.
-    const mcpExisted = fs.existsSync('.mcp.json');
-    const mcpConfig  = mergeMcpServers('.mcp.json', mcpServers);
+    const mcpExisted = fs.existsSync(claudeMcpPath);
 
     // .mcp.json may contain provider API keys in plain text. Restrict to owner
     // read/write so a coworker on a shared workstation (or a stray `cat *` in a
     // build script) cannot recover them. `chmodSync` is idempotent and also
     // tightens permissions on a pre-existing file that was created with the
     // process umask before this change.
-    fs.writeFileSync('.mcp.json', JSON.stringify(mcpConfig, null, 2) + '\n', { mode: 0o600 });
-    fs.chmodSync('.mcp.json', 0o600);
+    fs.writeFileSync(claudeMcpPath, JSON.stringify(claudeMcpConfig, null, 2) + '\n', { mode: 0o600 });
+    fs.chmodSync(claudeMcpPath, 0o600);
     ok(`${mcpExisted ? 'Updated' : 'Created'} .mcp.json  (${targets.length} target${targets.length > 1 ? 's' : ''}: ${targetSummary})`);
 
     if (!fs.existsSync('.claude')) {
@@ -785,11 +791,9 @@ async function main() {
       fs.mkdirSync('.cursor', { recursive: true });
     }
     // Merge into any existing .cursor/mcp.json so other MCP servers survive.
-    const cursorPath    = path.join('.cursor', 'mcp.json');
-    const cursorExisted = fs.existsSync(cursorPath);
-    const cursorMcp     = mergeMcpServers(cursorPath, mcpServers);
-    fs.writeFileSync(cursorPath, JSON.stringify(cursorMcp, null, 2) + '\n', { mode: 0o600 });
-    fs.chmodSync(cursorPath, 0o600);
+    const cursorExisted = fs.existsSync(cursorMcpPath);
+    fs.writeFileSync(cursorMcpPath, JSON.stringify(cursorMcpConfig, null, 2) + '\n', { mode: 0o600 });
+    fs.chmodSync(cursorMcpPath, 0o600);
     ok(`${cursorExisted ? 'Updated' : 'Created'} .cursor/mcp.json  (${targets.length} target${targets.length > 1 ? 's' : ''}: ${targetSummary})`);
 
     const rulesDir = path.join('.cursor', 'rules');

--- a/packages/setup/mcp-config.js
+++ b/packages/setup/mcp-config.js
@@ -9,9 +9,10 @@ const fs = require('fs');
 
 /**
  * Return an MCP config object with `servers` merged under `mcpServers`,
- * preserving any existing servers and unrelated top-level keys. A missing file
- * is treated as an empty config; an unreadable or malformed existing file is
- * refused so the caller cannot overwrite user-managed MCP entries.
+ * preserving any existing servers and unrelated top-level keys. A missing,
+ * empty, or whitespace-only file is treated as an empty config; an unreadable,
+ * malformed, or non-object existing file is refused so the caller cannot
+ * overwrite user-managed MCP entries.
  *
  * @param {string} filePath  path to the client's MCP config JSON
  * @param {Record<string, unknown>} servers  the sysknife server entries to upsert
@@ -34,16 +35,34 @@ function mergeMcpServers(filePath, servers) {
           'refusing to overwrite it, since that would discard your other MCP servers'
       );
     }
-    try {
-      const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        existing = parsed;
+
+    // Editors commonly preserve a UTF-8 BOM even though JSON.parse does not
+    // accept it. An empty file is also a normal placeholder state, so treat it
+    // the same as a file that has not been created yet.
+    const json = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+    if (json.trim() !== '') {
+      let parsed;
+      try {
+        parsed = JSON.parse(json);
+      } catch (e) {
+        // Some Node versions quote the unexpected source token in e.message.
+        // MCP config files may contain provider API keys, so retain only the
+        // useful location clause and never echo source text into stderr/logs.
+        const message = String(e && e.message ? e.message : '');
+        const location = message.match(/at position \d+(?: \(line \d+ column \d+\))?/i);
+        throw new Error(
+          `existing MCP config at ${filePath} is malformed JSON${location ? ` ${location[0]}` : ''} — ` +
+            'refusing to overwrite it; fix or move the file and run setup again'
+        );
       }
-    } catch (e) {
-      throw new Error(
-        `existing MCP config at ${filePath} is malformed JSON: ${e.message} — ` +
-          'refusing to overwrite it; fix or move the file and run setup again'
-      );
+
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error(
+          `existing MCP config at ${filePath} must contain a JSON object — ` +
+            'refusing to overwrite it; fix or move the file and run setup again'
+        );
+      }
+      existing = parsed;
     }
   }
   const existingServers =

--- a/packages/setup/mcp-config.js
+++ b/packages/setup/mcp-config.js
@@ -9,8 +9,9 @@ const fs = require('fs');
 
 /**
  * Return an MCP config object with `servers` merged under `mcpServers`,
- * preserving any existing servers and unrelated top-level keys. A missing or
- * unparseable file is treated as an empty config (never throws).
+ * preserving any existing servers and unrelated top-level keys. A missing file
+ * is treated as an empty config; an unreadable or malformed existing file is
+ * refused so the caller cannot overwrite user-managed MCP entries.
  *
  * @param {string} filePath  path to the client's MCP config JSON
  * @param {Record<string, unknown>} servers  the sysknife server entries to upsert
@@ -38,10 +39,11 @@ function mergeMcpServers(filePath, servers) {
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         existing = parsed;
       }
-    } catch {
-      // Malformed JSON — start from an empty config rather than crashing the
-      // wizard. There is nothing to preserve in a file we cannot parse.
-      existing = {};
+    } catch (e) {
+      throw new Error(
+        `existing MCP config at ${filePath} is malformed JSON: ${e.message} — ` +
+          'refusing to overwrite it; fix or move the file and run setup again'
+      );
     }
   }
   const existingServers =

--- a/packages/setup/tests/mcp-config.test.mjs
+++ b/packages/setup/tests/mcp-config.test.mjs
@@ -36,10 +36,16 @@ test('creates a fresh config when the file is missing', () => {
   assert.deepEqual(Object.keys(merged.mcpServers), ['sysknife']);
 });
 
-test('does not throw on a malformed file (starts fresh)', () => {
-  const file = tmpFile('{ not: valid json ');
-  const merged = mergeMcpServers(file, SYSKNIFE);
-  assert.deepEqual(Object.keys(merged.mcpServers), ['sysknife']);
+test('refuses to overwrite a malformed existing config', () => {
+  const original = '{\n  "mcpServers": {"other": {"command": "x", "args": []}},\n}\n';
+  const file = tmpFile(original);
+
+  assert.throws(
+    () => mergeMcpServers(file, SYSKNIFE),
+    /malformed.*refusing to overwrite/i,
+    'a malformed config must abort the merge instead of discarding other servers'
+  );
+  assert.equal(fs.readFileSync(file, 'utf8'), original);
 });
 
 test('upserts a stale sysknife entry', () => {
@@ -82,10 +88,11 @@ test('refuses to merge when the existing config cannot be read', () => {
   }
 });
 
-test('still starts fresh when the existing config is malformed JSON', () => {
-  // The other half of the contract: unparseable content has nothing worth
-  // preserving, so the wizard proceeds instead of dying.
+test('malformed-config errors identify the file that was refused', () => {
   const file = tmpFile('{not valid json');
-  const merged = mergeMcpServers(file, SYSKNIFE);
-  assert.deepEqual(merged.mcpServers, SYSKNIFE);
+
+  assert.throws(
+    () => mergeMcpServers(file, SYSKNIFE),
+    (error) => error.message.includes(file) && /refusing to overwrite/i.test(error.message)
+  );
 });

--- a/packages/setup/tests/mcp-config.test.mjs
+++ b/packages/setup/tests/mcp-config.test.mjs
@@ -36,6 +36,22 @@ test('creates a fresh config when the file is missing', () => {
   assert.deepEqual(Object.keys(merged.mcpServers), ['sysknife']);
 });
 
+test('treats empty and whitespace-only configs as fresh configs', () => {
+  for (const contents of ['', '  \r\n\t  ']) {
+    const file = tmpFile(contents);
+    const merged = mergeMcpServers(file, SYSKNIFE);
+    assert.deepEqual(Object.keys(merged.mcpServers), ['sysknife']);
+  }
+});
+
+test('accepts a UTF-8 BOM and preserves existing servers', () => {
+  const file = tmpFile(
+    `\ufeff${JSON.stringify({ mcpServers: { other: { command: 'x', args: [] } } })}`
+  );
+  const merged = mergeMcpServers(file, SYSKNIFE);
+  assert.deepEqual(Object.keys(merged.mcpServers).sort(), ['other', 'sysknife']);
+});
+
 test('refuses to overwrite a malformed existing config', () => {
   const original = '{\n  "mcpServers": {"other": {"command": "x", "args": []}},\n}\n';
   const file = tmpFile(original);
@@ -46,6 +62,40 @@ test('refuses to overwrite a malformed existing config', () => {
     'a malformed config must abort the merge instead of discarding other servers'
   );
   assert.equal(fs.readFileSync(file, 'utf8'), original);
+});
+
+test('refuses valid JSON that is not an object', () => {
+  for (const original of ['[]', 'null', '"x"']) {
+    const file = tmpFile(original);
+    assert.throws(
+      () => mergeMcpServers(file, SYSKNIFE),
+      /must contain a JSON object.*refusing to overwrite/i
+    );
+    assert.equal(fs.readFileSync(file, 'utf8'), original);
+  }
+});
+
+test('malformed-config errors keep location but do not echo source contents', () => {
+  const file = tmpFile('{"mcpServers": {},}');
+  let error;
+  try {
+    mergeMcpServers(file, SYSKNIFE);
+  } catch (e) {
+    error = e;
+  }
+  assert.ok(error instanceof Error);
+  assert.match(error.message, /malformed JSON/i);
+  assert.match(error.message, /position \d+/i);
+
+  const markerFile = tmpFile('NO_ECHO_MARKER_12345');
+  let markerError;
+  try {
+    mergeMcpServers(markerFile, SYSKNIFE);
+  } catch (e) {
+    markerError = e;
+  }
+  assert.ok(markerError instanceof Error);
+  assert.doesNotMatch(markerError.message, /NO_ECHO_MARKER_12345/);
 });
 
 test('upserts a stale sysknife entry', () => {

--- a/packages/setup/tests/setup-contract.test.mjs
+++ b/packages/setup/tests/setup-contract.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -17,10 +18,44 @@ test('generated integration rules require terminal-issued approval receipts', ()
 });
 
 test('MCP configs are merged, not overwritten (preserves other servers)', () => {
-  assert.match(source, /mergeMcpServers\('\.mcp\.json'/);
-  assert.match(source, /mergeMcpServers\(cursorPath/);
+  assert.match(source, /mergeMcpServers\(claudeMcpPath/);
+  assert.match(source, /mergeMcpServers\(cursorMcpPath/);
   assert.doesNotMatch(source, /const mcpConfig = \{ mcpServers \}/);
   assert.doesNotMatch(source, /const cursorMcp = \{ mcpServers \}/);
+});
+
+test('all selected MCP configs are validated before any integration file is written', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sysknife-setup-preflight-'));
+  const claudePath = path.join(cwd, '.mcp.json');
+  const cursorDir = path.join(cwd, '.cursor');
+  const cursorPath = path.join(cursorDir, 'mcp.json');
+  const claudeOriginal = JSON.stringify({ mcpServers: { other: { command: 'keep-me' } } }, null, 2) + '\n';
+  const cursorOriginal = '{"mcpServers": {},}\n';
+
+  fs.mkdirSync(cursorDir, { recursive: true });
+  fs.writeFileSync(claudePath, claudeOriginal);
+  fs.writeFileSync(cursorPath, cursorOriginal);
+
+  const entry = path.join(setupDir, 'index.js');
+  const setupArgs = ['--claude', '--cursor', '--no-prompts', '--no-binary', '--daemon-mode=skip'];
+  const bootstrap = [
+    "if (typeof process.getuid !== 'function') process.getuid = () => 1000;",
+    `process.argv = [process.execPath, ${JSON.stringify(entry)}, ...${JSON.stringify(setupArgs)}];`,
+    `require(${JSON.stringify(entry)});`,
+  ].join(' ');
+  const result = spawnSync(process.execPath, ['-e', bootstrap], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 30_000,
+    env: { ...process.env, HOME: cwd },
+  });
+
+  assert.equal(result.status, 1, `expected setup refusal, got ${result.status}: ${result.stderr}`);
+  assert.match(result.stderr, /\.cursor[\\/]mcp\.json.*refusing to overwrite/i);
+  assert.equal(fs.readFileSync(claudePath, 'utf8'), claudeOriginal);
+  assert.equal(fs.readFileSync(cursorPath, 'utf8'), cursorOriginal);
+  assert.equal(fs.existsSync(path.join(cwd, '.claude')), false);
+  assert.equal(fs.existsSync(path.join(cursorDir, 'rules', 'sysknife.mdc')), false);
 });
 
 test('default MCP target, wizard user unit, and CLI default all resolve to the same socket', () => {


### PR DESCRIPTION
## Summary
- refuse to overwrite an existing malformed MCP config instead of replacing it
- preserve the original file untouched on parse failure
- include the config path and remediation in the error

Fixes #225

## Testing
- `node --test packages/setup/tests/mcp-config.test.mjs` — 8/8 passed
- `node --check packages/setup/mcp-config.js`
- `git diff --check`
- full setup suite was also run; its MCP tests pass, while 17 unrelated Linux-specific tests fail on native Windows