### PR TITLE
fix(e2e): keep provider keys out of VM process arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Check provider parity across E2E entry points
         run: bash tests/e2e/provider-parity.test.sh
 
+      - name: Check VM harnesses keep provider keys out of process arguments
+        run: bash tests/e2e/vm-env-secrets.test.sh
+
       - name: Check story metadata is derived from the story files
         run: bash tests/e2e/story-metadata.test.sh
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -279,6 +279,7 @@ run_hygiene_group() {
     run_step 'hygiene: systemd-directory-modes.test.sh' bash "$repo_root/tests/release/systemd-directory-modes.test.sh"
     run_step 'hygiene: ubuntu-vm-bootstrap.test.sh' bash "$repo_root/tests/e2e/ubuntu-vm-bootstrap.test.sh"
     run_step 'hygiene: provider-parity.test.sh' bash "$repo_root/tests/e2e/provider-parity.test.sh"
+    run_step 'hygiene: vm-env-secrets.test.sh' bash "$repo_root/tests/e2e/vm-env-secrets.test.sh"
     run_step 'hygiene: story-metadata.test.sh' bash "$repo_root/tests/e2e/story-metadata.test.sh"
     run_step 'hygiene: vm-sync-parity.test.sh' bash "$repo_root/tests/e2e/vm-sync-parity.test.sh"
     run_step 'hygiene: docs-share-cards.test.sh' bash "$repo_root/tests/release/docs-share-cards.test.sh"

--- a/tests/e2e/atomic-vm.sh
+++ b/tests/e2e/atomic-vm.sh
@@ -104,6 +104,7 @@ VM_SUBDIR="${VM_DIR}/${VM_NAME}"
 # contributor's personal ~/.ssh/id_* keys because those are typically
 # passphrase-protected, which breaks rsync/non-interactive ssh.
 SSH_KEY="${SYSKNIFE_VM_SSH_KEY:-$HOME/.ssh/sysknife-vm}"
+GUEST_ENV_FILE="/run/sysknife-e2e.env"
 
 ssh_opts() {
     printf -- '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i %s -o IdentitiesOnly=yes' "$SSH_KEY"
@@ -115,6 +116,21 @@ ssh_opts() {
 
 log() { printf '[atomic-vm] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
+
+write_guest_env_file() {
+    local assignment value var
+    local assignments=()
+    for var in "$@"; do
+        eval "value=\${$var-}"
+        if [ -n "$value" ]; then
+            printf -v assignment '%s=%q' "$var" "$value"
+            assignments+=("$assignment")
+        fi
+    done
+
+    printf '%s\n' "${assignments[@]}" \
+        | cmd_ssh "sudo sh -c 'umask 077 && cat > ${GUEST_ENV_FILE}'"
+}
 
 require_tools() {
     local missing=()
@@ -310,17 +326,11 @@ cmd_provision() {
         -e "ssh $(ssh_opts) -p $port" \
         "$repo_root/" "${VM_USER}@127.0.0.1:/home/${VM_USER}/sysknife/"
     log "Running provisioner inside the VM..."
-    local prov_env=""
-    for var in OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
-               GROQ_API_KEY DEEPSEEK_API_KEY MISTRAL_API_KEY XAI_API_KEY \
-               SYSKNIFE_SKIP_OLLAMA \
-               SYSKNIFE_TEST_MODEL VM_USER; do
-        eval "val=\${$var:-}"
-        if [ -n "$val" ]; then
-            prov_env+=" $var='$val'"
-        fi
-    done
-    cmd_ssh "cd /home/${VM_USER}/sysknife && sudo${prov_env} bash tests/e2e/provision.sh"
+    write_guest_env_file \
+        OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
+        GROQ_API_KEY DEEPSEEK_API_KEY MISTRAL_API_KEY XAI_API_KEY \
+        SYSKNIFE_SKIP_OLLAMA SYSKNIFE_TEST_MODEL VM_USER
+    cmd_ssh "cd /home/${VM_USER}/sysknife && sudo bash -c 'set -e; trap \"rm -f ${GUEST_ENV_FILE}\" EXIT; set -a; . ${GUEST_ENV_FILE}; set +a; rm -f ${GUEST_ENV_FILE}; trap - EXIT; exec bash tests/e2e/provision.sh'"
 }
 
 # Generate a dedicated SSH key for the VM (no passphrase). Idempotent.
@@ -449,22 +459,13 @@ cmd_run() {
         log "Running read-only stories (default set). Set SYSKNIFE_ALLOW_DESTRUCTIVE=1 for all 54."
     fi
 
-    # Forward relevant env vars through SSH → sudo. Passing them as
-    # `sudo VAR=val VAR2=val2 cmd` injects them into the command's env
-    # regardless of sudoers env_reset/env_keep settings.
-    local sudo_env=""
-    for var in SYSKNIFE_ALLOW_DESTRUCTIVE SYSKNIFE_LLM_PROVIDER SYSKNIFE_LLM_MODEL \
-               SYSKNIFE_TEST_MODEL SYSKNIFE_OLLAMA_URL SYSKNIFE_LISTEN_URI \
-               SYSKNIFE_STORY_TIMEOUT SYSKNIFE_MAX_RPM \
-               SYSKNIFE_CASSETTE SYSKNIFE_CASSETTE_MODE \
-               SYSKNIFE_RESULTS_JSON \
-               OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
-               GROQ_API_KEY DEEPSEEK_API_KEY MISTRAL_API_KEY XAI_API_KEY; do
-        eval "val=\${$var:-}"
-        if [ -n "$val" ]; then
-            sudo_env+=" $var='$val'"
-        fi
-    done
+    write_guest_env_file \
+        SYSKNIFE_ALLOW_DESTRUCTIVE SYSKNIFE_LLM_PROVIDER SYSKNIFE_LLM_MODEL \
+        SYSKNIFE_TEST_MODEL SYSKNIFE_OLLAMA_URL SYSKNIFE_LISTEN_URI \
+        SYSKNIFE_STORY_TIMEOUT SYSKNIFE_MAX_RPM \
+        SYSKNIFE_CASSETTE SYSKNIFE_CASSETTE_MODE SYSKNIFE_RESULTS_JSON \
+        OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
+        GROQ_API_KEY DEEPSEEK_API_KEY MISTRAL_API_KEY XAI_API_KEY
 
     # Forward positional args (specific story numbers, e.g. `run 1 3 7`)
     # through to run-stories.sh so contributors can target individual
@@ -473,7 +474,7 @@ cmd_run() {
     if [ $# -gt 0 ]; then
         story_args=" $*"
     fi
-    cmd_ssh "cd /home/${VM_USER}/sysknife && sudo${sudo_env} bash tests/e2e/run-stories.sh${story_args}"
+    cmd_ssh "cd /home/${VM_USER}/sysknife && sudo bash -c 'set -e; trap \"rm -f ${GUEST_ENV_FILE}\" EXIT; set -a; . ${GUEST_ENV_FILE}; set +a; rm -f ${GUEST_ENV_FILE}; trap - EXIT; exec bash tests/e2e/run-stories.sh${story_args}'"
 }
 
 cmd_test_daemon() {

--- a/tests/e2e/ubuntu-vm.sh
+++ b/tests/e2e/ubuntu-vm.sh
@@ -84,6 +84,7 @@ CLOUD_INIT_DIR="${VM_DIR}/cloud-init"
 
 # Dedicated passphrase-less SSH key for the VM. Shared with atomic-vm.sh.
 SSH_KEY="${SYSKNIFE_VM_SSH_KEY:-$HOME/.ssh/sysknife-vm}"
+GUEST_ENV_FILE="/run/sysknife-e2e.env"
 SSH_OPTIONS=(
     -o StrictHostKeyChecking=no
     -o UserKnownHostsFile=/dev/null
@@ -105,6 +106,21 @@ _MIN_IMAGE_SIZE=314572800
 
 log()  { printf '[ubuntu-vm:%s] %s\n' "$UBUNTU_RELEASE" "$*" >&2; }
 die()  { log "ERROR: $*"; exit 1; }
+
+write_guest_env_file() {
+    local assignment value var
+    local assignments=()
+    for var in "$@"; do
+        eval "value=\${$var-}"
+        if [ -n "$value" ]; then
+            printf -v assignment '%s=%q' "$var" "$value"
+            assignments+=("$assignment")
+        fi
+    done
+
+    printf '%s\n' "${assignments[@]}" \
+        | cmd_ssh "sudo sh -c 'umask 077 && cat > ${GUEST_ENV_FILE}'"
+}
 
 require_tools() {
     local missing=()
@@ -498,39 +514,28 @@ cmd_provision() {
     [ -f "$SSH_KEY" ] || die "SSH key not found. Run '$0 download' first."
     cmd_sync
     log "Running ubuntu-provision.sh inside the VM as root..."
-    local prov_env=""
-    for var in OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
-               GROQ_API_KEY DEEPSEEK_API_KEY MISTRAL_API_KEY XAI_API_KEY \
-               SYSKNIFE_SKIP_OLLAMA SYSKNIFE_TEST_MODEL; do
-        eval "val=\${$var:-}"
-        if [ -n "$val" ]; then
-            prov_env+=" $var='$val'"
-        fi
-    done
+    write_guest_env_file \
+        OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
+        GROQ_API_KEY DEEPSEEK_API_KEY MISTRAL_API_KEY XAI_API_KEY \
+        SYSKNIFE_SKIP_OLLAMA SYSKNIFE_TEST_MODEL
     # shellcheck disable=SC2029
-    cmd_ssh "cd /home/${VM_USER}/sysknife && sudo${prov_env} bash tests/e2e/ubuntu-provision.sh"
+    cmd_ssh "cd /home/${VM_USER}/sysknife && sudo bash -c 'set -e; trap \"rm -f ${GUEST_ENV_FILE}\" EXIT; set -a; . ${GUEST_ENV_FILE}; set +a; rm -f ${GUEST_ENV_FILE}; trap - EXIT; exec bash tests/e2e/ubuntu-provision.sh'"
 }
 
 cmd_run() {
     [ -f "$SSH_KEY" ] || die "SSH key not found."
-    local sudo_env=""
-    for var in SYSKNIFE_ALLOW_DESTRUCTIVE SYSKNIFE_LLM_PROVIDER SYSKNIFE_LLM_MODEL \
-               SYSKNIFE_TEST_MODEL SYSKNIFE_OLLAMA_URL SYSKNIFE_LISTEN_URI \
-               SYSKNIFE_STORY_TIMEOUT SYSKNIFE_MAX_RPM \
-               SYSKNIFE_CASSETTE SYSKNIFE_CASSETTE_MODE \
-               SYSKNIFE_RESULTS_JSON \
-               OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
-               GROQ_API_KEY DEEPSEEK_API_KEY MISTRAL_API_KEY XAI_API_KEY; do
-        eval "val=\${$var:-}"
-        if [ -n "$val" ]; then
-            sudo_env+=" $var='$val'"
-        fi
-    done
+    write_guest_env_file \
+        SYSKNIFE_ALLOW_DESTRUCTIVE SYSKNIFE_LLM_PROVIDER SYSKNIFE_LLM_MODEL \
+        SYSKNIFE_TEST_MODEL SYSKNIFE_OLLAMA_URL SYSKNIFE_LISTEN_URI \
+        SYSKNIFE_STORY_TIMEOUT SYSKNIFE_MAX_RPM \
+        SYSKNIFE_CASSETTE SYSKNIFE_CASSETTE_MODE SYSKNIFE_RESULTS_JSON \
+        OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
+        GROQ_API_KEY DEEPSEEK_API_KEY MISTRAL_API_KEY XAI_API_KEY
     local story_args=""
     if [ $# -gt 0 ]; then
         story_args=" $*"
     fi
-    cmd_ssh "cd /home/${VM_USER}/sysknife && sudo${sudo_env} bash tests/e2e/run-stories.sh${story_args}"
+    cmd_ssh "cd /home/${VM_USER}/sysknife && sudo bash -c 'set -e; trap \"rm -f ${GUEST_ENV_FILE}\" EXIT; set -a; . ${GUEST_ENV_FILE}; set +a; rm -f ${GUEST_ENV_FILE}; trap - EXIT; exec bash tests/e2e/run-stories.sh${story_args}'"
 }
 
 cmd_stop() {

--- a/tests/e2e/vm-env-secrets.test.sh
+++ b/tests/e2e/vm-env-secrets.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Ensure VM harnesses send provider secrets over stdin, never in process argv.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+config_rs="$repo_root/crates/sysknife-brain/src/config.rs"
+harnesses=(
+    "tests/e2e/atomic-vm.sh"
+    "tests/e2e/ubuntu-vm.sh"
+)
+
+keys=()
+while IFS= read -r key; do
+    keys+=("$key")
+done < <(grep -oE '[A-Z0-9]+_API_KEY' "$config_rs" | sort -u)
+if [ "${#keys[@]}" -lt 7 ]; then
+    printf 'provider extraction found only %d keys\n' "${#keys[@]}" >&2
+    exit 1
+fi
+
+failures=0
+report() {
+    printf 'FAIL  %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+for rel in "${harnesses[@]}"; do
+    harness="$repo_root/$rel"
+
+    [ "$(grep -c '^[[:space:]]*write_guest_env_file \\' "$harness")" -eq 2 ] \
+        || report "$rel must stage environment for both provision and run"
+    grep -Fq "| cmd_ssh \"sudo sh -c 'umask 077 && cat > \${GUEST_ENV_FILE}'\"" "$harness" \
+        || report "$rel does not transfer the environment over SSH stdin"
+    [ "$(grep -c 'rm -f \${GUEST_ENV_FILE}.*exec bash tests/e2e/' "$harness")" -eq 2 ] \
+        || report "$rel must remove the guest environment before both scripts execute"
+
+    if grep -Eq '[a-z_]+_env\+="? \$var=|sudo\$\{[a-z_]+_env\}' "$harness"; then
+        report "$rel still interpolates forwarded variables into an argv command"
+    fi
+
+    for key in "${keys[@]}"; do
+        grep -Fq "$key" "$harness" \
+            || report "$rel does not forward $key"
+    done
+done
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%d VM environment secret handling failure(s).\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'VM environment secrets are stdin-only across %d harnesses.\n' "${#harnesses[@]}"


### PR DESCRIPTION
## Summary
- serialize the explicit VM environment allow-lists with shell-safe quoting
- transfer them through SSH stdin into a root-only `/run` file instead of interpolating values into SSH and sudo commands
- source and remove the file before execing provision or story scripts, with failure-path cleanup
- apply the fix to provision and run in both Fedora Atomic and Ubuntu harnesses
- derive provider keys from the Rust configuration in a new host-side regression test, wired into local and GitHub CI

## Security check
The regression check rejects the old assignment/`sudo${...}` argv patterns and requires stdin staging plus pre-exec deletion at all four call sites. A repository search confirms no harness command string interpolates the forwarded values anymore.

## Verification
- `bash tests/e2e/vm-env-secrets.test.sh`
- `bash -n tests/e2e/atomic-vm.sh tests/e2e/ubuntu-vm.sh tests/e2e/vm-env-secrets.test.sh scripts/ci-local.sh`
- parsed `.github/workflows/ci.yml` with Ruby YAML
- `git diff --check`

The existing `provider-parity.test.sh` and `vm-sync-parity.test.sh` require Bash 4 `mapfile` and cannot run under the host macOS Bash 3.2; the new test is Bash 3.2-compatible and those existing checks remain wired for Linux CI. No VM image was available for a live guest run.

Closes #299