### PR TITLE
fix(setup): report incomplete wizard runs

### DIFF
--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -898,18 +898,23 @@ async function main() {
   // After install, probe whether the daemon is reachable so the "Try it"
   // section can give accurate next-step advice.
 
+  let daemonSocketReachable = null;
   const firstLocalSocket = targets.find(t => !t.socket.startsWith('vsock://') && t.socket.startsWith('/'));
   if (firstLocalSocket) {
     // Retrying, because the daemon was started seconds ago and systemd returns
     // before it binds. See checkSocketWithRetry.
-    const reachable = checkSocketWithRetry(firstLocalSocket.socket);
-    if (reachable === true) {
+    daemonSocketReachable = checkSocketWithRetry(firstLocalSocket.socket);
+    if (daemonSocketReachable === true) {
       ok(`Daemon socket reachable: ${firstLocalSocket.socket}`);
-    } else if (reachable === false) {
+    } else if (daemonSocketReachable === false) {
       warn(`Daemon socket not reachable after 6s: ${firstLocalSocket.socket}`);
       step('Check it with:  systemctl --user status sysknife-daemon');
     }
   }
+
+  const daemonSetupIncomplete = daemonInstall
+    && !daemonInstall.daemonInstalled
+    && daemonSocketReachable !== true;
 
   // ── Next steps ───────────────────────────────────────────────────────────
 
@@ -923,8 +928,9 @@ async function main() {
   //
   // This used to fire only for `mode === 'system'`, which left the two other
   // not-installed outcomes ending on the success banner: a host without systemd
-  // (which returned no result at all) and a deliberate skip.
-  if (daemonInstall && !daemonInstall.daemonInstalled) {
+  // (which returned no result at all) and a deliberate skip. A reachable socket
+  // is the exception: an externally managed daemon already makes setup usable.
+  if (daemonSetupIncomplete) {
     const headline = {
       system: 'The system daemon is not installed yet.',
       none:   'No daemon service was installed: systemd was not detected.',
@@ -979,7 +985,7 @@ async function main() {
   }
 
   console.log();
-  if (daemonInstall && !daemonInstall.daemonInstalled) {
+  if (daemonSetupIncomplete) {
     const remainingSteps = daemonInstall.manualSteps.length
       + (daemonInstall.mode === 'system' ? 1 : 0);
     const stepLabel = remainingSteps === 1 ? 'step' : 'steps';

--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -979,7 +979,14 @@ async function main() {
   }
 
   console.log();
-  ok('Setup complete');
+  if (daemonInstall && !daemonInstall.daemonInstalled) {
+    const remainingSteps = daemonInstall.manualSteps.length;
+    const stepLabel = remainingSteps === 1 ? 'step' : 'steps';
+    warn(`Setup incomplete: ${remainingSteps} ${stepLabel} left`);
+    process.exitCode = 3;
+  } else {
+    ok('Setup complete');
+  }
   console.log();
 }
 
@@ -1049,6 +1056,12 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   --dry-run     With --uninstall, print what would be removed and change
                 nothing.
   --help, -h    Show this help message and exit.
+
+\x1b[1mEXIT STATUS\x1b[0m
+  0  setup is usable
+  1  setup failed
+  2  command-line arguments are invalid or incomplete
+  3  setup finished with outstanding steps
 
 \x1b[1mDESCRIPTION\x1b[0m
   Interactive wizard that:

--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -980,7 +980,8 @@ async function main() {
 
   console.log();
   if (daemonInstall && !daemonInstall.daemonInstalled) {
-    const remainingSteps = daemonInstall.manualSteps.length;
+    const remainingSteps = daemonInstall.manualSteps.length
+      + (daemonInstall.mode === 'system' ? 1 : 0);
     const stepLabel = remainingSteps === 1 ? 'step' : 'steps';
     warn(`Setup incomplete: ${remainingSteps} ${stepLabel} left`);
     process.exitCode = 3;
@@ -1058,7 +1059,7 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   --help, -h    Show this help message and exit.
 
 \x1b[1mEXIT STATUS\x1b[0m
-  0  setup is usable
+  0  setup finished without reported outstanding steps
   1  setup failed
   2  command-line arguments are invalid or incomplete
   3  setup finished with outstanding steps

--- a/packages/setup/tests/setup-contract.test.mjs
+++ b/packages/setup/tests/setup-contract.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -11,8 +12,9 @@ const setupDir = path.resolve(here, '..');
 const source = fs.readFileSync(path.join(setupDir, 'index.js'), 'utf8');
 const daemonInstaller = fs.readFileSync(path.join(setupDir, 'install-daemon.js'), 'utf8');
 
-function runWizard({ daemonMode = 'skip', daemonInstall } = {}) {
-  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sysknife-setup-contract-'));
+function runWizard({ daemonMode = 'skip', daemonInstall, cwd: suppliedCwd, env = {} } = {}) {
+  const cwd = suppliedCwd ?? fs.mkdtempSync(path.join(os.tmpdir(), 'sysknife-setup-contract-'));
+  const ownsCwd = suppliedCwd === undefined;
   const entry = path.join(setupDir, 'index.js');
   const setupArgs = ['--claude', '--no-prompts', '--no-binary', `--daemon-mode=${daemonMode}`];
   const bootstrap = [
@@ -38,10 +40,10 @@ function runWizard({ daemonMode = 'skip', daemonInstall } = {}) {
       encoding: 'utf8',
       input: '',
       timeout: 30_000,
-      env: { ...process.env, HOME: cwd },
+      env: { ...process.env, HOME: cwd, ...env },
     });
   } finally {
-    fs.rmSync(cwd, { recursive: true, force: true });
+    if (ownsCwd) fs.rmSync(cwd, { recursive: true, force: true });
   }
 }
 
@@ -185,3 +187,46 @@ test('the final setup status pluralizes outstanding steps and preserves complete
   assert.doesNotMatch(completeOutput, /Setup incomplete/);
   assert.equal(complete.status, 0, `complete setup must exit 0:\n${completeOutput}`);
 });
+
+test(
+  'a reachable externally managed daemon makes a skipped install complete',
+  { skip: process.platform === 'win32' ? 'Unix-domain netcat probe is exercised by Ubuntu CI' : false },
+  async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sysknife-setup-reachable-'));
+    const socketDir = path.join(cwd, 'sysknife');
+    const socketPath = path.join(socketDir, 'daemon.sock');
+    fs.mkdirSync(socketDir, { recursive: true });
+
+    const server = net.createServer(socket => socket.end());
+    try {
+      await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(socketPath, resolve);
+      });
+
+      const result = runWizard({
+        cwd,
+        env: { XDG_RUNTIME_DIR: cwd },
+        daemonInstall: {
+          mode: 'skip',
+          daemonInstalled: false,
+          manualSteps: [`Start manually:  ${path.join(cwd, 'sysknife-daemon')}`],
+        },
+      });
+      const output = `${result.stdout}${result.stderr}`;
+
+      assert.match(output, new RegExp(`Daemon socket reachable: ${socketPath.replaceAll('\\', '\\\\')}`));
+      assert.doesNotMatch(output, /nothing will execute until these steps are done/);
+      assert.match(output, /Setup complete/);
+      assert.doesNotMatch(output, /Setup incomplete/);
+      assert.equal(result.status, 0, `reachable daemon must make setup complete:\n${output}`);
+    } finally {
+      if (server.listening) {
+        await new Promise((resolve, reject) => {
+          server.close(error => (error ? reject(error) : resolve()));
+        });
+      }
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/setup/tests/setup-contract.test.mjs
+++ b/packages/setup/tests/setup-contract.test.mjs
@@ -32,13 +32,17 @@ function runWizard({ daemonMode = 'skip', daemonInstall } = {}) {
     `require(${JSON.stringify(entry)});`,
   );
 
-  return spawnSync(process.execPath, ['-e', bootstrap.join(' ')], {
-    cwd,
-    encoding: 'utf8',
-    input: '',
-    timeout: 30_000,
-    env: { ...process.env, HOME: cwd },
-  });
+  try {
+    return spawnSync(process.execPath, ['-e', bootstrap.join(' ')], {
+      cwd,
+      encoding: 'utf8',
+      input: '',
+      timeout: 30_000,
+      env: { ...process.env, HOME: cwd },
+    });
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
 }
 
 test('generated integration rules require terminal-issued approval receipts', () => {
@@ -123,7 +127,7 @@ test('--help remains a non-interactive smoke test', () => {
     encoding: 'utf8',
   });
   assert.match(output, /sysknife-setup/);
-  assert.match(output, /0\s+setup is usable/);
+  assert.match(output, /0\s+setup finished without reported outstanding steps/);
   assert.match(output, /1\s+setup failed/);
   assert.match(output, /2\s+command-line arguments are invalid or incomplete/);
   assert.match(output, /3\s+setup finished with outstanding steps/);
@@ -168,7 +172,7 @@ test('the final setup status pluralizes outstanding steps and preserves complete
     },
   });
   const incompleteOutput = `${incomplete.stdout}${incomplete.stderr}`;
-  assert.match(incompleteOutput, /Setup incomplete: 2 steps left/);
+  assert.match(incompleteOutput, /Setup incomplete: 3 steps left/);
   assert.doesNotMatch(incompleteOutput, /Setup complete/);
   assert.equal(incomplete.status, 3, `incomplete setup must exit 3:\n${incompleteOutput}`);
 

--- a/packages/setup/tests/setup-contract.test.mjs
+++ b/packages/setup/tests/setup-contract.test.mjs
@@ -11,6 +11,36 @@ const setupDir = path.resolve(here, '..');
 const source = fs.readFileSync(path.join(setupDir, 'index.js'), 'utf8');
 const daemonInstaller = fs.readFileSync(path.join(setupDir, 'install-daemon.js'), 'utf8');
 
+function runWizard({ daemonMode = 'skip', daemonInstall } = {}) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sysknife-setup-contract-'));
+  const entry = path.join(setupDir, 'index.js');
+  const setupArgs = ['--claude', '--no-prompts', '--no-binary', `--daemon-mode=${daemonMode}`];
+  const bootstrap = [
+    "if (typeof process.getuid !== 'function') process.getuid = () => 1000;",
+  ];
+
+  if (daemonInstall) {
+    const daemonInstallerPath = path.join(setupDir, 'install-daemon.js');
+    bootstrap.push(
+      `const daemonInstaller = require(${JSON.stringify(daemonInstallerPath)});`,
+      `daemonInstaller.installDaemonService = async () => (${JSON.stringify(daemonInstall)});`,
+    );
+  }
+
+  bootstrap.push(
+    `process.argv = [process.execPath, ${JSON.stringify(entry)}, ...${JSON.stringify(setupArgs)}];`,
+    `require(${JSON.stringify(entry)});`,
+  );
+
+  return spawnSync(process.execPath, ['-e', bootstrap.join(' ')], {
+    cwd,
+    encoding: 'utf8',
+    input: '',
+    timeout: 30_000,
+    env: { ...process.env, HOME: cwd },
+  });
+}
+
 test('generated integration rules require terminal-issued approval receipts', () => {
   assert.match(source, /sysknife approve <transaction-id>/);
   assert.match(source, /chat response such as \"yes\" is not approval/i);
@@ -93,6 +123,10 @@ test('--help remains a non-interactive smoke test', () => {
     encoding: 'utf8',
   });
   assert.match(output, /sysknife-setup/);
+  assert.match(output, /0\s+setup is usable/);
+  assert.match(output, /1\s+setup failed/);
+  assert.match(output, /2\s+command-line arguments are invalid or incomplete/);
+  assert.match(output, /3\s+setup finished with outstanding steps/);
 });
 
 test('a daemon that was not installed is reported as outstanding, whatever the reason', () => {
@@ -101,14 +135,9 @@ test('a daemon that was not installed is reported as outstanding, whatever the r
   // configured and nothing able to execute. Both are not-installed outcomes and
   // both must say so.
   //
-  // Run in a throwaway cwd: the wizard writes .mcp.json and .claude/ where it
-  // is invoked, and --no-binary keeps it off the network.
-  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sysknife-setup-outstanding-'));
-  const result = spawnSync(
-    process.execPath,
-    [path.join(setupDir, 'index.js'), '--claude', '--no-prompts', '--no-binary', '--daemon-mode=skip'],
-    { cwd, encoding: 'utf8', input: '', timeout: 30_000 },
-  );
+  // runWizard uses a throwaway cwd: the wizard writes .mcp.json and .claude/
+  // where it is invoked, and --no-binary keeps it off the network.
+  const result = runWizard();
 
   const output = `${result.stdout}${result.stderr}`;
   // The headline differs by reason — "You skipped …" where systemd exists,
@@ -124,4 +153,31 @@ test('a daemon that was not installed is reported as outstanding, whatever the r
     /Start manually:/,
     `the outstanding block must carry the steps, not just the warning:\n${output}`,
   );
+  assert.match(output, /Setup incomplete: 1 step left/);
+  assert.doesNotMatch(output, /Setup complete/);
+  assert.equal(result.status, 3, `incomplete setup must exit 3:\n${output}`);
+});
+
+test('the final setup status pluralizes outstanding steps and preserves complete success', () => {
+  const incomplete = runWizard({
+    daemonMode: 'system',
+    daemonInstall: {
+      mode: 'system',
+      daemonInstalled: false,
+      manualSteps: ['first daemon step', 'second daemon step'],
+    },
+  });
+  const incompleteOutput = `${incomplete.stdout}${incomplete.stderr}`;
+  assert.match(incompleteOutput, /Setup incomplete: 2 steps left/);
+  assert.doesNotMatch(incompleteOutput, /Setup complete/);
+  assert.equal(incomplete.status, 3, `incomplete setup must exit 3:\n${incompleteOutput}`);
+
+  const complete = runWizard({
+    daemonMode: 'user',
+    daemonInstall: { mode: 'user', daemonInstalled: true, manualSteps: [] },
+  });
+  const completeOutput = `${complete.stdout}${complete.stderr}`;
+  assert.match(completeOutput, /Setup complete/);
+  assert.doesNotMatch(completeOutput, /Setup incomplete/);
+  assert.equal(complete.status, 0, `complete setup must exit 0:\n${completeOutput}`);
 });

--- a/packages/setup/tests/setup-contract.test.mjs
+++ b/packages/setup/tests/setup-contract.test.mjs
@@ -17,15 +17,18 @@ function runWizard({ daemonMode = 'skip', daemonInstall, cwd: suppliedCwd, env =
   const ownsCwd = suppliedCwd === undefined;
   const entry = path.join(setupDir, 'index.js');
   const setupArgs = ['--claude', '--no-prompts', '--no-binary', `--daemon-mode=${daemonMode}`];
+  const childEnv = { ...process.env, HOME: cwd, ...env };
   const bootstrap = [
     "if (typeof process.getuid !== 'function') process.getuid = () => 1000;",
   ];
 
   if (daemonInstall) {
     const daemonInstallerPath = path.join(setupDir, 'install-daemon.js');
+    childEnv.SYSKNIFE_SETUP_TEST_DAEMON_INSTALL = JSON.stringify(daemonInstall);
     bootstrap.push(
       `const daemonInstaller = require(${JSON.stringify(daemonInstallerPath)});`,
-      `daemonInstaller.installDaemonService = async () => (${JSON.stringify(daemonInstall)});`,
+      'daemonInstaller.installDaemonService = async () => '
+        + 'JSON.parse(process.env.SYSKNIFE_SETUP_TEST_DAEMON_INSTALL);',
     );
   }
 
@@ -40,7 +43,7 @@ function runWizard({ daemonMode = 'skip', daemonInstall, cwd: suppliedCwd, env =
       encoding: 'utf8',
       input: '',
       timeout: 30_000,
-      env: { ...process.env, HOME: cwd, ...env },
+      env: childEnv,
     });
   } finally {
     if (ownsCwd) fs.rmSync(cwd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- report setup as incomplete when the wizard did not install a daemon and no daemon socket is known to be reachable
- return exit `3` for that operationally incomplete result, while preserving `0` for a usable setup, `1` for failure, and `2` for invalid arguments
- treat a reachable externally managed daemon as complete, suppressing the contradictory "nothing will execute" warning
- document all four exit statuses in `--help` and cover singular, plural, preserved-success, and real Unix-socket paths

A deliberate `--daemon-mode=skip` still means the operator got the choice they requested. If no daemon is reachable, however, the configured MCP clients cannot execute anything, so the final status now says setup is incomplete. If the selected socket is already reachable, setup remains complete even though this wizard did not install the service.

## Related Issue

Closes #297

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed
- [x] Security impact considered
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [ ] CI passes — the new fork-head workflows require maintainer approval and have not executed yet

Exact local evidence on current `main` `ecf8c7d`, using Node.js 24.16.0:

- test-first real-socket check: against the pre-fix production path it observed the reachable-socket message but still got the contradictory warning, `Setup incomplete`, and exit `3`
- Ubuntu/WSL focused contract: 9 passed, 0 failed
- Ubuntu/WSL full setup package: 102 passed, 0 failed
- Windows focused contract: 8 passed, 0 failed, 1 expected skip for the Unix-domain netcat probe
- Windows full setup package: **not green**, 88 passed, 13 failed, 1 skipped; untouched `main` was **not green**, 86 passed and 14 failed, with the same 13 POSIX-assumption failures plus the original contract harness's Windows `process.getuid` failure
- `node --check packages/setup/index.js`: passed
- `PYTHONUTF8=1 python scripts/check_evidence_claims.py`: passed
- the committed diff contains no `.rs` path, so the documented non-Rust exception applies
- `git diff --check`: passed with Windows LF-to-CRLF notices only
- staged credential screen: passed after feeding the CRLF checkout's script to Bash with CR removed; the script itself was not changed

The broad Windows result is a baseline-compared platform limitation, not a green suite. Ubuntu fork CI remains the hosted platform gate.

## Review resolution

The CODEOWNER direction in [comment 5454214468](https://github.com/lacs-project/sysknife/pull/312#issuecomment-5454214468) is implemented with one tri-state socket result and one shared `daemonSetupIncomplete` predicate. A reachable socket (`true`) produces the complete path; unreachable (`false`) and unprobed (`null`) remain conservatively incomplete. The same predicate gates both the warning block and final banner, and the contract test uses a real listening Unix socket.

## Notes for Reviewers

This changes only final result reporting and its existing contract tests. It does not alter daemon installation, manual-step construction, client configuration, privilege handling, or the trust boundary.

Prepared and published by an autonomous OpenAI Codex agent under the repository's disclosed AI-assistance policy. The complete diff and every claim above were reviewed against the recorded commands before publication.