### PR TITLE
fix(make): refuse an install that cannot finish, before it writes anything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check the docs share cards name an image the build produces
         run: bash tests/release/docs-share-cards.test.sh
 
+      - name: Check the install knows every directory it writes into
+        run: bash tests/release/install-paths.test.sh
+
       - name: Check provider parity across E2E entry points
         run: bash tests/e2e/provider-parity.test.sh
 

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,16 @@ POLKIT      ?= /usr/share/polkit-1/rules.d
 SUDOERS     ?= /etc/sudoers.d
 HELPERS     ?= /usr/lib/sysknife
 
+# Every directory daemon-install writes into, in one place so the preflight
+# below cannot fall behind the recipe. tests/release/install-paths.test.sh
+# derives the recipe's own $(VAR) uses and fails if this list disagrees.
+INSTALL_DIRS = $(BINDIR) $(SYSUSERS) $(TMPFILES) $(SYSTEMD) $(POLKIT) \
+               $(SUDOERS) $(HELPERS)
+
 CARGO_BUILD_FLAGS ?= --release --locked
 
-.PHONY: build install uninstall daemon-install cli-install daemon-uninstall cli-uninstall check
+.PHONY: build install uninstall daemon-install daemon-install-preflight \
+	cli-install daemon-uninstall cli-uninstall check
 
 ## ── Build ────────────────────────────────────────────────────────────────────
 
@@ -38,6 +45,39 @@ CARGO_BUILD_FLAGS ?= --release --locked
 build:
 	cargo build $(CARGO_BUILD_FLAGS) -p sysknife-daemon -p sysknife-cli
 	@echo "Build complete. Binaries: target/release/sysknife-daemon, target/release/sysknife"
+
+## ── Preflight ────────────────────────────────────────────────────────────────
+
+# Refuse an install that cannot finish, before it writes anything.
+#
+# daemon-install is a sequence of `install` calls with no rollback, so a
+# directory that turns out to be unwritable halfway leaves a working systemd
+# unit and twelve sudo grants naming helper scripts that were never installed.
+# That is worse than not installing at all: the grants are live and their
+# targets are absent. Observed on Fedora Atomic, where /usr is read-only and
+# $(HELPERS) defaults underneath it (see issue #301).
+#
+# `install -D` creates missing parents, so the thing to test is the nearest
+# ancestor that exists, not the leaf.
+daemon-install-preflight:
+	@unwritable=""; \
+	for d in $(INSTALL_DIRS); do \
+		probe="$$d"; \
+		while [ ! -d "$$probe" ] && [ "$$probe" != "/" ]; do \
+			probe="$$(dirname "$$probe")"; \
+		done; \
+		[ -w "$$probe" ] || unwritable="$$unwritable $$d"; \
+	done; \
+	if [ -n "$$unwritable" ]; then \
+		echo "make: refusing to install; nothing has been written." >&2; \
+		echo "" >&2; \
+		echo "These directories are not writable:" >&2; \
+		for d in $$unwritable; do echo "  $$d" >&2; done; \
+		echo "" >&2; \
+		echo "On an rpm-ostree host (Silverblue, Kinoite, Sericea, Onyx)" >&2; \
+		echo "/usr is read-only. See docs/distro-support.md and issue #301." >&2; \
+		exit 1; \
+	fi
 
 ## ── Install ──────────────────────────────────────────────────────────────────
 
@@ -51,7 +91,7 @@ cli-install: build
 	install -Dm 755 target/release/sysknife $(BINDIR)/sysknife
 	@echo "CLI installed: $(BINDIR)/sysknife"
 
-daemon-install: build
+daemon-install: daemon-install-preflight build
 	install -Dm 755 target/release/sysknife-daemon $(BINDIR)/sysknife-daemon
 
 	# System user and group (idempotent via systemd-sysusers).

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -49,9 +49,38 @@ apt and a read-only root, so the Debian-family action set cannot apply.
 | **Ubuntu 22.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, **79/79**, recorded in `ubuntu-22.04-gpt-oss-120b.json` and fully reproduced by its `.replay.json` twin — zero misses, `cassette_audit.verdict` `ok`. This is the release whose twin exercises the recorded-rejection path: story 101's first call was refused by the provider (`tool_use_failed`), and the replay serves the refusal, the correction and the answer, 81 calls for 79 stories | **Validated** |
 | **Ubuntu 26.04 LTS** | apt, ufw, netplan, snap, AppArmor, systemd, containers | live-VM story suite, **79/79**, recorded in `ubuntu-26.04-gpt-oss-120b.json` and fully reproduced by its `.replay.json` twin — zero misses, `cassette_audit.verdict` `ok`; plus sudo-rs sudoers verification (26.04 ships sudo-rs 0.2.x; `visudo -cf` parses the SysKnife sudoers and every grant — including the trailing-`*` wildcard grants — is honoured) | **Validated** |
 | **Every other Ubuntu 20.04+ release** (20.04, 20.10, 21.x, 23.x, 25.x, 26.10, …) | Ubuntu/apt family | Eligible by release family; no per-release VM run | **Smoke-tested** |
