### PR TITLE
fix(e2e): stop atomic-vm.sh copying the Ubuntu harness's disks into the guest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Check Ubuntu VM bootstrap contract
         run: bash tests/e2e/ubuntu-vm-bootstrap.test.sh
 
+      - name: Check no harness syncs another harness's VM disk into its guest
+        run: bash tests/e2e/vm-sync-parity.test.sh
+
       - name: Lint markdown
         run: |
           markdownlint-cli2 \

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -280,6 +280,7 @@ run_hygiene_group() {
     run_step 'hygiene: ubuntu-vm-bootstrap.test.sh' bash "$repo_root/tests/e2e/ubuntu-vm-bootstrap.test.sh"
     run_step 'hygiene: provider-parity.test.sh' bash "$repo_root/tests/e2e/provider-parity.test.sh"
     run_step 'hygiene: story-metadata.test.sh' bash "$repo_root/tests/e2e/story-metadata.test.sh"
+    run_step 'hygiene: vm-sync-parity.test.sh' bash "$repo_root/tests/e2e/vm-sync-parity.test.sh"
 
     if have markdownlint-cli2; then
         run_step 'hygiene: markdownlint-cli2' hygiene_markdownlint

--- a/tests/e2e/atomic-vm.sh
+++ b/tests/e2e/atomic-vm.sh
@@ -59,6 +59,21 @@ VARIANT="$(printf '%s' "${SYSKNIFE_VM_VARIANT:-silverblue}" | tr '[:upper:]' '[:
 VM_DIR="${SYSKNIFE_VM_DIR:-tests/e2e/vm}"
 VM_USER="${SYSKNIFE_VM_USER:-lacsdev}"
 
+# What never goes into the guest. `cmd_sync` and `cmd_provision` share one list
+# so they cannot drift apart, and so the sibling harness's VM directory is not
+# forgotten again: tests/e2e/ubuntu-vm holds multi-gigabyte qcow2 overlays that
+# are gitignored but sit in the worktree, and copying them filled the guest's
+# 38G disk mid-rsync. tests/e2e/ubuntu-vm.sh has excluded both directories since
+# it was written; this script excluded only its own.
+RSYNC_EXCLUDES=(
+    --exclude=target
+    --exclude=node_modules
+    --exclude=.git
+    --exclude="$VM_DIR"
+    --exclude=tests/e2e/vm
+    --exclude=tests/e2e/ubuntu-vm
+)
+
 # quickget's canonical capitalized edition name for the `quickget` CLI.
 # quickget writes the config file with the edition lowercased.
 case "$VARIANT" in
@@ -278,8 +293,7 @@ cmd_sync() {
     port="$(vm_ssh_port)"
     repo_root="$(git rev-parse --show-toplevel)"
     log "Syncing repo to VM (no build, no provision)..."
-    rsync -az --exclude=target --exclude=node_modules --exclude=.git \
-        --exclude="$VM_DIR" \
+    rsync -az "${RSYNC_EXCLUDES[@]}" \
         -e "ssh $(ssh_opts) -p $port" \
         "$repo_root/" "${VM_USER}@127.0.0.1:/home/${VM_USER}/sysknife/"
     log "Sync complete. Run '$0 test-exec' or '$0 test-daemon' to exercise the new scripts."
@@ -292,8 +306,7 @@ cmd_provision() {
     port="$(vm_ssh_port)"
     repo_root="$(git rev-parse --show-toplevel)"
     log "Copying repo to VM via rsync on port $port..."
-    rsync -az --exclude=target --exclude=node_modules --exclude=.git \
-        --exclude="$VM_DIR" \
+    rsync -az "${RSYNC_EXCLUDES[@]}" \
         -e "ssh $(ssh_opts) -p $port" \
         "$repo_root/" "${VM_USER}@127.0.0.1:/home/${VM_USER}/sysknife/"
     log "Running provisioner inside the VM..."

--- a/tests/e2e/vm-sync-parity.test.sh
+++ b/tests/e2e/vm-sync-parity.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# vm-sync-parity.test.sh — no harness may copy another harness's VM disk into
+# its own guest.
+#
+# tests/e2e/ubuntu-vm.sh has excluded both tests/e2e/vm and
+# tests/e2e/ubuntu-vm from its repo-to-guest rsync since it was written.
+# tests/e2e/atomic-vm.sh excluded only its own. So a worktree that had run the
+# Ubuntu harness carried three qcow2 overlays totalling 24G, and provisioning
+# the Fedora guest pushed them across the wire until its 38G disk filled:
+#
+#   rsync: [receiver] write failed on ".../tests/e2e/ubuntu-vm/noble/overlay.qcow2":
+#   No space left on device (28)
+#
+# The overlays are gitignored, so nothing in review or CI ever saw them, and a
+# clean checkout provisions fine. The failure needs a contributor who ran both
+# harnesses, which is the contributor most likely to be trusted.
+#
+# Two design rules, following provider-parity.test.sh:
+#
+#   * The excluded directories are derived from .gitignore, never restated
+#     here, so a third harness with a gitignored VM directory joins the rule
+#     on its own.
+#   * Every repo-to-guest rsync is checked, not one per script. A script with
+#     a correct `sync` and a stale `provision` is the bug this test exists for.
+#
+# Host-side only: greps scripts, needs no VM, no daemon and no network.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gitignore="$repo_root/.gitignore"
+[ -f "$gitignore" ] || { printf 'missing file: %s\n' "$gitignore" >&2; exit 1; }
+
+# Scripts that rsync the worktree into a guest.
+harnesses=(
+    "tests/e2e/ubuntu-vm.sh"
+    "tests/e2e/atomic-vm.sh"
+)
+for rel in "${harnesses[@]}"; do
+    [ -f "$repo_root/$rel" ] || { printf 'missing file: %s\n' "$rel" >&2; exit 1; }
+done
+
+# Derive the directories that hold VM state: gitignored directory entries under
+# tests/e2e/, reduced to their first component. A trailing slash is what marks
+# an entry as a directory, which is what separates tests/e2e/vm/ from the log
+# globs beside it.
+mapfile -t vm_dirs < <(
+    grep -E '^tests/e2e/[^/]+/([^/*]+/)*$' "$gitignore" \
+        | sed -E 's#^(tests/e2e/[^/]+)/.*#\1#' \
+        | sort -u
+)
+if [ "${#vm_dirs[@]}" -eq 0 ]; then
+    printf 'derived no VM directories from .gitignore; the rule cannot be checked\n' >&2
+    exit 1
+fi
+
+failures=0
+for rel in "${harnesses[@]}"; do
+    script="$repo_root/$rel"
+
+    # Every rsync that targets the guest's repo path. Counting them is the
+    # point: a script whose `sync` is right and whose `provision` is stale
+    # passes any check that only looks at the first one.
+    rsync_lines="$(grep -n 'rsync -az' "$script" || true)"
+    rsync_count="$(printf '%s' "$rsync_lines" | grep -c . || true)"
+    if [ "$rsync_count" -eq 0 ]; then
+        printf '%s: no `rsync -az` invocation found; this test no longer covers it\n' "$rel" >&2
+        failures=$((failures + 1))
+        continue
+    fi
+
+    for dir in "${vm_dirs[@]}"; do
+        # The exclude may be written literally or reached through a variable
+        # holding that default, so accept either spelling.
+        if grep -q -- "--exclude=$dir" "$script" \
+            || grep -qE "(VM_DIR|vm_dir)=\"?\\\$\{[A-Z_]+:-$dir\}" "$script"; then
+            continue
+        fi
+        printf '%s does not exclude %s from its guest sync (%s rsync invocation(s))\n' \
+            "$rel" "$dir" "$rsync_count" >&2
+        failures=$((failures + 1))
+    done
+
+    # A single shared exclude list is what keeps the invocations from drifting.
+    # Not mandatory, but if the excludes are inline they must be inline in all
+    # of them, so check each invocation carries the same exclude count.
+    counts="$(grep -o 'rsync -az[^\\]*' "$script" | grep -c 'exclude' || true)"
+    if [ "$counts" -ne 0 ] && [ "$counts" -ne "$rsync_count" ]; then
+        printf '%s: %s of %s rsync invocations carry inline excludes; the rest may be stale\n' \
+            "$rel" "$counts" "$rsync_count" >&2
+        failures=$((failures + 1))
+    fi
+done
+
+if [ "$failures" -ne 0 ]; then
+    printf '\nvm-sync-parity: %s failure(s)\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'vm-sync-parity: %s harness(es) exclude all %s VM directory(ies): %s\n' \
+    "${#harnesses[@]}" "${#vm_dirs[@]}" "${vm_dirs[*]}"


### PR DESCRIPTION
Provisioning the Fedora guest died mid-rsync, on a worktree that had also run the Ubuntu harness:

```
rsync: [receiver] write failed on ".../tests/e2e/ubuntu-vm/noble/overlay.qcow2":
No space left on device (28)
rsync error: error in file IO (code 11) at receiver.c(381)
```

`tests/e2e/ubuntu-vm/` held three qcow2 overlays totalling 24G (jammy 9.0G, noble 7.5G, resolute 6.9G), and `atomic-vm.sh` was pushing all of them into a 38G guest. Its rsync excluded `target`, `node_modules`, `.git` and its own `$VM_DIR`, and nothing else.

`tests/e2e/ubuntu-vm.sh` has excluded both `tests/e2e/vm` and `tests/e2e/ubuntu-vm` since it was written. This script never got that fix. It is the same drift `provider-parity.test.sh` was written for, and its header names `atomic-vm.sh` as the script that test's first version missed.

The overlays are gitignored, so no review and no CI run has seen them, and a clean checkout provisions fine. Reproducing it takes someone who has run both harnesses, which is the contributor most likely to be trusted with a destructive story suite.

### The change

`cmd_sync` and `cmd_provision` share one `RSYNC_EXCLUDES` array instead of repeating the list, so the next entry cannot land in one and miss the other.

`tests/e2e/vm-sync-parity.test.sh` derives the directories from `.gitignore` rather than restating them, so a third harness with a gitignored VM directory joins the rule with no edit. The trailing slash is what separates a directory entry from the log and cassette globs beside it, which must reach the guest. It checks every rsync invocation in each harness rather than the first, and fails when the derivation comes back empty instead of passing over nothing. Wired into `ci.yml` and `scripts/ci-local.sh`.

### Mutations, restoring in between

| mutation | result |
| --- | --- |
| drop the `ubuntu-vm` exclude (the original bug) | fails, names the script and the directory |
| one invocation keeps inline excludes while the shared list loses the entry | fails, reports 1 of 2 invocations |
| unmutated | passes, `2 harness(es) exclude all 2 VM directory(ies)` |

### Verified

`scripts/ci-local.sh`'s board via the pre-commit hook: fmt, clippy `--workspace --all-features --all-targets`, doc, and `cargo nextest run --workspace --locked` at 1,769/1,769 against the then-current baseline. Rebased onto `main` at 1,771 since; no Rust changed here.

`shellcheck --severity=warning` clean on `atomic-vm.sh`, `vm-sync-parity.test.sh` and `ci-local.sh`, checked against a negative control so a silent no-op could not read as clean. `yamllint` clean on `ci.yml`.

The Fedora guest re-provisions past the point it died, which is what sent me looking.
