### PR TITLE
ci: move off Node 20, pin the lint tools, and stop Scorecard filling the Security tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -70,6 +70,9 @@ jobs:
 
       - name: Check the secret scanner catches keys and ignores fixtures
         run: bash tests/release/no-secrets.test.sh
+
+      - name: Check no workflow pins an end-of-life Node release
+        run: bash tests/release/node-eol.test.sh
 
       - name: Check systemd directory modes match tmpfiles
         run: bash tests/release/systemd-directory-modes.test.sh
@@ -173,7 +176,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Pinned, because this job holds the workflow token: an unpinned global
+      # install lets a compromised release of any of these three run arbitrary
+      # code on the trusted side of the build. Bump deliberately.
       - name: Install lint tools
         run: |
-          npm install --global markdownlint-cli2 markdown-link-check
+          npm install --global markdownlint-cli2@0.23.2 markdown-link-check@3.15.0
           python -m pip install --upgrade pip
-          pip install yamllint
+          pip install yamllint==1.38.0
 
       - name: Check required repository files
         run: bash scripts/check_repo_completeness.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Validate tag and package versions
         run: bash scripts/check_release_versions.sh "${{ github.ref_name }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,8 +3,15 @@ name: scorecard
 
 # OpenSSF Scorecard: grades the repo against ~18 supply-chain security
 # heuristics (branch protection, pinned deps, token permissions, CI tests, …)
-# and publishes results so the README can carry a Scorecard badge. Advisory —
-# it produces a report and SARIF alerts, never a hard pass/fail gate.
+# and publishes results so the README can carry a Scorecard badge. Advisory:
+# it produces a report, never a hard pass/fail gate.
+#
+# The SARIF upload is deliberately absent. Every Scorecard heuristic became a
+# code-scanning alert, five of them with no file attached, and the Security tab
+# stopped meaning "an analysis found something in this code". Four high-severity
+# CodeQL findings sat unread for 36 days behind that noise (#305). `publish_results`
+# still feeds the badge and the public Scorecard API, so nothing a reader sees is
+# lost.
 
 on:
   branch_protection_rule:
@@ -18,14 +25,12 @@ permissions:
 
 jobs:
   analysis:
-    # Scorecard publishes results and uploads SARIF to code scanning, both of
-    # which require the repo to be public (GHAS). Gate on visibility (same
-    # pattern as codeql.yml) so the run stays green while private and resumes
-    # automatically on the public flip.
+    # Publishing results requires the repo to be public. Gate on visibility
+    # (same pattern as codeql.yml) so the run stays green while private and
+    # resumes automatically on the public flip.
     if: github.event.repository.visibility == 'public'
     runs-on: ubuntu-latest
     permissions:
-      security-events: write  # upload SARIF to code scanning
       id-token: write  # OIDC, required by publish_results
     steps:
       - name: Checkout
