### PR TITLE
feat(cli): export audit chain rows as JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Check postgres-contract still requires both job tokens
         run: bash tests/release/postgres-contract-guard.test.sh
 
+      - name: Check the audit export states its confidentiality class
+        run: bash tests/release/audit-export-confidentiality.test.sh
+
       - name: Check provider parity across E2E entry points
         run: bash tests/e2e/provider-parity.test.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+### Added
+
+- **`sysknife audit export` writes the signed chain rows as JSON.**
+  ([#215](https://github.com/lacs-project/sysknife/issues/215),
+  [#260](https://github.com/lacs-project/sysknife/pull/260))
+  Emits the stored transaction-chain rows in ascending `seq` order, with
+  `--since` and `--limit`, including `prev_chain_hash` and the Ed25519 signature
+  stored as `chain_hash`, so an offline consumer has the linkage and signature
+  bytes without opening the database itself. It reconstructs nothing the signed
+  row never stored, and the store is opened without acquiring a signing key.
+  Contributed by @danial-razi.
+
+  `docs/cli.md` and `docs/the-audit-chain.md` now state that an export is not a
+  redacted artifact: `request_hash` commits to the unredacted parameters as one
+  unsalted SHA-256, so an export inherits the confidentiality class of the
+  `0600` database it came from ([#268](https://github.com/lacs-project/sysknife/issues/268)).
+
 ### Fixed
 
 - **`postgres-contract` reported success when no database was configured.**

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,778 Rust tests and 72 frontend tests** form the current deterministic
+**1,785 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/README.md
+++ b/README.md
@@ -361,8 +361,9 @@ See [ROADMAP.md](ROADMAP.md) for the full milestone breakdown.
 
 - ✅ **Ubuntu 22.04** — 79/79 stories on a live VM (recorded in `tests/evidence/story-runs/`)
 - ✅ **Ubuntu 24.04 and 26.04** — 79/79 and 79/79 on live VMs; every LTS run has a replay twin that reproduces it
+- ✅ `sysknife audit export` — stored signed chain rows as JSON with `--since` / `--limit`
 - 📋 Telegram inline-button approvals
-- 📋 `sysknife audit export` (CEF / NDJSON for SIEM ingest)
+- 📋 CEF / NDJSON output modes for SIEM ingest
 - 📋 Fleet plan/execute (one plan, N targets, parallel approval)
 
 ## Protocol

--- a/apps/sysknife-cli/src/cli.rs
+++ b/apps/sysknife-cli/src/cli.rs
@@ -137,6 +137,9 @@ impl Command {
 /// `sysknife audit <subcommand>` subcommands.
 #[derive(Subcommand, Debug, Clone)]
 pub enum AuditCommand {
+    /// Export the stored signed audit-chain rows as JSON.
+    Export(AuditExportArgs),
+
     /// Verify the tamper-evident Ed25519-signed hash chain over the audit log.
     ///
     /// Exits 0 if the chain is intact, 1 if any row is broken, and 2 if the
@@ -149,6 +152,18 @@ pub enum AuditCommand {
     /// append-only database, then verify all anchored checkpoints against the
     /// local chain (detects tail-truncation and rewrite).
     Checkpoint(AuditCheckpointArgs),
+}
+
+/// Arguments for `sysknife audit export`.
+#[derive(Args, Debug, Clone)]
+pub struct AuditExportArgs {
+    /// Export rows recorded at or after this RFC 3339 datetime.
+    #[arg(long, value_name = "DATETIME")]
+    pub since: Option<String>,
+
+    /// Maximum number of rows to export. By default every matching row is emitted.
+    #[arg(long, value_name = "N")]
+    pub limit: Option<u32>,
 }
 
 /// Arguments for `sysknife audit verify`.
@@ -356,6 +371,29 @@ mod tests {
                 assert_eq!(args.since.as_deref(), Some("2026-01-01T00:00:00Z"));
             }
             other => panic!("expected Command::History, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_export_subcommand_with_filters() {
+        let cli = Cli::try_parse_from([
+            "sysknife",
+            "audit",
+            "export",
+            "--since",
+            "2026-01-01T00:00:00Z",
+            "--limit",
+            "5",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Command::Audit {
+                command: AuditCommand::Export(args),
+            }) => {
+                assert_eq!(args.since.as_deref(), Some("2026-01-01T00:00:00Z"));
+                assert_eq!(args.limit, Some(5));
+            }
+            other => panic!("expected audit export, got {other:?}"),
         }
     }
 

--- a/apps/sysknife-cli/src/main.rs
+++ b/apps/sysknife-cli/src/main.rs
@@ -137,6 +137,9 @@ async fn dispatch(
 
         // --- sysknife audit verify ---
         Some(Command::Audit { command }) => match command {
+            crate::cli::AuditCommand::Export(args) => {
+                runner::run_audit_export(args.clone(), log).await
+            }
             crate::cli::AuditCommand::Verify(args) => {
                 runner::run_audit_verify(args.clone(), log).await
             }

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -32,7 +32,7 @@ use sysknife_types::{
 use sysknife_brain::state_client::StateClient as _;
 
 use crate::approval::{ApprovalDecision, ApprovalPolicy, MaxRisk};
-use crate::cli::{AuditVerifyArgs, Cli, HistoryArgs};
+use crate::cli::{AuditExportArgs, AuditVerifyArgs, Cli, HistoryArgs};
 use crate::client::{DaemonClient, SocketTarget};
 use crate::error::CliError;
 
@@ -782,8 +782,63 @@ impl RunOpts {
 }
 
 // ---------------------------------------------------------------------------
-// run_audit_verify
+// run_audit_export / run_audit_verify
 // ---------------------------------------------------------------------------
+
+/// Export the signed transaction-chain rows from the configured audit store.
+///
+/// This is deliberately a local storage read, just like `audit verify`; it
+/// does not cross the daemon protocol or load the private audit key.
+pub async fn run_audit_export(args: AuditExportArgs, log: &Logger) -> Result<(), CliError> {
+    use sysknife_core::config::LacsConfig;
+    use sysknife_daemon::audit_chain::{select_chain_rows_for_export, validate_export_since};
+
+    if let Some(since) = args.since.as_deref() {
+        validate_export_since(since).map_err(|e| CliError::ConfigOrDaemon(e.to_string()))?;
+    }
+
+    let lacs_config = LacsConfig::load();
+    let resolved_store = sysknife_core::resolve_audit_store();
+    if let Some(note) = resolved_store.note() {
+        log.print_stderr(&format!("note: {note}"));
+    }
+
+    let rows = match lacs_config.storage.as_ref() {
+        Some(storage) if storage.backend.eq_ignore_ascii_case("postgres") => {
+            let config = postgres_config(storage)
+                .map_err(|reason| CliError::ConfigOrDaemon(format!("audit export: {reason}")))?;
+            sysknife_daemon::store::postgres::PostgresStore::read_chain_rows(&config)
+                .await
+                .map_err(|e| {
+                    CliError::ConfigOrDaemon(format!("postgres audit chain query failed: {e}"))
+                })?
+        }
+        _ => {
+            use sysknife_daemon::transactions::TransactionStore;
+
+            let db_path = resolved_store.path();
+            if !db_path.exists() {
+                return Err(CliError::ConfigOrDaemon(format!(
+                    "audit database not found at {}; set $SYSKNIFE_DATABASE_PATH or run the daemon first",
+                    db_path.display()
+                )));
+            }
+            let store = TransactionStore::open_read_only(db_path).map_err(|e| {
+                CliError::ConfigOrDaemon(format!("opening audit database failed: {e}"))
+            })?;
+            store
+                .fetch_chain_rows()
+                .map_err(|e| CliError::ConfigOrDaemon(format!("audit chain query failed: {e}")))?
+        }
+    };
+
+    let rows = select_chain_rows_for_export(rows, args.since.as_deref(), args.limit)
+        .map_err(|e| CliError::ConfigOrDaemon(e.to_string()))?;
+    let json = serde_json::to_string(&rows)
+        .map_err(|e| CliError::ConfigOrDaemon(format!("serializing audit export failed: {e}")))?;
+    log.println(&json);
+    Ok(())
+}
 
 /// Walk the audit log hash chain and report integrity status.
 ///
@@ -1183,39 +1238,12 @@ pub(crate) async fn verify_postgres(
     storage: &sysknife_core::config::StorageSection,
     verifier: &Verifier,
 ) -> AuditVerification {
-    use sysknife_core::config::StorageBackend;
-    use sysknife_daemon::store::postgres::{PostgresConfig, PostgresStore};
+    use sysknife_daemon::store::postgres::PostgresStore;
 
-    // Project the relaxed config form into the type-state-checked enum;
-    // the match below makes future backends a compile-time decision.
-    let parsed = match storage.parsed() {
-        Ok(p) => p,
+    let cfg = match postgres_config(storage) {
+        Ok(config) => config,
         Err(reason) => return cannot_verify_all(reason),
     };
-    let (url, pool) =
-        match parsed {
-            StorageBackend::Sqlite => return cannot_verify_all(
-                "verify_postgres called with backend = \"sqlite\" — caller picks the wrong path"
-                    .to_string(),
-            ),
-            StorageBackend::Postgres { url, pool } => (url, pool),
-        };
-
-    let mut cfg = PostgresConfig {
-        url,
-        ..PostgresConfig::default()
-    };
-    {
-        if let Some(n) = pool.max_connections {
-            cfg.max_connections = n;
-        }
-        if let Some(s) = pool.acquire_timeout_secs {
-            cfg.acquire_timeout = std::time::Duration::from_secs(s);
-        }
-        if let Some(c) = pool.statement_cache_capacity {
-            cfg.statement_cache_capacity = c;
-        }
-    }
 
     match verifier {
         Verifier::Private(key) => {
@@ -1236,6 +1264,41 @@ pub(crate) async fn verify_postgres(
             }
         }
     }
+}
+
+/// Project the relaxed user-facing storage section into Postgres' checked
+/// connection configuration. Both audit readers use this so `verify` and
+/// `export` cannot drift on pool settings or URL validation.
+fn postgres_config(
+    storage: &sysknife_core::config::StorageSection,
+) -> Result<sysknife_daemon::store::postgres::PostgresConfig, String> {
+    use sysknife_core::config::StorageBackend;
+    use sysknife_daemon::store::postgres::PostgresConfig;
+
+    let (url, pool) = match storage.parsed()? {
+        StorageBackend::Sqlite => {
+            return Err(
+                "postgres reader called with backend = \"sqlite\" — caller picked the wrong path"
+                    .to_string(),
+            );
+        }
+        StorageBackend::Postgres { url, pool } => (url, pool),
+    };
+
+    let mut config = PostgresConfig {
+        url,
+        ..PostgresConfig::default()
+    };
+    if let Some(value) = pool.max_connections {
+        config.max_connections = value;
+    }
+    if let Some(value) = pool.acquire_timeout_secs {
+        config.acquire_timeout = std::time::Duration::from_secs(value);
+    }
+    if let Some(value) = pool.statement_cache_capacity {
+        config.statement_cache_capacity = value;
+    }
+    Ok(config)
 }
 
 /// What the chain verdict says about the standing of the attribution counts.

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -24,6 +24,11 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use std::process::Command;
+use std::sync::Arc;
+use sysknife_daemon::audit_chain::{AuditKey, ChainRow};
+use sysknife_daemon::auth::CallerPrincipal;
+use sysknife_daemon::transactions::{NewTransaction, TransactionStore};
+use sysknife_types::{CallerRole, RiskLevel};
 
 /// Path the CLI tries to connect to in tests — points at a directory we
 /// own so the failure mode is "ENOENT" rather than "ECONNREFUSED on a
@@ -123,6 +128,64 @@ fn audit_verify_exits_with_code_2_when_the_key_file_is_missing() {
         .arg(dir.path().join("no-such-key.pub"))
         .assert()
         .code(2);
+}
+
+#[test]
+fn audit_export_emits_the_stored_rows_as_parseable_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("daemon.sqlite");
+    let key = Arc::new(AuditKey::load_or_generate(&dir.path().join("audit-key")).unwrap());
+    let store = TransactionStore::open_with_key(&db_path, key).unwrap();
+    for request_id in ["req-1", "req-2"] {
+        store
+            .record(NewTransaction {
+                request_id: request_id.to_string(),
+                request_hash: format!("hash-{request_id}"),
+                action_name: "UpdateSystem".to_string(),
+                risk_level: RiskLevel::High,
+                summary: "Upgrade the system".to_string(),
+                warnings: vec![],
+                caller_role: CallerRole::Dev,
+                caller_principal: CallerPrincipal::Uid(1000),
+            })
+            .unwrap();
+    }
+    let stored = store.fetch_chain_rows().unwrap();
+    drop(store);
+
+    let output = cli()
+        .env("SYSKNIFE_DATABASE_PATH", &db_path)
+        .env("HOME", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .args(["audit", "export", "--limit", "1"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let exported: Vec<ChainRow> = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(exported.len(), 1);
+    assert_eq!(exported[0], stored[0]);
+    assert_eq!(
+        exported[0].chain_hash.as_bytes(),
+        stored[0].chain_hash.as_bytes()
+    );
+}
+
+#[test]
+fn audit_export_rejects_an_invalid_since_timestamp() {
+    let dir = tempfile::tempdir().unwrap();
+    cli()
+        .env("SYSKNIFE_DATABASE_PATH", dir.path().join("unused.sqlite"))
+        .env("HOME", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .args(["audit", "export", "--since", "not-a-timestamp"])
+        .assert()
+        .code(4)
+        .stderr(predicate::str::contains("--since"));
 }
 
 #[test]

--- a/crates/sysknife-daemon/src/audit_chain.rs
+++ b/crates/sysknife-daemon/src/audit_chain.rs
@@ -658,7 +658,7 @@ pub fn outcome_to_exit_code(outcome: &VerifyOutcome) -> i32 {
 }
 
 /// One row's worth of chain data, as fetched from the store.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ChainRow {
     pub seq: u64,
     pub key_id: String,
@@ -684,6 +684,61 @@ pub struct ChainRow {
     /// required for `chain_version = 3`. Scheme-prefixed, see
     /// [`ChainIdentity::V3`].
     pub caller_principal: Option<String>,
+}
+
+/// Invalid input or stored data encountered while selecting rows for export.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ChainExportError {
+    #[error("--since: {0:?} is not a valid RFC 3339 timestamp")]
+    InvalidSince(String),
+    #[error("audit row {seq} has an invalid RFC 3339 created_at value {created_at:?}")]
+    InvalidCreatedAt { seq: u64, created_at: String },
+}
+
+/// Validate the timestamp accepted by `sysknife audit export --since`.
+pub fn validate_export_since(since: &str) -> Result<(), ChainExportError> {
+    chrono::DateTime::parse_from_rfc3339(since)
+        .map(|_| ())
+        .map_err(|_| ChainExportError::InvalidSince(since.to_string()))
+}
+
+/// Select stored chain rows for export while preserving their `seq` order.
+///
+/// The storage readers return rows in ascending `seq` order. Filtering here,
+/// rather than re-encoding any fields, keeps every exported byte-for-byte
+/// value (especially `chain_hash` and `warnings_json`) exactly as stored and
+/// gives SQLite and PostgreSQL identical `--since` semantics.
+pub fn select_chain_rows_for_export(
+    rows: Vec<ChainRow>,
+    since: Option<&str>,
+    limit: Option<u32>,
+) -> Result<Vec<ChainRow>, ChainExportError> {
+    let since = since
+        .map(|value| {
+            chrono::DateTime::parse_from_rfc3339(value)
+                .map_err(|_| ChainExportError::InvalidSince(value.to_string()))
+        })
+        .transpose()?;
+    let limit = limit.map_or(usize::MAX, |value| value as usize);
+
+    rows.into_iter()
+        .filter_map(|row| {
+            let keep = match since.as_ref() {
+                None => true,
+                Some(since) => match chrono::DateTime::parse_from_rfc3339(&row.created_at) {
+                    Ok(created_at) => created_at >= *since,
+                    Err(_) => {
+                        return Some(Err(ChainExportError::InvalidCreatedAt {
+                            seq: row.seq,
+                            created_at: row.created_at,
+                        }));
+                    }
+                },
+            };
+            keep.then_some(Ok(row))
+        })
+        .take(limit)
+        .collect()
 }
 
 /// Why a stored row's columns do not describe a verifiable encoding.
@@ -1775,6 +1830,95 @@ mod tests {
             prev = hash;
         }
         rows
+    }
+
+    #[test]
+    fn exported_chain_row_json_round_trips_without_changing_the_signature() {
+        let key = fixed_key();
+        let row = build_chain(&key, 1).remove(0);
+
+        let json = serde_json::to_string(&row).expect("chain row serializes");
+        let decoded: ChainRow = serde_json::from_str(&json).expect("chain row deserializes");
+
+        assert_eq!(decoded, row);
+        assert_eq!(decoded.chain_hash.as_bytes(), row.chain_hash.as_bytes());
+    }
+
+    #[test]
+    fn exported_chain_row_uses_the_stored_column_contract_and_json_nulls() {
+        let key = fixed_key();
+        let mut row = build_chain(&key, 1).remove(0);
+        row.approval_id = None;
+        row.caller_role = None;
+        row.event_tip = None;
+        row.caller_principal = None;
+
+        let value = serde_json::to_value(&row).expect("chain row serializes");
+        let object = value.as_object().expect("chain row is a JSON object");
+        let keys: Vec<&str> = object.keys().map(String::as_str).collect();
+
+        assert_eq!(
+            keys,
+            vec![
+                "action_name",
+                "approval_id",
+                "caller_principal",
+                "caller_role",
+                "chain_hash",
+                "chain_version",
+                "created_at",
+                "event_tip",
+                "key_id",
+                "prev_chain_hash",
+                "request_hash",
+                "request_id",
+                "risk_level",
+                "seq",
+                "summary",
+                "transaction_id",
+                "warnings_json",
+            ]
+        );
+        for optional in [
+            "approval_id",
+            "caller_role",
+            "event_tip",
+            "caller_principal",
+        ] {
+            assert!(object[optional].is_null(), "{optional} must be JSON null");
+        }
+        assert!(!object.contains_key("argv"));
+        assert!(!object.contains_key("outcome"));
+        assert!(!object.contains_key("signature"));
+    }
+
+    #[test]
+    fn export_since_is_inclusive_and_limit_preserves_chain_order() {
+        let key = fixed_key();
+        let mut rows = build_chain(&key, 4);
+        for (row, created_at) in rows.iter_mut().zip([
+            "2026-08-19T09:00:00Z",
+            "2026-08-19T10:00:00Z",
+            "2026-08-19T11:00:00Z",
+            "2026-08-19T12:00:00Z",
+        ]) {
+            row.created_at = created_at.to_string();
+        }
+
+        let selected =
+            select_chain_rows_for_export(rows, Some("2026-08-19T10:00:00+00:00"), Some(2)).unwrap();
+
+        assert_eq!(
+            selected.iter().map(|row| row.seq).collect::<Vec<_>>(),
+            [2, 3]
+        );
+    }
+
+    #[test]
+    fn export_rejects_an_invalid_since_timestamp() {
+        let error = select_chain_rows_for_export(Vec::new(), Some("last Tuesday"), None)
+            .expect_err("invalid --since must fail before reading rows");
+        assert!(matches!(error, ChainExportError::InvalidSince(_)));
     }
 
     // ── caller identity in the signed content ─────────────────────────────

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -297,6 +297,16 @@ impl PostgresStore {
         }
     }
 
+    /// Read the transaction chain without a signing key or schema mutation.
+    /// Used by `sysknife audit export`, which must never acquire signing
+    /// capability merely to serialize rows that already exist.
+    pub async fn read_chain_rows(
+        config: &PostgresConfig,
+    ) -> Result<Vec<ChainRow>, TransactionStoreError> {
+        let pool = Self::connect_pool(config).await?;
+        fetch_chain_rows_from_pool(&pool).await
+    }
+
     /// All three checks with the daemon's key.
     pub async fn verify_all(
         &self,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -145,6 +145,25 @@ receipt.
 Inspect and anchor the tamper-evident, Ed25519-signed audit chain the daemon
 writes for every executed action.
 
+#### `sysknife audit export`
+
+Export the transaction-chain rows from the configured SQLite or PostgreSQL
+audit store as a JSON array, in ascending `seq` order. Each object contains the
+17 stored `ChainRow` columns, including `prev_chain_hash` and `chain_hash`.
+The latter is the Ed25519 signature and is deliberately not renamed. Optional
+values that were not recorded are JSON `null`; `argv`, `outcome`, and a
+separate `signature` field are not reconstructed.
+
+```sh
+sysknife audit export
+sysknife audit export --since 2026-08-01T00:00:00Z --limit 500
+```
+
+| Flag | Description |
+|---|---|
+| `--since DATETIME` | Include rows recorded at or after this RFC 3339 timestamp |
+| `--limit N` | Emit at most N matching rows; omitted means all matching rows |
+
 #### `sysknife audit verify`
 
 Verify the audit trail: the transaction chain, the approval-event chain, and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -164,6 +164,22 @@ sysknife audit export --since 2026-08-01T00:00:00Z --limit 500
 | `--since DATETIME` | Include rows recorded at or after this RFC 3339 timestamp |
 | `--limit N` | Emit at most N matching rows; omitted means all matching rows |
 
+An export is not a redacted artifact. It inherits the confidentiality class of
+the audit database, which the daemon keeps `0600` inside a `0700` directory, and
+writing one moves that content across the boundary those modes exist to hold.
+
+Every row carries `request_hash`, a single unsalted SHA-256 over the action name
+and the **unredacted** parameters. `compute_request_hash` runs before
+`redact_params`, so redaction never reaches the hashed preimage. Where an
+action's parameters are low entropy and partly public the hash is worth
+attacking: for `ConfigureWifi` the SSID is broadcast, which leaves the
+passphrase as the only unknown. High-entropy values such as `ProAttach` tokens
+are unaffected.
+
+The column cannot be dropped, because `request_hash` is part of the signed bytes
+an offline verifier rebuilds. Treat an export with the same care as the database
+itself rather than as a sanitised report.
+
 #### `sysknife audit verify`
 
 Verify the audit trail: the transaction chain, the approval-event chain, and

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,778 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,785 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,778 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,785 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -401,6 +401,12 @@ signature bytes without opening SQLite itself. It does not invent `argv`,
 Absent optional columns are JSON `null`, while a value actually recorded as an
 empty string remains an empty string.
 
+An export inherits the confidentiality class of the audit database and is not a
+redacted artifact. `request_hash` commits to the unredacted parameters as one
+unsalted SHA-256, so a low-entropy value such as a Wi-Fi passphrase remains
+attackable in an exported file even though the stored preview is redacted.
+Handle an export like the `0600` database it came from.
+
 Anchor and check signed checkpoints against an external database:
 
 ```sh

--- a/docs/the-audit-chain.md
+++ b/docs/the-audit-chain.md
@@ -13,7 +13,8 @@ for a security-sensitive deployment, this is the page to try to break.
 Each row in the transaction table captures the decision the daemon made about
 one action, at the moment it made it. `sysknife history` renders a subset;
 `caller_role`, `caller_principal` and `event_tip` are chain fields, read with
-`sysknife audit verify` or directly from the database:
+`sysknife audit export` (or directly from the database) and checked with
+`sysknife audit verify`:
 
 | Field | What it commits to |
 |---|---|
@@ -389,7 +390,16 @@ Machine-readable output for CI or a SIEM pipeline:
 
 ```sh
 sysknife audit verify --pubkey audit-key.pub --json
+sysknife audit export --since 2026-08-01T00:00:00Z --limit 500 > audit-rows.json
 ```
+
+`audit export` emits the stored transaction-chain rows as one JSON array in
+ascending `seq` order. It includes both `prev_chain_hash` and the Ed25519
+signature stored as `chain_hash`, so an offline consumer has the linkage and
+signature bytes without opening SQLite itself. It does not invent `argv`,
+`outcome`, or a separate `signature` field that the signed row never stored.
+Absent optional columns are JSON `null`, while a value actually recorded as an
+empty string remains an empty string.
 
 Anchor and check signed checkpoints against an external database:
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -284,6 +284,7 @@ run_hygiene_group() {
     run_step 'hygiene: docs-share-cards.test.sh' bash "$repo_root/tests/release/docs-share-cards.test.sh"
     run_step 'hygiene: install-paths.test.sh' bash "$repo_root/tests/release/install-paths.test.sh"
     run_step 'hygiene: postgres-contract-guard.test.sh' bash "$repo_root/tests/release/postgres-contract-guard.test.sh"
+    run_step 'hygiene: audit-export-confidentiality.test.sh' bash "$repo_root/tests/release/audit-export-confidentiality.test.sh"
 
     if have markdownlint-cli2; then
         run_step 'hygiene: markdownlint-cli2' hygiene_markdownlint

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "b25be48a37a586a14eaee8c4faf1f3f2e452e2a5"
+    "tests": "ca46b7ab317e8958ff724964f220cb4de899ad00"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-08-28T09:19:50-06:00"
+    "tests": "2026-09-01T09:29:37-06:00"
   },
-  "tests": 1778,
+  "tests": 1785,
   "version": 1
 }

--- a/tests/release/audit-export-confidentiality.test.sh
+++ b/tests/release/audit-export-confidentiality.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# audit-export-confidentiality.test.sh — `sysknife audit export` moves signed
+# chain rows out of a 0600 database, and every row carries `request_hash`, an
+# unsalted SHA-256 over the UNREDACTED params. The docs have to say so.
+#
+# The export docs enumerated what the format omits (argv, outcome, a separate
+# signature) and said nothing about what it carries, which reads as a redacted
+# artifact to anyone skimming. See issue #268.
+#
+# The doc claim rests on one code fact: the hash is computed before redaction.
+# This check derives that fact from dispatcher.rs rather than restating it, so
+# if someone ever moves `redact_params` above `compute_request_hash` the docs
+# become wrong and this fails, instead of the docs quietly outliving the code.
+#
+# Host-side only: greps files, no daemon, no network.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+dispatcher="$repo_root/crates/sysknife-daemon/src/dispatcher.rs"
+cli_doc="$repo_root/docs/cli.md"
+chain_doc="$repo_root/docs/the-audit-chain.md"
+
+for f in "$dispatcher" "$cli_doc" "$chain_doc"; do
+    [ -f "$f" ] || { printf 'FAIL: missing file: %s\n' "$f" >&2; exit 1; }
+done
+
+failures=0
+report() { printf 'FAIL  %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+# The code fact. An empty line number is a failure, not a pass over nothing.
+hash_line="$(grep -n 'let request_hash = compute_request_hash(' "$dispatcher" | head -1 | cut -d: -f1)"
+redact_line="$(grep -n 'let redacted_params = redact_params(' "$dispatcher" | head -1 | cut -d: -f1)"
+
+if [ -z "$hash_line" ] || [ -z "$redact_line" ]; then
+    printf 'FAIL: cannot locate compute_request_hash / redact_params in %s\n' "$dispatcher" >&2
+    exit 1
+fi
+
+if [ "$hash_line" -ge "$redact_line" ]; then
+    printf 'NOTE: redaction now precedes the request hash (%s:%s before %s).\n' \
+        "$dispatcher" "$redact_line" "$hash_line" >&2
+    printf 'The export confidentiality wording is derived from the opposite order; update both.\n' >&2
+    exit 1
+fi
+
+# The docs must name the exposure, not merely mention export.
+grep -Fq 'not a redacted artifact' "$cli_doc" \
+    || report "docs/cli.md does not state that an export is not a redacted artifact"
+grep -Fq 'request_hash' "$cli_doc" \
+    || report "docs/cli.md does not name request_hash in the export section"
+grep -Fq 'unredacted' "$cli_doc" \
+    || report "docs/cli.md does not say the hash commits to unredacted parameters"
+
+grep -Fq 'redacted artifact' "$chain_doc" \
+    || report "docs/the-audit-chain.md does not state the export confidentiality class"
+grep -Fq 'request_hash' "$chain_doc" \
+    || report "docs/the-audit-chain.md does not name request_hash"
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%d audit-export confidentiality failure(s).\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'audit export confidentiality stated in docs/cli.md and docs/the-audit-chain.md (hash at line %s precedes redaction at %s).\n' \
+    "$hash_line" "$redact_line"


### PR DESCRIPTION
Lands @danial-razi's `sysknife audit export` from #260, which they closed on 2026-08-21 before deleting their fork. On 2026-08-23 I offered two ways to finish it and said I would assume the second if a week passed without a reply. It did, and the date I named was 2026-08-30, so this is two days late.

Their commit is first and unchanged, with their authorship intact:

```
ca46b7a  danial <danial.razi2112@gmail.com>  2026-08-19
         feat(cli): export audit chain rows as JSON
```

One conflict on the rebase, in `crates/sysknife-daemon/src/store/postgres.rs`: their `read_chain_rows` and the `unreadable_events` helper that landed with #277 were added at the same point in the impl block. Both are kept, neither is altered.

### The second commit is mine

**The confidentiality statement #268 asked for.** The export docs enumerated what the format omits and said nothing about what it carries. Every row carries `request_hash`, one unsalted SHA-256 over the **unredacted** params, because `compute_request_hash` runs at `dispatcher.rs:2001` and `redact_params` at `:2041`. For a low-entropy, partly public parameter set the hash is worth attacking; `ConfigureWifi` broadcasts the SSID and leaves the passphrase as the only unknown. `docs/cli.md` and `docs/the-audit-chain.md` now say an export inherits the `0600` database's confidentiality class and is not a redacted artifact.

I said in #260 that everything I raised was optional except one bookkeeping commit. That was wrong, and #268 is the counter-example I had filed myself four days earlier. Correcting it here rather than leaving it in the thread.

**A guard for it.** `tests/release/audit-export-confidentiality.test.sh` derives the ordering from `dispatcher.rs` instead of restating it, so moving `redact_params` above `compute_request_hash` fails the check and names both line numbers rather than letting the wording outlive the code. Wired into `docs-and-hygiene` and `scripts/ci-local.sh`.

**Baseline.** 1,778 to 1,785 for the seven tests the export adds, with the three published figures moved in the same commit.

### Verification

Ubuntu, at `2446058`:

```
cargo fmt --all --check                                    clean
cargo clippy --workspace --all-features --all-targets ...  clean
scripts/test_baseline.sh                                   1785 passed, matches the artifact
scripts/check_evidence_claims.py                           figures match
tests/release/public-claims.test.sh                        pass
tests/release/audit-export-confidentiality.test.sh         pass
tests/release/postgres-contract-guard.test.sh              pass
shellcheck --severity=warning (four trees)                 clean
```

Five mutations against the new guard, all caught and each verified as actually applied: removing either doc statement, removing `request_hash` from `docs/cli.md`, inverting the two dispatcher calls, and hiding `dispatcher.rs` from the check itself.

### Known red

`docs-and-hygiene` will fail on `Check markdown links`. `https://registry.modelcontextprotocol.io` stopped answering today at about 15:00 UTC; it resolves and the connection times out, from the runners and locally. I checked all ten CI-linked markdown files with the repo's own config: that URL is the only dead link, and it lives in a `README.md` line untouched here. #316 and #317 hit the same wall.

`request_hash` keeps its bare-hash form. Keying it with an HMAC needs a `chain_version` bump, so #268 stays open for that half.

Closes #215. Refs #260, #268.