-| **Fedora Silverblue 44** | rpm-ostree, Flatpak, toolbox, firewalld, systemd, containers | Harness and fixture coverage; no current live-VM run | **Experimental** (eligible, awaiting a fresh VM run) |
-| **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests | **Experimental** (eligible, awaiting a fresh VM run) |
+| **Fedora Silverblue 44** | rpm-ostree, Flatpak, toolbox, firewalld, systemd, containers | Harness and fixture coverage; no live-VM run on this release | **Blocked** (`make install` does not complete on rpm-ostree, [#301](https://github.com/lacs-project/sysknife/issues/301)) |
+| **Other Fedora Atomic 41+ variants** | rpm-ostree family | Detection and shared action tests, plus a live VM run on Fedora 43 Silverblue (2026-08-24) that provisioned and then stopped at `make install` | **Blocked** (`make install` does not complete on rpm-ostree, [#301](https://github.com/lacs-project/sysknife/issues/301)) |
 | **Fedora Workstation / Server** | `dnf` family incomplete | Detection tests only | **Experimental** |
+
+## Fedora Atomic cannot be installed yet
+
+A live run on Fedora 43 Silverblue on 2026-08-24 provisioned the guest and then
+stopped:
+
+```text
+install -Dm 755 packaging/sysknife-apt-pin-edit /usr/lib/sysknife/apt-pin-edit
+install: cannot create directory '/usr/lib/sysknife': Read-only file system
+```
+
+`HELPERS` defaults to `/usr/lib/sysknife`, and rpm-ostree mounts `/usr`
+read-only. The twelve privileged helper scripts have nowhere to go, and the path
+is not a free choice: twelve daemon constants and twelve `NOPASSWD` sudoers
+grants name it. [#301](https://github.com/lacs-project/sysknife/issues/301)
+carries the options and
+[discussion #307](https://github.com/lacs-project/sysknife/discussions/307) is
+where the shape is being argued.
+
+`make install` no longer discovers this halfway. `daemon-install-preflight`
+checks every directory in `INSTALL_DIRS` before the first write and refuses the
+whole install, naming the directories at fault. Before that, the run had already
+written the daemon binary, the systemd unit, the polkit rules and all twelve
+sudo grants, leaving live grants for helper scripts that did not exist.
+
+Everything above the install still holds: detection, the rpm-ostree action
+family and the atomic story family are implemented and covered by the workspace
+suite. What is missing is a way to put the helpers somewhere the daemon's own
+grants already point.
 
 The deterministic workspace baseline is 1,772 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -282,6 +282,7 @@ run_hygiene_group() {
     run_step 'hygiene: story-metadata.test.sh' bash "$repo_root/tests/e2e/story-metadata.test.sh"
     run_step 'hygiene: vm-sync-parity.test.sh' bash "$repo_root/tests/e2e/vm-sync-parity.test.sh"
     run_step 'hygiene: docs-share-cards.test.sh' bash "$repo_root/tests/release/docs-share-cards.test.sh"
+    run_step 'hygiene: install-paths.test.sh' bash "$repo_root/tests/release/install-paths.test.sh"
 
     if have markdownlint-cli2; then
         run_step 'hygiene: markdownlint-cli2' hygiene_markdownlint

--- a/tests/release/install-paths.test.sh
+++ b/tests/release/install-paths.test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# install-paths.test.sh — the install must know, before it writes anything,
+# every directory it is going to write into; and a path under a read-only
+# prefix must be redirected on hosts where that prefix is read-only.
+#
+# `make install` on Fedora Atomic wrote the daemon binary, the systemd unit,
+# the polkit rules and twelve sudo grants, then hit $(HELPERS) at
+# /usr/lib/sysknife, discovered /usr was read-only, and stopped. That left
+# live grants naming helper scripts that did not exist. The rpm-ostree branch
+# in tests/e2e/provision.sh redirects four path variables and was written when
+# there were two helpers and no $(HELPERS) variable; it has not changed since
+# f1d9806 while the helper count went to twelve. See issue #301.
+#
+# Two checks, both derived rather than restated:
+#
+#   1. $(INSTALL_DIRS), which the preflight iterates, must cover every $(VAR)
+#      the daemon-install recipe actually writes into. A preflight that has
+#      fallen behind the recipe is worse than none, because it reports a clean
+#      bill for a path it never looked at.
+#   2. Every path variable whose default sits under a prefix that rpm-ostree
+#      mounts read-only must be redirected by that branch, or be listed here
+#      as a known gap with the issue that tracks it.
+#
+# Host-side only: reads the Makefile and one shell script. No make, no network.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+makefile="$repo_root/Makefile"
+provision="$repo_root/tests/e2e/provision.sh"
+for f in "$makefile" "$provision"; do
+    [ -f "$f" ] || { printf 'missing file: %s\n' "$f" >&2; exit 1; }
+done
+
+fail_count=0
+note() { printf 'install-paths: %s\n' "$1" >&2; fail_count=$((fail_count + 1)); }
+
+# ── 1. INSTALL_DIRS must cover what daemon-install writes into ───────────────
+
+# The recipe runs from `daemon-install:` to the next line that starts a new
+# target or a comment block at column 0.
+recipe="$(awk '
+    /^daemon-install:/ { inside = 1; next }
+    inside && /^[^\t#]/ && NF { exit }
+    inside { print }
+' "$makefile")"
+[ -n "$recipe" ] || { printf 'could not extract the daemon-install recipe\n' >&2; exit 1; }
+
+# Variables the recipe writes into: the $(VAR) that appear as a destination.
+recipe_vars="$(printf '%s\n' "$recipe" \
+    | grep -oE '\$\([A-Z_]+\)' | tr -d '$()' | sort -u)"
+[ -n "$recipe_vars" ] || { printf 'derived no variables from the recipe\n' >&2; exit 1; }
+
+declared="$(sed -nE 's/^INSTALL_DIRS[[:space:]]*=[[:space:]]*(.*)$/\1/p' "$makefile")"
+# The assignment is line-continued, so pull the whole logical line.
+declared="$(awk '/^INSTALL_DIRS[[:space:]]*=/{ found=1 } found { print; if ($0 !~ /\\$/) exit }' "$makefile" \
+    | grep -oE '\$\([A-Z_]+\)' | tr -d '$()' | sort -u)"
+[ -n "$declared" ] || { printf 'Makefile declares no INSTALL_DIRS\n' >&2; exit 1; }
+
+missing="$(comm -23 <(printf '%s\n' "$recipe_vars") <(printf '%s\n' "$declared") || true)"
+for v in $missing; do
+    note "daemon-install writes into \$($v) but INSTALL_DIRS omits it, so the preflight never checks it"
+done
+
+# ── 2. read-only prefixes must be redirected on rpm-ostree ───────────────────
+
+# rpm-ostree mounts /usr read-only. /usr/local is a symlink to /var/usrlocal
+# and stays writable, so it does not count.
+readonly_on_ostree() {
+    case "$1" in
+        /usr/local/*) return 1 ;;
+        /usr/*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Known gaps: variable name, then the issue that tracks it. Keep this empty.
+declare -A known_gap=(
+    [HELPERS]="#301"
+)
+
+# The rpm-ostree branch's overrides, read from the script rather than restated.
+overrides="$(awk '
+    /rpm-ostree status --booted/ { inside = 1 }
+    inside && /^else/ { exit }
+    inside { print }
+' "$provision" | grep -oE '^[[:space:]]+[A-Z_]+=' | tr -d ' =' | sort -u)"
+[ -n "$overrides" ] || { printf 'derived no overrides from the rpm-ostree branch\n' >&2; exit 1; }
+
+checked=0
+for v in $declared; do
+    default="$(sed -nE "s/^${v}[[:space:]]*\\?=[[:space:]]*(.*)$/\\1/p" "$makefile" | head -1)"
+    # Resolve one level of $(PREFIX), the only indirection in use.
+    prefix_default="$(sed -nE 's/^PREFIX[[:space:]]*\?=[[:space:]]*(.*)$/\1/p' "$makefile" | head -1)"
+    default="${default//\$(PREFIX)/$prefix_default}"
+    [ -n "$default" ] || continue
+    checked=$((checked + 1))
+    readonly_on_ostree "$default" || continue
+    printf '%s\n' "$overrides" | grep -qx "$v" && continue
+    if [ -n "${known_gap[$v]:-}" ]; then
+        printf 'install-paths: KNOWN GAP %s defaults to %s and is not redirected on rpm-ostree (%s)\n' \
+            "$v" "$default" "${known_gap[$v]}"
+        continue
+    fi
+    note "$v defaults to $default, which rpm-ostree mounts read-only, and the ostree branch does not redirect it"
+done
+[ "$checked" -gt 0 ] || { printf 'resolved no variable defaults; the rule checked nothing\n' >&2; exit 1; }
+
+if [ "$fail_count" -ne 0 ]; then
+    printf '\ninstall-paths: %s failure(s)\n' "$fail_count" >&2
+    exit 1
+fi
+
+printf 'install-paths: INSTALL_DIRS covers all %s recipe destinations; %s defaults checked against the ostree overrides\n' \
+    "$(printf '%s\n' "$recipe_vars" | grep -c .)" "$checked"


### PR DESCRIPTION
Part of #301, the half that is wrong on every distro rather than only on rpm-ostree. The path question stays open in #301 and is being argued in discussion #307.

### The half-install

`daemon-install` is a sequence of `install` calls with no rollback. On Fedora 43 Silverblue it got this far before stopping:

```text
/usr/local/bin/sysknife-daemon              installed
/etc/systemd/system/sysknife-daemon.service installed, daemon-reload done
/etc/polkit-1/rules.d/50-sysknife.rules     installed
/etc/sudoers.d/sysknife                     installed  (all 12 helper grants)
/usr/lib/sysknife/                          Read-only file system
```

Twelve live `NOPASSWD` grants naming helper scripts that do not exist. Worse than not installing at all.

`daemon-install-preflight` walks `INSTALL_DIRS`, tests the nearest **existing** ancestor of each (since `install -D` creates parents), and refuses the whole install naming the directories at fault. It runs before `build`, so a host that cannot be installed to does not pay for a release build first.

Measured on the exact Fedora shape, with only `$(HELPERS)` unwritable:

```
$ make daemon-install PREFIX=$D SYSUSERS=$D/su ... SUDOERS=$D/so
make: refusing to install; nothing has been written.

These directories are not writable:
  /usr/lib/sysknife

files created under $D: 0
```

Zero, where it previously created the binary, the unit, the polkit rules and twelve grants.

### The test, derived both ways

`tests/release/install-paths.test.sh` checks two things and restates neither.

**`INSTALL_DIRS` must cover what the recipe writes into.** It extracts the `daemon-install` recipe and pulls its `$(VAR)` destinations out of it. A preflight that has fallen behind the recipe is worse than none, because it reports a clean bill for a path it never looked at.

**A default under a read-only prefix must be redirected.** It resolves each variable's default (following one level of `$(PREFIX)`), and requires anything under a prefix rpm-ostree mounts read-only to appear in the ostree branch's override list, which it reads out of `provision.sh`. `/usr/local` is excluded, being a symlink to `/var/usrlocal` and writable.

`HELPERS` is the one known gap, listed with `#301`, and it **prints on every run** rather than being silently excluded:

```
install-paths: KNOWN GAP HELPERS defaults to /usr/lib/sysknife and is not redirected on rpm-ostree (#301)
install-paths: INSTALL_DIRS covers all 7 recipe destinations; 7 defaults checked against the ostree overrides
```

Mutations, restoring in between:

| mutation | result |
| --- | --- |
| `INSTALL_DIRS` drops `HELPERS` | fails, names the variable and why it matters |
| `SYSUSERS` removed from the ostree override list | fails, names it |
| the known-gap entry deleted | `HELPERS` surfaces as a real failure, so the allowlist records an open item rather than hiding one |
| the ostree branch removed entirely | fails on the empty derivation instead of passing over nothing |
| unmutated | passes, with the gap reported |

Both the first and second were re-verified after a shellcheck `SC1087` fix to the line that resolves defaults, since I had edited the derivation itself.

### The docs were overstating

Both Fedora Atomic rows in `docs/distro-support.md` said "eligible, awaiting a fresh VM run". The run happened on 2026-08-24 and found this. They now say **Blocked** and name the issue, the Fedora 43 evidence sits on the "Other Fedora Atomic 41+" row it actually supports rather than the 44 row, and a new section explains the constraint that the preflight's error message points at.

### Verified

Full board via the pre-commit hook. `shellcheck --severity=warning` clean with the real exit code checked, `yamllint` clean, `markdownlint` clean, claim screen agrees. Wired into `ci.yml` and `scripts/ci-local.sh`.
