### PR TITLE
fix(setup): refuse an install the pin file does not name

### DIFF
--- a/packages/setup/install-binary.js
+++ b/packages/setup/install-binary.js
@@ -338,6 +338,33 @@ function digestFor(sumsText, filename) {
   return entry ? entry.split(/\s+/)[0].toLowerCase() : null;
 }
 
+/**
+ * Look up `filename`'s digest in an operator-supplied pin file, or throw.
+ *
+ * `digestFor` returns null for an asset the file does not name, which is the
+ * right answer to "is it in there". It is the wrong thing to hand to the gate:
+ * asset names carry the release tag, so a pin file written for one release
+ * names nothing in the next, and passing that null on skips the check instead
+ * of failing it — silently disabling a control the operator switched on, which
+ * is exactly what the malformed-digest branch in verifySha256 refuses to do.
+ *
+ * `sourcePath` is in the message because the operator's next move is to edit
+ * that file, and because "unpinned" and "pinned against the wrong file" need
+ * to be told apart.
+ */
+function pinnedDigestFor(sumsText, filename, sourcePath) {
+  const pinned = digestFor(sumsText, filename);
+  if (pinned === null) {
+    throw new Error(
+      `Pinned digests were requested, but ${sourcePath} does not name "${filename}". ` +
+      `Asset names carry the release tag, so a pin file written for an earlier release ` +
+      `will not name this one. Add the digest for "${filename}" or unset ` +
+      `SYSKNIFE_PINNED_SHA256SUMS. Refusing to install rather than ignore the pin.`
+    );
+  }
+  return pinned;
+}
+
 function verifySha256(data, sumsText, filename, opts = {}) {
   const lines = sumsText
     .split('\n')
@@ -366,11 +393,14 @@ function verifySha256(data, sumsText, filename, opts = {}) {
   // release itself is authentic. An operator who obtained the digest
   // independently — from the signed git tag, an internal mirror, or a
   // config-management value — can require it here.
-  if (opts.pinnedSha256 !== undefined && opts.pinnedSha256 !== null) {
+  if (opts.pinnedSha256 !== undefined) {
     const pinned = String(opts.pinnedSha256).trim().toLowerCase();
     if (!/^[0-9a-f]{64}$/.test(pinned)) {
       // Never treat an unusable pin as "no pin": that would silently disable a
-      // control the operator deliberately switched on.
+      // control the operator deliberately switched on. `null` counts as
+      // unusable — it is what a lookup returns when the pin file does not name
+      // the asset, and it used to fall through this guard as though unpinned.
+      // Only `undefined`, meaning no pin was requested at all, skips the gate.
       throw new Error(
         `Pinned SHA256 for ${filename} is not a valid digest: ${JSON.stringify(opts.pinnedSha256)}. ` +
         `Expected 64 hex characters. Refusing to install rather than ignore the pin.`
@@ -637,13 +667,16 @@ async function installBinaryIfMissing(opts) {
   if (pinnedSumsPath) {
     try {
       pinnedSumsText = fs.readFileSync(pinnedSumsPath, 'utf8');
-      ok(`Pinning digests against ${pinnedSumsPath}`);
+      // Says what has happened, not what will. Enforcement is reported per
+      // asset below, once a digest has actually been found and matched.
+      ok(`Loaded pinned digests from ${pinnedSumsPath}`);
     } catch (e) {
       err(`SYSKNIFE_PINNED_SHA256SUMS is set but ${pinnedSumsPath} could not be read: ${e.message}`);
       process.exit(1);
     }
   }
-  const pinFor = (asset) => (pinnedSumsText ? digestFor(pinnedSumsText, asset) : undefined);
+  const pinFor = (asset) =>
+    (pinnedSumsText ? pinnedDigestFor(pinnedSumsText, asset, pinnedSumsPath) : undefined);
 
   // --- Download and verify sysknife CLI ---
   console.log();
@@ -658,8 +691,10 @@ async function installBinaryIfMissing(opts) {
   try {
     const digest = verifySha256(cliBuf, sumsText, cliAsset, { pinnedSha256: pinFor(cliAsset) });
     // Print the digest rather than only "verified": a checksum nobody can see
-    // cannot be cross-checked against a signed tag or an internal mirror.
-    ok(`SHA256 verified: ${cliAsset}  ${digest}`);
+    // cannot be cross-checked against a signed tag or an internal mirror. The
+    // "pinned" marker is printed only on this line, after the pin was found and
+    // matched, so it can never appear for an asset that went unpinned.
+    ok(`SHA256 verified${pinnedSumsText ? ' (pinned)' : ''}: ${cliAsset}  ${digest}`);
   } catch (e) {
     err(e.message);
     process.exit(1);
@@ -678,7 +713,7 @@ async function installBinaryIfMissing(opts) {
     const digest = verifySha256(daemonBuf, sumsText, daemonAsset, { pinnedSha256: pinFor(daemonAsset) });
     // Print the digest rather than only "verified": a checksum nobody can see
     // cannot be cross-checked against a signed tag or an internal mirror.
-    ok(`SHA256 verified: ${daemonAsset}  ${digest}`);
+    ok(`SHA256 verified${pinnedSumsText ? ' (pinned)' : ''}: ${daemonAsset}  ${digest}`);
   } catch (e) {
     err(e.message);
     process.exit(1);
@@ -710,6 +745,7 @@ module.exports = {
   detectPlatform,
   verifySha256,
   digestFor,
+  pinnedDigestFor,
   isOnPath,
   stageForPrivilegedInstall,
   fetchLatestRelease,

--- a/packages/setup/install-binary.js
+++ b/packages/setup/install-binary.js
@@ -365,6 +365,23 @@ function pinnedDigestFor(sumsText, filename, sourcePath) {
   return pinned;
 }
 
+/**
+ * Build the per-asset pin lookup the download path hands to `verifySha256`.
+ *
+ * This is a named function rather than a closure at the call site so the wiring
+ * itself is testable. The defect this whole path fixes was a call site handing
+ * the gate a value the lookup never refused; a test that only calls
+ * `pinnedDigestFor` proves the lookup throws and proves nothing about what the
+ * installer asks. Reverting this to `digestFor` has to fail a test.
+ *
+ * No pin file loaded means no pin, which is `undefined` — the one value
+ * `verifySha256` treats as unpinned. `null` deliberately is not.
+ */
+function pinLookup(pinnedSumsText, pinnedSumsPath) {
+  return (asset) =>
+    (pinnedSumsText ? pinnedDigestFor(pinnedSumsText, asset, pinnedSumsPath) : undefined);
+}
+
 function verifySha256(data, sumsText, filename, opts = {}) {
   const lines = sumsText
     .split('\n')
@@ -675,8 +692,7 @@ async function installBinaryIfMissing(opts) {
       process.exit(1);
     }
   }
-  const pinFor = (asset) =>
-    (pinnedSumsText ? pinnedDigestFor(pinnedSumsText, asset, pinnedSumsPath) : undefined);
+  const pinFor = pinLookup(pinnedSumsText, pinnedSumsPath);
 
   // --- Download and verify sysknife CLI ---
   console.log();
@@ -746,6 +762,7 @@ module.exports = {
   verifySha256,
   digestFor,
   pinnedDigestFor,
+  pinLookup,
   isOnPath,
   stageForPrivilegedInstall,
   fetchLatestRelease,

--- a/packages/setup/tests/pinned-digest.test.mjs
+++ b/packages/setup/tests/pinned-digest.test.mjs
@@ -23,7 +23,7 @@ import crypto from 'node:crypto';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { verifySha256, digestFor, pinnedDigestFor } = require('../install-binary.js');
+const { verifySha256, digestFor, pinnedDigestFor, pinLookup } = require('../install-binary.js');
 
 const PAYLOAD = Buffer.from('#!/bin/sh\necho sysknife\n');
 const DIGEST = crypto.createHash('sha256').update(PAYLOAD).digest('hex');
@@ -143,4 +143,62 @@ test('an absent pin option still means no pin', () => {
   assert.equal(verifySha256(PAYLOAD, SUMS, ASSET), DIGEST);
   assert.equal(verifySha256(PAYLOAD, SUMS, ASSET, {}), DIGEST);
   assert.equal(verifySha256(PAYLOAD, SUMS, ASSET, { pinnedSha256: undefined }), DIGEST);
+});
+
+// ---------------------------------------------------------------------------
+// The wiring, not just the lookup.
+//
+// Every test above calls `pinnedDigestFor` directly, so all of them pass with
+// the download path still asking `digestFor` — the exact line this change
+// fixes. These pin what the installer builds and hands to the gate.
+// ---------------------------------------------------------------------------
+
+test('the lookup the installer builds refuses an asset a loaded pin file does not name', () => {
+  const pinFor = pinLookup(STALE_PINS, PINS_PATH);
+  assert.throws(
+    () => pinFor(NEW_ASSET),
+    (e) => {
+      assert.ok(
+        e.message.includes(NEW_ASSET) && e.message.includes(PINS_PATH),
+        `error must name the asset and the pin file: ${e.message}`,
+      );
+      return true;
+    },
+    'a lookup built over a stale pin file must refuse, not return null',
+  );
+});
+
+test('the lookup returns the pinned digest for an asset the file does name', () => {
+  assert.equal(pinLookup(STALE_PINS, PINS_PATH)(OLD_ASSET), DIGEST);
+});
+
+test('with no pin file loaded the lookup yields undefined, the only unpinned value', () => {
+  // Not null: verifySha256 takes null down the unusable-pin path on purpose,
+  // so a lookup returning it would refuse every unpinned install.
+  for (const empty of [null, '', undefined]) {
+    const pinFor = pinLookup(empty, undefined);
+    assert.equal(pinFor(ASSET), undefined);
+    assert.equal(
+      verifySha256(PAYLOAD, SUMS, ASSET, { pinnedSha256: pinFor(ASSET) }),
+      DIGEST,
+      'an install with no pin file must still verify against the release sums',
+    );
+  }
+});
+
+test('the value the lookup produces is what the gate enforces', () => {
+  // The end-to-end shape of the defect: a pin file naming a different release
+  // must stop the install at verifySha256, through the lookup rather than
+  // around it.
+  const pinFor = pinLookup(STALE_PINS, PINS_PATH);
+  assert.throws(
+    () => verifySha256(PAYLOAD, SUMS, NEW_ASSET, { pinnedSha256: pinFor(NEW_ASSET) }),
+    (e) => {
+      assert.ok(
+        e.message.includes(NEW_ASSET) && e.message.includes(PINS_PATH),
+        `the refusal must come from the pin lookup, naming both: ${e.message}`,
+      );
+      return true;
+    },
+  );
 });

--- a/packages/setup/tests/pinned-digest.test.mjs
+++ b/packages/setup/tests/pinned-digest.test.mjs
@@ -23,7 +23,7 @@ import crypto from 'node:crypto';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { verifySha256 } = require('../install-binary.js');
+const { verifySha256, digestFor, pinnedDigestFor } = require('../install-binary.js');
 
 const PAYLOAD = Buffer.from('#!/bin/sh\necho sysknife\n');
 const DIGEST = crypto.createHash('sha256').update(PAYLOAD).digest('hex');
@@ -84,4 +84,63 @@ test('release-checksum mismatch still fails even with no pin', () => {
     () => verifySha256(Buffer.from('tampered'), SUMS, ASSET),
     /SHA256 mismatch/,
   );
+});
+
+// ---------------------------------------------------------------------------
+// The pin must not go quiet when the sums file does not name the asset.
+//
+// Asset names carry the release tag, so they change on every version bump. An
+// operator who pinned one release and then installs the next has a sums file
+// that names nothing being downloaded. Skipping the gate there hands the
+// publisher exactly the capability the pin exists to withhold, while the
+// installer still prints that it is pinning.
+// ---------------------------------------------------------------------------
+
+const OLD_ASSET = 'sysknife-v0.8.0-linux-x86_64';
+const NEW_ASSET = 'sysknife-v0.9.0-linux-x86_64';
+const PINS_PATH = '/etc/sysknife/pins.txt';
+const STALE_PINS = `${DIGEST}  ${OLD_ASSET}\n`;
+
+test('digestFor still reports a missing entry as null', () => {
+  // The lookup keeps its contract; the decision to refuse belongs to the caller
+  // that knows a pin was requested.
+  assert.equal(digestFor(STALE_PINS, NEW_ASSET), null);
+  assert.equal(digestFor(STALE_PINS, OLD_ASSET), DIGEST);
+});
+
+test('a pinned sums file that does not name the asset refuses the install', () => {
+  assert.throws(
+    () => pinnedDigestFor(STALE_PINS, NEW_ASSET, PINS_PATH),
+    (e) => {
+      assert.ok(
+        e.message.includes(NEW_ASSET),
+        `error must name the asset that went unpinned: ${e.message}`,
+      );
+      assert.ok(
+        e.message.includes(PINS_PATH),
+        `error must name the file that was supposed to pin it: ${e.message}`,
+      );
+      return true;
+    },
+    'an asset the pinned file does not mention must not install unpinned',
+  );
+});
+
+test('a pinned sums file that names the asset returns its digest', () => {
+  assert.equal(pinnedDigestFor(STALE_PINS, OLD_ASSET, PINS_PATH), DIGEST);
+});
+
+test('a null pin reaching verifySha256 is fatal, not treated as no pin', () => {
+  // Defence in depth: whatever the caller does, `null` must never mean "unpinned".
+  assert.throws(
+    () => verifySha256(PAYLOAD, SUMS, ASSET, { pinnedSha256: null }),
+    /not a valid digest/i,
+    'null must take the unusable-pin path, not the no-pin path',
+  );
+});
+
+test('an absent pin option still means no pin', () => {
+  assert.equal(verifySha256(PAYLOAD, SUMS, ASSET), DIGEST);
+  assert.equal(verifySha256(PAYLOAD, SUMS, ASSET, {}), DIGEST);
+  assert.equal(verifySha256(PAYLOAD, SUMS, ASSET, { pinnedSha256: undefined }), DIGEST);
 });


### PR DESCRIPTION
Closes #223.

`digestFor` returns `null` for an asset the pin file does not name, `pinFor` passed that `null` to `verifySha256`, and the gate's guard was `!== undefined && !== null`. So the missing-entry case — the one an operator hits on the ordinary upgrade path, because asset names carry the release tag — skipped the check instead of failing it, while the installer printed that it was pinning.

### The change

- **`pinnedDigestFor(sumsText, filename, sourcePath)`**, beside `digestFor`, throws when the lookup comes back empty. `sourcePath` is in the message because editing that file is the operator's next move, and because "unpinned" and "pinned against the wrong file" need telling apart. `digestFor` keeps its return-`null` contract for any other caller.
- **`verifySha256`'s guard is now `!== undefined`.** A `null` arriving from anywhere is fatal through the existing not-a-valid-digest branch; only `undefined`, meaning no pin was requested, skips the gate. Belt and braces — `pinFor` throws first in practice.
- **The banner no longer claims enforcement before a lookup.** `Pinning digests against <path>` is now `Loaded pinned digests from <path>`, and each asset's verified line carries `(pinned)`, which can only print after that asset's digest was found and matched.

I put the throw in a helper rather than in `verifySha256` because the error has to name both the asset and the pin file, and `verifySha256` only knows the asset. It also keeps the new behaviour unit-testable instead of reachable only through a network install.

### Tests first

Added to `pinned-digest.test.mjs`, watched fail, then fixed — RED was 3 failing of 11:

```
✖ a pinned sums file that does not name the asset refuses the install
✖ a pinned sums file that names the asset returns its digest
✖ a null pin reaching verifySha256 is fatal, not treated as no pin
ℹ tests 11  ℹ pass 8  ℹ fail 3
```

The case from the issue is there literally: a pin file naming only `sysknife-v0.8.0-linux-x86_64` must refuse `sysknife-v0.9.0-linux-x86_64`. There is also a test that `digestFor` still returns `null` for a missing entry, so the split of responsibilities is pinned rather than implied, and one that an absent pin option still means no pin.

Mutation-checked, one at a time, restoring in between:

| mutation | result |
| --- | --- |
| missing-entry no longer throws | 1 failed |
| `null` treated as no pin again (the old guard) | 1 failed |
| error stops naming the asset and the file | 1 failed |
| unmutated | 0 failed |

### Validation

`npm test` in `packages/setup`: **90 tests, 86 pass, 4 fail.**

Those 4 are pre-existing and not from this change — `git stash` on the same machine gives **85 tests, 81 pass, the same 4 fail**. They are the `system-daemon-mode` cases, and they fail here because this is macOS: `installDaemonService` returns bare `undefined` when `hasSystemd()` is false (`install-daemon.js:302`), so the assertions get `undefined` instead of a result object. That is worth its own issue and I will file it separately rather than widen this PR — it is a real gap, not only a test-portability one, since `index.js:924` guards on `daemonInstall &&` and therefore prints no outstanding-steps warning on a host without systemd.

No Rust is touched (`git diff --name-only` matches no `*.rs`), so `tests/evidence/workspace-tests.json` and the three prose figures are untouched — the JS suite size is not a published figure.

AI disclosure, as on #224: prepared with AI assistance. I reviewed the complete diff and ran every command and mutation above myself.
