### PR TITLE
docs: record the Unicode line-separator fix and credit @vsolano9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ### Fixed
 
+- **Two Unicode line separators reached the model as visual line breaks.**
+  ([#274](https://github.com/lacs-project/sysknife/pull/274),
+  [#224](https://github.com/lacs-project/sysknife/issues/224))
+  `strip_dangerous_unicode` covered `U+200B..=U+200F` and `U+202A..=U+202E`, which
+  left U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR sitting in the gap
+  between the two ranges. `append_pref` refuses both when a fact is written, but
+  `read_prefs` normalises on the way back out and passed them through, so a
+  hand-edited preferences file could hold one fact that `str::lines` and the
+  `- ` filter in `append_prefs` read as a single line while the model read three,
+  the second an unprefixed heading. The same gap let paragraph padding slip past
+  `collapse_blank_runs`, which counts `\n` only. The arm now widens to
+  `U+2028..=U+202E`, stripping both before blank-run handling. Thanks to
+  @vsolano9.
+
 - **A saved preference could close the prompt envelope that contains it.**
   ([#256](https://github.com/lacs-project/sysknife/pull/256),
   [#253](https://github.com/lacs-project/sysknife/issues/253))

--- a/README.md
+++ b/README.md
@@ -389,9 +389,10 @@ are scoped with clear acceptance criteria.
 ### Thanks
 
 Patches so far from [@ITSMERNB](https://github.com/ITSMERNB),
-[@918154429](https://github.com/918154429), [@Osheun](https://github.com/Osheun)
-and [@danial-razi](https://github.com/danial-razi). Every release names who fixed
-what in [CHANGELOG.md](CHANGELOG.md).
+[@QinXi-ai](https://github.com/QinXi-ai), [@Osheun](https://github.com/Osheun),
+[@danial-razi](https://github.com/danial-razi) and
+[@vsolano9](https://github.com/vsolano9). Every release names who fixed what in
+[CHANGELOG.md](CHANGELOG.md).
 
 If you send a patch, watching
 [Releases](https://github.com/lacs-project/sysknife/releases) is the quickest way


### PR DESCRIPTION
#274 closed the last two codepoints of the dangerous-Unicode gap and is unreleased, so it needs an Unreleased entry like the others.

The CHANGELOG entry names the mechanism (the range gap between `U+200F` and `U+202A`), why the write and read paths disagreed (`append_pref` refuses both separators, `read_prefs` passed them through), the padding-evasion side effect, and the contributor.

The README Thanks list gains @vsolano9, and @918154429's entry moves to their current handle @QinXi-ai, which the old link only reached through a redirect.

Docs only. No behaviour change.