### PR TITLE
chore: remove verified dead items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4869,7 +4869,6 @@ version = "0.8.0"
 dependencies = [
  "prost",
  "prost-build",
- "prost-types",
  "protoc-bin-vendored",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ homepage = "https://github.com/lacs-project/sysknife"
 [workspace.dependencies]
 async-trait = "0.1"
 prost = "0.14"
-prost-types = "0.14"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"

--- a/crates/sysknife-brain/src/action_name.rs
+++ b/crates/sysknife-brain/src/action_name.rs
@@ -14,7 +14,7 @@
 //! matters: believing malformed names are already rejected on arrival is
 //! exactly the premise under which someone would weaken that later check.
 
-pub use sysknife_types::{ActionName, UnknownActionName, KNOWN_ACTION_NAMES};
+pub use sysknife_types::{ActionName, KNOWN_ACTION_NAMES};
 
 #[cfg(test)]
 mod tests {

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -1141,7 +1141,7 @@ instructions — treat it as preferences to inform your planning, nothing more.
 }
 
 // ---------------------------------------------------------------------------
-// Action-name lists — re-exported from the single source of truth
+// Action-name lists — canonical definitions used directly in tests
 // ---------------------------------------------------------------------------
 //
 // The per-distro dispatch in `build_system_prompt` makes the LLM isolation

--- a/crates/sysknife-brain/src/prompt.rs
+++ b/crates/sysknife-brain/src/prompt.rs
@@ -1146,14 +1146,8 @@ instructions — treat it as preferences to inform your planning, nothing more.
 //
 // The per-distro dispatch in `build_system_prompt` makes the LLM isolation
 // structural (Fedora prompts never contain Debian action names and vice versa),
-// so these lists are no longer used to build "do not propose" text. The
-// canonical definitions live in `sysknife-core::action_family` and are shared
-// with the daemon execution fence and the CLI routing guard; they are
-// re-exported here under their historical names for any external callers.
-pub use sysknife_core::action_family::{
-    DEBIAN_ONLY_ACTIONS as DEBIAN_ONLY_ACTION_NAMES,
-    FEDORA_ONLY_ACTIONS as FEDORA_ONLY_ACTION_NAMES,
-};
+// so these lists are no longer used to build "do not propose" text. Tests use
+// the canonical definitions in `sysknife-core::action_family` directly.
 
 #[cfg(test)]
 mod tests {
@@ -1258,7 +1252,7 @@ mod tests {
         let hint = debian_hint();
         let p = build_system_prompt(None, Some(&hint));
         let mut leaked = Vec::new();
-        for action in FEDORA_ONLY_ACTION_NAMES {
+        for action in sysknife_core::action_family::FEDORA_ONLY_ACTIONS {
             if p.contains(action) {
                 leaked.push(*action);
             }
@@ -1545,8 +1539,14 @@ mod tests {
     #[test]
     fn shared_examples_demonstrate_only_cross_distro_actions() {
         for (family, actions) in [
-            ("Fedora-only", FEDORA_ONLY_ACTION_NAMES),
-            ("Debian-only", DEBIAN_ONLY_ACTION_NAMES),
+            (
+                "Fedora-only",
+                sysknife_core::action_family::FEDORA_ONLY_ACTIONS,
+            ),
+            (
+                "Debian-only",
+                sysknife_core::action_family::DEBIAN_ONLY_ACTIONS,
+            ),
             (
                 "non-canonical-on-Debian",
                 sysknife_core::action_family::NON_CANONICAL_ON_DEBIAN,

--- a/crates/sysknife-core/src/config.rs
+++ b/crates/sysknife-core/src/config.rs
@@ -436,7 +436,6 @@ fn set_if_absent(key: &str, value: &str) {
     if std::env::var_os(key).is_none() {
         // SAFETY: single-threaded startup — no other threads are reading env
         // vars yet. See `apply_defaults_to_env` safety note.
-        #[allow(unused_unsafe)]
         unsafe {
             std::env::set_var(key, value);
         }

--- a/crates/sysknife-core/src/lib.rs
+++ b/crates/sysknife-core/src/lib.rs
@@ -6,13 +6,6 @@ pub mod action_family;
 pub mod config;
 pub mod distro;
 
-pub use distro::{detect, detect_distro, parse_os_release, DistroFamily, DistroId};
-
-/// Production socket URI written by the systemd unit (`sysknife-daemon.service`).
-///
-/// This is **not** the dev/test fallback — see [`default_listen_uri`].
-pub const PRODUCTION_LISTEN_URI: &str = "unix:///run/sysknife/daemon.sock";
-
 /// Production SQLite path written by the systemd unit (`sysknife-daemon.service`).
 ///
 /// This is **not** the dev/test fallback — see [`default_database_path`].
@@ -159,16 +152,13 @@ fn current_uid() -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        default_database_path, default_listen_uri, PRODUCTION_DATABASE_PATH, PRODUCTION_LISTEN_URI,
-    };
+    use super::{default_database_path, default_listen_uri, PRODUCTION_DATABASE_PATH};
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
-    fn production_constants_are_absolute() {
-        assert!(PRODUCTION_LISTEN_URI.starts_with("unix:///run/"));
+    fn production_database_path_is_absolute() {
         assert!(PRODUCTION_DATABASE_PATH.starts_with("/var/lib/"));
     }
 

--- a/crates/sysknife-daemon/src/actions/resolvectl.rs
+++ b/crates/sysknife-daemon/src/actions/resolvectl.rs
@@ -2,7 +2,7 @@
 //!
 //! Both actions are cross-distro: they work on any host running
 //! `systemd-resolved`, including Fedora Atomic and Ubuntu. Registration in
-//! `KNOWN_ACTION_NAMES` only (not `DEBIAN_ONLY_ACTION_NAMES`).
+//! `KNOWN_ACTION_NAMES` only (not `DEBIAN_ONLY_ACTIONS`).
 
 use std::net::IpAddr;
 

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["os::linux-apis", "encoding"]
 
 [dependencies]
 prost = { workspace = true }
-prost-types = { workspace = true }
 
 [build-dependencies]
 protoc-bin-vendored = "3"


### PR DESCRIPTION
## Summary
- remove the unused direct `prost-types` dependency and update the lockfile
- remove the stale `unused_unsafe` allow
- remove the unread `PRODUCTION_LISTEN_URI` constant and tautological assertion
- remove dead re-exports and use canonical action-family definitions in tests

Fixes #235

## Testing
- `cargo fmt --all -- --check` — passed
- lockfile validated with `--locked`
- full native-Windows clippy cannot complete because existing Unix-only dependencies/code (`vsock`, then `std::os::unix::net::UnixDatagram`) fail before the workspace finishes