### PR TITLE
chore(release): 0.9.1

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "homepage": "https://lacs-project.github.io/sysknife/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-08-24
+
+Four fixes from outside contributors, three of them closing the same class of
+gap. [#256](https://github.com/lacs-project/sysknife/pull/256) stopped a saved
+preference from closing the prompt envelope that contains it, then
+[#274](https://github.com/lacs-project/sysknife/pull/274) and
+[#280](https://github.com/lacs-project/sysknife/pull/280) removed U+2028 and
+U+2029 from both paths that render untrusted text: the one the model reads and
+the one the operator approves from.
+[#282](https://github.com/lacs-project/sysknife/pull/282) took the last
+hand-typed wire numbers out of the envelope encoder. No public item was removed,
+renamed or re-signed, so this is a patch.
+
 ### Fixed
 
 - **Two Unicode line separators reached the model as visual line breaks.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "tempfile",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "prost",
  "prost-build",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,11 +15,11 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.9.0" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.9.0" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.9.0" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.9.1" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.9.1" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.9.1" }
 chrono = "0.4"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.9.0" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.9.1" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -39,11 +39,11 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.9.0", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.9.1", features = ["test-support"] }
 # and `AttributionCensus::from_counts_for_tests`, so the verify renderers can be
 # tested without building signed chain rows. Dev-only: production builds of this
 # bin do not compile dev-dependencies, so the constructor stays unreachable there.
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.9.0", features = ["test-support"] }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.9.1", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "react": "^19.2.8",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.9.0" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.9.0" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.9.1" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.9.1" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.9.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.9.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.9.1" }
+sysknife-types = { path = "../sysknife-types", version = "0.9.1" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.9.0"
+version = "0.9.1"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.9.0" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.9.1" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,8 +17,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 test-support = []
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.9.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.9.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.9.1" }
+sysknife-types = { path = "../sysknife-types", version = "0.9.1" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -61,7 +61,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.9.0" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.9.1" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.9.0" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.9.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Six fixes since 0.9.0, four from outside contributors and three closing the same prompt-injection class: the preference envelope (#256), then U+2028/U+2029 on the model path (#274) and the operator path (#280). #282 removed the last hand-typed wire numbers from the envelope encoder.

## Why a patch and not 0.10.0

No public item was removed, renamed or re-signed, and no run that used to succeed now fails. #282 deleted three functions but they were private `fn`, and the integers it stopped hand-writing are the same ones the generated enum produces, so the encoding is byte-identical. By the table in [docs/release.md](docs/release.md#version-numbering) that is the last digit.

## Version surface

31 occurrences across 14 files, plus the 8 workspace crates in `Cargo.lock` (every gate runs `--locked`).

```
check_release_versions   All release versions match 0.9.1 (15 internal dependency pins checked)
check_public_claims      Published figures match the evidence artifacts
check_repo_completeness  clean
public-claims            PASS    registry-manifest      PASS
smithery-manifest        PASS    codex-plugin-manifest  PASS
release-rehearsal        PASS
registry preflight       all 7 slots available for 0.9.1
pre-commit board         1768/1768, baseline matched
```

Host validation in [docs/release-readiness.md](docs/release-readiness.md) is unchanged from 0.9.0: no new VM story run was recorded for this commit, and nothing here touches distro detection, the action catalogue or packaging.