### PR TITLE
fix(e2e): put an existing Rust toolchain on PATH before asking if one exists

### DIFF
--- a/tests/e2e/provision.sh
+++ b/tests/e2e/provision.sh
@@ -74,14 +74,24 @@ echo "Phase 1 already complete (found $LAYERED_MARKER). Continuing phase 2."
 # ---------------------------------------------------------------------------
 
 step "Install Rust via rustup"
+# Put an existing toolchain on PATH BEFORE asking whether one exists. This
+# script runs under sudo, whose secure_path does not include ~/.cargo/bin, so
+# `command -v cargo` answers no on a guest that already has cargo installed and
+# the download runs on every provision. That is wasteful when the network is
+# good and a hang when it is not: one re-run stalled at 10,612,736 of
+# 20,838,840 bytes of rustup-init and sat there, while `cargo 1.94.1` was
+# already installed two directories away.
+# shellcheck disable=SC1091
+source "$HOME/.cargo/env" 2>/dev/null || true
+export PATH="$HOME/.cargo/bin:$PATH"
 if ! command -v cargo &>/dev/null; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable \
         || fail "Install Rust"
+    # shellcheck disable=SC1091
+    source "$HOME/.cargo/env" 2>/dev/null || true
+    export PATH="$HOME/.cargo/bin:$PATH"
 fi
-# shellcheck disable=SC1091
-source "$HOME/.cargo/env" 2>/dev/null || true
-export PATH="$HOME/.cargo/bin:$PATH"
 cargo --version || fail "Rust install verification"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`provision.sh` runs under `sudo`, whose `secure_path` does not include `~/.cargo/bin`. So `command -v cargo` answers no on a guest that already has cargo installed, and the rustup download runs on every provision.

On a good network that costs 20 MB and a minute. On a bad one it hangs. A re-run of the Fedora guest stalled here and sat:

```
rustup-init downloaded:  10,612,736 bytes
rustup-init actual size: 20,838,840 bytes   (50.9%)
```

The provisioner was blocked behind that curl with load average 0.00 for 45 minutes, while `/root/.cargo/bin/cargo 1.94.1` was installed and working the whole time.

### Proven in the guest that hit it

```
$ sudo bash -c 'command -v cargo'
NOT-FOUND

$ sudo bash -c 'source $HOME/.cargo/env; export PATH=$HOME/.cargo/bin:$PATH; command -v cargo'
FOUND: cargo 1.94.1 (29ea6fb6a 2026-03-24)
```

`$HOME` is `/root` under sudo and `/root/.cargo/env` exists, so the toolchain was two lines of setup away from being visible.

### The change

Move the `source` and `PATH` export above the check, so the guard answers the question it was written to answer. The download branch re-sources afterwards, because a fresh install still needs `PATH` set before `cargo --version` verifies it.

### Verified

`scripts/ci-local.sh`'s board via the pre-commit hook: fmt, clippy `--workspace --all-features --all-targets`, doc, and `cargo nextest run --workspace --locked` at 1,771/1,771 with the baseline matching. `shellcheck --severity=warning` clean.
