### PR TITLE
fix(demo): drop the unused ITALIC escape that fails scripts-lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ changes; [docs/release.md](docs/release.md#version-numbering) has the rules.
 Releases before `0.2.5` predate the public launch; their notes live in the
 [git tag history](https://github.com/lacs-project/sysknife/tags).
 
+## [Unreleased]
+
+### Documentation
+
+- **The README hero is an Ubuntu recording, and the social preview leads with
+  Ubuntu.** The demo GIF moved from the Fedora Atomic flow to a new Ubuntu 24.04
+  one covering `UfwAllow`, `AptInstall` and `UfwStatus`, with the Atomic recording
+  still linked for `rpm-ostree` hosts. The social preview now names Ubuntu 20.04+
+  first and describes Fedora as Atomic-only, which is what the support matrix
+  says. `assets/demo/README.md` records the render pipeline, including the ffmpeg
+  frame-rate step that takes a raw 424-frame VHS render down to 170 frames and
+  2.12 MB; that step is load-bearing rather than cosmetic, since `gifsicle` only
+  touches the palette.
+- Contributors are named in the README, with a pointer at Releases for anyone who
+  wants to see their own fix ship.
+  ([#265](https://github.com/lacs-project/sysknife/pull/265))
+
 ## [0.9.0] — 2026-08-19
 
 The first outside contributions land in this release, and four dead public items

--- a/assets/demo/ubuntu-flow-mock.sh
+++ b/assets/demo/ubuntu-flow-mock.sh
@@ -27,7 +27,6 @@ YELLOW=$'\033[38;2;255;213;79m'
 RED=$'\033[38;2;255;107;107m'
 PURPLE=$'\033[38;2;179;136;255m'
 RESET=$'\033[0m'
-ITALIC=$'\033[3m'
 
 sleep_ms() { sleep "$(awk -v ms="$1" 'BEGIN{printf "%.3f", ms/1000}')"; }
 


### PR DESCRIPTION
`scripts-lint` shellchecks `assets/demo/**`, and `assets/demo/ubuntu-flow-mock.sh:30` declares `ITALIC=$'\033[3m'` without ever using it, so SC2034 at `--severity=warning` fails the job and takes the e2e workflow with it. main has been red since `5f7ffef`.

Deleting the declaration is the whole fix. The other six colour escapes in that block are all used: `RESET` 84 times, `BOLD` 12, `PURPLE` 6, `YELLOW` 5, `GREEN` 4, `RED` 1. The variable was orphaned because the palette block came from `mcp-flow-mock.sh`, which renders a plan-card intent line in italics that this mock does not draw.

Verified with the CI command and the same shellcheck version CI installs (0.10.0):

```
$ find tests/e2e tests/release scripts assets/demo -type f -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning
before: exit 123, one SC2034 finding
after:  exit 0
```

The second commit records what `#265` actually shipped. That PR was meant to add a contributor Thanks block and, through a `git add -A` in a shared working tree, also carried the Ubuntu demo recording, its tape and mock, the demo README and the rewritten social preview. The content was finished work and stays; the CHANGELOG now describes it, including why the render pipeline has an ffmpeg frame-rate step the other two GIFs do not.