### PR TITLE
fix(types): route outbound envelope encoding through the generated enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,15 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   The shell script now reads `CLAIM_FILES` from the Python module, and refuses to
   report success when that read comes back empty, which `set -euo pipefail` cannot
   catch on its own inside process substitution. Thanks to @Osheun.
+- **Outbound envelope encoding hand-typed the wire numbers while inbound
+  trusted the generated enum.** ([#281](https://github.com/lacs-project/sysknife/issues/281))
+  The three `From<…> for proto::…` conversions existed but were unused, and the
+  encode path wrote integers from three literal match tables instead. A
+  renumbered `.proto` would have moved the decode side with the file while the
+  encode side kept writing the old numbers — a peer reading `High` as `Medium`,
+  which decides whether an approval receipt is required. The encode path now
+  goes through the same prost-generated enums the decode path already trusts
+  (`i32::from(proto::X::from(value))`), and the three tables are deleted.
 
 ### Documentation
 

--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -586,40 +586,11 @@ pub struct TransactionRecord {
     pub warnings: Vec<String>,
 }
 
-fn caller_role_code(value: CallerRole) -> i32 {
-    match value {
-        CallerRole::Observer => 1,
-        CallerRole::Dev => 2,
-        CallerRole::Admin => 3,
-        CallerRole::Boot => 4,
-    }
-}
-
-fn risk_level_code(value: RiskLevel) -> i32 {
-    match value {
-        RiskLevel::Low => 1,
-        RiskLevel::Medium => 2,
-        RiskLevel::High => 3,
-    }
-}
-
-fn job_state_code(value: JobState) -> i32 {
-    match value {
-        JobState::Queued => 1,
-        JobState::Running => 2,
-        JobState::Succeeded => 3,
-        JobState::Failed => 4,
-        JobState::Canceled => 5,
-        JobState::RolledBack => 6,
-        JobState::NeedsReboot => 7,
-    }
-}
-
 impl From<CallerRole> for proto::CallerRole {
-    // Matched directly rather than round-tripping through the i32 code table
-    // and unwrapping. The conversion is total, so it should not be able to
-    // panic: this bridge is not on the live request path today, but once the
-    // daemon speaks proto it would be a panic-on-drift inside a root process.
+    // Matched directly against the variants rather than round-tripping through
+    // an i32 code table, so a renumbered `.proto` moves this conversion along
+    // with the prost-generated enum instead of drifting behind it. The
+    // conversion is total, so it cannot panic.
     fn from(value: CallerRole) -> Self {
         match value {
             CallerRole::Observer => proto::CallerRole::Observer,
@@ -755,7 +726,7 @@ impl From<RequestEnvelope> for proto::RequestEnvelope {
             action_name: value.action_name,
             request_id: value.request_id,
             params_json: serde_json::to_string(&value.params).expect("json serialization"),
-            caller_role: caller_role_code(value.caller_role),
+            caller_role: i32::from(proto::CallerRole::from(value.caller_role)),
             request_hash: value.request_hash.into_inner(),
         }
     }
@@ -789,7 +760,7 @@ impl From<PreviewEnvelope> for proto::PreviewEnvelope {
     fn from(value: PreviewEnvelope) -> Self {
         Self {
             summary: value.summary,
-            risk_level: risk_level_code(value.risk_level),
+            risk_level: i32::from(proto::RiskLevel::from(value.risk_level)),
             current_state_json: serde_json::to_string(&value.current_state)
                 .expect("json serialization"),
             proposed_change_json: serde_json::to_string(&value.proposed_change)
@@ -836,7 +807,7 @@ impl TryFrom<proto::PreviewEnvelope> for PreviewEnvelope {
 impl From<ResultEnvelope> for proto::ResultEnvelope {
     fn from(value: ResultEnvelope) -> Self {
         Self {
-            status: job_state_code(value.status),
+            status: i32::from(proto::JobState::from(value.status)),
             summary: value.summary,
             warnings: value.warnings,
             job_id: value.job_id.unwrap_or_default(),
@@ -883,8 +854,8 @@ impl From<TransactionRecord> for proto::TransactionRecord {
             request_id: value.request_id,
             request_hash: value.request_hash,
             action_name: value.action_name,
-            risk_level: risk_level_code(value.risk_level),
-            status: job_state_code(value.status),
+            risk_level: i32::from(proto::RiskLevel::from(value.risk_level)),
+            status: i32::from(proto::JobState::from(value.status)),
             approval_id: value.approval_id.unwrap_or_default(),
             summary: value.summary,
             warnings: value.warnings,


### PR DESCRIPTION
## Summary

The two directions of the envelope bridge disagreed about which spelling of a wire number is authoritative. Inbound routes through the prost-generated enum, so a renumbered `.proto` moves it. Outbound wrote integers from three hand-maintained match tables (`caller_role_code`, `risk_level_code`, `job_state_code`), so it would have kept writing the old numbers — a peer reading `High` as `Medium`, and the risk level is what decides whether an approval receipt is required.

The variant-to-variant conversions (`impl From<X> for proto::X`) already existed and were unused. This routes the five outbound call sites through them — `i32::from(proto::X::from(value))` — so the encode path consults the same generated authority the decode path already trusts, and deletes the three tables. The mutation the issue describes (renumbering `risk_level_code`) now has nowhere to land: no integer remains in the encode path.

## Related Issue

Closes #281. (#231 deliberately left untouched, as the issue asks.)

## Validation

- [x] Tests added or updated — no new tests needed; the existing round-trip suite covers the encode path and passes unchanged
- [x] Documentation updated if behavior changed — CHANGELOG entry added
- [x] Security impact considered — this removes a drift surface in the approval-deciding risk level encoding; no behavior change while the numbers match
- [x] Trust boundary preserved (daemon remains the only privileged executor) — types-crate conversion only
- [x] CI passes — locally in container: `cargo test -p sysknife-types` (3+13+8 pass), `cargo fmt --check`, `cargo doc` (`-D warnings`), `cargo clippy --workspace --all-features --all-targets -- -D warnings` all clean; `cargo nextest run --workspace --locked` — 1764/1768 pass; the 4 failures are the same `sysknife-daemon` process-stop tests that fail on untouched `main` in this container environment, unrelated to this change

## Notes for Reviewers

Net deletion (−38/+18). Five call sites, three table deletions, one stale comment refreshed, all in `crates/sysknife-types/src/lib.rs`. No references to the deleted functions remain anywhere in the tree.