### PR TITLE
docs: stop asking contributors to chase a figure that moves without them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,32 @@ grep -rn 'Rust tests' README.md docs/introduction.md docs/distro-support.md
 CI gates both halves, so bumping the artifact alone turns `docs-and-hygiene` red
 after `rust` goes green.
 
+**Do not chase the figure.** It moved fifteen times in the twenty days to
+2026-08-24, so on any PR that waits a day or two the number you recorded stops
+being the answer, and that is not your problem to solve. Record it once, say in
+the PR how many tests you added, and if it has expired by the time the PR is
+ready the maintainer regenerates it at merge. Whoever merges is what moves the
+figure, so whoever merges carries it. If `rust` is red only on the baseline, the
+PR is not blocked on you.
+
+`scripts/test_baseline.sh` names both numbers when they disagree
+(`rust suite has 1772 tests, baseline says 1771`), so a red run tells you the
+answer rather than setting a puzzle.
+
+**A change that touches no Rust skips the Rust gate.** The workspace suite exists
+to stop a Rust regression reaching `main`, and a diff with no `.rs` file in it
+cannot cause one:
+
+```sh
+git diff --name-only upstream/main... | grep '\.rs$'   # empty means the gate does not apply
+```
+
+For such a diff the gate is the Node suite for the package you touched,
+`scripts/check_evidence_claims.py`, and CI on Ubuntu. Run the claim screen even
+for a JavaScript change: `packages/setup/index.js` is in `CLAIM_FILES`, and the
+screen is pure Python with no subprocess calls, so it runs anywhere Python does.
+Say which of the three you ran.
+
 **Which release your change lands in.** While SysKnife is in the `0.y` series, a
 change that breaks a consumer moves the middle digit and everything else moves the
 last one. [docs/release.md](docs/release.md#version-numbering) carries the rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,9 +126,12 @@ ready the maintainer regenerates it at merge. Whoever merges is what moves the
 figure, so whoever merges carries it. If `rust` is red only on the baseline, the
 PR is not blocked on you.
 
-`scripts/test_baseline.sh` names both numbers when they disagree
-(`rust suite has 1772 tests, baseline says 1771`), so a red run tells you the
-answer rather than setting a puzzle.
+`scripts/test_baseline.sh` names both numbers when they disagree, in the form
+`rust suite has <measured> tests, baseline says <recorded>`, so a red run tells
+you the answer rather than setting a puzzle. (Real digits are not written here on
+purpose: this file is screened by `scripts/check_evidence_claims.py`, and an
+illustrative figure reads as a published claim. That screen caught this very
+paragraph.)
 
 **A change that touches no Rust skips the Rust gate.** The workspace suite exists
 to stop a Rust regression reaching `main`, and a diff with no `.rs` file in it


### PR DESCRIPTION
Closes #306, and writes down the policy I gave in #297.

### The figure moves without the author

The recorded Rust test count moved fifteen times in the twenty days to 2026-08-24, 1681 to 1771. Any PR that adds a test and waits a day or two has its four figures invalidated by somebody else's merge, and `rust` stays red until the author re-derives a number they did not move.

It has cost four PRs, and in two of them the stale number came from me:

| PR | what happened |
| --- | --- |
| #284 | my review said 1769. It was 1772 by the time the author acted on it. |
| #275 | recorded 1771 from a base of 1768; needs 1774 rebased. |
| #260 | I quoted 1759 and worked out 1766. The answer is 1778 now. |
| #295 | the author could not run nextest at all, derived it from their own diff, and said so. |

So CONTRIBUTING now says: record it once, say how many tests you added, and if it has expired the maintainer regenerates it at merge. Whoever merges is what moves the figure. A `rust` job red only on the baseline does not block the author.

**One thing #306 proposed already exists.** I suggested making the `rust` job print the expected value on failure. `scripts/test_baseline.sh:126` already does:

```
test_baseline: rust suite has 1772 tests, baseline says 1771.
```

The run that made me think otherwise had hit the suite-failed path at `:91`, which withholds the count, correctly, since a failed suite has measured nothing. CONTRIBUTING now points at the behaviour rather than my adding it twice.

### A JavaScript change does not need the Rust gate

From #297, where a contributor was blocked on `cargo nextest run --workspace` for a change to `packages/setup` on a Windows host with no Linux build stack, and asked rather than bypassing it.

The workspace suite exists to stop a Rust regression reaching `main`. A diff with no `.rs` file in it cannot cause one, and that is checkable:

```sh
git diff --name-only upstream/main... | grep '\.rs$'   # empty means the gate does not apply
```

CONTRIBUTING now names what stands in its place: the Node suite for the package touched, `scripts/check_evidence_claims.py`, and CI on Ubuntu. It also says to run the claim screen anyway, since `packages/setup/index.js` is in `CLAIM_FILES` and the screen is pure Python with no subprocess calls, so it runs on Windows unchanged.

### Verified

Docs only. `markdownlint-cli2` clean on `CONTRIBUTING.md`, and the full board passed via the pre-commit hook with the baseline matching at 1,771.
