### PR TITLE
feat(docs): give every docs page a share card, and pin its image to the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Check grub-kargs-edit screens karg deletions
         run: bash tests/release/grub-kargs-edit.test.sh
 
+      - name: Check the docs share cards name an image the build produces
+        run: bash tests/release/docs-share-cards.test.sh
+
       - name: Check provider parity across E2E entry points
         run: bash tests/e2e/provider-parity.test.sh
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ on:
       # outside docs/. Without this the one file the build hard-depends on could
       # be renamed or deleted without ever triggering the build that would fail.
       - "theme/**"
+      # docs/images/social-preview.png is a symlink into assets/, and
+      # theme/head.hbs points every page's og:image at it. A new card image
+      # must redeploy the pages that advertise its dimensions.
+      - "assets/social-preview.png"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 

--- a/docs/images/social-preview.png
+++ b/docs/images/social-preview.png
@@ -1,0 +1,1 @@
+../../assets/social-preview.png

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -281,6 +281,7 @@ run_hygiene_group() {
     run_step 'hygiene: provider-parity.test.sh' bash "$repo_root/tests/e2e/provider-parity.test.sh"
     run_step 'hygiene: story-metadata.test.sh' bash "$repo_root/tests/e2e/story-metadata.test.sh"
     run_step 'hygiene: vm-sync-parity.test.sh' bash "$repo_root/tests/e2e/vm-sync-parity.test.sh"
+    run_step 'hygiene: docs-share-cards.test.sh' bash "$repo_root/tests/release/docs-share-cards.test.sh"
 
     if have markdownlint-cli2; then
         run_step 'hygiene: markdownlint-cli2' hygiene_markdownlint

--- a/tests/release/docs-share-cards.test.sh
+++ b/tests/release/docs-share-cards.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# docs-share-cards.test.sh — the docs pages' og:image must name a file the
+# build actually produces, at the size the tags declare.
+#
+# theme/head.hbs gives every docs page an Open Graph and Twitter card, so a
+# link shared into Slack, Mastodon, LinkedIn or HN renders as a card instead of
+# a bare URL. The image URL in those tags is absolute and hand-written, because
+# mdBook exposes the source path (`index.md`) rather than the built one and
+# handlebars has no string replace. A hand-written URL rots: rename the file,
+# move the site, change the image, and the tags keep pointing at a 404 that
+# nothing in the build notices. A card that fails to load is worse than no
+# card, because the scraper caches the failure.
+#
+# So derive both sides and compare:
+#
+#   og:image URL      ──strip──▶  site-url from book.toml  ──▶  images/social-preview.png
+#   book.toml `src`   ──join──▶   docs/images/social-preview.png  ──▶  must exist
+#   declared w/h      ──vs──▶     the PNG's own IHDR header
+#
+# Needs no mdbook, no network and no built book, so it runs in the same job as
+# the rest of tests/release.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+head_hbs="$repo_root/theme/head.hbs"
+book_toml="$repo_root/book.toml"
+for f in "$head_hbs" "$book_toml"; do
+    [ -f "$f" ] || { printf 'missing file: %s\n' "$f" >&2; exit 1; }
+done
+
+fail() { printf 'docs-share-cards: %s\n' "$1" >&2; exit 1; }
+
+# ── The URL the tags advertise ───────────────────────────────────────────────
+og_image="$(sed -nE 's#.*property="og:image" content="([^"]+)".*#\1#p' "$head_hbs" | head -1)"
+[ -n "$og_image" ] || fail 'theme/head.hbs declares no og:image'
+
+tw_image="$(sed -nE 's#.*name="twitter:image" content="([^"]+)".*#\1#p' "$head_hbs" | head -1)"
+[ "$tw_image" = "$og_image" ] \
+    || fail "twitter:image ($tw_image) and og:image ($og_image) name different files"
+
+# ── Where that URL lands in the source tree ──────────────────────────────────
+site_url="$(sed -nE 's#^site-url *= *"([^"]+)".*#\1#p' "$book_toml" | head -1)"
+[ -n "$site_url" ] || fail 'book.toml sets no site-url, so the URL cannot be checked'
+src_dir="$(sed -nE 's#^src *= *"([^"]+)".*#\1#p' "$book_toml" | head -1)"
+[ -n "$src_dir" ] || fail 'book.toml sets no src, so the URL cannot be checked'
+
+# Strip scheme+host, then the site-url prefix, leaving the path inside the book.
+url_path="${og_image#*://}"
+url_path="/${url_path#*/}"
+case "$url_path" in
+    "$site_url"*) rel="${url_path#"$site_url"}" ;;
+    *) fail "og:image path ($url_path) is not under book.toml's site-url ($site_url)" ;;
+esac
+[ -n "$rel" ] || fail "og:image resolves to the site root, not an image"
+
+asset="$repo_root/$src_dir/$rel"
+[ -f "$asset" ] \
+    || fail "og:image names $rel, but $src_dir/$rel does not exist, so every card 404s"
+
+# ── The size the tags declare must be the size the file is ───────────────────
+declared_w="$(sed -nE 's#.*property="og:image:width" content="([0-9]+)".*#\1#p' "$head_hbs" | head -1)"
+declared_h="$(sed -nE 's#.*property="og:image:height" content="([0-9]+)".*#\1#p' "$head_hbs" | head -1)"
+if [ -n "$declared_w" ] || [ -n "$declared_h" ]; then
+    read -r actual_w actual_h < <(python3 - "$asset" <<'PY'
+import struct, sys
+with open(sys.argv[1], 'rb') as fh:
+    header = fh.read(24)
+if header[:8] != b'\x89PNG\r\n\x1a\n':
+    raise SystemExit('og:image is not a PNG; the width/height check cannot read it')
+print(*struct.unpack('>II', header[16:24]))
+PY
+    )
+    [ "$declared_w" = "$actual_w" ] && [ "$declared_h" = "$actual_h" ] \
+        || fail "tags declare ${declared_w}x${declared_h} but $rel is ${actual_w}x${actual_h}"
+
+    # Below this, Slack, LinkedIn and X all drop to the small square card, which
+    # is the layout the summary_large_image tag exists to avoid.
+    if [ "$actual_w" -lt 1200 ] || [ "$actual_h" -lt 630 ]; then
+        fail "$rel is ${actual_w}x${actual_h}; summary_large_image needs at least 1200x630"
+    fi
+fi
+
+printf 'docs-share-cards: og:image %s -> %s/%s (%sx%s)\n' \
+    "$rel" "$src_dir" "$rel" "$actual_w" "$actual_h"

--- a/theme/head.hbs
+++ b/theme/head.hbs
@@ -1,0 +1,39 @@
+{{!
+  Extra <head> content for every docs page. mdBook injects this file verbatim;
+  the rest of the default theme is untouched.
+
+  Why: a link to any docs page rendered as a bare URL everywhere it was shared
+  — Slack, Mastodon, LinkedIn, HN — because the pages carried a description tag
+  and nothing else. GitHub had a social preview image; the docs site had no way
+  to reach it.
+
+  og:url is deliberately absent. mdBook exposes the source path (`index.md`),
+  not the built one, and handlebars has no string replace, so a derived URL
+  would name a file that does not exist. Scrapers fall back to the URL they
+  fetched, which is correct. A wrong canonical is worse than no canonical.
+
+  Every variable used here was checked against BOTH mdBook 0.4.40 (the version
+  .github/workflows/docs.yml pins) and 0.5.2, and renders identically.
+
+  The og:image URL is absolute and hand-written, for the same reason. It points
+  at docs/images/social-preview.png, which is a symlink into assets/ so the card
+  image has one source of truth: assets/raster/README.md names that file as the
+  one to upload to GitHub's own social-preview setting, and generates it from
+  the SVG. mdBook resolves the symlink and copies the content.
+
+  tests/release/docs-share-cards.test.sh derives both sides of that URL and
+  fails if they stop agreeing, because a card whose image 404s is worse than no
+  card: the scraper caches the failure.
+}}
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="{{ book_title }}">
+<meta property="og:title" content="{{ title }}">
+<meta property="og:description" content="{{ description }}">
+<meta property="og:image" content="https://lacs-project.github.io/sysknife/images/social-preview.png">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="SysKnife: an AI that administers Linux through typed, approval-gated, Ed25519-audited actions">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ title }}">
+<meta name="twitter:description" content="{{ description }}">
+<meta name="twitter:image" content="https://lacs-project.github.io/sysknife/images/social-preview.png">


### PR DESCRIPTION
A link to any page on lacs-project.github.io/sysknife rendered as a bare URL wherever it was shared. The pages carried a `description` tag and nothing else, so Slack, Mastodon, LinkedIn and HN had no title, no image and no site name to draw. GitHub has had a social preview image for months. The docs site had no route to it.

### The template

`theme/head.hbs` is mdBook's extra-head hook, so the rest of the default theme is untouched. `og:title` and `twitter:title` come from the page, so each chapter shares under its own name instead of the book's.

`og:url` is deliberately absent. mdBook exposes the source path (`index.md`), not the built one, and handlebars has no string replace, so any derived URL would name a file that does not exist. Scrapers fall back to the URL they fetched. A wrong canonical is worse than none.

Every variable used was checked against **mdBook 0.4.40**, which `docs.yml` pins, and **0.5.2**, and renders identically. The 0.4.40 binary was fetched and verified against the same sha256 the workflow checks:

```
mdbook.tar.gz: OK
mdbook v0.4.40
```

### The image is a symlink, not a copy

`docs/images/social-preview.png` points at `assets/social-preview.png`. `assets/raster/README.md` names that file as the one to upload to GitHub's own social-preview setting and gives the command that generates it from the SVG, so the card image keeps one source of truth and the repo does not carry 176K twice. mdBook resolves the symlink and copies the content into the output. `docs.yml` now triggers on that path, since a new image must redeploy the pages advertising its dimensions.

### The test, because a hand-written URL rots

`tests/release/docs-share-cards.test.sh` takes the og:image URL out of `head.hbs`, strips `book.toml`'s `site-url`, joins `book.toml`'s `src`, and requires the file to be there at the declared dimensions. Nothing is restated. It also refuses anything under 1200x630, since below that Slack, LinkedIn and X all drop to the small square card that `summary_large_image` exists to avoid.

A card whose image 404s is worse than no card, because the scraper caches the failure.

Mutations, restoring in between:

| mutation | result |
| --- | --- |
| one-character typo in the og:image path | fails, names the missing file |
| declared width no longer matches the PNG header | fails, prints both sizes |
| `twitter:image` diverges from `og:image` | fails, prints both URLs |
| `og:image` deleted | fails, says none is declared |
| the asset renamed in the source tree | fails, names the missing file |
| unmutated | passes |

### Verified

Built with both mdBook versions and read the rendered tags off `book/cli.html`:

```
og:title    CLI Reference - SysKnife
og:image    https://lacs-project.github.io/sysknife/images/social-preview.png
book/images/social-preview.png   179648 bytes, 1280x640
```

Wired into `ci.yml` beside its `tests/release` siblings and into `scripts/ci-local.sh`. Full board green via the pre-commit hook. `shellcheck --severity=warning` and `yamllint` clean.
