### PR TITLE
feat(cli): export audit chain rows as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,9 @@ See [ROADMAP.md](ROADMAP.md) for the full milestone breakdown.
 
 - ✅ **Ubuntu 22.04** — 79/79 stories on a live VM (recorded in `tests/evidence/story-runs/`)
 - ✅ **Ubuntu 24.04 and 26.04** — 79/79 and 79/79 on live VMs; every LTS run has a replay twin that reproduces it
+- ✅ `sysknife audit export` — stored signed chain rows as JSON with `--since` / `--limit`
 - 📋 Telegram inline-button approvals
-- 📋 `sysknife audit export` (CEF / NDJSON for SIEM ingest)
+- 📋 CEF / NDJSON output modes for SIEM ingest
 - 📋 Fleet plan/execute (one plan, N targets, parallel approval)
 
 ## Protocol

--- a/apps/sysknife-cli/src/cli.rs
+++ b/apps/sysknife-cli/src/cli.rs
@@ -137,6 +137,9 @@ impl Command {
 /// `sysknife audit <subcommand>` subcommands.
 #[derive(Subcommand, Debug, Clone)]
 pub enum AuditCommand {
+    /// Export the stored signed audit-chain rows as JSON.
+    Export(AuditExportArgs),
+
     /// Verify the tamper-evident Ed25519-signed hash chain over the audit log.
     ///
     /// Exits 0 if the chain is intact, 1 if any row is broken, and 2 if the
@@ -149,6 +152,18 @@ pub enum AuditCommand {
     /// append-only database, then verify all anchored checkpoints against the
     /// local chain (detects tail-truncation and rewrite).
     Checkpoint(AuditCheckpointArgs),
+}
+
+/// Arguments for `sysknife audit export`.
+#[derive(Args, Debug, Clone)]
+pub struct AuditExportArgs {
+    /// Export rows recorded at or after this RFC 3339 datetime.
+    #[arg(long, value_name = "DATETIME")]
+    pub since: Option<String>,
+
+    /// Maximum number of rows to export. By default every matching row is emitted.
+    #[arg(long, value_name = "N")]
+    pub limit: Option<u32>,
 }
 
 /// Arguments for `sysknife audit verify`.
@@ -356,6 +371,29 @@ mod tests {
                 assert_eq!(args.since.as_deref(), Some("2026-01-01T00:00:00Z"));
             }
             other => panic!("expected Command::History, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_export_subcommand_with_filters() {
+        let cli = Cli::try_parse_from([
+            "sysknife",
+            "audit",
+            "export",
+            "--since",
+            "2026-01-01T00:00:00Z",
+            "--limit",
+            "5",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Command::Audit {
+                command: AuditCommand::Export(args),
+            }) => {
+                assert_eq!(args.since.as_deref(), Some("2026-01-01T00:00:00Z"));
+                assert_eq!(args.limit, Some(5));
+            }
+            other => panic!("expected audit export, got {other:?}"),
         }
     }
 

--- a/apps/sysknife-cli/src/main.rs
+++ b/apps/sysknife-cli/src/main.rs
@@ -137,6 +137,9 @@ async fn dispatch(
 
         // --- sysknife audit verify ---
         Some(Command::Audit { command }) => match command {
+            crate::cli::AuditCommand::Export(args) => {
+                runner::run_audit_export(args.clone(), log).await
+            }
             crate::cli::AuditCommand::Verify(args) => {
                 runner::run_audit_verify(args.clone(), log).await
             }

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -32,7 +32,7 @@ use sysknife_types::{
 use sysknife_brain::state_client::StateClient as _;
 
 use crate::approval::{ApprovalDecision, ApprovalPolicy, MaxRisk};
-use crate::cli::{AuditVerifyArgs, Cli, HistoryArgs};
+use crate::cli::{AuditExportArgs, AuditVerifyArgs, Cli, HistoryArgs};
 use crate::client::{DaemonClient, SocketTarget};
 use crate::error::CliError;
 
@@ -782,8 +782,63 @@ impl RunOpts {
 }
 
 // ---------------------------------------------------------------------------
-// run_audit_verify
+// run_audit_export / run_audit_verify
 // ---------------------------------------------------------------------------
+
+/// Export the signed transaction-chain rows from the configured audit store.
+///
+/// This is deliberately a local storage read, just like `audit verify`; it
+/// does not cross the daemon protocol or load the private audit key.
+pub async fn run_audit_export(args: AuditExportArgs, log: &Logger) -> Result<(), CliError> {
+    use sysknife_core::config::LacsConfig;
+    use sysknife_daemon::audit_chain::{select_chain_rows_for_export, validate_export_since};
+
+    if let Some(since) = args.since.as_deref() {
+        validate_export_since(since).map_err(|e| CliError::ConfigOrDaemon(e.to_string()))?;
+    }
+
+    let lacs_config = LacsConfig::load();
+    let resolved_store = sysknife_core::resolve_audit_store();
+    if let Some(note) = resolved_store.note() {
+        log.print_stderr(&format!("note: {note}"));
+    }
+
+    let rows = match lacs_config.storage.as_ref() {
+        Some(storage) if storage.backend.eq_ignore_ascii_case("postgres") => {
+            let config = postgres_config(storage)
+                .map_err(|reason| CliError::ConfigOrDaemon(format!("audit export: {reason}")))?;
+            sysknife_daemon::store::postgres::PostgresStore::read_chain_rows(&config)
+                .await
+                .map_err(|e| {
+                    CliError::ConfigOrDaemon(format!("postgres audit chain query failed: {e}"))
+                })?
+        }
+        _ => {
+            use sysknife_daemon::transactions::TransactionStore;
+
+            let db_path = resolved_store.path();
+            if !db_path.exists() {
+                return Err(CliError::ConfigOrDaemon(format!(
+                    "audit database not found at {}; set $SYSKNIFE_DATABASE_PATH or run the daemon first",
+                    db_path.display()
+                )));
+            }
+            let store = TransactionStore::open_read_only(db_path).map_err(|e| {
+                CliError::ConfigOrDaemon(format!("opening audit database failed: {e}"))
+            })?;
+            store
+                .fetch_chain_rows()
+                .map_err(|e| CliError::ConfigOrDaemon(format!("audit chain query failed: {e}")))?
+        }
+    };
+
+    let rows = select_chain_rows_for_export(rows, args.since.as_deref(), args.limit)
+        .map_err(|e| CliError::ConfigOrDaemon(e.to_string()))?;
+    let json = serde_json::to_string(&rows)
+        .map_err(|e| CliError::ConfigOrDaemon(format!("serializing audit export failed: {e}")))?;
+    log.println(&json);
+    Ok(())
+}
 
 /// Walk the audit log hash chain and report integrity status.
 ///
@@ -1168,39 +1223,12 @@ pub(crate) async fn verify_postgres(
     storage: &sysknife_core::config::StorageSection,
     verifier: &Verifier,
 ) -> AuditVerification {
-    use sysknife_core::config::StorageBackend;
-    use sysknife_daemon::store::postgres::{PostgresConfig, PostgresStore};
+    use sysknife_daemon::store::postgres::PostgresStore;
 
-    // Project the relaxed config form into the type-state-checked enum;
-    // the match below makes future backends a compile-time decision.
-    let parsed = match storage.parsed() {
-        Ok(p) => p,
+    let cfg = match postgres_config(storage) {
+        Ok(config) => config,
         Err(reason) => return cannot_verify_all(reason),
     };
-    let (url, pool) =
-        match parsed {
-            StorageBackend::Sqlite => return cannot_verify_all(
-                "verify_postgres called with backend = \"sqlite\" — caller picks the wrong path"
-                    .to_string(),
-            ),
-            StorageBackend::Postgres { url, pool } => (url, pool),
-        };
-
-    let mut cfg = PostgresConfig {
-        url,
-        ..PostgresConfig::default()
-    };
-    {
-        if let Some(n) = pool.max_connections {
-            cfg.max_connections = n;
-        }
-        if let Some(s) = pool.acquire_timeout_secs {
-            cfg.acquire_timeout = std::time::Duration::from_secs(s);
-        }
-        if let Some(c) = pool.statement_cache_capacity {
-            cfg.statement_cache_capacity = c;
-        }
-    }
 
     match verifier {
         Verifier::Private(key) => {
@@ -1221,6 +1249,41 @@ pub(crate) async fn verify_postgres(
             }
         }
     }
+}
+
+/// Project the relaxed user-facing storage section into Postgres' checked
+/// connection configuration. Both audit readers use this so `verify` and
+/// `export` cannot drift on pool settings or URL validation.
+fn postgres_config(
+    storage: &sysknife_core::config::StorageSection,
+) -> Result<sysknife_daemon::store::postgres::PostgresConfig, String> {
+    use sysknife_core::config::StorageBackend;
+    use sysknife_daemon::store::postgres::PostgresConfig;
+
+    let (url, pool) = match storage.parsed()? {
+        StorageBackend::Sqlite => {
+            return Err(
+                "postgres reader called with backend = \"sqlite\" — caller picked the wrong path"
+                    .to_string(),
+            );
+        }
+        StorageBackend::Postgres { url, pool } => (url, pool),
+    };
+
+    let mut config = PostgresConfig {
+        url,
+        ..PostgresConfig::default()
+    };
+    if let Some(value) = pool.max_connections {
+        config.max_connections = value;
+    }
+    if let Some(value) = pool.acquire_timeout_secs {
+        config.acquire_timeout = std::time::Duration::from_secs(value);
+    }
+    if let Some(value) = pool.statement_cache_capacity {
+        config.statement_cache_capacity = value;
+    }
+    Ok(config)
 }
 
 /// What the chain verdict says about the standing of the attribution counts.

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -24,6 +24,11 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use std::process::Command;
+use std::sync::Arc;
+use sysknife_daemon::audit_chain::{AuditKey, ChainRow};
+use sysknife_daemon::auth::CallerPrincipal;
+use sysknife_daemon::transactions::{NewTransaction, TransactionStore};
+use sysknife_types::{CallerRole, RiskLevel};
 
 /// Path the CLI tries to connect to in tests — points at a directory we
 /// own so the failure mode is "ENOENT" rather than "ECONNREFUSED on a
@@ -123,6 +128,64 @@ fn audit_verify_exits_with_code_2_when_the_key_file_is_missing() {
         .arg(dir.path().join("no-such-key.pub"))
         .assert()
         .code(2);
+}
+
+#[test]
+fn audit_export_emits_the_stored_rows_as_parseable_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("daemon.sqlite");
+    let key = Arc::new(AuditKey::load_or_generate(&dir.path().join("audit-key")).unwrap());
+    let store = TransactionStore::open_with_key(&db_path, key).unwrap();
+    for request_id in ["req-1", "req-2"] {
+        store
+            .record(NewTransaction {
+                request_id: request_id.to_string(),
+                request_hash: format!("hash-{request_id}"),
+                action_name: "UpdateSystem".to_string(),
+                risk_level: RiskLevel::High,
+                summary: "Upgrade the system".to_string(),
+                warnings: vec![],
+                caller_role: CallerRole::Dev,
+                caller_principal: CallerPrincipal::Uid(1000),
+            })
+            .unwrap();
+    }
+    let stored = store.fetch_chain_rows().unwrap();
+    drop(store);
+
+    let output = cli()
+        .env("SYSKNIFE_DATABASE_PATH", &db_path)
+        .env("HOME", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .args(["audit", "export", "--limit", "1"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let exported: Vec<ChainRow> = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(exported.len(), 1);
+    assert_eq!(exported[0], stored[0]);
+    assert_eq!(
+        exported[0].chain_hash.as_bytes(),
+        stored[0].chain_hash.as_bytes()
+    );
+}
+
+#[test]
+fn audit_export_rejects_an_invalid_since_timestamp() {
+    let dir = tempfile::tempdir().unwrap();
+    cli()
+        .env("SYSKNIFE_DATABASE_PATH", dir.path().join("unused.sqlite"))
+        .env("HOME", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .args(["audit", "export", "--since", "not-a-timestamp"])
+        .assert()
+        .code(4)
+        .stderr(predicate::str::contains("--since"));
 }
 
 #[test]

--- a/crates/sysknife-daemon/src/audit_chain.rs
+++ b/crates/sysknife-daemon/src/audit_chain.rs
@@ -658,7 +658,7 @@ pub fn outcome_to_exit_code(outcome: &VerifyOutcome) -> i32 {
 }
 
 /// One row's worth of chain data, as fetched from the store.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ChainRow {
     pub seq: u64,
     pub key_id: String,
@@ -684,6 +684,61 @@ pub struct ChainRow {
     /// required for `chain_version = 3`. Scheme-prefixed, see
     /// [`ChainIdentity::V3`].
     pub caller_principal: Option<String>,
+}
+
+/// Invalid input or stored data encountered while selecting rows for export.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ChainExportError {
+    #[error("--since: {0:?} is not a valid RFC 3339 timestamp")]
+    InvalidSince(String),
+    #[error("audit row {seq} has an invalid RFC 3339 created_at value {created_at:?}")]
+    InvalidCreatedAt { seq: u64, created_at: String },
+}
+
+/// Validate the timestamp accepted by `sysknife audit export --since`.
+pub fn validate_export_since(since: &str) -> Result<(), ChainExportError> {
+    chrono::DateTime::parse_from_rfc3339(since)
+        .map(|_| ())
+        .map_err(|_| ChainExportError::InvalidSince(since.to_string()))
+}
+
+/// Select stored chain rows for export while preserving their `seq` order.
+///
+/// The storage readers return rows in ascending `seq` order. Filtering here,
+/// rather than re-encoding any fields, keeps every exported byte-for-byte
+/// value (especially `chain_hash` and `warnings_json`) exactly as stored and
+/// gives SQLite and PostgreSQL identical `--since` semantics.
+pub fn select_chain_rows_for_export(
+    rows: Vec<ChainRow>,
+    since: Option<&str>,
+    limit: Option<u32>,
+) -> Result<Vec<ChainRow>, ChainExportError> {
+    let since = since
+        .map(|value| {
+            chrono::DateTime::parse_from_rfc3339(value)
+                .map_err(|_| ChainExportError::InvalidSince(value.to_string()))
+        })
+        .transpose()?;
+    let limit = limit.map_or(usize::MAX, |value| value as usize);
+
+    rows.into_iter()
+        .filter_map(|row| {
+            let keep = match since.as_ref() {
+                None => true,
+                Some(since) => match chrono::DateTime::parse_from_rfc3339(&row.created_at) {
+                    Ok(created_at) => created_at >= *since,
+                    Err(_) => {
+                        return Some(Err(ChainExportError::InvalidCreatedAt {
+                            seq: row.seq,
+                            created_at: row.created_at,
+                        }));
+                    }
+                },
+            };
+            keep.then_some(Ok(row))
+        })
+        .take(limit)
+        .collect()
 }
 
 /// Why a stored row's columns do not describe a verifiable encoding.
@@ -1770,6 +1825,95 @@ mod tests {
             prev = hash;
         }
         rows
+    }
+
+    #[test]
+    fn exported_chain_row_json_round_trips_without_changing_the_signature() {
+        let key = fixed_key();
+        let row = build_chain(&key, 1).remove(0);
+
+        let json = serde_json::to_string(&row).expect("chain row serializes");
+        let decoded: ChainRow = serde_json::from_str(&json).expect("chain row deserializes");
+
+        assert_eq!(decoded, row);
+        assert_eq!(decoded.chain_hash.as_bytes(), row.chain_hash.as_bytes());
+    }
+
+    #[test]
+    fn exported_chain_row_uses_the_stored_column_contract_and_json_nulls() {
+        let key = fixed_key();
+        let mut row = build_chain(&key, 1).remove(0);
+        row.approval_id = None;
+        row.caller_role = None;
+        row.event_tip = None;
+        row.caller_principal = None;
+
+        let value = serde_json::to_value(&row).expect("chain row serializes");
+        let object = value.as_object().expect("chain row is a JSON object");
+        let keys: Vec<&str> = object.keys().map(String::as_str).collect();
+
+        assert_eq!(
+            keys,
+            vec![
+                "action_name",
+                "approval_id",
+                "caller_principal",
+                "caller_role",
+                "chain_hash",
+                "chain_version",
+                "created_at",
+                "event_tip",
+                "key_id",
+                "prev_chain_hash",
+                "request_hash",
+                "request_id",
+                "risk_level",
+                "seq",
+                "summary",
+                "transaction_id",
+                "warnings_json",
+            ]
+        );
+        for optional in [
+            "approval_id",
+            "caller_role",
+            "event_tip",
+            "caller_principal",
+        ] {
+            assert!(object[optional].is_null(), "{optional} must be JSON null");
+        }
+        assert!(!object.contains_key("argv"));
+        assert!(!object.contains_key("outcome"));
+        assert!(!object.contains_key("signature"));
+    }
+
+    #[test]
+    fn export_since_is_inclusive_and_limit_preserves_chain_order() {
+        let key = fixed_key();
+        let mut rows = build_chain(&key, 4);
+        for (row, created_at) in rows.iter_mut().zip([
+            "2026-08-19T09:00:00Z",
+            "2026-08-19T10:00:00Z",
+            "2026-08-19T11:00:00Z",
+            "2026-08-19T12:00:00Z",
+        ]) {
+            row.created_at = created_at.to_string();
+        }
+
+        let selected =
+            select_chain_rows_for_export(rows, Some("2026-08-19T10:00:00+00:00"), Some(2)).unwrap();
+
+        assert_eq!(
+            selected.iter().map(|row| row.seq).collect::<Vec<_>>(),
+            [2, 3]
+        );
+    }
+
+    #[test]
+    fn export_rejects_an_invalid_since_timestamp() {
+        let error = select_chain_rows_for_export(Vec::new(), Some("last Tuesday"), None)
+            .expect_err("invalid --since must fail before reading rows");
+        assert!(matches!(error, ChainExportError::InvalidSince(_)));
     }
 
     // ── caller identity in the signed content ─────────────────────────────

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -243,6 +243,16 @@ impl PostgresStore {
         ))
     }
 
+    /// Read the transaction chain without a signing key or schema mutation.
+    /// Used by `sysknife audit export`, which must never acquire signing
+    /// capability merely to serialize rows that already exist.
+    pub async fn read_chain_rows(
+        config: &PostgresConfig,
+    ) -> Result<Vec<ChainRow>, TransactionStoreError> {
+        let pool = Self::connect_pool(config).await?;
+        fetch_chain_rows_from_pool(&pool).await
+    }
+
     /// All three checks with the daemon's key.
     pub async fn verify_all(
         &self,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -145,6 +145,25 @@ receipt.
 Inspect and anchor the tamper-evident, Ed25519-signed audit chain the daemon
 writes for every executed action.
 
+#### `sysknife audit export`
+
+Export the transaction-chain rows from the configured SQLite or PostgreSQL
+audit store as a JSON array, in ascending `seq` order. Each object contains the
+17 stored `ChainRow` columns, including `prev_chain_hash` and `chain_hash`.
+The latter is the Ed25519 signature and is deliberately not renamed. Optional
+values that were not recorded are JSON `null`; `argv`, `outcome`, and a
+separate `signature` field are not reconstructed.
+
+```sh
+sysknife audit export
+sysknife audit export --since 2026-08-01T00:00:00Z --limit 500
+```
+
+| Flag | Description |
+|---|---|
+| `--since DATETIME` | Include rows recorded at or after this RFC 3339 timestamp |
+| `--limit N` | Emit at most N matching rows; omitted means all matching rows |
+
 #### `sysknife audit verify`
 
 Verify the audit trail: the transaction chain, the approval-event chain, and

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -13,7 +13,8 @@ for a security-sensitive deployment, this is the page to try to break.
 Each row in the transaction table captures the decision the daemon made about
 one action, at the moment it made it. `sysknife history` renders a subset;
 `caller_role`, `caller_principal` and `event_tip` are chain fields, read with
-`sysknife audit verify` or directly from the database:
+`sysknife audit export` (or directly from the database) and checked with
+`sysknife audit verify`:
 
 | Field | What it commits to |
 |---|---|
@@ -389,7 +390,16 @@ Machine-readable output for CI or a SIEM pipeline:
 
 ```sh
 sysknife audit verify --pubkey audit-key.pub --json
+sysknife audit export --since 2026-08-01T00:00:00Z --limit 500 > audit-rows.json
 ```
+
+`audit export` emits the stored transaction-chain rows as one JSON array in
+ascending `seq` order. It includes both `prev_chain_hash` and the Ed25519
+signature stored as `chain_hash`, so an offline consumer has the linkage and
+signature bytes without opening SQLite itself. It does not invent `argv`,
+`outcome`, or a separate `signature` field that the signed row never stored.
+Absent optional columns are JSON `null`, while a value actually recorded as an
+empty string remains an empty string.
 
 Anchor and check signed checkpoints against an external database:
 


### PR DESCRIPTION
## Summary

- add `sysknife audit export` with inclusive `--since` and optional `--limit` filters
- serialize all 17 stored `ChainRow` columns without renaming `chain_hash` or reconstructing unsigned fields
- read the configured SQLite or PostgreSQL audit store without loading the signing key
- document the export contract and cover JSON round-tripping, byte-identical signatures, null optionals, CLI parsing, and an end-to-end SQLite export

## Why

`audit verify` reports whether the signed chains are intact, but it does not expose the rows that were signed. Consumers therefore had to open the audit database directly to inspect or export the trail.

This follows the clarified issue contract: `chain_hash` is the Ed25519 signature, `prev_chain_hash` is required for offline linkage checks, and `argv`, `outcome`, and a separate `signature` field are intentionally absent because they are not stored on `ChainRow`.

## User impact

Operators and auditors can now export the signed transaction-chain rows as a JSON array from either supported backend. Missing optional values remain JSON `null`, while values actually recorded as empty strings remain empty strings.

## Testing

- `cargo nextest run --workspace --exclude sysknife-shell --locked` — 1751 passed
- `cargo clippy --workspace --exclude sysknife-shell --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The local full-workspace build including `sysknife-shell` was not available because my environment lacks the Tauri system packages (`pkg-config`, WebKitGTK, GTK). The upstream CI workflow installs those dependencies before running its full Rust gate.

Closes #215
