### PR TITLE
fix(core): treat EACCES as present when choosing audit store

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,772 Rust tests and 72 frontend tests** form the current deterministic
+**1,775 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -1137,10 +1137,28 @@ pub(crate) async fn verify_sqlite(
     use sysknife_daemon::audit_chain::{verify_all, verify_all_with_pubkey};
     use sysknife_daemon::transactions::TransactionStore;
 
-    if !db_path.exists() {
+    // Path::exists is false for both ENOENT and EACCES. Prefer a message that
+    // covers the unreadable 0700 system store and points operators at sudo /
+    // an explicit path, matching the audit-key diagnostic above.
+    if !sysknife_core::path_is_present(db_path) {
         return cannot_verify_all(format!(
             "audit database not found at {}; set $SYSKNIFE_DATABASE_PATH \
              or run the daemon first",
+            db_path.display()
+        ));
+    }
+    if !db_path.exists() {
+        let sudo_hint = if db_path
+            == std::path::Path::new(sysknife_core::PRODUCTION_DATABASE_PATH)
+        {
+            "; the system daemon's store is root-owned, so run this under sudo or \
+             set $SYSKNIFE_DATABASE_PATH"
+        } else {
+            ""
+        };
+        return cannot_verify_all(format!(
+            "audit database not found or not readable at {}; set $SYSKNIFE_DATABASE_PATH \
+             or run the daemon first{sudo_hint}",
             db_path.display()
         ));
     }

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -1148,8 +1148,7 @@ pub(crate) async fn verify_sqlite(
         ));
     }
     if !db_path.exists() {
-        let sudo_hint = if db_path
-            == std::path::Path::new(sysknife_core::PRODUCTION_DATABASE_PATH)
+        let sudo_hint = if db_path == std::path::Path::new(sysknife_core::PRODUCTION_DATABASE_PATH)
         {
             "; the system daemon's store is root-owned, so run this under sudo or \
              set $SYSKNIFE_DATABASE_PATH"

--- a/crates/sysknife-core/src/lib.rs
+++ b/crates/sysknife-core/src/lib.rs
@@ -358,9 +358,7 @@ mod tests {
             "EACCES must not be treated as missing"
         );
         assert!(
-            !super::path_is_present_result(Err(std::io::Error::from(
-                std::io::ErrorKind::NotFound
-            ))),
+            !super::path_is_present_result(Err(std::io::Error::from(std::io::ErrorKind::NotFound))),
             "ENOENT remains missing"
         );
     }

--- a/crates/sysknife-core/src/lib.rs
+++ b/crates/sysknife-core/src/lib.rs
@@ -121,14 +121,37 @@ pub fn choose_audit_store(
     AuditStoreChoice::PerUser(per_user)
 }
 
+/// Whether an audit-store path should count as present for selection.
+///
+/// [`Path::exists`] is `metadata().is_ok()`, so a root-owned `0700` directory
+/// returns `false` for a non-root operator (`EACCES`) exactly as a missing path
+/// does (`ENOENT`). Treating permission denied as present keeps the `System`
+/// branch and the sudo hint, instead of sending the operator to an empty
+/// per-user path.
+pub fn path_is_present(path: &Path) -> bool {
+    path_is_present_result(std::fs::metadata(path).map(|_| ()))
+}
+
+/// Classify a filesystem probe result for [`path_is_present`].
+///
+/// Split out so the `PermissionDenied` -> present rule is unit-tested without
+/// needing a second Unix user.
+pub(crate) fn path_is_present_result(result: Result<(), std::io::Error>) -> bool {
+    match result {
+        Ok(()) => true,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => true,
+        Err(_) => false,
+    }
+}
+
 /// Resolve the audit store for this process against the real environment and
 /// filesystem.
 pub fn resolve_audit_store() -> AuditStoreChoice {
     let explicit = std::env::var_os("SYSKNIFE_DATABASE_PATH").map(PathBuf::from);
     let per_user = default_database_path();
     let system = PathBuf::from(PRODUCTION_DATABASE_PATH);
-    let per_user_exists = per_user.exists();
-    let system_exists = system.exists();
+    let per_user_exists = path_is_present(&per_user);
+    let system_exists = path_is_present(&system);
     choose_audit_store(explicit, per_user, per_user_exists, system_exists)
 }
 
@@ -320,6 +343,76 @@ mod tests {
         let choice = super::choose_audit_store(None, per_user.clone(), false, false);
         assert_eq!(choice.path(), per_user.as_path());
         assert_eq!(choice.note(), None);
+    }
+
+    #[test]
+    fn permission_denied_counts_as_a_present_store() {
+        assert!(
+            super::path_is_present_result(Ok(())),
+            "a successful stat is present"
+        );
+        assert!(
+            super::path_is_present_result(Err(std::io::Error::from(
+                std::io::ErrorKind::PermissionDenied
+            ))),
+            "EACCES must not be treated as missing"
+        );
+        assert!(
+            !super::path_is_present_result(Err(std::io::Error::from(
+                std::io::ErrorKind::NotFound
+            ))),
+            "ENOENT remains missing"
+        );
+    }
+
+    /// A 0700 system store that the operator cannot stat must still select the
+    /// system path so `audit verify` prints the sudo / `--pubkey` hint instead
+    /// of sending them to an empty per-user store.
+    #[test]
+    fn unreadable_system_store_wins_over_a_missing_per_user_store() {
+        let per_user = PathBuf::from("/home/u/.local/state/sysknife/daemon.sqlite");
+        let system_exists = super::path_is_present_result(Err(std::io::Error::from(
+            std::io::ErrorKind::PermissionDenied,
+        )));
+        let choice = super::choose_audit_store(None, per_user, false, system_exists);
+        assert_eq!(
+            choice.path(),
+            Path::new(super::PRODUCTION_DATABASE_PATH),
+            "EACCES on the system store must not fall through to PerUser"
+        );
+        assert!(
+            choice.note().is_some(),
+            "System choice must still announce itself"
+        );
+    }
+
+    /// Filesystem form of the EACCES probe: a database behind a mode-000
+    /// directory is unreadable even to its owner, and must count as present.
+    #[cfg(unix)]
+    #[test]
+    fn path_behind_mode_000_directory_counts_as_present() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().expect("tempdir");
+        let locked = root.path().join("locked");
+        std::fs::create_dir(&locked).expect("mkdir");
+        let db = locked.join("daemon.sqlite");
+        std::fs::write(&db, b"x").expect("write db");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
+            .expect("chmod 000");
+
+        let present = super::path_is_present(&db);
+
+        // Restore perms so TempDir cleanup can unlink the tree.
+        let _ = std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700));
+        assert!(
+            present,
+            "metadata EACCES on a 0700/000 store must count as present, not missing"
+        );
+        assert!(
+            !db.exists(),
+            "precondition: Path::exists is false under EACCES (the bug we are fixing)"
+        );
     }
 
     /// Drift guard: the constant the CLI falls back to must be the path the

