### PR TITLE
chore: point the registries at the channel people actually install through

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/lacs-project/sysknife"
-homepage = "https://github.com/lacs-project/sysknife"
+homepage = "https://lacs-project.github.io/sysknife/"
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 description = "Approval-gated AI system administration CLI and MCP server"
 readme = "README.md"
-keywords = ["linux", "sysadmin", "mcp", "ai-agent"]
+keywords = ["linux", "sysadmin", "mcp", "ai-agent", "llm"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [[bin]]

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -31,8 +31,20 @@
   "keywords": [
     "sysknife",
     "mcp",
+    "model-context-protocol",
     "claude",
-    "linux"
+    "claude-code",
+    "cursor",
+    "codex",
+    "linux",
+    "sysadmin",
+    "ai-agent",
+    "llm",
+    "devops",
+    "systemd",
+    "ubuntu",
+    "fedora",
+    "audit-log"
   ],
   "license": "MIT",
   "mcpName": "io.github.lacs-project/sysknife",


### PR DESCRIPTION
### Where people actually arrive

| channel | figure |
| --- | --- |
| `npx sysknife-setup` (npm, last 30 days) | 2,368 |
| `cargo install sysknife-cli` (crates.io, all time) | 404 |

Both numbers include mirror and CI traffic, so neither is a user count. The ratio is the useful part: npm is roughly six times the busier door, and it was carrying four keywords.

```
"keywords": ["sysknife", "mcp", "claude", "linux"]
```

Sixteen now. Every addition is a term someone would type while having the problem this solves: `model-context-protocol` spelled out beside the acronym, the three clients the wizard configures (`claude-code`, `cursor`, `codex`), and the domain words that until now existed only in the GitHub topics (`sysadmin`, `ai-agent`, `llm`, `devops`, `systemd`, `ubuntu`, `fedora`, `audit-log`).

### The docs site had no route from crates.io

crates.io renders Homepage and Repository as two separate links. Both pointed at the same GitHub page, so none of the six crate pages reached the book at https://lacs-project.github.io/sysknife/ (live, HTTP 200, titled and described). `homepage` in `[workspace.package]` now points there. `repository` is unchanged, so the GitHub link stays.

`sysknife-cli` takes `llm` in its fifth keyword slot, which was empty. crates.io caps keywords at five and every other crate is already at four or five, so they keep theirs. Checked all six against the cap and the character rules.

### Verified

No code, no behaviour, no published figure. `scripts/check_release_versions.sh` still reports all 15 internal pins at 0.9.1, and `scripts/ci-local.sh` passes the full board via the pre-commit hook, including `cargo nextest run --workspace --locked` at 1,771/1,771.
