### PR TITLE
docs: write down the contributor norms the tracker has been teaching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,13 @@ the design direction before you sink time into a PR. For tiny fixes
 (typos, comment improvements, a missing test), skip the issue and go
 straight to a PR.
 
+**Say so in the thread before you start.** We add the `claimed` label when
+someone does, and that label is what everyone else reads. Two contributors
+picked up the same issue a minute apart recently and one of them lost the work.
+A one-line comment prevents it. If an issue already carries `claimed` and the
+thread has been quiet for a week, say you are taking it over rather than opening
+a competing PR.
+
 ### 2. Branch, code, test
 
 ```sh
@@ -84,6 +91,19 @@ cargo fmt --all -- --check
 **TDD is the project rhythm.** Write the failing test first, watch it
 fail, then write the minimum code to make it pass. The test suite is the
 contract.
+
+**One command runs the whole board.**
+
+```sh
+scripts/ci-local.sh
+```
+
+It reproduces every gate CI runs, including the ones that only fail after the
+obvious ones pass: the evidence artifact below, the prose claim screen over
+every doc that carries a published figure, ShellCheck, and the registry
+manifests. A per-crate run like
+`cargo test -p sysknife-types` never touches those, so a green crate is not a
+green board.
 
 **Adding or removing a Rust test moves a published figure.** The suite size lives
 in `tests/evidence/workspace-tests.json`, and `README.md`,
@@ -127,12 +147,56 @@ Bodies should explain *why*. The diff already says what.
 - Sign off your commits if your employer asks for DCO; we don't require
   it but we accept it.
 
+**Before you open it.** Three habits account for most of the rework on this
+tracker, and each is cheap:
+
+- Run `scripts/ci-local.sh`. A compile error in a crate your machine cannot
+  build is still a compile error, and finding it costs a review round.
+- Read `git status` before committing. Plans, prompts, harness logs and scratch
+  directories belong outside the tree. Stage explicit paths rather than `-A`,
+  which also sweeps up anything a parallel session left behind.
+- Report only what you ran. If you filtered a test run by name, say which names.
+  A validation list shorter than the diff describes coverage that does not exist,
+  and the test it skipped is usually the one that fails.
+
+**Check `main` before calling a failure pre-existing.** `main` is green and its CI
+history is public. A failure that appears only on your branch is yours. One that
+appears only on your machine is worth an issue with the output, because a flake
+in this suite is worth knowing about either way.
+
+**Your first PR needs a maintainer to approve each CI run.** GitHub holds fork
+workflows until you have something merged here, and it holds them again after
+every push. An empty check board is not a green one, so wait for the runs to
+appear before drawing conclusions from them, and say so in the thread if they
+look stuck.
+
 ### 5. Review
 
 Every PR gets a review pass + a sonnet code-reviewer agent dispatch
 (automatic). Security-sensitive PRs (privilege boundary, IPC, validators,
 audit chain) also get a red-team agent dispatch. Aim for review turnaround
 under 48h; ping in the PR if you've been waiting longer.
+
+## Working with an AI assistant
+
+Use one if it helps. Several merged changes here were written with one, and
+[#274](https://github.com/lacs-project/sysknife/pull/274) is the model: the
+author named the tool that assisted, reviewed the whole diff themselves, and
+every figure in the description came from a run they had actually done.
+
+Two things are asked in return, and neither is about the tool.
+
+Read the diff before you open the PR. You are its author. Review here goes into
+tracing a change to a live path and mutation-testing the guards it touches, and
+that effort is wasted on a diff nobody has read.
+
+Do not let it write claims you have not checked. A validation checklist states
+what happened rather than offering a template to fill in. The costliest version
+of this is a confident summary attached to a branch that does not compile,
+because a reviewer who believes it stops reading.
+
+Disclosure is welcome and never counts against a PR. It tells a reviewer where to
+look harder, which helps both of us.
 
 ## Trust-boundary rules
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -25,6 +25,31 @@ Behaviour counts, not only types. v0.9.0 also made `sysknife-setup` refuse a
 malformed `.mcp.json` that earlier versions overwrote, so a run that used to
 succeed now exits 1. No signature changed and it is still a compatibility break.
 
+### Public enums stay exhaustive
+
+Adding a variant to a `pub enum` that is not `#[non_exhaustive]` is a major change
+under [Cargo's rules](https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new),
+because a downstream `match` stops compiling. In the `0.y` series that moves the
+middle digit. `BindingOutcome` gained `NotChecked` in
+[#289](https://github.com/lacs-project/sysknife/pull/289), so that change ships in
+0.10.0 rather than 0.9.2.
+
+Marking those enums `#[non_exhaustive]` would make every later variant free, and
+this project deliberately does not. `sysknife-cli` matches `BindingOutcome` across
+a crate boundary in every place it reports one, and the compiler refusing to build
+until each of those readers has an arm is a guard the codebase relies on by
+design. `audit_chain.rs`
+argues the same point about the signing-generation tag, where an `if let` chain
+would have let a new generation encode byte-identically to `LegacyV1`.
+
+That PR is the evidence it works. Adding one variant forced both the MCP report
+and the CLI JSON writer to decide what to print, which is why both files are in
+that diff. Under a wildcard arm the new state would have reached an operator as
+silence, on a tool whose whole job is saying what it does not know.
+
+So the trade is deliberate: a variant costs a minor bump and buys a compile error
+instead of a silent gap.
+
 ### After 1.0.0
 
 Once the public API is declared stable the digits take their usual


### PR DESCRIPTION
Five outside PRs landed this week. The rework in most of them traced to the same handful of things, none of which were written down anywhere.

## CONTRIBUTING.md

- **Claim it in the thread first.** Two contributors took the same issue a minute apart and one lost the work. The `claimed` label is the signal; the section also says what to do when a claimed issue has gone quiet.
- **`scripts/ci-local.sh` reproduces the whole board**, with the reason it matters: a per-crate run never touches the published-figure coupling, so a green crate is not a green board.
- **A pre-open list**: run the board, read `git status` before committing (harness logs and scratch directories stay out of the tree; stage explicit paths rather than `-A`), and report only what you ran.
- **Check `main` before calling a failure pre-existing.**
- **A fork's first PR needs approval on every run**, so an empty check board is not a green one.
- **A section on AI assistants.** #274 is named as the model: tool disclosed, diff read by its author, every figure from a run that happened. Disclosure is welcome and never counts against a PR.

## docs/release.md

Why public enums stay exhaustive. Adding a variant is a middle-digit bump under Cargo's rules, so #289 ships in 0.10.0 rather than 0.9.2. Marking those enums `#[non_exhaustive]` would make the next variant free at the cost of a compile-time guard this codebase leans on by design, and #289 is the worked example: one variant forced both readers to decide what to print.

## No hardcoded counts

The first draft said "eleven places" and "sixteen files". Both were removed rather than corrected. The first had already rotted (#289's merge made it 17), and `docs/release.md` is not in `CLAIM_FILES`, so a figure there rots unscreened. That is what #229 and #278 are about.

Docs only. Claim screen, `public-claims.test.sh` and markdownlint all pass; pre-commit board green at 1769.