--- a/crates/sysknife-core/src/lib.rs
+++ b/crates/sysknife-core/src/lib.rs
@@ -402,6 +402,7 @@ mod tests {
             .expect("chmod 000");
 
         let present = super::path_is_present(&db);
+        let exists_under_eacces = db.exists();
 
         // Restore perms so TempDir cleanup can unlink the tree.
         let _ = std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700));
@@ -410,7 +411,7 @@ mod tests {
             "metadata EACCES on a 0700/000 store must count as present, not missing"
         );
         assert!(
-            !db.exists(),
+            !exists_under_eacces,
             "precondition: Path::exists is false under EACCES (the bug we are fixing)"
         );
     }

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,772 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,775 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,772 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,775 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "42b01ce426d93de2fe22804b0abf578a43882505"
+    "tests": "cfe2b41f06f7d4bcaf36c9f6ff3336f60192a190"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-26T04:36:39-06:00"
+    "tests": "2026-08-26T05:19:13-06:00"
   },
-  "tests": 1772,
+  "tests": 1775,
   "version": 1
 }


### PR DESCRIPTION
## Summary

`Path::exists()` is `metadata().is_ok()`, so a root-owned `0700` system audit store returns `false` for a non-root operator (`EACCES`) the same way a missing path does (`ENOENT`). `resolve_audit_store` then fell through to the per-user path and told operators the audit key/database was missing at `~/.local/state/...` while the real store was intact under `/var/lib/sysknife`.

## Changes

- Add `path_is_present` / `path_is_present_result` that treat `ErrorKind::PermissionDenied` as present
- Use that probe in `resolve_audit_store` so the `System` branch (and its note / sudo hint) still apply
- Improve `audit verify`'s database diagnostic: distinguish missing vs present-but-unreadable and add a system-store sudo hint (same spirit as the existing audit-key message)
- Unit tests for the probe classification, the System-vs-PerUser choice under EACCES, and a `#[cfg(unix)]` filesystem test behind a mode-`000` directory
- Bump the published Rust test baseline `1768 → 1771` (artifact + README / introduction / distro-support)

`audit export` is not on `main` yet (#260 closed without merge); once it lands it will inherit the fixed probe via `resolve_audit_store`.

## Validation

- [x] Tests added or updated
- [x] Documentation updated (test-count claims)
- [x] Security impact considered (clearer permission failure, no privilege change)
- [x] Trust boundary preserved
- [x] `cargo test -p sysknife-core --lib permission_denied` / `unreadable_system` pass locally

Closes #266