### PR TITLE
sysknife-types: add the missing RiskLevel wire anchor test

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,771 Rust tests and 72 frontend tests** form the current deterministic
+**1,772 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/crates/sysknife-types/tests/proto_bridge.rs
+++ b/crates/sysknife-types/tests/proto_bridge.rs
@@ -34,6 +34,12 @@ fn risk_level_round_trips_through_proto() {
     let local_level = RiskLevel::try_from(proto_level).unwrap();
 
     assert_eq!(local_level, RiskLevel::High);
+
+    // Anchor the encode direction too. Decode alone leaves the outbound map
+    // unpinned: every envelope test uses RiskLevel::Medium, and proto_bridge.rs
+    // hard-codes `risk_level: 2` in both fixtures, so High never traverses the
+    // map and swapping its arm keeps the whole type-layer suite green.
+    assert_eq!(i32::from(proto::RiskLevel::from(RiskLevel::High)), 3);
 }
 
 #[test]

--- a/crates/sysknife-types/tests/proto_bridge.rs
+++ b/crates/sysknife-types/tests/proto_bridge.rs
@@ -29,6 +29,14 @@ fn failure_category_round_trips_through_proto() {
 }
 
 #[test]
+fn risk_level_round_trips_through_proto() {
+    let proto_level = proto::RiskLevel::try_from(3).unwrap();
+    let local_level = RiskLevel::try_from(proto_level).unwrap();
+
+    assert_eq!(local_level, RiskLevel::High);
+}
+
+#[test]
 fn request_envelope_round_trips_through_proto() {
     let value = RequestEnvelope {
         action_name: "InstallFlatpak".to_string(),

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -53,7 +53,7 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
 
-The deterministic workspace baseline is 1,771 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,772 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,771 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,772 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "b17ce802b69e166c95622f739749845e96bbda32"
+    "tests": "42b01ce426d93de2fe22804b0abf578a43882505"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-24T05:41:16+00:00"
+    "tests": "2026-08-26T04:36:39-06:00"
   },
-  "tests": 1771,
+  "tests": 1772,
   "version": 1
 }


### PR DESCRIPTION
Problem:
- `proto_bridge.rs` anchors `CallerRole`, `JobState` and `FailureCategory` each to a literal protobuf wire number so a .proto renumbering cannot pass unnoticed, but `RiskLevel` has no anchor — it only appears inside envelope round-trips, which encode and decode through mutually inverse hand-written tables and therefore cancel out. Renumbering both tables (e.g. Low=0, Medium=1, High=2) passes every test while a peer speaking the real .proto reads every High as Medium.

Solution:
- Add the anchor in the same shape as the three sibling tests: `proto::RiskLevel::try_from(3)` decoded to the local type, asserted equal to `RiskLevel::High`. The .proto authority is `RISK_LEVEL_HIGH = 3`.

Result:
- New test `risk_level_round_trips_through_proto` passes; the whole proto_bridge suite is 14/14. `cargo fmt --check` clean.

Fixes #231