### PR TITLE
fix(audit): report unrun binding checks

### DIFF
--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -310,8 +310,9 @@ pub struct AuditVerifyReport {
     /// `"cannot_verify"`. Reported separately from `status` so a clean
     /// authorisation trail can never paper over a tampered approval trail.
     pub approval_events_status: String,
-    /// `"consistent"` or `"missing_event"`: whether every event tip committed
-    /// by a transaction row is still present in the event chain.
+    /// `"consistent"`, `"not_checked"`, or `"missing_event"`: whether every
+    /// event tip committed by a transaction row is still present in the event
+    /// chain.
     pub binding_status: String,
     /// Backend label: a filesystem path for SQLite, the literal `"postgres"`
     /// for Postgres deployments.
@@ -1035,11 +1036,20 @@ fn outcome_label(outcome: &sysknife_daemon::audit_chain::VerifyOutcome) -> &'sta
     }
 }
 
+fn binding_outcome_label(outcome: &sysknife_daemon::audit_chain::BindingOutcome) -> &'static str {
+    use sysknife_daemon::audit_chain::BindingOutcome;
+    match outcome {
+        BindingOutcome::Consistent { .. } => "consistent",
+        BindingOutcome::NotChecked => "not_checked",
+        BindingOutcome::MissingEvent { .. } => "missing_event",
+    }
+}
+
 fn outcome_to_report(
     verification: sysknife_daemon::audit_chain::AuditVerification,
     backend: String,
 ) -> AuditVerifyReport {
-    use sysknife_daemon::audit_chain::{BindingOutcome, VerifyOutcome};
+    use sysknife_daemon::audit_chain::VerifyOutcome;
 
     // One helper for both report arms and for the `CannotVerify` arm below, so
     // the census can only reach the report one way. The first version of this
@@ -1055,11 +1065,7 @@ fn outcome_to_report(
         VerifyOutcome::CannotVerify { .. } => 0,
     };
     let approval_events_status = outcome_label(&verification.events).to_string();
-    let binding_status = match &verification.binding {
-        BindingOutcome::Consistent { .. } => "consistent",
-        BindingOutcome::MissingEvent { .. } => "missing_event",
-    }
-    .to_string();
+    let binding_status = binding_outcome_label(&verification.binding).to_string();
 
     // The detail fields describe the first *break*, wherever it was found. A
     // broken transaction chain is reported ahead of a broken event chain
@@ -1158,6 +1164,8 @@ fn with_socket_caveat(mut report: AuditVerifyReport, caveat: Option<String>) -> 
 }
 
 fn cannot_verify_report(backend: String, reason: String) -> AuditVerifyReport {
+    use sysknife_daemon::audit_chain::BindingOutcome;
+
     AuditVerifyReport {
         status: "cannot_verify".to_string(),
         rows_checked: 0,
@@ -1169,7 +1177,7 @@ fn cannot_verify_report(backend: String, reason: String) -> AuditVerifyReport {
         backend,
         events_checked: 0,
         approval_events_status: "cannot_verify".to_string(),
-        binding_status: "consistent".to_string(),
+        binding_status: binding_outcome_label(&BindingOutcome::NotChecked).to_string(),
         // The chain verdict for a report built before any row was read. Callers
         // that reach this constructor overwrite it when they know better.
         chain_status: "cannot_verify".to_string(),
@@ -1383,9 +1391,16 @@ mod tests {
     /// `null`. An agent alerting on attribution must be able to tell "no data" from
     /// "no account named", which a `0` here would hide.
     #[test]
-    fn a_report_for_a_store_that_was_never_read_nulls_every_count() {
+    fn an_unreadable_store_marks_binding_not_checked_and_nulls_every_count() {
+        use sysknife_daemon::audit_chain::BindingOutcome;
+
         let report = cannot_verify_report("/tmp/store.sqlite".into(), "no key".into());
 
+        assert_eq!(
+            binding_outcome_label(&BindingOutcome::NotChecked),
+            "not_checked"
+        );
+        assert_eq!(report.binding_status, "not_checked");
         assert!(report.attributed_rows.is_none());
         assert!(report.unattributed_rows.is_none());
         assert!(report.rows_without_principal.is_none());

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -1122,9 +1122,7 @@ fn cannot_verify_all(reason: String) -> AuditVerification {
             reason: reason.clone(),
         },
         events: VerifyOutcome::CannotVerify { reason },
-        binding: BindingOutcome::Consistent {
-            bindings_checked: 0,
-        },
+        binding: BindingOutcome::NotChecked,
         // The store or the key could not be opened, so no census was taken.
         // `None`, not a census of zero rows: a database nobody could read and an
         // empty one that read fine must not serialize the same way.
@@ -1377,17 +1375,7 @@ fn emit_verification(
             "rows_without_principal": census.map(|c| c.not_recorded()),
             "rows_unattested": census.map(|c| c.unattested()),
             "rows_naming_no_account": census.map(|c| c.unnamed()),
-            "binding": match &verification.binding {
-                BindingOutcome::Consistent { bindings_checked } => json!({
-                    "status": "consistent",
-                    "bindings_checked": bindings_checked,
-                }),
-                BindingOutcome::MissingEvent { transaction_seq, event_tip } => json!({
-                    "status": "missing_event",
-                    "transaction_seq": transaction_seq,
-                    "event_tip": event_tip,
-                }),
-            },
+            "binding": binding_json(&verification.binding),
         });
         log.println(
             &serde_json::to_string_pretty(&payload)
@@ -1473,6 +1461,9 @@ fn emit_verification(
                 "OK: {bindings_checked} row(s) still match the approval event they committed to"
             ));
         }
+        BindingOutcome::NotChecked => {
+            log.println("CANNOT VERIFY binding: transaction or approval-event rows were not read");
+        }
         BindingOutcome::MissingEvent {
             transaction_seq,
             event_tip,
@@ -1518,6 +1509,27 @@ fn outcome_json(outcome: &sysknife_daemon::audit_chain::VerifyOutcome) -> serde_
         VerifyOutcome::CannotVerify { reason } => json!({
             "status": "cannot_verify",
             "reason": reason,
+        }),
+    }
+}
+
+fn binding_json(outcome: &sysknife_daemon::audit_chain::BindingOutcome) -> serde_json::Value {
+    use sysknife_daemon::audit_chain::BindingOutcome;
+    match outcome {
+        BindingOutcome::Consistent { bindings_checked } => json!({
+            "status": "consistent",
+            "bindings_checked": bindings_checked,
+        }),
+        BindingOutcome::NotChecked => json!({
+            "status": "not_checked",
+        }),
+        BindingOutcome::MissingEvent {
+            transaction_seq,
+            event_tip,
+        } => json!({
+            "status": "missing_event",
+            "transaction_seq": transaction_seq,
+            "event_tip": event_tip,
         }),
     }
 }
@@ -2292,18 +2304,32 @@ mod tests {
     /// nothing was found: that is the same confusion as the counter this release
     /// replaced, one level up.
     #[test]
-    fn the_json_report_distinguishes_no_census_from_a_census_of_nothing() {
-        use sysknife_daemon::audit_chain::VerifyOutcome;
-        let text = rendered(
-            VerifyOutcome::CannotVerify {
-                reason: "audit database not found".to_string(),
+    fn the_json_report_marks_an_unreadable_binding_not_checked() {
+        use sysknife_daemon::audit_chain::BindingOutcome;
+        let verification = cannot_verify_all("audit database not found".to_string());
+
+        assert_eq!(verification.binding, BindingOutcome::NotChecked);
+        assert_eq!(verification.exit_code(), 2);
+        assert_eq!(binding_json(&verification.binding)["status"], "not_checked");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("verify.log");
+        let log = Logger::new(Some(&path)).expect("logger");
+        emit_verification(
+            &crate::cli::AuditVerifyArgs {
+                json: true,
+                pubkey: None,
             },
+            &log,
+            &verification,
+            "/tmp/test.db",
             None,
-            true,
         );
+        let text = std::fs::read_to_string(&path).expect("logger wrote the rendered output");
 
         let parsed: serde_json::Value =
             serde_json::from_str(&text).expect("--json must emit one JSON document");
+        assert_eq!(parsed["binding"]["status"], "not_checked");
         for key in [
             "attributed_rows",
             "unattributed_rows",

--- a/crates/sysknife-daemon/src/audit_chain.rs
+++ b/crates/sysknife-daemon/src/audit_chain.rs
@@ -1082,6 +1082,9 @@ fn parse_event_kind(raw: &str) -> Option<AuditEventKind> {
 pub enum BindingOutcome {
     /// Every committed tip is present in the event chain.
     Consistent { bindings_checked: u64 },
+    /// The transaction or approval-event rows could not be read, so the
+    /// cross-chain binding check did not run.
+    NotChecked,
     /// A transaction row committed to an event tip that no longer exists —
     /// approval events were deleted from the end of the event chain, which the
     /// event chain walk alone cannot see.
@@ -1417,10 +1420,12 @@ pub fn verify_all_with_pubkey(
 }
 
 /// Exit code for the binding check, on the same scale as
-/// [`outcome_to_exit_code`]: a missing event is a detected tamper (`1`).
+/// [`outcome_to_exit_code`]: a missing event is a detected tamper (`1`), while
+/// a check that could not run is inconclusive (`2`).
 pub fn binding_outcome_to_exit_code(outcome: &BindingOutcome) -> i32 {
     match outcome {
         BindingOutcome::Consistent { .. } => 0,
+        BindingOutcome::NotChecked => 2,
         BindingOutcome::MissingEvent { .. } => 1,
     }
 }
@@ -2915,7 +2920,7 @@ mod tests {
     }
 
     #[test]
-    fn binding_exit_codes_split_clean_from_tampered() {
+    fn binding_exit_codes_split_clean_tampered_and_unchecked() {
         assert_eq!(
             binding_outcome_to_exit_code(&BindingOutcome::Consistent {
                 bindings_checked: 0
@@ -2929,6 +2934,7 @@ mod tests {
             }),
             1
         );
+        assert_eq!(binding_outcome_to_exit_code(&BindingOutcome::NotChecked), 2);
     }
 
     #[test]

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -444,6 +444,10 @@ the same as "I checked and it's fine." When the three checks disagree, the
 worst wins, and `1` outranks `2`: if anything is provably broken, saying
 "could not verify" would understate what is known.
 
+When the store cannot be read, the cross-chain binding status is
+`not_checked`, not `consistent`; no transaction or approval-event rows were
+available to compare.
+
 ## Limits and honest scope {#limits-and-honest-scope}
 
 The chain is strong evidence, not a magic guarantee. Be precise about what


### PR DESCRIPTION
## Summary

Represent an unrun transaction-to-approval-event binding check separately from a successful zero-row check. When the audit store or key cannot be opened, CLI JSON and the MCP report now publish `not_checked` instead of `consistent`, while the aggregate result keeps exit code 2.

## Related Issue

Closes #277.

## Validation

- [x] Tests updated without changing the published test count
- [x] `cargo +stable test -p sysknife-daemon audit_chain --locked` — 83 passed
- [x] `cargo +stable test -p sysknife-cli binding --locked` — 2 passed
- [x] `cargo +stable fmt --all -- --check`
- [x] Clippy passed for `sysknife-daemon` and `sysknife-cli`; only the existing macOS-only vsock dead-code/unused-variable warnings were allowed
- [x] `npm ci`, production dependency audit, TypeScript check, and frontend baseline — 72 passed
- [x] Changed-file pre-commit hooks, Markdown lint, and repository secret scan
- [x] Documentation updated for the new machine-readable status
- [x] Security impact considered; no signing, verification, trust-boundary, or `verify_event_binding` behavior changed

`scripts/ci-local.sh --no-postgres` was also run on macOS. Its remaining failures reproduce platform assumptions already present on `main` (Linux-only vsock references, Ubuntu-only apt/distro tests, and Bash 4/GNU utility requirements); the Ubuntu PR checks are authoritative for those gates.

## Notes for Reviewers

`BindingOutcome::NotChecked` is a new public enum variant, so exhaustive downstream matches will need an arm. Under the project's 0.y versioning policy, that is a next-minor release consideration even though the runtime fix is small.

AI assistance disclosure: OpenAI Codex helped inspect the issue, implement the patch, and run the validation commands. I reviewed the resulting diff and test output before submission.