@@ -39,8 +44,3 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-
-      - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4
-        with:
-          sarif_file: results.sarif

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -276,6 +276,7 @@ run_hygiene_group() {
     run_step 'hygiene: registry-manifest.test.sh' bash "$repo_root/tests/release/registry-manifest.test.sh"
     run_step 'hygiene: smithery-manifest.test.sh' bash "$repo_root/tests/release/smithery-manifest.test.sh"
     run_step 'hygiene: release-rehearsal.test.sh' bash "$repo_root/tests/release/release-rehearsal.test.sh"
+    run_step 'hygiene: node-eol.test.sh' bash "$repo_root/tests/release/node-eol.test.sh"
     run_step 'hygiene: systemd-directory-modes.test.sh' bash "$repo_root/tests/release/systemd-directory-modes.test.sh"
     run_step 'hygiene: ubuntu-vm-bootstrap.test.sh' bash "$repo_root/tests/e2e/ubuntu-vm-bootstrap.test.sh"
     run_step 'hygiene: provider-parity.test.sh' bash "$repo_root/tests/e2e/provider-parity.test.sh"

--- a/tests/release/node-eol.test.sh
+++ b/tests/release/node-eol.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# node-eol.test.sh — no workflow may pin a Node major that upstream has retired.
+#
+# A GitHub Actions runner executes `npm ci` with the workflow token in its
+# environment. Running that on a Node release that no longer receives security
+# fixes puts an unpatched runtime on the trusted side of the build, and it also
+# blocks dependency updates: jsdom 30 needs Node 22.22 or newer, so a CI pinned
+# to 20 cannot take it.
+#
+# The end-of-life dates below are copied from the Node.js release schedule:
+#   https://github.com/nodejs/Release/blob/main/schedule.json
+# They are compared against today, so this test starts failing on its own when
+# the pinned major ages out, rather than waiting for someone to notice.
+#
+# Host-side only: no network, no VM.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workflows="$repo_root/.github/workflows"
+
+[ -d "$workflows" ] || { printf 'missing %s\n' "$workflows" >&2; exit 1; }
+
+# major:end-of-life
+NODE_SCHEDULE="18:2025-04-30 20:2026-04-30 22:2027-04-30 24:2028-04-30 26:2029-04-30"
+
+eol_of() {
+    local major="$1" entry
+    for entry in $NODE_SCHEDULE; do
+        if [ "${entry%%:*}" = "$major" ]; then
+            printf '%s' "${entry#*:}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+today="$(date -u +%Y-%m-%d)"
+failures=0
+pins=0
+
+report() {
+    printf 'FAIL  %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+while IFS= read -r hit; do
+    file="${hit%%:*}"
+    rest="${hit#*:}"
+    line="${rest%%:*}"
+    # `node-version: "20"`, `node-version: '20'` and `node-version: 20` all
+    # reach here; keep only the leading integer.
+    version="$(printf '%s' "${rest#*:}" | tr -d "\"' " | sed 's/^node-version://')"
+    major="${version%%.*}"
+    pins=$((pins + 1))
+
+    case "$major" in
+        '' | *[!0-9]*)
+            report "$(basename "$file"):$line pins an unreadable Node version '$version'"
+            continue
+            ;;
+    esac
+
+    if ! eol="$(eol_of "$major")"; then
+        report "$(basename "$file"):$line pins Node $major, which is absent from the schedule table in this test; add it from nodejs/Release"
+        continue
+    fi
+
+    if [ "$eol" \< "$today" ]; then
+        report "$(basename "$file"):$line pins Node $major, end-of-life since $eol"
+    fi
+done < <(grep -rn '^[[:space:]]*node-version:' "$workflows" || true)
+
+if [ "$pins" -eq 0 ]; then
+    printf 'no node-version pin found under .github/workflows; the extraction is broken, not the workflows\n' >&2
+    exit 1
+fi
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%d workflow Node pin failure(s).\n' "$failures" >&2
+    exit 1
+fi
+
+printf '%d workflow Node pins, all on a supported release as of %s.\n' "$pins" "$today"


### PR DESCRIPTION
Node 20 reached end-of-life on 2026-04-30. Three workflow jobs still pinned it, including the two that run `npm ci` with the workflow token in the environment. All three move to 24, the current active LTS, whose own end-of-life is 2028-04-30.

The pin was also blocking a dependency update. #322 bumps jsdom to 30, which needs Node 22.22 or newer; on 20 the frontend job dies before a single test runs:

```
Caused by: TypeError: webidl.util.markAsUncloneable is not a function
  ❯ new CacheStorage node_modules/undici/lib/web/cache/cachestorage.js:20:17
  ❯ Object.<anonymous> node_modules/jsdom/lib/api.js:12:33
```

`test_baseline --frontend` caught that correctly, refusing to report a count rather than passing a run of zero tests.

## The guard

`tests/release/node-eol.test.sh` reads every `node-version:` under `.github/workflows` and compares its major against the end-of-life dates published in [nodejs/Release](https://github.com/nodejs/Release/blob/main/schedule.json). Comparing against today means the check goes red on its own once a pinned major ages out, instead of waiting for someone to notice.

Two failure modes it handles deliberately:

- A major with no entry in the table fails rather than passing, so the table has to be updated when the project moves to 26.
- Finding no pin at all fails, because that means the extraction broke rather than the workflows being clean.

## Mutation proof

Six mutations, six caught:

| Mutation | Result |
|---|---|
| revert one pin to 20 | `ci.yml:28 pins Node 20, end-of-life since 2026-04-30` |
| pin 18 | `ci.yml:28 pins Node 18, end-of-life since 2025-04-30` |
| pin an unknown major (99) | `pins Node 99, which is absent from the schedule table in this test` |
| pin `lts/*` | `pins an unreadable Node version 'lts/*'` |
| break the grep so it matches nothing | `no node-version pin found …; the extraction is broken, not the workflows` |
| backdate 24's end-of-life in the table | `release-rehearsal.yml:38 pins Node 24, end-of-life since 2020-01-01` |

Wired into `docs-and-hygiene` and `scripts/ci-local.sh`.

## Not in this PR

`packages/setup` declares `engines.node: ">=18"`, and Node 18 has been end-of-life since 2025-04-30. That is a user-facing support claim rather than a CI pin, and raising it drops people, so it needs its own decision. Filing separately.
