### PR TITLE
test: verify live systemd directory modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,829 Rust tests and 72 frontend tests** form the current deterministic
+**1,831 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/crates/sysknife-daemon/src/transport/listen.rs
+++ b/crates/sysknife-daemon/src/transport/listen.rs
@@ -93,6 +93,7 @@ pub fn bind_unix_listener(target: &ListenTarget) -> Result<UnixListener, ListenT
     match target {
         ListenTarget::Unix(path) => {
             if let Some(parent) = path.parent() {
+                let parent_existed = parent.exists();
                 fs::create_dir_all(parent).map_err(|err| {
                     // Name the socket as well as the directory: the socket is
                     // what the operator configured, the directory is only how
@@ -103,6 +104,22 @@ pub fn bind_unix_listener(target: &ListenTarget) -> Result<UnixListener, ListenT
                         path.display()
                     ))
                 })?;
+
+                // Match the packaged RuntimeDirectoryMode when a manual start
+                // has to recreate /run/sysknife. Do not change an existing
+                // operator-owned directory just because a socket lives in it.
+                if !parent_existed {
+                    use std::os::unix::fs::PermissionsExt;
+                    fs::set_permissions(parent, fs::Permissions::from_mode(0o750)).map_err(
+                        |err| {
+                            ListenTargetError::Io(format!(
+                                "cannot set permissions on directory {} for socket {}: {err}",
+                                parent.display(),
+                                path.display()
+                            ))
+                        },
+                    )?;
+                }
             }
 
             if path.exists() {
@@ -208,6 +225,47 @@ mod tests {
         let _second = bind_unix_listener(&target).expect("a stale socket must be reclaimed");
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn newly_created_socket_parent_uses_runtime_directory_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root =
+            std::env::temp_dir().join(format!("sysknife-bind-parent-mode-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        let parent = root.join("run/sysknife");
+        let path = parent.join("daemon.sock");
+
+        let _listener = bind_unix_listener(&ListenTarget::Unix(path))
+            .expect("binding should create the socket parent");
+
+        let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o750);
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn existing_socket_parent_keeps_its_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "sysknife-bind-existing-parent-mode-{}",
+            std::process::id()
+        ));
+        let parent = root.join("socket-dir");
+        std::fs::create_dir_all(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let path = parent.join("daemon.sock");
+        let _listener =
+            bind_unix_listener(&ListenTarget::Unix(path)).expect("binding should succeed");
+
+        let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,829 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,831 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,829 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,831 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/e2e/ubuntu-provision.sh
+++ b/tests/e2e/ubuntu-provision.sh
@@ -40,6 +40,30 @@ fail() {
     exit 1
 }
 
+tmpfiles_mode_for() {
+    local path="$1"
+    local mode
+    mode="$(awk -v path="$path" '$1 == "d" && $2 == path { print $3; exit }' \
+        "${REPO_DIR}/packaging/sysknife-tmpfiles.conf")"
+    if [[ ! "$mode" =~ ^0?[0-7]{3}$ ]]; then
+        printf 'invalid tmpfiles mode for %s: %s\n' "$path" "${mode:-<empty>}" >&2
+        return 1
+    fi
+    printf '%s\n' "${mode#0}"
+}
+
+assert_live_directory_mode() {
+    local path="$1"
+    local expected actual
+    expected="$(tmpfiles_mode_for "$path")" \
+        || fail "Could not derive tmpfiles mode for $path"
+    actual="$(stat -c %a "$path")" \
+        || fail "stat failed for live directory $path"
+    [ "$actual" = "$expected" ] \
+        || fail "Live mode for $path is $actual; tmpfiles declares $expected"
+    echo "Live directory mode matches tmpfiles: $path = $actual"
+}
+
 # ---------------------------------------------------------------------------
 # Detect Ubuntu version
 # ---------------------------------------------------------------------------
@@ -339,6 +363,9 @@ systemctl daemon-reload
 systemctl enable --now sysknife-daemon || fail "Start sysknife-daemon"
 sleep 2
 systemctl is-active sysknife-daemon    || fail "sysknife-daemon not active after start"
+
+assert_live_directory_mode /run/sysknife
+assert_live_directory_mode /var/lib/sysknife
 
 # ---------------------------------------------------------------------------
 # Step 8: Verify daemon socket is reachable

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "b9f20620a2f08f7a8889a42251b4c073ea7b2d6a"
+    "tests": "cf81ecc4581f8d25333db25f7f23f1ee1285799b"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-09-01T17:23:17-06:00"
+    "tests": "2026-09-02T06:10:39+02:00"
   },
-  "tests": 1829,
+  "tests": 1831,
   "version": 1
 }


### PR DESCRIPTION
Closes #269.

This follows #263 through to the running system:

- derive the expected runtime/state modes from `packaging/sysknife-tmpfiles.conf`
- assert the live `/run/sysknife` and `/var/lib/sysknife` modes immediately after systemd starts the daemon in the Ubuntu provision path
- make manual Unix-socket parent creation set `0750` when SysKnife creates a missing parent, while leaving existing operator-owned directories unchanged
- add unit coverage for both the newly-created and pre-existing parent cases

Local checks:
- `bash -n tests/e2e/ubuntu-provision.sh`
- `bash tests/release/systemd-directory-modes.test.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- mutation proof: forcing a `0755` directory against the tmpfiles-derived `0750` expectation is rejected (`expected=750 actual=755`)

The Windows host cannot execute the Unix daemon tests directly; the Linux Rust CI on this PR is the full compile/test check.