### PR TITLE
fix(test): fail postgres-contract when the database was never configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,7 @@ jobs:
     env:
       SYSKNIFE_TEST_POSTGRES_URL: >-
         postgres://sysknife:sysknife@127.0.0.1:5432/sysknife_test?sslmode=disable
+      SYSKNIFE_REQUIRE_POSTGRES: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
@@ -265,7 +266,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
 
       - name: Run live Postgres migration and store contract
-        run: cargo test -p sysknife-daemon --test postgres_store --locked
+        run: cargo test -p sysknife-daemon --test postgres_store --locked -- --include-ignored
 
   security-audit:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+### Fixed
+
+- **`postgres-contract` reported success when no database was configured.**
+  ([#313](https://github.com/lacs-project/sysknife/pull/313),
+  [#294](https://github.com/lacs-project/sysknife/issues/294))
+  Five tests in `postgres_store.rs` returned early when
+  `SYSKNIFE_TEST_POSTGRES_URL` was unset, so a renamed variable or a dropped
+  `services:` block left one of `main`'s five required checks green over a
+  contract it never ran. nextest prints per-test stdout only on failure, so the
+  existing notice was invisible in exactly that run. The five live tests are now
+  `#[ignore]`, the job sets `SYSKNIFE_REQUIRE_POSTGRES` and runs with
+  `--include-ignored`, and a required-but-unconfigured run panics instead of
+  passing. A local run without a database reports them ignored rather than
+  passed.
+
 ## [0.10.0] — 2026-08-26
 
 The middle digit moves because [#289](https://github.com/lacs-project/sysknife/pull/289)

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,775 Rust tests and 72 frontend tests** form the current deterministic
+**1,774 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/crates/sysknife-daemon/tests/postgres_store.rs
+++ b/crates/sysknife-daemon/tests/postgres_store.rs
@@ -10,7 +10,64 @@ use sysknife_daemon::transactions::NewTransaction;
 use sysknife_types::{CallerRole, JobState, PreviewEnvelope, RequestHash, RiskLevel};
 
 fn test_url() -> Option<String> {
-    std::env::var("SYSKNIFE_TEST_POSTGRES_URL").ok()
+    std::env::var("SYSKNIFE_TEST_POSTGRES_URL")
+        .ok()
+        .filter(|url| !url.is_empty())
+}
+
+fn postgres_is_required() -> bool {
+    std::env::var("SYSKNIFE_REQUIRE_POSTGRES").is_ok()
+}
+
+/// Live-contract URL, or `None` to skip. Panics when a server is required
+/// (`SYSKNIFE_REQUIRE_POSTGRES`) but no URL was configured, so CI cannot
+/// report success after the database never started.
+fn resolve_live_postgres_url(url: Option<String>, required: bool) -> Option<String> {
+    match url {
+        Some(url) => Some(url),
+        None if required => panic!(
+            "SYSKNIFE_REQUIRE_POSTGRES is set but SYSKNIFE_TEST_POSTGRES_URL is unset; \
+             the live Postgres contract was not requested"
+        ),
+        None => None,
+    }
+}
+
+fn live_postgres_url() -> Option<String> {
+    resolve_live_postgres_url(test_url(), postgres_is_required())
+}
+
+#[test]
+fn live_postgres_url_is_none_when_neither_is_set() {
+    assert_eq!(resolve_live_postgres_url(None, false), None);
+}
+
+#[test]
+fn live_postgres_url_returns_the_configured_url() {
+    let url = "postgres://sysknife@127.0.0.1/sysknife_test".to_string();
+    assert_eq!(
+        resolve_live_postgres_url(Some(url.clone()), true),
+        Some(url)
+    );
+}
+
+#[test]
+#[should_panic(
+    expected = "SYSKNIFE_REQUIRE_POSTGRES is set but SYSKNIFE_TEST_POSTGRES_URL is unset"
+)]
+fn live_postgres_url_panics_when_required_and_missing() {
+    let _ = resolve_live_postgres_url(None, true);
+}
+
+#[test]
+fn require_postgres_fails_closed_when_the_url_is_missing() {
+    if postgres_is_required() {
+        assert!(
+            test_url().is_some(),
+            "SYSKNIFE_REQUIRE_POSTGRES is set but SYSKNIFE_TEST_POSTGRES_URL is unset; \
+             the live Postgres contract was not requested and would have been skipped"
+        );
+    }
 }
 
 fn new_transaction() -> NewTransaction {
@@ -41,9 +98,9 @@ fn preview() -> PreviewEnvelope {
 }
 
 #[tokio::test]
+#[ignore = "live Postgres; set SYSKNIFE_TEST_POSTGRES_URL and run with --include-ignored"]
 async fn migrates_legacy_schema_and_enforces_store_contract() {
-    let Some(url) = test_url() else {
-        eprintln!("SYSKNIFE_TEST_POSTGRES_URL is unset; live Postgres contract not requested");
+    let Some(url) = live_postgres_url() else {
         return;
     };
     assert!(
@@ -361,6 +418,7 @@ async fn migrates_legacy_schema_and_enforces_store_contract() {
 /// and in parallel, so two destructive tests sharing `public` would race — the
 /// first version of this test tore down the other test's tables mid-run.
 #[tokio::test]
+#[ignore = "live Postgres; set SYSKNIFE_TEST_POSTGRES_URL and run with --include-ignored"]
 async fn postgres_checkpoint_sink_round_trips_and_detects_truncation() {
     use sysknife_daemon::checkpoint_sink::{
         anchor_once, AnchorOutcome, CheckpointSink, PostgresCheckpointSink,
@@ -368,8 +426,7 @@ async fn postgres_checkpoint_sink_round_trips_and_detects_truncation() {
 
     const SCHEMA: &str = "checkpoint_sink_test";
 
-    let Some(url) = test_url() else {
-        eprintln!("SYSKNIFE_TEST_POSTGRES_URL is unset; live Postgres contract not requested");
+    let Some(url) = live_postgres_url() else {
         return;
     };
     assert!(
@@ -469,13 +526,13 @@ async fn postgres_checkpoint_sink_round_trips_and_detects_truncation() {
 /// account". That is the misreport the census exists to prevent, and on the
 /// Postgres path nothing else would catch it.
 #[tokio::test]
+#[ignore = "live Postgres; set SYSKNIFE_TEST_POSTGRES_URL and run with --include-ignored"]
 async fn attribution_census_over_a_real_postgres_round_trip() {
     use sysknife_daemon::audit_chain::AttributionCensus;
 
     const SCHEMA: &str = "attribution_census_test";
 
-    let Some(url) = test_url() else {
-        eprintln!("SYSKNIFE_TEST_POSTGRES_URL is unset; live Postgres contract not requested");
+    let Some(url) = live_postgres_url() else {
         return;
     };
     assert!(
@@ -663,9 +720,9 @@ fn url_with_schema(url: &str, schema: &str) -> String {
 }
 
 #[tokio::test]
+#[ignore = "live Postgres; set SYSKNIFE_TEST_POSTGRES_URL and run with --include-ignored"]
 async fn an_auditor_denied_the_event_table_cannot_verify() {
-    let Some(url) = test_url() else {
-        eprintln!("SYSKNIFE_TEST_POSTGRES_URL is unset; live Postgres contract not requested");
+    let Some(url) = live_postgres_url() else {
         return;
     };
     assert!(
@@ -831,6 +888,7 @@ async fn an_auditor_denied_the_event_table_cannot_verify() {
 }
 
 #[tokio::test]
+#[ignore = "live Postgres; set SYSKNIFE_TEST_POSTGRES_URL and run with --include-ignored"]
 async fn a_chain_predating_the_event_table_still_verifies() {
     // The other half of the same guard. Failing closed on an unreadable event
     // table must not fail closed on a chain written before `audit_events`
@@ -838,8 +896,7 @@ async fn a_chain_predating_the_event_table_still_verifies() {
     // the original `unwrap_or_default()` was right about this case. Without
     // this test the fix could be "return CannotVerify on any error" and still
     // look correct.
-    let Some(url) = test_url() else {
-        eprintln!("SYSKNIFE_TEST_POSTGRES_URL is unset; live Postgres contract not requested");
+    let Some(url) = live_postgres_url() else {
         return;
     };
     assert!(

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,775 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,774 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,775 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,774 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -336,7 +336,7 @@ run_security_group() {
 
 run_postgres_contract_group() {
     printf '\n### postgres-contract (optional)\n'
-    local label="postgres-contract: cargo test -p sysknife-daemon --test postgres_store --locked"
+    local label="postgres-contract: cargo test -p sysknife-daemon --test postgres_store --locked -- --include-ignored"
 
     if [[ "$run_postgres" != true ]]; then
         record SKIP "${label} (--no-postgres)"
@@ -344,7 +344,8 @@ run_postgres_contract_group() {
     fi
 
     if [[ -n "${SYSKNIFE_TEST_POSTGRES_URL:-}" ]]; then
-        run_step "$label" cargo test -p sysknife-daemon --test postgres_store --locked
+        SYSKNIFE_REQUIRE_POSTGRES=1 \
+            run_step "$label" cargo test -p sysknife-daemon --test postgres_store --locked -- --include-ignored
         return
     fi
 
@@ -386,7 +387,8 @@ run_postgres_contract_group() {
     done
 
     SYSKNIFE_TEST_POSTGRES_URL="postgres://sysknife:sysknife@127.0.0.1:${POSTGRES_HOST_PORT}/sysknife_test?sslmode=disable" \
-        run_step "$label" cargo test -p sysknife-daemon --test postgres_store --locked
+    SYSKNIFE_REQUIRE_POSTGRES=1 \
+        run_step "$label" cargo test -p sysknife-daemon --test postgres_store --locked -- --include-ignored
 
     "$runtime" rm -f "$POSTGRES_CONTAINER_NAME" >/dev/null 2>&1 || true
 }

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -10,8 +10,8 @@
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-26T05:19:13-06:00"
+    "tests": "2026-08-27T14:53:28+02:00"
   },
-  "tests": 1775,
+  "tests": 1774,
   "version": 1
 }


### PR DESCRIPTION
Closes #294.

`postgres-contract` is one of the five required checks on `main`. Its job is to prove the live PostgreSQL store. On current `main` (`6ca1467`) five of the seven tests in `postgres_store.rs` return early when `SYSKNIFE_TEST_POSTGRES_URL` is unset, so a renamed variable, a dropped `services:` block, or a dead health check still reports success. nextest prints per-test stdout only for failures, so the existing `eprintln!` is invisible in exactly that run.

The issue was filed against five tests, three of which skipped. Two more live-contract tests have landed since; this applies the same fail-closed skip to all five. The two URL-policy tests never needed a server and still run unconditionally.

### Change

- **`resolve_live_postgres_url`** returns the URL, `None` to skip, or panics when `SYSKNIFE_REQUIRE_POSTGRES` is set without a URL.
- The five live tests are `#[ignore]`, so a local run without a database reports `5 ignored` rather than `passed`.
- The `postgres-contract` job sets `SYSKNIFE_REQUIRE_POSTGRES=1` and runs with `--include-ignored`, so a broken service block fails the job instead of skipping it. `scripts/ci-local.sh` mirrors that when it actually starts Postgres.
- Workspace baseline moves `1,775 → 1,774`: nextest's `Starting N` count excludes ignored tests (`+4` helper tests, `-5` live tests now skipped in the workspace job).

### Proof (darwin/arm64, no Postgres)

Issue commands, current `main` first:

```
cargo test -p sysknife-daemon --test postgres_store --locked
# 7 passed; 0 failed; 0 ignored

SYSKNIFE_REQUIRE_POSTGRES=1 cargo test -p sysknife-daemon --test postgres_store --locked
# 7 passed; 0 failed; 0 ignored     ← the bug
```

This branch:

```
cargo test -p sysknife-daemon --test postgres_store --locked
# 6 passed; 0 failed; 5 ignored

SYSKNIFE_REQUIRE_POSTGRES=1 cargo test -p sysknife-daemon --test postgres_store --locked
# 5 passed; 1 failed; 5 ignored
# require_postgres_fails_closed_when_the_url_is_missing panics

SYSKNIFE_REQUIRE_POSTGRES=1 cargo test -p sysknife-daemon --test postgres_store --locked -- --include-ignored
# 5 passed; 6 failed; 0 ignored
# the five live tests panic too
```

Helper tests (env-free): missing URL is `None`, a configured URL is returned even when required, required-and-missing panics. The last of those was red against a stub that returned `url` unchanged, then green.

`cargo fmt --all --check` is clean. I did not dispatch a hosted run. The live contract with a real server still belongs to the `postgres-contract` job.