### PR TITLE
fix(cli): operator_safe drops U+2028 and U+2029

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   The shell script now reads `CLAIM_FILES` from the Python module, and refuses to
   report success when that read comes back empty, which `set -euo pipefail` cannot
   catch on its own inside process substitution. Thanks to @Osheun.
+- **`operator_safe` kept U+2028 and U+2029, so the invisible-character set it
+  calls complete was not.** ([#276](https://github.com/lacs-project/sysknife/issues/276))
+  The drop arms covered `U+200B..=U+200F` and `U+202A..=U+202E`, leaving the two
+  line/paragraph separators in the gap between them. Terminals render both as
+  nothing, which is exactly the class the function drops by name: a plan summary
+  reading `remove nothing` could hide a different target from the operator
+  approving it. The bidi arm is now `U+2028..=U+202E`, the same widening
+  [#274](https://github.com/lacs-project/sysknife/pull/274) applied on the
+  model-facing path.
 
 ### Documentation
 

--- a/apps/sysknife-cli/src/operator_text.rs
+++ b/apps/sysknife-cli/src/operator_text.rs
@@ -104,7 +104,10 @@ pub(crate) fn operator_safe(s: &str) -> String {
             // C1 controls: U+009B is CSI to a terminal in 8-bit mode.
             c if ('\u{80}'..='\u{9f}').contains(&c) => false,
             // Bidi overrides and isolates — reorder what is displayed.
-            '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}' => false,
+            // U+2028/U+2029 sit in the gap below the bidi arm; terminals
+            // render them as nothing, so they belong in the same drop set
+            // (#274 widened the brain-side range the same way).
+            '\u{2028}'..='\u{202e}' | '\u{2066}'..='\u{2069}' => false,
             // Zero-width and byte-order marks — hide text in plain sight.
             '\u{200b}'..='\u{200f}' | '\u{feff}' => false,
             // U+061C ARABIC LETTER MARK is a bidi control in exactly the way
@@ -276,6 +279,9 @@ mod tests {
         for ch in [
             '\u{202a}', '\u{202b}', '\u{202c}', '\u{202d}', '\u{202e}', '\u{2066}', '\u{2067}',
             '\u{2068}', '\u{2069}', '\u{200b}', '\u{200e}', '\u{feff}',
+            // U+2028/U+2029 sit in the gap between the U+200F and U+202A arms.
+            // Terminals render them as nothing, same class as the rest.
+            '\u{2028}', '\u{2029}',
         ] {
             let safe = operator_safe(&format!("remove{ch}nothing"));
             assert!(!safe.contains(ch), "U+{:04X} survived: {safe:?}", ch as u32);


### PR DESCRIPTION
## Summary

`operator_safe` documents its invisible-character drop set as complete, but the arms covered `U+200B..=U+200F` and `U+202A..=U+202E`, leaving U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR in the gap between them. Terminals render both as nothing — the same class the function already drops by name — so a plan summary like `remove\u2028nothing` can read one way to the operator approving it and mean another. This is the operator-facing half of the hole #274 closed on the model path.

The fix widens the bidi arm to `'\u{2028}'..='\u{202e}'`, the same widening #274 applied. `operator_safe_block` inherits it (it calls `operator_safe` per line); the issue notes `str::lines` ignores both codepoints, so neither can inflate the rendered line count past `MAX_RENDERED_LINES`.

## Related Issue

Closes #276.

## Validation

- [x] Tests added or updated — `bidi_overrides_and_zero_width_characters_are_dropped` now covers both codepoints; confirmed failing before the match change, passing after (TDD)
- [x] Documentation updated if behavior changed — CHANGELOG entry added in the project's style
- [x] Security impact considered — this change only extends an existing drop set
- [x] Trust boundary preserved (daemon remains the only privileged executor) — CLI-only change, no daemon/planner/shell code touched
- [x] CI passes — locally: `cargo fmt --check`, `cargo doc` (`-D warnings`), `cargo clippy --workspace --all-features --all-targets -- -D warnings` all clean; `cargo nextest run --workspace --locked` — 1765/1768 pass; the 3 failures are in `sysknife-daemon::execute_spec` process-stop tests and reproduce identically on untouched `main` in this container environment (process-group stop confirmation doesn't work here), unrelated to this change

## Notes for Reviewers

Single match arm + two test loop entries + changelog. No behavior change for any character outside U+2028/U+2029.