### PR TITLE
test(ci): fail if postgres-contract drops a required token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Check the install knows every directory it writes into
         run: bash tests/release/install-paths.test.sh
 
+      - name: Check postgres-contract still requires both job tokens
+        run: bash tests/release/postgres-contract-guard.test.sh
+
       - name: Check provider parity across E2E entry points
         run: bash tests/e2e/provider-parity.test.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   and ends the then-branch with `true`, so a missing packages file is
   optional rather than an error.
 
+- **`postgres-contract` could still report success on zero live tests.**
+  ([#317](https://github.com/lacs-project/sysknife/pull/317),
+  [#315](https://github.com/lacs-project/sysknife/issues/315))
+  [#313](https://github.com/lacs-project/sysknife/pull/313) made the job fail
+  closed on a missing database, but split the guarantee across two tokens:
+  `SYSKNIFE_REQUIRE_POSTGRES` fails loudly from inside the test file, while
+  `--include-ignored` is what runs the five `#[ignore]` live tests at all.
+  Dropping the flag left the job reporting `6 passed; 5 ignored` and exiting 0
+  with no database touched. `tests/release/postgres-contract-guard.test.sh` now
+  reads the CI job and both `scripts/ci-local.sh` branches and fails when either
+  token goes missing. It derives the variable name from `postgres_store.rs` and
+  asserts no test count, so adding a store test does not break it.
+
 ## [0.10.0] — 2026-08-26
 
 The middle digit moves because [#289](https://github.com/lacs-project/sysknife/pull/289)

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -283,6 +283,7 @@ run_hygiene_group() {
     run_step 'hygiene: vm-sync-parity.test.sh' bash "$repo_root/tests/e2e/vm-sync-parity.test.sh"
     run_step 'hygiene: docs-share-cards.test.sh' bash "$repo_root/tests/release/docs-share-cards.test.sh"
     run_step 'hygiene: install-paths.test.sh' bash "$repo_root/tests/release/install-paths.test.sh"
+    run_step 'hygiene: postgres-contract-guard.test.sh' bash "$repo_root/tests/release/postgres-contract-guard.test.sh"
 
     if have markdownlint-cli2; then
         run_step 'hygiene: markdownlint-cli2' hygiene_markdownlint

--- a/tests/release/postgres-contract-guard.test.sh
+++ b/tests/release/postgres-contract-guard.test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# postgres-contract-guard.test.sh — both halves of the live Postgres contract
+# must stay on the job that claims to run it.
+#
+# #313 closed the case where postgres-contract reported success with no
+# database configured. The job now sets SYSKNIFE_REQUIRE_POSTGRES and runs
+# with --include-ignored. Both are load-bearing; only the variable fails
+# loudly from inside the test file. Drop the flag and cargo reports
+# "6 passed; 5 ignored" and exits 0 — #294's shape with a different cause.
+# See issue #315.
+#
+# This check reads the job and fails when either token is missing. It does
+# not assert a test count: that would break the next time anyone adds a
+# store test and teach whoever hit it to edit the number rather than read
+# the check.
+#
+# Two design rules, both from tests/e2e/provider-parity.test.sh:
+#
+#   * The tokens are derived from postgres_store.rs, never restated as a
+#     count, so renaming the env var or dropping #[ignore] fails here
+#     until the job catches up.
+#   * It covers every entry point, not just CI. ci-local.sh carries the
+#     pair in two branches (URL already exported, and the path that starts
+#     a container first). A guard that watches CI and ignores the local
+#     mirror leaves half the surface open.
+#
+# A pattern that matched nothing would make every assertion below vacuously
+# true, which is the exact failure this suite exists to stop. Missing files
+# and an empty job extract fail rather than pass over nothing to read.
+#
+# Host-side only: greps files, needs no VM, no daemon, no network.
+# Wired into docs-and-hygiene and scripts/ci-local.sh; a test nothing
+# invokes is the same defect in a different costume.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ci_yml="$repo_root/.github/workflows/ci.yml"
+ci_local="$repo_root/scripts/ci-local.sh"
+store="$repo_root/crates/sysknife-daemon/tests/postgres_store.rs"
+
+for f in "$ci_yml" "$ci_local" "$store"; do
+    [ -f "$f" ] || { printf 'FAIL: missing file: %s\n' "$f" >&2; exit 1; }
+done
+
+# Fail-closed env var, taken from the store test the job runs.
+# sort -u consumes every grep hit so a later head cannot SIGPIPE the pipeline
+# under `set -o pipefail`.
+require_token="$(grep -o 'SYSKNIFE_REQUIRE_POSTGRES' "$store" | sort -u)"
+if [ -z "$require_token" ]; then
+    printf 'FAIL: %s no longer names SYSKNIFE_REQUIRE_POSTGRES; the job token cannot be derived\n' \
+        "$store" >&2
+    exit 1
+fi
+
+# Live tests carry #[ignore]; without --include-ignored cargo never runs them
+# and still exits 0. Demand the attribute rather than trusting a count.
+if ! grep -Eq '#\[ignore' "$store"; then
+    printf 'FAIL: %s has no #[ignore] tests; --include-ignored would not run the live contract\n' \
+        "$store" >&2
+    exit 1
+fi
+# cargo's flag for #[ignore] tests. Named here once; the rust file proves
+# those tests are ignored, the job must still pass the flag.
+ignore_token='--include-ignored'
+
+tokens=("$require_token" "$ignore_token")
+
+failures=0
+report() {
+    printf 'FAIL  %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+# Top-level GitHub Actions job. Empty extract is a failure: grepping nothing
+# would report every token present.
+extract_job() {
+    local file="$1"
+    local job="$2"
+    awk -v job="$job" '
+        $0 ~ ("^  " job ":[[:space:]]*$") { inside = 1 }
+        inside && /^  [A-Za-z0-9_-]+:/ && $0 !~ ("^  " job ":") { exit }
+        inside { print }
+    ' "$file"
+}
+
+job="$(extract_job "$ci_yml" "postgres-contract")"
+if [ -z "$job" ]; then
+    report "$ci_yml has no postgres-contract job to read"
+else
+    for token in "${tokens[@]}"; do
+        grep -Fq -- "$token" <<<"$job" \
+            || report "$ci_yml postgres-contract job is missing $token"
+    done
+fi
+
+# Each cargo invocation of postgres_store, including the env lines that
+# continue onto it. The label string also names the command, so only
+# statements that actually call run_step count as a branch.
+extract_invocations() {
+    awk '
+        {
+            if (buf != "") buf = buf "\n" $0
+            else buf = $0
+            if ($0 ~ /\\$/) next
+            if (buf ~ /run_step/ && buf ~ /postgres_store/) printf "%s\x1e", buf
+            buf = ""
+        }
+    ' "$1"
+}
+
+branch_count=0
+while IFS= read -r -d $'\x1e' stmt; do
+    [ -z "$stmt" ] && continue
+    branch_count=$((branch_count + 1))
+    for token in "${tokens[@]}"; do
+        grep -Fq -- "$token" <<<"$stmt" \
+            || report "$ci_local postgres-contract branch $branch_count is missing $token"
+    done
+done < <(extract_invocations "$ci_local")
+
+if [ "$branch_count" -lt 2 ]; then
+    report "$ci_local has $branch_count postgres-contract run_step branch(es); both the exported-URL path and the container-start path must carry the pair"
+fi
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%d postgres-contract guard failure(s).\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'postgres-contract guard passed: %s and %s present on the CI job and %d ci-local.sh branches.\n' \
+    "$require_token" "$ignore_token" "$branch_count"


### PR DESCRIPTION
## Summary

#313 closed the case where `postgres-contract` reported success with no
database configured. The job now sets `SYSKNIFE_REQUIRE_POSTGRES` and runs
with `--include-ignored`. Both are load-bearing; only the variable fails
loudly from inside the test file.

Drop the flag, change nothing else, and cargo reports the ignored live
tests and exits 0. Same shape as #294, different cause.

This check reads the job and both `ci-local.sh` branches (exported-URL
path and container-start path) and fails when either token is missing.
It does not assert a test count.

## Related Issue

Closes #315

## Validation

- [x] Tests added or updated
- [x] Documentation updated if behavior changed (N/A — CI hygiene only)
- [x] Security impact considered (none; host-side greps)
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [ ] CI passes

Local: `bash tests/release/postgres-contract-guard.test.sh` (exit 0);
`shellcheck --severity=warning tests/release/postgres-contract-guard.test.sh scripts/ci-local.sh`;
`yamllint .github/workflows/ci.yml`.
Mutation: dropping either token from `ci.yml` or either `ci-local.sh` branch
fails and names the file; a missing workflow path fails rather than passing
over nothing; restore is green.

No Rust in the diff, so the workspace nextest gate does not apply.

## Notes for Reviewers

Tokens are derived from `postgres_store.rs` (`SYSKNIFE_REQUIRE_POSTGRES` plus
a floor that `#[ignore]` still exists). `--include-ignored` is cargo's flag
for that attribute.

`ci-local.sh` is two branches, not one. The container path puts the env
assignment and `run_step` on different lines; the check joins continuation
lines so that branch cannot hide a missing `SYSKNIFE_REQUIRE_POSTGRES`.