### PR TITLE
sysknife-types: encode envelope enums through the generated proto codes

### DIFF
--- a/crates/sysknife-types/src/lib.rs
+++ b/crates/sysknife-types/src/lib.rs
@@ -586,35 +586,6 @@ pub struct TransactionRecord {
     pub warnings: Vec<String>,
 }
 
-fn caller_role_code(value: CallerRole) -> i32 {
-    match value {
-        CallerRole::Observer => 1,
-        CallerRole::Dev => 2,
-        CallerRole::Admin => 3,
-        CallerRole::Boot => 4,
-    }
-}
-
-fn risk_level_code(value: RiskLevel) -> i32 {
-    match value {
-        RiskLevel::Low => 1,
-        RiskLevel::Medium => 2,
-        RiskLevel::High => 3,
-    }
-}
-
-fn job_state_code(value: JobState) -> i32 {
-    match value {
-        JobState::Queued => 1,
-        JobState::Running => 2,
-        JobState::Succeeded => 3,
-        JobState::Failed => 4,
-        JobState::Canceled => 5,
-        JobState::RolledBack => 6,
-        JobState::NeedsReboot => 7,
-    }
-}
-
 impl From<CallerRole> for proto::CallerRole {
     // Matched directly rather than round-tripping through the i32 code table
     // and unwrapping. The conversion is total, so it should not be able to
@@ -755,7 +726,7 @@ impl From<RequestEnvelope> for proto::RequestEnvelope {
             action_name: value.action_name,
             request_id: value.request_id,
             params_json: serde_json::to_string(&value.params).expect("json serialization"),
-            caller_role: caller_role_code(value.caller_role),
+            caller_role: i32::from(proto::CallerRole::from(value.caller_role)),
             request_hash: value.request_hash.into_inner(),
         }
     }
@@ -789,7 +760,7 @@ impl From<PreviewEnvelope> for proto::PreviewEnvelope {
     fn from(value: PreviewEnvelope) -> Self {
         Self {
             summary: value.summary,
-            risk_level: risk_level_code(value.risk_level),
+            risk_level: i32::from(proto::RiskLevel::from(value.risk_level)),
             current_state_json: serde_json::to_string(&value.current_state)
                 .expect("json serialization"),
             proposed_change_json: serde_json::to_string(&value.proposed_change)
@@ -836,7 +807,7 @@ impl TryFrom<proto::PreviewEnvelope> for PreviewEnvelope {
 impl From<ResultEnvelope> for proto::ResultEnvelope {
     fn from(value: ResultEnvelope) -> Self {
         Self {
-            status: job_state_code(value.status),
+            status: i32::from(proto::JobState::from(value.status)),
             summary: value.summary,
             warnings: value.warnings,
             job_id: value.job_id.unwrap_or_default(),
@@ -883,8 +854,8 @@ impl From<TransactionRecord> for proto::TransactionRecord {
             request_id: value.request_id,
             request_hash: value.request_hash,
             action_name: value.action_name,
-            risk_level: risk_level_code(value.risk_level),
-            status: job_state_code(value.status),
+            risk_level: i32::from(proto::RiskLevel::from(value.risk_level)),
+            status: i32::from(proto::JobState::from(value.status)),
             approval_id: value.approval_id.unwrap_or_default(),
             summary: value.summary,
             warnings: value.warnings,


### PR DESCRIPTION
Problem:
- Outbound envelope encoding writes wire numbers from hand-maintained tables (`caller_role_code`, `risk_level_code`, `job_state_code`) while inbound decoding goes through the prost-generated enums derived from `sysknife.proto`. If the .proto is renumbered, the two directions silently disagree — e.g. `High` encoded as 3 but decoded as whatever 3 now means — and the existing round-trip tests only fail if they disagree *today*, not if the .proto later drifts.

Solution:
- The variant-to-variant `From` impls for all three enums already existed and were unused. Route the five encode sites through them (`i32::from(proto::X::from(value))`) so encode and decode share the same generated authority, then delete the three tables. `FailureCategory` needs nothing, as noted in the issue — it has no envelope encode path.

Result:
- Mutation check, as suggested in the issue: before the change, renumbering `risk_level_code(RiskLevel::High)` to 2 passes `cargo test -p sysknife-types` (8+13 tests) — that is the gap. After the change there is no integer in the encode path left to mutate.
- `cargo test -p sysknife-types` all passing, `cargo fmt --check` and `cargo clippy -p sysknife-types --all-targets` clean.

Fixes #281