### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "homepage": "https://lacs-project.github.io/sysknife/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,114 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-08-26
+
+The middle digit moves because [#289](https://github.com/lacs-project/sysknife/pull/289)
+added a variant to `BindingOutcome`, a public enum this codebase deliberately
+keeps exhaustive, so any downstream `match` over it stops compiling. That is the
+whole of the breaking change; nothing was removed, renamed or re-signed.
+
+Sixteen changes, seven of them from five outside contributors and two from
+Dependabot. Three closed cases where a check reported a verdict it had not
+earned: a Postgres auditor grading an event table it could not read, a binding
+check that never ran reported as consistent, and a pin file that stopped
+enforcing when it did not name the asset.
+
+### Changed
+
+- **`BindingOutcome` gained `NotChecked`.**
+  ([#289](https://github.com/lacs-project/sysknife/pull/289))
+  A cross-chain binding check that could not run used to be indistinguishable
+  from one that ran over zero rows and agreed. It now has its own variant,
+  mapping to exit `2` on the same inconclusive/detected scale as
+  `outcome_to_exit_code`. Public enums here stay exhaustive on purpose, so an
+  added variant is a compile-time prompt to handle it rather than a silent
+  default; [docs/release.md](docs/release.md#public-enums-stay-exhaustive) has
+  the reasoning. Thanks to @k4its1t.
+
+### Fixed
+
+- **The Postgres auditor graded evidence it never read.**
+  ([#295](https://github.com/lacs-project/sysknife/pull/295),
+  [#246](https://github.com/lacs-project/sysknife/issues/246))
+  `verify_all_from_config` swallowed every error from the approval-event read
+  with `unwrap_or_default()`, justified by pre-migration chains that have no
+  `audit_events` table. A revoked `SELECT`, a dropped table or a lost connection
+  became "zero approval events", which is either a clean bill for a trail nobody
+  read or, when a transaction row commits a non-empty event tip, a
+  `MissingEvent` published in the words operators are taught to read as deleted
+  approvals. It now asks `to_regclass` whether the table is genuinely absent and
+  fails closed on everything else. Thanks to @vsolano9.
+
+- **`SYSKNIFE_PINNED_SHA256SUMS` stopped enforcing when the pin file did not name
+  the asset.** ([#290](https://github.com/lacs-project/sysknife/pull/290),
+  [#223](https://github.com/lacs-project/sysknife/issues/223))
+  Asset names carry the release tag, so a pin file written for one release names
+  nothing in the next. The lookup returned `null`, the gate treated `null` as
+  "no pin", and the install proceeded unpinned with the control switched on. The
+  lookup now refuses, and the gate refuses `null` even if a future lookup hands
+  one over. Thanks to @vsolano9.
+
+- **The setup wizard reported success for a daemon it never installed.**
+  ([#293](https://github.com/lacs-project/sysknife/pull/293),
+  [#291](https://github.com/lacs-project/sysknife/issues/291))
+  `installDaemonService` returned bare `undefined` when systemd was absent while
+  its three siblings returned a result, and the caller gated the
+  outstanding-steps block on `mode === 'system'`. A host without systemd and a
+  deliberate `--daemon-mode=skip` both ended on the success banner. Thanks to
+  @vsolano9.
+
+- **`resolve_audit_store` read a permission error as a missing database.**
+  ([#275](https://github.com/lacs-project/sysknife/pull/275),
+  [#266](https://github.com/lacs-project/sysknife/issues/266))
+  `Path::exists` is false for both ENOENT and EACCES, so an unreadable `0700`
+  system store sent the operator to an empty per-user store instead of telling
+  them to use `sudo`. Thanks to @VedantMadane.
+
+- **The 4 MiB frame limit was declared in three places.**
+  ([#285](https://github.com/lacs-project/sysknife/pull/285),
+  [#230](https://github.com/lacs-project/sysknife/issues/230))
+  Now `sysknife_types::MAX_MESSAGE_BYTES`, with a test that walks the three
+  crates and asserts exactly one declaration. Thanks to @kragent66-glitch.
+
+- **`RiskLevel` was the one wire enum with no anchored protobuf number.**
+  ([#284](https://github.com/lacs-project/sysknife/pull/284),
+  [#231](https://github.com/lacs-project/sysknife/issues/231))
+  Anchored in both directions: the decode assertion alone left the outbound map
+  unpinned, because every envelope test uses `Medium` and both fixtures hard-code
+  `risk_level: 2`, so `High` never traversed the map. Thanks to @Georgefifth.
+
+- **`make install` failed halfway on an immutable-root host.**
+  ([#309](https://github.com/lacs-project/sysknife/pull/309),
+  [#301](https://github.com/lacs-project/sysknife/issues/301))
+  `daemon-install` wrote the binary, the systemd unit, the polkit rules and all
+  twelve sudo grants before discovering `/usr` was read-only, leaving live grants
+  for helper scripts that did not exist. A preflight now checks every directory
+  in `INSTALL_DIRS` and refuses the whole install before the first write. Fedora
+  Atomic remains uninstallable pending the path decision in #301.
+
+- **Two E2E harness defects that only appear on a machine that ran both VM
+  harnesses.** ([#296](https://github.com/lacs-project/sysknife/pull/296),
+  [#298](https://github.com/lacs-project/sysknife/pull/298))
+  `atomic-vm.sh` rsynced `tests/e2e/ubuntu-vm/`, 24 GB of gitignored qcow2
+  overlays, into a 38 GB guest; and `provision.sh` asked `command -v cargo`
+  before putting `~/.cargo/bin` on PATH under `sudo`, so it re-downloaded rustup
+  on every run.
+
+### Documentation
+
+- Contributor norms, the baseline-ownership convention, and the rule that a diff
+  with no `.rs` file in it does not need the Rust workspace gate
+  ([#292](https://github.com/lacs-project/sysknife/pull/292),
+  [#308](https://github.com/lacs-project/sysknife/pull/308)).
+- Every docs page now carries an Open Graph card, with a test tying the image URL
+  to a file the build produces
+  ([#302](https://github.com/lacs-project/sysknife/pull/302)).
+- npm keywords and the crates.io homepage now point at the docs site rather than
+  repeating the repository link
+  ([#300](https://github.com/lacs-project/sysknife/pull/300)).
+
+
 ## [0.9.1] — 2026-08-24
 
 Four fixes from outside contributors, three of them closing the same class of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,11 +15,11 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.9.1" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.9.1" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.9.1" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.10.0" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.10.0" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.10.0" }
 chrono = "0.4"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.9.1" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.10.0" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -39,11 +39,11 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.9.1", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.10.0", features = ["test-support"] }
 # and `AttributionCensus::from_counts_for_tests`, so the verify renderers can be
 # tested without building signed chain rows. Dev-only: production builds of this
 # bin do not compile dev-dependencies, so the constructor stays unreachable there.
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.9.1", features = ["test-support"] }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.10.0", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "react": "^19.2.8",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.9.1" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.9.1" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.10.0" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.10.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.9.1" }
-sysknife-types = { path = "../sysknife-types", version = "0.9.1" }
+sysknife-core = { path = "../sysknife-core", version = "0.10.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.10.0" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.9.1"
+version = "0.10.0"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.9.1" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.10.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,8 +17,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 test-support = []
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.9.1" }
-sysknife-types = { path = "../sysknife-types", version = "0.9.1" }
+sysknife-core = { path = "../sysknife-core", version = "0.10.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.10.0" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -61,7 +61,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.9.1" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.10.0" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.9.1" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.10.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Cuts 0.10.0. Sixteen changes since 0.9.1, seven of them from five outside contributors and two from Dependabot.

### Why the middle digit moves

One reason only. [#289](https://github.com/lacs-project/sysknife/pull/289) added `NotChecked` to `BindingOutcome`, a public enum this codebase keeps exhaustive on purpose, so a downstream `match` over it stops compiling. Nothing was removed, renamed or re-signed, and I re-confirmed the enum still carries no `#[non_exhaustive]` before writing that.

### Three fixes retired a verdict nobody had earned

- **#295** the Postgres auditor swallowed every error from the approval-event read, publishing either a clean bill for a trail nobody had read or a fabricated tamper in the words operators are taught to read as deleted approvals.
- **#289** a binding check that could not run was indistinguishable from one that ran over zero rows and agreed.
- **#290** `SYSKNIFE_PINNED_SHA256SUMS` stopped enforcing whenever the pin file did not name the asset, which is every release after the one it was written for.

### The lockfile is generated, not edited

Worth recording, because two wrong approaches each produced a `Cargo.lock` that looked right:

```
sed 's/0\.9\.1/0.10.0/g'      also rewrites the prefix of 0.9.12
                              -> five toml/dependency pins became 0.10.02

sed -E 's/\b0\.9\.1\b/0.10.0/' anchors correctly and still fails, because
                              memoffset is a real dependency at exactly 0.9.1
                              -> cargo metadata --locked refused the tree
```

No textual rule can separate our version from a dependency that happens to share it. The manifests move by anchored sed (40 lines, 14 files); `Cargo.lock` is regenerated by cargo and changes exactly **8 lines**, one per workspace package. The other six `0.9.1` occurrences in it were memoffset plus the five `0.9.12` pins, which accounts for all 14.

### Gates

| gate | result |
| --- | --- |
| `check_release_versions.sh v0.10.0` | all 15 internal pins at 0.10.0 |
| `check_registry_versions.sh v0.10.0` | all 7 registry slots free |
| `cargo metadata --locked` | clean |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-features --all-targets --locked -D warnings` | clean |
| `cargo nextest run --workspace --locked` | 1,775/1,775, baseline matching |
| `cargo doc --no-deps --workspace --locked` | clean |
| `postgres_store` contract | 7/7 against live Postgres 17 under podman |
| `release_rehearsal.sh --full` | passed; npm tarball 34.4 kB / 11 files, release profile built |
| hygiene board | all pass |

`ci-local.sh` reports `postgres-contract` as failing because it reaches for docker, where published ports reset on this host. Run under podman it is 7/7. Worth noting that the same suite also reports 7/7 with **no** database configured, in 0.31s against 1.41s, which is [#294](https://github.com/lacs-project/sysknife/issues/294) and still open.

### Credits, checked rather than recalled

My first draft of the changelog claimed eleven changes and six outside contributors, and omitted **@k4its1t**, the author of the very change that forces this minor bump. Corrected against actual PR authorship: @vsolano9 (3), @VedantMadane, @kragent66-glitch, @k4its1t, @Georgefifth. All five are credited by name in the entry.

Tag to follow once this lands, signed and verified.
