### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "homepage": "https://lacs-project.github.io/sysknife/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,83 @@ All notable changes to SysKnife are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the version stays in the `0.y` series the middle digit carries breaking
+changes; [docs/release.md](docs/release.md#version-numbering) has the rules.
 
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
+
+## [0.9.0] — 2026-08-19
+
+The first outside contributions land in this release, and four dead public items
+leave with them. Removing published paths is a breaking change under Cargo's 0.x
+rules, which is why this is 0.9.0 and not 0.8.1.
+
+### Removed
+
+- **Four verified-dead items, and the public paths they occupied.**
+  ([#244](https://github.com/lacs-project/sysknife/pull/244))
+  `sysknife_core::PRODUCTION_LISTEN_URI`, the root re-export of `detect`,
+  `detect_distro`, `parse_os_release`, `DistroFamily` and `DistroId`,
+  `sysknife_brain::action_name::UnknownActionName`, and the
+  `DEBIAN_ONLY_ACTION_NAMES` / `FEDORA_ONLY_ACTION_NAMES` aliases in
+  `sysknife_brain::prompt` are gone. Every live caller already went through the
+  module path, so in-tree code is unchanged, and `sysknife_types::UnknownActionName`
+  and `sysknife_core::action_family::{DEBIAN_ONLY_ACTIONS, FEDORA_ONLY_ACTIONS}`
+  remain the canonical spellings. The unused direct `prost-types` dependency went
+  with them. Thanks to @ITSMERNB.
+
+### Fixed
+
+- **A malformed `.mcp.json` was replaced rather than refused, discarding the
+  user's other MCP servers.** ([#243](https://github.com/lacs-project/sysknife/pull/243),
+  [#225](https://github.com/lacs-project/sysknife/issues/225))
+  `mergeMcpServers` treated unparseable content as an empty config, so the wizard
+  wrote a sysknife-only file over a config that still held the user's other
+  servers, kept no backup, and reported success. It now refuses, and the refusal
+  happens before any integration file is written, so a bad `.cursor/mcp.json` no
+  longer leaves `.mcp.json` and three hookify rules already on disk. An empty,
+  whitespace-only or BOM-prefixed file is treated as a fresh config instead of a
+  failure, valid JSON that is not an object is refused, and the error carries the
+  parser's position without echoing file contents, since these files hold provider
+  API keys. Thanks to @ITSMERNB.
+- **The audit-database migration could half-move, and `--purge` could not see the
+  result.** ([#241](https://github.com/lacs-project/sysknife/pull/241))
+- **Two plugin registry metadata gaps that cost trust points.**
+  ([#220](https://github.com/lacs-project/sysknife/pull/220))
+
+### Security
+
+- **h2 queued unbounded empty HTTP/2 DATA frames (RUSTSEC-2026-0258).**
+  ([#245](https://github.com/lacs-project/sysknife/pull/245)) Bumped to 0.4.16.
+  `cargo audit` names the advisory without the bump and exits clean with it.
+
+### Changed
+
+- `scripts/check_release_versions.sh` now also checks the internal
+  `sysknife-* = { path = …, version = … }` pins against the package version, and
+  refuses to report success when its manifest globs match nothing. A bump that
+  missed a pin would otherwise publish a crate depending on the previously
+  released version of its sibling.
+- Dependency bumps: futures 0.3.34 and uuid 1.24.1
+  ([#257](https://github.com/lacs-project/sysknife/pull/257)),
+  @testing-library/jest-dom 7.0.1
+  ([#255](https://github.com/lacs-project/sysknife/pull/255)), the
+  `rust:1-bookworm` base image digest
+  ([#254](https://github.com/lacs-project/sysknife/pull/254)), and four pinned
+  GitHub Actions ([#258](https://github.com/lacs-project/sysknife/pull/258)).
+
+### Documentation
+
+- **How the version number is chosen is now written down.** `docs/release.md`
+  explains why a removal moves the middle digit while the leading zero stands,
+  names the three conditions for 1.0.0, and `CONTRIBUTING.md` points contributors
+  at it alongside the test-baseline artifact they need to regenerate when they add
+  a test.
+- Five published figures that had drifted past the guards were corrected
+  ([#242](https://github.com/lacs-project/sysknife/pull/242)), and three dead ends
+  in the contributor path were removed
+  ([#214](https://github.com/lacs-project/sysknife/pull/214)).
 
 ## [0.8.0] — 2026-08-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,25 @@ cargo fmt --all -- --check
 fail, then write the minimum code to make it pass. The test suite is the
 contract.
 
+**Adding or removing a Rust test moves a published figure.** The suite size lives
+in `tests/evidence/workspace-tests.json`, and `README.md`,
+`docs/introduction.md` and `docs/distro-support.md` state it in prose. Regenerate
+the artifact and update those three files in the same commit:
+
+```sh
+UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh
+grep -rn 'Rust tests' README.md docs/introduction.md docs/distro-support.md
+```
+
+CI gates both halves, so bumping the artifact alone turns `docs-and-hygiene` red
+after `rust` goes green.
+
+**Which release your change lands in.** While SysKnife is in the `0.y` series, a
+change that breaks a consumer moves the middle digit and everything else moves the
+last one. [docs/release.md](docs/release.md#version-numbering) carries the rules
+and the criteria for 1.0.0. Say so in your PR description when you remove or
+rename a public item, so it goes out in the right release.
+
 ### 3. Commit style
 
 Conventional Commits on the title:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,11 +15,11 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.8.0" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.8.0" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.8.0" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.9.0" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.9.0" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.9.0" }
 chrono = "0.4"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.8.0" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.9.0" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -39,11 +39,11 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.8.0", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.9.0", features = ["test-support"] }
 # and `AttributionCensus::from_counts_for_tests`, so the verify renderers can be
 # tested without building signed chain rows. Dev-only: production builds of this
 # bin do not compile dev-dependencies, so the constructor stays unreachable there.
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.8.0", features = ["test-support"] }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.9.0", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "react": "^19.2.8",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.8.0" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.8.0" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.9.0" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.9.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.8.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.8.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.9.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.9.0" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.8.0"
+version = "0.9.0"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.8.0" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.9.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,8 +17,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 test-support = []
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.8.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.8.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.9.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.9.0" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -61,7 +61,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.8.0" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.9.0" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.8.0" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.9.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,6 +4,49 @@ SysKnife releases are intentionally tag-driven and one way. npm and crates.io
 versions cannot be replaced after publication, so a tag is pushed only after
 the [release-readiness checklist](release-readiness.md) is complete.
 
+## Version numbering
+
+SysKnife is in the `0.y.z` series. Cargo and npm both treat the leftmost non-zero
+component as the compatibility unit, so while the leading zero stands the middle
+digit carries breaking changes and the last one carries everything else:
+
+| Change | Bump | Example |
+|---|---|---|
+| Removing or renaming a public item, changing a signature, changing behaviour a caller relied on | `0.y` | v0.9.0 removed `PRODUCTION_LISTEN_URI` and three dead re-exports |
+| Compatible additions, fixes, dependency bumps | `0.y.z` | a new action, a bug fix, a security patch |
+
+A consumer writing `sysknife-core = "0.8"` accepts 0.8.1 and refuses 0.9.0. That
+is the whole reason a removal has to move the middle digit: shipping it as a patch
+hands the breakage to everyone pinned to the series, and
+[the Cargo book](https://doc.rust-lang.org/cargo/reference/semver.html) classifies
+removing a public item, a `pub use` re-export included, as a major change.
+
+Behaviour counts, not only types. v0.9.0 also made `sysknife-setup` refuse a
+malformed `.mcp.json` that earlier versions overwrote, so a run that used to
+succeed now exits 1. No signature changed and it is still a compatibility break.
+
+### After 1.0.0
+
+Once the public API is declared stable the digits take their usual
+[SemVer](https://semver.org/) meaning: MAJOR for breaking changes, MINOR for
+compatible features, PATCH for fixes.
+
+1.0.0 is not a maturity badge and it is not scheduled. Three things have to be
+true first, so the switch is a decision rather than a mood:
+
+1. The daemon protocol is settled. The wire enums and `ChainRow` still gain
+   fields, and `chain_version` exists because the encoding is expected to move.
+2. The action catalogue naming is settled. [#237](https://github.com/lacs-project/sysknife/issues/237)
+   splits the Ubuntu-only actions out of `DEBIAN_ONLY_ACTIONS` and
+   [#239](https://github.com/lacs-project/sysknife/issues/239) adds nftables
+   vocabulary. Both rename or re-scope public items.
+3. Something outside this repository depends on the library crates. Today the only
+   reverse dependencies of `sysknife-core` on crates.io are `sysknife-brain`,
+   `sysknife-daemon` and `sysknife-cli`, all pinned to the same version, so there
+   is no outside consumer to stabilise for yet.
+
+Until then, expect a minor bump whenever a release removes or renames something.
+
 ## What the workflow publishes
 
 Pushing a tag matching `vMAJOR.MINOR.PATCH` on `main` starts

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -52,4 +52,37 @@ if [[ -n "$expected" && "$baseline" != "$expected" ]]; then
     exit 1
 fi
 
-printf 'All release versions match %s.\n' "$baseline"
+# Internal path dependencies carry an explicit `version` next to `path`, and that
+# field is what crates.io resolves at publish time. A bump that misses one
+# publishes sysknife-brain 0.9.0 depending on sysknife-core ^0.8.0, which resolves
+# to the crate already on the registry instead of the tree that was just built,
+# and the mistake is invisible until someone builds against the published crate.
+# The package-version loop above reads only `[package] version`, so these need
+# their own pass.
+pins="$(grep -rn '^sysknife-[a-z-]* = {' \
+    "$repo_root"/crates/*/Cargo.toml \
+    "$repo_root"/apps/sysknife-cli/Cargo.toml \
+    "$repo_root"/apps/sysknife-shell/src-tauri/Cargo.toml |
+    grep 'version = ')"
+
+# An empty result means the manifests moved, not that every pin agrees. Fail
+# loudly rather than reporting success for a check that inspected nothing.
+if [[ -z "$pins" ]]; then
+    printf 'No internal dependency pins found; the manifest paths in %s are stale.\n' \
+        "${BASH_SOURCE[0]}" >&2
+    exit 1
+fi
+
+pin_count=0
+while IFS= read -r pin; do
+    pin_count=$((pin_count + 1))
+    pinned="$(printf '%s' "$pin" | sed -n 's/.*version = "\([^"]*\)".*/\1/p')"
+    if [[ "$pinned" != "$baseline" ]]; then
+        printf 'Internal dependency pin does not match package version %s:\n  %s\n' \
+            "$baseline" "$pin" >&2
+        exit 1
+    fi
+done <<< "$pins"
+
+printf 'All release versions match %s (%d internal dependency pins checked).\n' \
+    "$baseline" "$pin_count"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Cuts v0.9.0, and adds the two things the release itself exposed.

The middle digit moves because #244 removed published items: `PRODUCTION_LISTEN_URI`, the `sysknife-core` root re-export of the distro helpers, `UnknownActionName`, and the two prompt aliases. Cargo and npm treat the leftmost non-zero component as the compatibility unit, so a consumer on `"0.8"` would have adopted a patch release carrying those removals. #243 also changed behaviour: a malformed `.mcp.json` that earlier versions overwrote now aborts the run.

## Also in here

- **`check_release_versions.sh` now checks the internal dependency pins.** It read only `[package] version`, so a bump that missed a `sysknife-* = { path = …, version = … }` pin passed. That publishes, say, `sysknife-brain` 0.9.0 depending on `sysknife-core` `^0.8.0`, which crates.io resolves to the crate already on the registry rather than the tree just built. The new pass covers all 15 pins and refuses to report success when its globs match nothing, so a directory move fails loudly instead of inspecting zero files.
- **`docs/release.md` documents how the digits are chosen** while the leading zero stands, and names three conditions for 1.0.0 so the switch to MAJOR-for-breaking is a decision rather than a mood. `CONTRIBUTING.md` points at it, next to the test-baseline artifact contributors need to regenerate when they add a Rust test.

## Verification

Run on this branch:

| Gate | Result |
|---|---|
| `scripts/release_rehearsal.sh --check` | passed for v0.9.0 on x86_64, 15 pins checked |
| `cargo fmt` / `clippy --workspace --all-features --all-targets --locked -D warnings` / `cargo doc -D warnings` | clean (pre-commit hook) |
| `scripts/test_baseline.sh` | 1759/1759, count matches the artifact |
| `scripts/test_baseline.sh --frontend` | 72, count matches |
| `cargo test -p sysknife-daemon --test postgres_store` | 5 passed against live `postgres:17-alpine` |
| `cargo audit` | exit 0, 18 allowed GUI-transitive warnings |
| markdownlint + markdown-link-check on the CI file set | 0 issues, links resolve |

The pin check was mutation-proved both ways: one stale pin fails with the file and line, and stale manifest globs fail with "the manifest paths are stale" rather than passing.
