### PR TITLE
feat(cli): --dangerously-skip-approval, for runs with no human in the loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,37 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ### Added
 
+- **`sysknife --dangerously-skip-approval` runs with no human in the loop.**
+  Until now `--yes` could never auto-approve a HIGH-risk step, and there was no
+  way to say otherwise. The rule is right for a terminal and wrong for a
+  scheduled run.
+
+  The flag lifts the approval gate: HIGH becomes auto-approvable and the
+  post-preview confirmation stops asking. The preview is still fetched and
+  printed, because it is the only record of what an unattended run was about to
+  change. An explicit `--max-risk` still wins, and `--dry-run` still executes
+  nothing.
+
+  It lifts nothing else. Only catalogue actions with validated parameters run,
+  the polkit allowlist still gates every privileged call, the run still aborts
+  when the daemon rates a step above what the CLI approved, role authorization
+  is unchanged, and every step is still signed into the chain.
+
+  Two keys are required. The flag alone prints an explanation and exits 1; it
+  also needs `SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT=1`, and only that exact value.
+  A flag left in a script and a variable left in a profile are the two ways
+  this gets armed by accident, so neither is sufficient alone. No short form,
+  no abbreviation, and a red banner naming the host and account before anything
+  runs.
+
+  The audit trail records it. The daemon writes a warning into the transaction's
+  `warnings`, which is stored as `warnings_json` and signed as one of the fields
+  in `ChainContent::canonical_bytes`, so an unattended run cannot later be
+  presented as one a human approved: editing the marker out of the stored column
+  makes `sysknife audit verify` report that row `Broken`. The CLI refuses to
+  execute if a daemon too old to record it drops the declaration.
+  [docs/cli.md](docs/cli.md#unattended-mode) has the full contract.
+
 - **`sysknife audit export` writes the signed chain rows as JSON.**
   ([#215](https://github.com/lacs-project/sysknife/issues/215),
   [#260](https://github.com/lacs-project/sysknife/pull/260))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,60 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   unsalted SHA-256, so an export inherits the confidentiality class of the
   `0600` database it came from ([#268](https://github.com/lacs-project/sysknife/issues/268)).
 
+### Security
+
+- **The VM harnesses put provider API keys in the host and guest process tables.**
+  ([#316](https://github.com/lacs-project/sysknife/pull/316),
+  [#299](https://github.com/lacs-project/sysknife/issues/299))
+  `ubuntu-vm.sh` and `atomic-vm.sh` built `sudo VAR='value' bash …` into the ssh
+  command string, so every configured provider key was readable in `ps` on both
+  sides for the length of a story run. The variables now travel over ssh stdin
+  into a `0600` file under `/run`, written with `umask 077` before the
+  redirection, sourced by the guest shell and deleted before the test script
+  `exec`s. Measured rather than argued: a stub that records `cmd_ssh`'s arguments
+  sees four canaries on the old path and none on the new one. The single-quote
+  interpolation it replaces was also a command-injection hole, since any value
+  containing a quote became shell syntax on the guest.
+  `tests/e2e/vm-env-secrets.test.sh` holds the shape in CI. Thanks to
+  @xianjianlf2.
+
+- **CI ran on a Node release that no longer receives security fixes.**
+  ([#326](https://github.com/lacs-project/sysknife/pull/326))
+  Node 20 reached end-of-life on 2026-04-30, and three workflow jobs still
+  pinned it, two of them running `npm ci` with the workflow token in scope. All
+  three move to 24. `tests/release/node-eol.test.sh` compares every
+  `node-version:` pin against the dates published in
+  [nodejs/Release](https://github.com/nodejs/Release/blob/main/schedule.json),
+  so the check goes red on its own once a pinned major ages out, refuses a major
+  it has no entry for, and fails loudly if it finds no pin at all.
+
+  The same job installed `markdownlint-cli2`, `markdown-link-check` and
+  `yamllint` unpinned while holding that token; all three now name a version.
+
+### Changed
+
+- **`rmcp` 3.1, and the 2026-07-28 protocol revision with it.**
+  ([#324](https://github.com/lacs-project/sysknife/pull/324))
+  `ListResourcesResult` and `ListResourceTemplatesResult` gained `result_type`,
+  `ttl_ms` and `cache_scope`. All three stay `None`: an absent `result_type`
+  means complete, and advertising neither a cache scope nor a TTL keeps every
+  client asking the daemon rather than replaying a stored answer.
+  `ServerHandler::read_resource` now returns `ReadResourceResponse`, whose
+  `InputRequired` variant (SEP-2322) asks the client for more input before the
+  read finishes; SysKnife always answers `Complete`, because approval is a
+  terminal action against the daemon and an MCP-level input round would reach
+  the operator with no approval receipt behind it. A new stdio test drives a
+  real `resources/read` and asserts the result's exact key set.
+
+- **Scorecard no longer uploads its SARIF to code scanning.**
+  ([#326](https://github.com/lacs-project/sysknife/pull/326),
+  [#305](https://github.com/lacs-project/sysknife/issues/305))
+  Every Scorecard heuristic was becoming a code-scanning alert, five of them
+  with no file attached, and four high-severity CodeQL findings sat unread for
+  36 days behind that pile. `publish_results: true` stays, so the badge and the
+  public Scorecard API are unchanged, and the job gives up
+  `security-events: write`.
+
 ### Fixed
 
 - **`postgres-contract` reported success when no database was configured.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4840,6 +4840,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "indicatif",
+ "libc",
  "owo-colors",
  "predicates",
  "rmcp",

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,787 Rust tests and 72 frontend tests** form the current deterministic
+**1,819 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,819 Rust tests and 72 frontend tests** form the current deterministic
+**1,820 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -19,6 +19,7 @@ sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.10.0" }
 sysknife-core = { path = "../../crates/sysknife-core", version = "0.10.0" }
 sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.10.0" }
 chrono = "0.4"
+libc = "0.2"
 sysknife-types = { path = "../../crates/sysknife-types", version = "0.10.0" }
 
 clap = { version = "4", features = ["derive"] }

--- a/apps/sysknife-cli/src/approval.rs
+++ b/apps/sysknife-cli/src/approval.rs
@@ -3,15 +3,29 @@
 //! Determines whether plan steps can be auto-approved, need a human prompt,
 //! or must be rejected outright based on CLI flags.
 //!
-//! Security invariant: `--yes` NEVER auto-approves HIGH risk steps regardless
-//! of any flag combination. This is hardcoded, not configurable.
+//! Security invariant: `--yes` NEVER auto-approves HIGH risk steps. The single
+//! exception is `--dangerously-skip-approval`, which exists so an operator can
+//! run SysKnife unattended and which the CLI refuses to honour unless
+//! `SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT=1` is also set. It lifts the hardcoded
+//! cap and nothing else: the typed-action catalogue, the polkit allowlist, the
+//! CLI/daemon risk-skew abort and the signed audit chain are unaffected, and a
+//! transaction previewed in this mode carries a daemon-written warning inside
+//! the signed `warnings_json`, so the trail records that no human approved.
 
 use sysknife_brain::planner::{AuthorizedPlan, PlanRiskLevel};
 
 /// The maximum risk level that `--yes` can auto-approve.
 /// `--max-risk high` with `--yes` still only auto-approves up to MEDIUM.
-/// HIGH always requires a human in the loop.
+/// HIGH requires a human in the loop unless the operator has taken the two
+/// explicit steps that [`ApprovalPolicy::skip_approval`] represents.
 const HARDCODED_MAX_AUTO_APPROVE: MaxRisk = MaxRisk::Medium;
+
+/// The cap once the operator has opted out of the human-in-the-loop rule.
+///
+/// This is still a named ceiling rather than "no ceiling": an explicit
+/// `--max-risk low` continues to win, because the override removes the cap the
+/// project imposed, not the one the operator asked for.
+const UNATTENDED_MAX_AUTO_APPROVE: MaxRisk = MaxRisk::High;
 
 /// CLI risk-level argument (mirrors clap value-enum).
 ///
@@ -56,6 +70,9 @@ pub struct ApprovalPolicy {
     max_risk: Option<MaxRisk>,
     non_interactive: bool,
     dry_run: bool,
+    /// Set only by `--dangerously-skip-approval` plus its environment
+    /// confirmation. Raises the hardcoded cap from MEDIUM to HIGH.
+    skip_approval: bool,
 }
 
 /// The result of evaluating a step or plan against the policy.
@@ -82,12 +99,29 @@ pub enum ApprovalDecision {
 
 impl ApprovalPolicy {
     /// Construct from parsed CLI flags.
-    pub fn new(yes: bool, max_risk: Option<MaxRisk>, non_interactive: bool, dry_run: bool) -> Self {
+    ///
+    /// There is one constructor rather than a safe one and an unattended one,
+    /// so no call site can pick up the human-in-the-loop rule by accident and
+    /// none can drop it without saying so on the same line.
+    ///
+    /// `skip_approval` must only ever come from
+    /// [`crate::cli::UnattendedConsent`], which is the single place that reads
+    /// both the flag and the environment variable. Passing `true` from
+    /// anywhere else defeats the two-key rule; the structural test in
+    /// `main.rs` pins that there is exactly one such call site.
+    pub fn new(
+        yes: bool,
+        max_risk: Option<MaxRisk>,
+        non_interactive: bool,
+        dry_run: bool,
+        skip_approval: bool,
+    ) -> Self {
         Self {
             yes,
             max_risk,
             non_interactive,
             dry_run,
+            skip_approval,
         }
     }
 
@@ -102,9 +136,14 @@ impl ApprovalPolicy {
         // User-requested ceiling (default to Low when --yes is bare).
         let requested = self.max_risk.unwrap_or(MaxRisk::Low);
 
-        // Clamp using Ord::min: any variant ≥ HARDCODED_MAX_AUTO_APPROVE is
-        // reduced to the constant. Extension-safe — no named-arm match needed.
-        Some(requested.min(HARDCODED_MAX_AUTO_APPROVE))
+        // Clamp using Ord::min: any variant ≥ the cap is reduced to it.
+        // Extension-safe — no named-arm match needed.
+        let cap = if self.skip_approval {
+            UNATTENDED_MAX_AUTO_APPROVE
+        } else {
+            HARDCODED_MAX_AUTO_APPROVE
+        };
+        Some(requested.min(cap))
     }
 
     /// Decision for a single step's risk level.
@@ -161,6 +200,117 @@ impl ApprovalPolicy {
 }
 
 #[cfg(test)]
+mod unattended_tests {
+    use super::*;
+    use sysknife_brain::planner::PlanRiskLevel;
+
+    fn policy(skip: bool) -> ApprovalPolicy {
+        ApprovalPolicy::new(true, Some(MaxRisk::High), true, false, skip)
+    }
+
+    #[test]
+    fn without_the_override_high_is_never_auto_approved() {
+        assert_eq!(
+            policy(false).decide_step(&PlanRiskLevel::High),
+            ApprovalDecision::RequiresInteraction,
+            "the hardcoded Medium cap must still hold when the override is off"
+        );
+    }
+
+    #[test]
+    fn with_the_override_high_is_auto_approved() {
+        assert_eq!(
+            policy(true).decide_step(&PlanRiskLevel::High),
+            ApprovalDecision::AutoApproved,
+            "the override exists to lift exactly this"
+        );
+    }
+
+    #[test]
+    fn the_override_raises_the_effective_ceiling_to_high() {
+        assert_eq!(
+            policy(false).effective_auto_ceiling(),
+            Some(MaxRisk::Medium)
+        );
+        assert_eq!(policy(true).effective_auto_ceiling(), Some(MaxRisk::High));
+    }
+
+    #[test]
+    fn the_override_does_not_lift_an_explicit_lower_max_risk() {
+        // --dangerously-skip-approval --max-risk low still refuses a Medium
+        // step. The override removes the hardcoded cap; it does not overrule a
+        // ceiling the operator asked for by name.
+        let p = ApprovalPolicy::new(true, Some(MaxRisk::Low), true, false, true);
+        assert_eq!(
+            p.decide_step(&PlanRiskLevel::Medium),
+            ApprovalDecision::ExceedsCeiling(MaxRisk::Low)
+        );
+    }
+
+    #[test]
+    fn the_override_is_inert_without_yes() {
+        // The flag implies --yes at the CLI layer. If that wiring is ever
+        // dropped, the policy must not auto-approve on the override alone.
+        let p = ApprovalPolicy::new(false, Some(MaxRisk::High), true, false, true);
+        assert_eq!(p.effective_auto_ceiling(), None);
+        assert_eq!(
+            p.decide_step(&PlanRiskLevel::Low),
+            ApprovalDecision::RequiresInteraction
+        );
+    }
+
+    #[test]
+    fn dry_run_still_wins_over_the_override() {
+        let p = ApprovalPolicy::new(true, Some(MaxRisk::High), true, true, true);
+        assert_eq!(
+            p.decide_step(&PlanRiskLevel::High),
+            ApprovalDecision::AutoApproved,
+            "dry-run approves vacuously because nothing executes"
+        );
+    }
+
+    #[test]
+    fn a_whole_plan_of_high_steps_is_auto_approved_only_with_the_override() {
+        use sysknife_brain::action_name::ActionName;
+        use sysknife_brain::planner::{Plan, PlanStep};
+        let mk = || {
+            let steps = vec![
+                PlanStep::new(
+                    ActionName::parse("GetDiskUsage").unwrap(),
+                    "one".into(),
+                    PlanRiskLevel::High,
+                    serde_json::json!({}),
+                )
+                .unwrap(),
+                PlanStep::new(
+                    ActionName::parse("GetDiskUsage").unwrap(),
+                    "two".into(),
+                    PlanRiskLevel::Low,
+                    serde_json::json!({}),
+                )
+                .unwrap(),
+            ];
+            Plan::new(
+                "test".into(),
+                "test plan".into(),
+                "test explanation".into(),
+                steps,
+            )
+            .unwrap()
+            .assume_authorized()
+        };
+        assert_eq!(
+            policy(false).decide_plan(&mk()),
+            ApprovalDecision::RequiresInteraction
+        );
+        assert_eq!(
+            policy(true).decide_plan(&mk()),
+            ApprovalDecision::AutoApproved
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use sysknife_brain::action_name::ActionName;
@@ -197,7 +347,7 @@ mod tests {
         non_interactive: bool,
         dry_run: bool,
     ) -> ApprovalPolicy {
-        ApprovalPolicy::new(yes, max_risk, non_interactive, dry_run)
+        ApprovalPolicy::new(yes, max_risk, non_interactive, dry_run, false)
     }
 
     // --- Step-level: security policy ---

--- a/apps/sysknife-cli/src/cli.rs
+++ b/apps/sysknife-cli/src/cli.rs
@@ -60,6 +60,20 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub step_by_step: bool,
 
+    /// Execute HIGH-risk steps with no human confirmation.
+    ///
+    /// Requires `SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT=1` in the environment as
+    /// well; the flag on its own refuses to run. Implies `--yes`,
+    /// `--max-risk high` and `--non-interactive` unless you set a lower
+    /// `--max-risk`, which still wins.
+    ///
+    /// This lifts the approval gate and nothing else. Typed actions,
+    /// parameter validation, the polkit allowlist, the CLI/daemon risk-skew
+    /// abort and the signed audit chain all still apply, and every step run
+    /// this way is recorded as unattended inside the signed audit row.
+    #[arg(long, global = true)]
+    pub dangerously_skip_approval: bool,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 }
@@ -233,6 +247,151 @@ impl From<MaxRiskArg> for MaxRisk {
             MaxRiskArg::Medium => MaxRisk::Medium,
             MaxRiskArg::High => MaxRisk::High,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// UnattendedConsent
+// ---------------------------------------------------------------------------
+
+/// The environment variable that must accompany `--dangerously-skip-approval`.
+pub const UNATTENDED_CONSENT_VAR: &str = "SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT";
+
+/// The value that variable must hold. Anything else is treated as unset, so a
+/// stray `=0` or `=false` left in a profile cannot arm the override.
+pub const UNATTENDED_CONSENT_VALUE: &str = "1";
+
+/// Proof that both halves of the two-key rule were supplied.
+///
+/// The type exists so `skip_approval` cannot be set from a bare boolean at a
+/// call site. `ApprovalPolicy::new_unattended` takes the boolean, but the only
+/// `true` in the binary comes from [`UnattendedConsent::resolve`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum UnattendedConsent {
+    /// Neither half supplied. Normal operation.
+    NotRequested,
+    /// Both halves supplied. The approval gate is lifted for this run.
+    Granted,
+    /// The flag without the variable.
+    FlagWithoutEnv,
+    /// The variable without the flag. Not an error, but worth saying: an
+    /// environment left armed is exactly what the two-key rule guards against.
+    EnvWithoutFlag,
+}
+
+impl UnattendedConsent {
+    /// Resolve the two keys. `env_value` is the raw `SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT`
+    /// reading, passed in rather than read here so this stays a pure function.
+    pub fn resolve(flag: bool, env_value: Option<&str>) -> Self {
+        let env_ok = env_value == Some(UNATTENDED_CONSENT_VALUE);
+        match (flag, env_ok) {
+            (true, true) => Self::Granted,
+            (true, false) => Self::FlagWithoutEnv,
+            (false, true) => Self::EnvWithoutFlag,
+            (false, false) => Self::NotRequested,
+        }
+    }
+
+    /// Read the environment and resolve.
+    pub fn from_env(flag: bool) -> Self {
+        let raw = std::env::var(UNATTENDED_CONSENT_VAR).ok();
+        Self::resolve(flag, raw.as_deref())
+    }
+
+    /// Whether the approval gate is lifted. The only place that answers `true`.
+    pub fn is_granted(&self) -> bool {
+        matches!(self, Self::Granted)
+    }
+
+    /// The message to print when the run cannot proceed, or `None` when it can.
+    pub fn refusal(&self) -> Option<String> {
+        match self {
+            Self::FlagWithoutEnv => Some(format!(
+                "--dangerously-skip-approval was passed but {UNATTENDED_CONSENT_VAR} is not set to \
+                 {UNATTENDED_CONSENT_VALUE}.\n\nThis flag lets an LLM's plan execute HIGH-risk \
+                 actions as root with nobody watching. It needs two keys on purpose, so that \
+                 neither a flag left in a script nor a variable left in a profile is enough on its \
+                 own.\n\nIf you meant it:  {UNATTENDED_CONSENT_VAR}={UNATTENDED_CONSENT_VALUE} \
+                 sysknife --dangerously-skip-approval ..."
+            )),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod unattended_consent_tests {
+    use super::*;
+
+    #[test]
+    fn both_keys_grant() {
+        assert_eq!(
+            UnattendedConsent::resolve(true, Some("1")),
+            UnattendedConsent::Granted
+        );
+        assert!(UnattendedConsent::resolve(true, Some("1")).is_granted());
+    }
+
+    #[test]
+    fn the_flag_alone_refuses_and_says_why() {
+        let c = UnattendedConsent::resolve(true, None);
+        assert_eq!(c, UnattendedConsent::FlagWithoutEnv);
+        assert!(!c.is_granted());
+        let msg = c.refusal().expect("a refusal must carry a message");
+        assert!(
+            msg.contains(UNATTENDED_CONSENT_VAR),
+            "names the variable: {msg}"
+        );
+        assert!(msg.contains("as root"), "says what is at stake: {msg}");
+    }
+
+    #[test]
+    fn the_variable_alone_does_not_arm_anything() {
+        let c = UnattendedConsent::resolve(false, Some("1"));
+        assert_eq!(c, UnattendedConsent::EnvWithoutFlag);
+        assert!(
+            !c.is_granted(),
+            "an armed profile must not skip approval on its own"
+        );
+        assert!(c.refusal().is_none(), "it is not an error, only inert");
+    }
+
+    #[test]
+    fn neither_key_is_ordinary_operation() {
+        let c = UnattendedConsent::resolve(false, None);
+        assert_eq!(c, UnattendedConsent::NotRequested);
+        assert!(!c.is_granted());
+        assert!(c.refusal().is_none());
+    }
+
+    // A profile carrying `=0`, `=false`, `=yes` or an empty value is the shape
+    // that would otherwise arm this by accident. Only the exact string counts.
+    #[test]
+    fn only_the_exact_value_counts() {
+        for v in ["0", "false", "true", "yes", "", " 1", "1 ", "01", "TRUE"] {
+            assert_eq!(
+                UnattendedConsent::resolve(true, Some(v)),
+                UnattendedConsent::FlagWithoutEnv,
+                "{v:?} must not satisfy the environment half"
+            );
+        }
+    }
+
+    #[test]
+    fn the_flag_parses_and_defaults_off() {
+        let cli = Cli::parse_from(["sysknife", "check disk"]);
+        assert!(!cli.dangerously_skip_approval);
+        let cli = Cli::parse_from(["sysknife", "--dangerously-skip-approval", "check disk"]);
+        assert!(cli.dangerously_skip_approval);
+    }
+
+    // There is deliberately no short form and no abbreviation. Typing it has to
+    // be a decision, which is the whole safeguard.
+    #[test]
+    fn the_flag_has_no_short_form() {
+        assert!(Cli::try_parse_from(["sysknife", "-d", "check disk"]).is_err());
+        assert!(Cli::try_parse_from(["sysknife", "--skip-approval", "check disk"]).is_err());
+        assert!(Cli::try_parse_from(["sysknife", "--dangerously-skip", "check disk"]).is_err());
     }
 }
 

--- a/apps/sysknife-cli/src/client.rs
+++ b/apps/sysknife-cli/src/client.rs
@@ -597,6 +597,23 @@ impl DaemonClient {
         action_name: &str,
         params: &Value,
     ) -> Result<PreparedPreview, CliError> {
+        self.preview_declaring(action_name, params, false).await
+    }
+
+    /// `preview`, declaring whether this client's approval gate is lifted.
+    ///
+    /// The daemon records the declaration in the signed transaction row. It
+    /// grants nothing, so a client that omits it gains no permission; what it
+    /// loses is the audit trail saying no human approved. That is why
+    /// `run_intent` refuses when it declared unattended and the marker does
+    /// not come back: an unrecorded unattended run is the one outcome worth
+    /// failing over.
+    pub async fn preview_declaring(
+        &self,
+        action_name: &str,
+        params: &Value,
+        unattended: bool,
+    ) -> Result<PreparedPreview, CliError> {
         let mut stream = self.connect_async().await?;
 
         let req = serde_json::to_vec(&serde_json::json!({
@@ -604,6 +621,7 @@ impl DaemonClient {
             "request_id": format!("cli-preview-{action_name}"),
             "action_name": action_name,
             "params": params,
+            "unattended": unattended,
         }))
         .map_err(|e| CliError::ConfigOrDaemon(format!("serialize: {e}")))?;
 

--- a/apps/sysknife-cli/src/error.rs
+++ b/apps/sysknife-cli/src/error.rs
@@ -47,6 +47,17 @@ pub enum CliError {
     #[error("plan requires interactive approval but --non-interactive was set")]
     NonInteractive,
 
+    /// `--dangerously-skip-approval` without `SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT=1`.
+    ///
+    /// Exit code 1, the "cannot proceed, and that is a legitimate outcome"
+    /// bucket, rather than clap's usual 2 for a usage error. Nothing
+    /// malfunctioned and no argument was malformed; the operator asked to run
+    /// unattended and has not completed the second half of the handshake. A
+    /// script that already treats 1 as "SysKnife declined to act" gets the
+    /// right answer without a new case.
+    #[error("{0}")]
+    UnattendedConsentMissing(String),
+
     /// Produced when `sysknife approve` is run without a terminal on stdin.
     ///
     /// Distinct from [`Self::NonInteractive`] because the cause is different and
@@ -79,6 +90,7 @@ impl CliError {
             | Self::Refused { .. }
             | Self::RiskCeilingExceeded { .. }
             | Self::NonInteractive
+            | Self::UnattendedConsentMissing(_)
             | Self::ApprovalNeedsTerminal => 1,
             Self::ExecutionFailed(_) => 2,
             Self::PlanningFailed(_) => 3,

--- a/apps/sysknife-cli/src/main.rs
+++ b/apps/sysknife-cli/src/main.rs
@@ -7,6 +7,7 @@ mod mcp_server;
 mod operator_text;
 mod render;
 mod runner;
+mod unattended;
 
 use clap::Parser;
 
@@ -108,6 +109,21 @@ async fn dispatch(
     socket: crate::client::SocketTarget,
     log: &Logger,
 ) -> Result<(), crate::error::CliError> {
+    // Both halves of the two-key rule are checked before any subcommand runs,
+    // so `--dangerously-skip-approval` on a read-only subcommand still fails
+    // loudly rather than being quietly ignored. A flag that is sometimes
+    // ignored teaches people it is harmless.
+    let consent = crate::cli::UnattendedConsent::from_env(cli.dangerously_skip_approval);
+    if let Some(refusal) = consent.refusal() {
+        return Err(crate::error::CliError::UnattendedConsentMissing(refusal));
+    }
+    // --dry-run executes nothing, so the banner would be theatre. Everything
+    // else, including the read-only subcommands, gets it: the point is that a
+    // run in this mode is never quiet.
+    if consent.is_granted() && !cli.dry_run {
+        crate::unattended::warn_and_pause().await;
+    }
+
     match &cli.command {
         // --- sysknife completions <shell> ---
         Some(Command::Completions { shell }) => {
@@ -177,5 +193,7 @@ fn build_run_opts(cli: &Cli, socket: crate::client::SocketTarget) -> RunOpts {
         dry_run: cli.dry_run,
         json: cli.json,
         step_by_step: cli.step_by_step,
+        skip_approval: crate::cli::UnattendedConsent::from_env(cli.dangerously_skip_approval)
+            .is_granted(),
     }
 }

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -328,8 +328,27 @@ fn anchor_caveat() -> &'static str {
 ///
 /// This adds no new refusal class to `--non-interactive`: a plan containing a
 /// HIGH step is already refused at the plan gate before this point.
+///
+/// `--dangerously-skip-approval` deliberately does not change this predicate.
+/// A HIGH step still takes the post-preview branch, so the daemon's preview is
+/// still fetched, still checked against the approved risk, and still printed;
+/// the policy then answers `AutoApproved` instead of asking. Short-circuiting
+/// here instead would have skipped the preview itself, and the preview is the
+/// only record of what an unattended run was about to change.
 fn post_preview_confirmation_required(step_by_step: bool, risk: &PlanRiskLevel) -> bool {
     step_by_step || matches!(risk, PlanRiskLevel::High)
+}
+
+/// Whether the daemon recorded the unattended declaration in this preview.
+///
+/// Compares against the daemon's own constant rather than a copy of the
+/// sentence. A local literal here would be a second source of truth that could
+/// drift silently, and the failure mode of that drift is the CLI deciding an
+/// unattended run *was* recorded when it was not.
+fn unattended_marker_present(warnings: &[String]) -> bool {
+    warnings
+        .iter()
+        .any(|w| w == sysknife_daemon::dispatcher::UNATTENDED_WARNING)
 }
 
 // ---------------------------------------------------------------------------
@@ -772,12 +791,21 @@ pub struct RunOpts {
     pub dry_run: bool,
     pub json: bool,
     pub step_by_step: bool,
+    /// Both halves of the two-key rule were supplied, so the approval gate is
+    /// lifted for this run. Set only from [`crate::cli::UnattendedConsent`].
+    pub skip_approval: bool,
 }
 
 impl RunOpts {
     /// Build the `ApprovalPolicy` for this set of flags.
     pub fn approval_policy(&self) -> ApprovalPolicy {
-        ApprovalPolicy::new(self.yes, self.max_risk, self.non_interactive, self.dry_run)
+        ApprovalPolicy::new(
+            self.yes,
+            self.max_risk,
+            self.non_interactive,
+            self.dry_run,
+            self.skip_approval,
+        )
     }
 }
 
@@ -1891,9 +1919,23 @@ pub async fn run_intent(intent: String, opts: &RunOpts, log: &Logger) -> Result<
         // meant the preview was never a decision point — consent had already
         // been given and execution followed immediately.
         let prepared = exec_client
-            .preview(step.action_name(), step.params())
+            .preview_declaring(step.action_name(), step.params(), opts.skip_approval)
             .await?;
         let preview = &prepared.preview;
+
+        // The declaration is only worth making if it was recorded. A daemon
+        // older than this field accepts the preview and drops it, which would
+        // leave an unattended run indistinguishable from an approved one in
+        // the signed chain. Refuse rather than execute unrecorded.
+        if opts.skip_approval && !unattended_marker_present(&preview.warnings) {
+            return Err(CliError::ConfigOrDaemon(format!(
+                "{}: this run has the approval gate lifted, but the daemon did not record it in \
+                 the preview warnings, so the audit row would not show that no human approved. \
+                 The daemon is older than this CLI. Upgrade it, or drop \
+                 --dangerously-skip-approval.",
+                step.action_name(),
+            )));
+        }
 
         // Fail closed on CLI/daemon risk skew: the plan-level decision used the
         // CLI's own linked catalogue. If the live daemon rates this step higher
@@ -2868,6 +2910,45 @@ mod tests {
         ));
     }
 
+    /// The skew check that stops an unattended run from executing unrecorded.
+    ///
+    /// A daemon older than the `unattended` field accepts the preview and
+    /// silently drops it, so the signed row would look exactly like one a
+    /// human approved. The CLI compares against the daemon crate's own
+    /// constant rather than a local copy of the sentence, because a copy that
+    /// drifted would answer "recorded" for a row that carries nothing.
+    #[test]
+    fn the_marker_check_matches_the_daemon_constant_exactly() {
+        let real = sysknife_daemon::dispatcher::UNATTENDED_WARNING.to_string();
+        assert!(unattended_marker_present(std::slice::from_ref(&real)));
+        assert!(unattended_marker_present(&[
+            "System state could not be collected".into(),
+            real.clone(),
+        ]));
+    }
+
+    #[test]
+    fn the_marker_check_rejects_an_absent_or_near_miss_warning() {
+        assert!(!unattended_marker_present(&[]));
+        assert!(!unattended_marker_present(&["something else".into()]));
+
+        // A near miss is the dangerous case: an older daemon, or one whose
+        // wording drifted, must read as "not recorded" rather than close
+        // enough. Substring matching would accept all three of these.
+        let real = sysknife_daemon::dispatcher::UNATTENDED_WARNING;
+        for near in [
+            real.trim_end_matches('.'),
+            &real.to_lowercase(),
+            &format!(" {real}"),
+            &real.replace("no operator", "No operator"),
+        ] {
+            assert!(
+                !unattended_marker_present(&[near.to_string()]),
+                "near miss must not count as recorded: {near:?}"
+            );
+        }
+    }
+
     /// Structural guard on the execute loop: the daemon preview must be
     /// fetched before any approval decision is taken for that step.
     ///
@@ -2883,10 +2964,19 @@ mod tests {
         let loop_start = src
             .find("    // ---- execute steps ---")
             .expect("execute-steps section marker present");
-        let body = &src[loop_start..];
+        // Stop at the test module. Without this bound the search window
+        // includes the two literals below, so the guard reads itself: the
+        // production call could be renamed away entirely and the assertion
+        // would still find a match, in the wrong order, and report a defect
+        // that is really a stale anchor.
+        let body_end = src[loop_start..]
+            .find("#[cfg(test)]")
+            .map(|i| loop_start + i)
+            .expect("the test module follows the execute loop");
+        let body = &src[loop_start..body_end];
 
         let preview_at = body
-            .find(".preview(step.action_name()")
+            .find(".preview_declaring(step.action_name()")
             .expect("the loop previews each step");
         let gate_at = body
             .find("policy.decide_step(")
@@ -3208,7 +3298,7 @@ mod tests {
             vec![mk("RebootSystem", PlanRiskLevel::Low)],
         )
         .unwrap();
-        let policy = ApprovalPolicy::new(true, Some(MaxRisk::Medium), false, false);
+        let policy = ApprovalPolicy::new(true, Some(MaxRisk::Medium), false, false, false);
         assert_eq!(
             policy.decide_plan(&under_rated.clone().assume_authorized()),
             ApprovalDecision::AutoApproved,
@@ -3246,7 +3336,7 @@ mod tests {
             vec![mk("RestartService", PlanRiskLevel::Low)],
         )
         .unwrap();
-        let policy = ApprovalPolicy::new(true, None, false, false);
+        let policy = ApprovalPolicy::new(true, None, false, false, false);
         assert_eq!(
             policy.decide_plan(&plan.clone().assume_authorized()),
             ApprovalDecision::AutoApproved,
@@ -3280,7 +3370,7 @@ mod tests {
             vec![mk("RestartService", PlanRiskLevel::Low)],
         )
         .unwrap();
-        let policy = ApprovalPolicy::new(true, None, true, false);
+        let policy = ApprovalPolicy::new(true, None, true, false, false);
         assert_eq!(
             policy.decide_plan(&plan.clone().assume_authorized()),
             ApprovalDecision::AutoApproved,
@@ -3315,7 +3405,7 @@ mod tests {
             vec![mk("GetDiskUsage", PlanRiskLevel::High)],
         )
         .unwrap();
-        let policy = ApprovalPolicy::new(true, Some(MaxRisk::Low), false, false);
+        let policy = ApprovalPolicy::new(true, Some(MaxRisk::Low), false, false, false);
         assert_eq!(
             policy.decide_plan(&plan.clone().assume_authorized()),
             ApprovalDecision::ExceedsCeiling(MaxRisk::Low),

--- a/apps/sysknife-cli/src/unattended.rs
+++ b/apps/sysknife-cli/src/unattended.rs
@@ -1,0 +1,200 @@
+//! The banner and the pause that `--dangerously-skip-approval` prints.
+//!
+//! Separated from `main` so the text is testable. The banner is the only
+//! notice an operator gets that a plan written by a language model is about to
+//! run HIGH-risk actions as root with nobody watching, so what it says is part
+//! of the feature rather than decoration around it.
+//!
+//! Two rules the tests pin:
+//!
+//! - It names the host and the account, because the mistake this guards
+//!   against is running it against the wrong machine.
+//! - It says what is still enforced. An operator who believes the flag
+//!   disabled the typed-action catalogue and the audit chain will make worse
+//!   decisions than one who knows it lifted the approval prompt alone.
+
+use std::io::IsTerminal;
+use std::time::Duration;
+
+/// How long the banner holds an interactive terminal before proceeding.
+///
+/// Only applied when stderr is a TTY. A CI job is not made safer by waiting,
+/// and a pause there is a cost with no reader.
+pub const INTERACTIVE_PAUSE: Duration = Duration::from_secs(5);
+
+/// Identity of the machine the run is about to change.
+///
+/// Passed in rather than read here so the banner text is a pure function of
+/// its inputs and can be asserted without a hostname on the test runner.
+pub struct RunTarget {
+    pub host: String,
+    pub user: String,
+    pub euid: u32,
+}
+
+impl RunTarget {
+    /// Read the current host and account.
+    pub fn detect() -> Self {
+        let host = std::fs::read_to_string("/etc/hostname")
+            .ok()
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+            .or_else(|| std::env::var("HOSTNAME").ok())
+            .unwrap_or_else(|| "unknown-host".to_owned());
+        let user = std::env::var("USER")
+            .or_else(|_| std::env::var("LOGNAME"))
+            .unwrap_or_else(|_| "unknown-user".to_owned());
+        // SAFETY: geteuid is always safe; it reads a process property and
+        // cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        Self { host, user, euid }
+    }
+}
+
+/// The banner text, without terminal colour.
+///
+/// Colour is added at print time so the string under test is the string an
+/// operator reads in a log file, where escape codes are noise.
+pub fn banner(target: &RunTarget) -> String {
+    let root_note = if target.euid == 0 {
+        "  Every action runs as root, because this process is already root."
+    } else {
+        "  Privileged actions run as root through the daemon."
+    };
+    format!(
+        "\
+================================================================================
+  UNATTENDED MODE — the approval gate is OFF for this run
+================================================================================
+
+  host   {host}
+  user   {user} (euid {euid})
+
+  A plan written by a language model will execute without anyone confirming
+  it, including steps rated HIGH risk.
+{root_note}
+
+  Still enforced, and not affected by this flag:
+    - only actions in the typed catalogue can run, with validated parameters
+    - the polkit allowlist still gates every privileged call
+    - the run aborts if the daemon rates a step above what was approved
+    - every step is still signed into the audit chain, and each transaction
+      previewed in this mode carries a warning inside the signed record
+
+  Turn this off by dropping --dangerously-skip-approval, or by unsetting
+  SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT.
+
+================================================================================",
+        host = target.host,
+        user = target.user,
+        euid = target.euid,
+        root_note = root_note,
+    )
+}
+
+/// Print the banner, and hold an interactive terminal for [`INTERACTIVE_PAUSE`].
+///
+/// Returns the pause actually applied, so a caller (and the tests) can tell
+/// the interactive path from the automated one.
+pub async fn warn_and_pause() -> Duration {
+    let target = RunTarget::detect();
+    let text = banner(&target);
+    if std::io::stderr().is_terminal() {
+        eprintln!("\x1b[1;31m{text}\x1b[0m");
+        eprintln!(
+            "  Starting in {}s. Ctrl-C now to stop.",
+            INTERACTIVE_PAUSE.as_secs()
+        );
+        tokio::time::sleep(INTERACTIVE_PAUSE).await;
+        INTERACTIVE_PAUSE
+    } else {
+        eprintln!("{text}");
+        Duration::ZERO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target() -> RunTarget {
+        RunTarget {
+            host: "prod-db-01".into(),
+            user: "deploy".into(),
+            euid: 1000,
+        }
+    }
+
+    /// The mistake this guards against is running against the wrong machine,
+    /// so the machine has to be on screen.
+    #[test]
+    fn the_banner_names_the_host_and_the_account() {
+        let b = banner(&target());
+        assert!(b.contains("prod-db-01"), "{b}");
+        assert!(b.contains("deploy"), "{b}");
+        assert!(b.contains("euid 1000"), "{b}");
+    }
+
+    #[test]
+    fn the_banner_says_the_gate_is_off_and_names_high_risk() {
+        let b = banner(&target());
+        assert!(b.contains("approval gate is OFF"), "{b}");
+        assert!(b.contains("HIGH risk"), "{b}");
+        assert!(
+            b.contains("language model"),
+            "the operator should be told what wrote the plan: {b}"
+        );
+    }
+
+    /// An operator who thinks the flag disabled the catalogue and the audit
+    /// chain will take worse risks than one who knows what it actually did.
+    #[test]
+    fn the_banner_lists_what_is_still_enforced() {
+        let b = banner(&target());
+        for claim in [
+            "typed catalogue",
+            "polkit allowlist",
+            "audit chain",
+            "above what was approved",
+        ] {
+            assert!(b.contains(claim), "banner must mention {claim:?}: {b}");
+        }
+    }
+
+    #[test]
+    fn the_banner_says_how_to_turn_it_off() {
+        let b = banner(&target());
+        assert!(b.contains("--dangerously-skip-approval"), "{b}");
+        assert!(b.contains("SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT"), "{b}");
+    }
+
+    /// Running as root is the worse case and reads differently.
+    #[test]
+    fn the_root_case_says_so() {
+        let mut t = target();
+        t.euid = 0;
+        let b = banner(&t);
+        assert!(b.contains("already root"), "{b}");
+
+        let b = banner(&target());
+        assert!(!b.contains("already root"), "{b}");
+        assert!(b.contains("through the daemon"), "{b}");
+    }
+
+    /// The banner is plain text. Colour is applied at print time, so a log
+    /// file gets something readable.
+    #[test]
+    fn the_banner_carries_no_escape_codes() {
+        assert!(
+            !banner(&target()).contains('\x1b'),
+            "colour belongs at the print site, not in the text"
+        );
+    }
+
+    #[test]
+    fn detect_never_panics_and_never_returns_empty_labels() {
+        let t = RunTarget::detect();
+        assert!(!t.host.is_empty());
+        assert!(!t.user.is_empty());
+    }
+}

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -297,3 +297,93 @@ fn audit_export_distinguishes_unreadable_from_absent() {
         }
     }
 }
+// ---------------------------------------------------------------------------
+// --dangerously-skip-approval: the two-key rule, exercised on the real binary
+// ---------------------------------------------------------------------------
+
+/// The flag on its own must stop the run and explain the second key.
+///
+/// Driven through the compiled binary rather than the pure resolver, because
+/// the property under test is that `dispatch` refuses *before* reaching a
+/// subcommand. A unit test on `UnattendedConsent` would still pass if that
+/// wiring were dropped.
+#[test]
+fn the_skip_approval_flag_alone_refuses_and_names_the_second_key() {
+    let dir = tempfile::tempdir().unwrap();
+    cli()
+        .env("SYSKNIFE_SOCKET", fake_socket(&dir))
+        .env_remove("SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT")
+        .args(["--dangerously-skip-approval", "doctor"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT")
+                .and(predicate::str::contains("as root")),
+        );
+}
+
+/// A value that is not exactly `1` must not satisfy the environment half. A
+/// profile carrying `=0` or `=false` is the accident this guards against.
+#[test]
+fn a_non_exact_consent_value_does_not_arm_the_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    for value in ["0", "false", "true", "yes", ""] {
+        cli()
+            .env("SYSKNIFE_SOCKET", fake_socket(&dir))
+            .env("SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT", value)
+            .args(["--dangerously-skip-approval", "doctor"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT",
+            ));
+    }
+}
+
+/// With both keys the refusal is gone and the banner is on stderr. The command
+/// still fails, because the socket does not exist, and that is the point: the
+/// run proceeded past the consent gate and failed for its own reason.
+#[test]
+fn both_keys_print_the_banner_and_let_the_command_run() {
+    let dir = tempfile::tempdir().unwrap();
+    cli()
+        .env("SYSKNIFE_SOCKET", fake_socket(&dir))
+        .env("SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT", "1")
+        .args(["--dangerously-skip-approval", "doctor"])
+        .assert()
+        .stderr(
+            predicate::str::contains("UNATTENDED MODE")
+                .and(predicate::str::contains("approval gate is OFF"))
+                .and(predicate::str::contains("polkit allowlist"))
+                .and(predicate::str::contains("is not set to").not()),
+        );
+}
+
+/// The environment variable on its own changes nothing. An operator who exports
+/// it in a profile and forgets has not armed anything.
+#[test]
+fn the_consent_variable_alone_is_inert() {
+    let dir = tempfile::tempdir().unwrap();
+    cli()
+        .env("SYSKNIFE_SOCKET", fake_socket(&dir))
+        .env("SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT", "1")
+        .args(["doctor"])
+        .assert()
+        .stderr(predicate::str::contains("UNATTENDED MODE").not());
+}
+
+/// `--help` has to carry the warning too. The flag is discovered there, and a
+/// help entry that reads like an ordinary option teaches the wrong thing.
+#[test]
+fn help_says_what_the_skip_approval_flag_does_and_does_not_do() {
+    cli()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--dangerously-skip-approval"));
+
+    cli().arg("--help").assert().success().stdout(
+        predicate::str::contains("SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT")
+            .or(predicate::str::contains("Requires")),
+    );
+}

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -252,6 +252,16 @@ enum DaemonRequest {
         request_id: String,
         action_name: String,
         params: Value,
+        /// The client is running with its approval gate lifted, so no human
+        /// will confirm this step.
+        ///
+        /// `#[serde(default)]` keeps an older client working unchanged. The
+        /// daemon does not trust this to *permit* anything; it only records
+        /// it, by appending [`UNATTENDED_WARNING`] to the preview warnings,
+        /// which are signed into the transaction row. A client that lies by
+        /// omission gains nothing, because the field grants no authority.
+        #[serde(default)]
+        unattended: bool,
     },
     Approve {
         request_id: String,
@@ -1252,6 +1262,7 @@ async fn dispatch_loop<S>(
                 request_id,
                 action_name,
                 params,
+                unattended,
             } => {
                 handle_preview(
                     framed,
@@ -1261,6 +1272,7 @@ async fn dispatch_loop<S>(
                     request_id,
                     action_name,
                     params,
+                    *unattended,
                 )
                 .await
             }
@@ -1969,6 +1981,22 @@ async fn handle_describe(
     .await
 }
 
+/// Recorded in the signed transaction row when a client declares that its
+/// approval gate was lifted for the run.
+///
+/// The exact string is part of the wire contract: the CLI looks for it in the
+/// returned warnings and refuses to execute if it is absent, which is how a
+/// new client detects that it is talking to a daemon too old to record the
+/// fact. Changing the text breaks that check, so change it deliberately.
+pub const UNATTENDED_WARNING: &str =
+    "Approved without a human: this step was previewed by a client running with \
+     --dangerously-skip-approval, so no operator confirmed it.";
+
+// Eight arguments, matching `handle_execute` and `run_action_job` below. The
+// alternative is a struct that exists only to carry the request body one frame
+// deeper, and the frames it would cross are the ones a reader of this file
+// most wants to see spelled out.
+#[allow(clippy::too_many_arguments)]
 async fn handle_preview(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     state: &DaemonState,
@@ -1977,6 +2005,7 @@ async fn handle_preview(
     request_id: &str,
     action_name: &str,
     params: &Value,
+    unattended: bool,
 ) -> Result<(), HandlerError> {
     let spec = match build_action_spec(action_name, params) {
         Ok(s) => s,
@@ -2089,6 +2118,13 @@ async fn handle_preview(
              Review the action carefully before approving."
                 .to_string(),
         );
+    }
+    // Recorded, not trusted. `warnings` is copied into `NewTransaction` below
+    // and signed as `warnings_json`, so this sentence is inside the Ed25519
+    // commitment for the row: an unattended run cannot later be presented as
+    // one a human approved without the signature failing to verify.
+    if unattended {
+        preview.warnings.push(UNATTENDED_WARNING.to_string());
     }
 
     // Persist a pending transaction so execute can verify a prior preview.

--- a/crates/sysknife-daemon/tests/unattended_audit_stamp.rs
+++ b/crates/sysknife-daemon/tests/unattended_audit_stamp.rs
@@ -1,0 +1,323 @@
+//! A run with its approval gate lifted has to be distinguishable, afterwards,
+//! from one a human approved.
+//!
+//! `--dangerously-skip-approval` is a client-side decision, so the daemon can
+//! only know about it because the client says so. What makes the declaration
+//! worth anything is where it lands: `preview.warnings` is copied into
+//! `NewTransaction.warnings`, stored as `warnings_json`, and `warnings_json` is
+//! one of the fields inside `ChainContent::canonical_bytes`. So the sentence is
+//! covered by the row's Ed25519 signature, and removing it from the database
+//! later makes `sysknife audit verify` report the row `Broken`.
+//!
+//! These tests drive the real dispatcher over a real socket pair and then read
+//! the stored row back, because the property under test is about what was
+//! persisted and signed, not about what the response happened to contain.
+
+use std::io;
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+use sysknife_daemon::audit_chain::VerifyOutcome;
+use sysknife_daemon::dispatcher::{connection_handler_with_executor, UNATTENDED_WARNING};
+use sysknife_daemon::executor::{ActionExecutor, RealActionExecutor};
+use sysknife_daemon::state::{DaemonConfig, DaemonState};
+use sysknife_daemon::state_collector::CommandRunner;
+use sysknife_daemon::transport::{framing::FramedStream, listen::ListenTarget};
+use sysknife_types::CallerRole;
+use tempfile::tempdir;
+use tokio::net::UnixStream;
+
+struct QuietRunner;
+
+impl CommandRunner for QuietRunner {
+    fn run(&self, program: &str, _args: &[&str]) -> Result<String, io::Error> {
+        match program {
+            "rpm-ostree" => Ok("{}".to_string()),
+            _ => Ok(String::new()),
+        }
+    }
+}
+
+/// Send one preview and hand back the whole response.
+///
+/// `request` is passed as a full JSON value rather than assembled here, so a
+/// test can send a body with the field absent, present-and-false, or holding a
+/// wrong type, which is the interesting range.
+async fn preview_once(db_name: &str, request: Value) -> (Value, DaemonState) {
+    let dir = tempdir().unwrap();
+    let config = DaemonConfig::new(
+        ListenTarget::Unix(dir.path().join(format!("{db_name}.sock"))),
+        dir.path().join(format!("{db_name}.db")),
+    );
+    let state = DaemonState::open(config.clone()).unwrap();
+    let handler_state = DaemonState::open(config).unwrap();
+
+    let (client, server) = UnixStream::pair().unwrap();
+    let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(QuietRunner);
+    let executor: Arc<dyn ActionExecutor> = Arc::new(RealActionExecutor);
+    tokio::spawn(async move {
+        connection_handler_with_executor(
+            server,
+            handler_state,
+            runner,
+            executor,
+            sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, CallerRole::Admin),
+        )
+        .await;
+    });
+    let mut framed = FramedStream::new(client);
+    framed
+        .send(&serde_json::to_vec(&request).unwrap())
+        .await
+        .unwrap();
+    let resp: Value = serde_json::from_slice(&framed.recv().await.unwrap()).unwrap();
+    // The tempdir is dropped at the end of this function, so anything the
+    // caller needs from disk has to be read through the returned state.
+    std::mem::forget(dir);
+    (resp, state)
+}
+
+fn warnings_of(resp: &Value) -> Vec<String> {
+    resp["preview"]["warnings"]
+        .as_array()
+        .expect("preview.warnings should be an array")
+        .iter()
+        .map(|w| w.as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn declaring_unattended_puts_the_warning_in_the_response() {
+    let (resp, _state) = preview_once(
+        "unattended-yes",
+        json!({
+            "type": "preview",
+            "request_id": "u-1",
+            "action_name": "GetMemoryInfo",
+            "params": {},
+            "unattended": true,
+        }),
+    )
+    .await;
+    assert_eq!(resp["type"], "preview_response", "got: {resp}");
+    let w = warnings_of(&resp);
+    assert!(
+        w.iter().any(|x| x == UNATTENDED_WARNING),
+        "expected the unattended marker, got: {w:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn not_declaring_it_leaves_the_warning_out() {
+    let (resp, _state) = preview_once(
+        "unattended-no",
+        json!({
+            "type": "preview",
+            "request_id": "u-2",
+            "action_name": "GetMemoryInfo",
+            "params": {},
+            "unattended": false,
+        }),
+    )
+    .await;
+    let w = warnings_of(&resp);
+    assert!(
+        !w.iter().any(|x| x == UNATTENDED_WARNING),
+        "an attended run must not be labelled unattended: {w:?}"
+    );
+}
+
+/// An older client sends no such field. That has to keep working, and it has to
+/// mean attended, not unattended.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_absent_field_is_accepted_and_means_attended() {
+    let (resp, _state) = preview_once(
+        "unattended-absent",
+        json!({
+            "type": "preview",
+            "request_id": "u-3",
+            "action_name": "GetMemoryInfo",
+            "params": {},
+        }),
+    )
+    .await;
+    assert_eq!(
+        resp["type"], "preview_response",
+        "a client that predates the field must still get a preview: {resp}"
+    );
+    let w = warnings_of(&resp);
+    assert!(
+        !w.iter().any(|x| x == UNATTENDED_WARNING),
+        "a missing declaration must default to attended: {w:?}"
+    );
+}
+
+/// The declaration confers no authority, so it cannot be used to reach an
+/// action the caller's role does not permit. This is the property that makes it
+/// safe for the daemon to accept an unauthenticated boolean from the client at
+/// all: it is evidence, not permission.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_declaration_grants_no_authority() {
+    let dir = tempdir().unwrap();
+    let config = DaemonConfig::new(
+        ListenTarget::Unix(dir.path().join("unattended-authz.sock")),
+        dir.path().join("unattended-authz.db"),
+    );
+    let state = DaemonState::open(config).unwrap();
+
+    let (client, server) = UnixStream::pair().unwrap();
+    let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(QuietRunner);
+    let executor: Arc<dyn ActionExecutor> = Arc::new(RealActionExecutor);
+    tokio::spawn(async move {
+        connection_handler_with_executor(
+            server,
+            state,
+            runner,
+            executor,
+            // Observer is the least-privileged role.
+            sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, CallerRole::Observer),
+        )
+        .await;
+    });
+    let mut framed = FramedStream::new(client);
+    framed
+        .send(
+            &serde_json::to_vec(&json!({
+                "type": "preview",
+                "request_id": "u-4",
+                "action_name": "AptUpgrade",
+                "params": {},
+                "unattended": true,
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    let resp: Value = serde_json::from_slice(&framed.recv().await.unwrap()).unwrap();
+    assert_eq!(
+        resp["type"], "error_response",
+        "an Observer must not reach a mutating action by claiming to be unattended: {resp}"
+    );
+    assert_eq!(resp["category"], "authorization_failure", "{resp}");
+}
+
+/// The point of the whole mechanism: the sentence is inside the signature.
+///
+/// Reads the stored row back through the audit chain and asserts both that the
+/// warning is there and that the chain still verifies with it, so the marker is
+/// part of the signed content rather than a field written beside it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_marker_is_inside_the_signed_row() {
+    let dir = tempdir().unwrap();
+    // The audit key defaults to `<db_dir>/audit-key`, so the verifier below
+    // reads exactly the key the daemon signed with.
+    let db_path = dir.path().join("unattended-signed.db");
+    let key_path = dir.path().join("audit-key");
+    let config = DaemonConfig::new(
+        ListenTarget::Unix(dir.path().join("unattended-signed.sock")),
+        db_path.clone(),
+    );
+    let state = DaemonState::open(config.clone()).unwrap();
+    let handler_state = DaemonState::open(config.clone()).unwrap();
+
+    let (client, server) = UnixStream::pair().unwrap();
+    let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(QuietRunner);
+    let executor: Arc<dyn ActionExecutor> = Arc::new(RealActionExecutor);
+    tokio::spawn(async move {
+        connection_handler_with_executor(
+            server,
+            handler_state,
+            runner,
+            executor,
+            sysknife_daemon::auth::CallerAttribution::from_peer_uid(1000, CallerRole::Admin),
+        )
+        .await;
+    });
+    let mut framed = FramedStream::new(client);
+    framed
+        .send(
+            &serde_json::to_vec(&json!({
+                "type": "preview",
+                "request_id": "u-5",
+                "action_name": "GetMemoryInfo",
+                "params": {},
+                "unattended": true,
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    let resp: Value = serde_json::from_slice(&framed.recv().await.unwrap()).unwrap();
+    assert_eq!(resp["type"], "preview_response", "got: {resp}");
+    let transaction_id = resp["transaction_id"].as_str().expect("transaction_id");
+
+    // Give the write a moment to land, then read the row back from storage.
+    let record = state
+        .audit
+        .get(transaction_id)
+        .await
+        .expect("read back the stored transaction")
+        .expect("the previewed transaction exists");
+    assert!(
+        record.warnings.iter().any(|w| w == UNATTENDED_WARNING),
+        "the stored row must carry the marker, got: {:?}",
+        record.warnings
+    );
+
+    // The marker being present is not the claim. The claim is that it is
+    // covered by the signature, so removing it later is detectable. Prove that
+    // by editing the stored `warnings_json` out from under the row and showing
+    // the chain stops verifying, then restoring it and showing it verifies
+    // again. A test that only asserted presence would pass just as happily if
+    // `warnings_json` were an unsigned column.
+    let key = sysknife_daemon::audit_chain::AuditKey::load_or_generate(&key_path)
+        .expect("the daemon's audit key");
+    assert_eq!(
+        state
+            .audit
+            .verify_audit_chain(&key)
+            .await
+            .expect("verify with the marker in place"),
+        VerifyOutcome::Intact { rows_checked: 1 },
+        "the row must verify as stored"
+    );
+
+    let conn = rusqlite::Connection::open(&db_path).expect("open the audit database");
+    let stored: String = conn
+        .query_row(
+            "SELECT warnings_json FROM transactions WHERE transaction_id = ?1",
+            rusqlite::params![transaction_id],
+            |r| r.get(0),
+        )
+        .expect("read warnings_json");
+    assert!(
+        stored.contains("no operator confirmed it"),
+        "the marker must be in the signed column, not only in the response: {stored}"
+    );
+
+    let scrubbed = serde_json::to_string(
+        &record
+            .warnings
+            .iter()
+            .filter(|w| *w != UNATTENDED_WARNING)
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE transactions SET warnings_json = ?1 WHERE transaction_id = ?2",
+        rusqlite::params![scrubbed, transaction_id],
+    )
+    .expect("scrub the marker");
+    drop(conn);
+
+    let after = state
+        .audit
+        .verify_audit_chain(&key)
+        .await
+        .expect("verify after scrubbing");
+    assert!(
+        !matches!(after, VerifyOutcome::Intact { .. }),
+        "scrubbing the marker must break the signature, got {after:?}"
+    );
+    drop(dir);
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -309,6 +309,86 @@ All flags apply to every subcommand and to free-form intents.
 | `--json` | Emit NDJSON to stdout — one JSON object per event (plan, preview, result).  All colour and spinner output is suppressed.  Safe to pipe. |
 | `--timeout SECS` | Hard wall-clock timeout in seconds.  Aborts the whole operation if exceeded. |
 | `--log-to FILE` | Tee all stdout output to FILE in addition to the terminal.  Appends if the file exists. |
+| `--dangerously-skip-approval` | Auto-approve HIGH-risk steps as well, with no human confirmation.  Refuses to run unless `SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT=1` is also set.  See [Unattended mode](#unattended-mode). |
+
+---
+
+## Unattended mode
+
+`--dangerously-skip-approval` lets a plan written by a language model execute
+HIGH-risk actions with nobody confirming them. It exists for scheduled and
+CI-driven runs, and it is the only way to lift the rule that `--yes` can never
+auto-approve HIGH.
+
+### Two keys, on purpose
+
+The flag alone does nothing but print an explanation and exit 1. It needs the
+environment variable as well:
+
+```sh
+SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT=1 \
+  sysknife --dangerously-skip-approval --json "apply pending security updates"
+```
+
+Neither half is enough alone. A flag left in a script and a variable left in a
+shell profile are the two ways this gets armed by accident, and requiring both
+means neither accident is sufficient. Only the exact value `1` counts; `true`,
+`yes` and `0` are all read as unset.
+
+The flag has no short form and no abbreviation. Typing it has to be a decision.
+
+### What it turns off
+
+One thing: the approval gate.
+
+- `--yes` may now auto-approve HIGH-risk steps. The cap moves from MEDIUM to
+  HIGH.
+- The post-preview confirmation on a HIGH step no longer asks. The preview is
+  still fetched and still printed, because it is the only record of what the
+  run was about to change.
+
+An explicit `--max-risk` still wins. `--dangerously-skip-approval --max-risk
+low` aborts on a MEDIUM step, because the flag removes the ceiling the project
+imposes, not the one you asked for. `--dry-run` still executes nothing.
+
+### What it does not turn off
+
+Everything that makes SysKnife more than a shell:
+
+- Only actions in the typed catalogue can run, with validated parameters. There
+  is no path from this flag to an arbitrary command.
+- The polkit allowlist still gates every privileged D-Bus call.
+- The run still aborts if the daemon rates a step above what the CLI approved.
+- Role-based authorization is unchanged. An account that cannot run an action
+  still cannot run it.
+- Every step is still previewed, still gets a transaction row, and is still
+  signed into the audit chain.
+
+If you want a tool that will run any command an LLM writes, this is not it, and
+no flag here turns it into one.
+
+### The audit trail records it
+
+A transaction previewed in this mode carries this sentence in its `warnings`:
+
+> Approved without a human: this step was previewed by a client running with
+> --dangerously-skip-approval, so no operator confirmed it.
+
+`warnings` is stored as `warnings_json`, and `warnings_json` is one of the
+fields inside the row's Ed25519 signature. So the record is not a log line that
+can be edited later: deleting it makes `sysknife audit verify` report that row
+`Broken`. `sysknife audit export` carries it like any other field.
+
+The CLI checks that the daemon sent the sentence back, and refuses to execute
+if it did not. A daemon older than this field accepts the declaration and drops
+it, which would leave an unattended run indistinguishable from an approved one.
+Upgrade the daemon, or drop the flag.
+
+### Before you use it
+
+Run it against a machine you can rebuild. The failure mode is not a bad diff to
+revert; it is a system change applied by a model with no one watching. A VM
+snapshot beforehand costs less than the alternative.
 
 ---
 
@@ -367,6 +447,15 @@ above.
 |---|---|
 | `SYSKNIFE_SOCKET` | Daemon socket the CLI dials (`unix://`, `vsock://`, or a bare path). Falls back to the same resolution as `SYSKNIFE_LISTEN_URI`: `$XDG_RUNTIME_DIR/sysknife/daemon.sock`, then `/tmp/sysknife-$UID.sock` as a last resort. Production deployments set this via the systemd unit to `/run/sysknife/daemon.sock`. |
 
+### Unattended-mode consent
+
+| Variable | Value | Meaning |
+|---|---|---|
+| `SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT` | exactly `1` | Second half of the two-key rule for `--dangerously-skip-approval`. Inert on its own: setting it changes nothing until the flag is also passed. Any other value, including `true` and `yes`, reads as unset. |
+
+See [Unattended mode](#unattended-mode) for what the flag does and does not
+turn off.
+
 ---
 
 ## Scripting and CI
@@ -386,6 +475,12 @@ sysknife --yes --max-risk medium --non-interactive "list layered packages"
 sysknife --yes --max-risk low --non-interactive --timeout 60 \
      --log-to /var/log/sysknife/run.log \
      "check disk usage"
+
+# Unattended, including HIGH-risk steps. Both keys are required, and every
+# step is recorded in the signed chain as having had no human approval.
+SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT=1 \
+  sysknife --dangerously-skip-approval --json --timeout 300 \
+     "apply pending security updates"
 ```
 
 The `--json` output schema:

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,787 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,819 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,819 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,820 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,819 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,820 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,787 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,819 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "55475ffa3cecb8689e5aaab240e80ef2edf83afc"
+    "tests": "881de18e4d2bd28aa6b3c639c8ec0bc8fb8a80f3"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-09-01T15:53:27-06:00"
+    "tests": "2026-09-01T15:42:02-06:00"
   },
-  "tests": 1787,
+  "tests": 1819,
   "version": 1
 }

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "881de18e4d2bd28aa6b3c639c8ec0bc8fb8a80f3"
+    "tests": "47d15196da46da394bf07bcf23d2ae53773186f2"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-09-01T15:42:02-06:00"
+    "tests": "2026-09-01T16:07:03-06:00"
   },
-  "tests": 1819,
+  "tests": 1820,
   "version": 1
 }


### PR DESCRIPTION
`--yes` could never auto-approve a HIGH-risk step, and there was no way to say otherwise. That rule is right for a terminal and wrong for a scheduled run, so the escape hatch existed only as "do not use SysKnife for that".

```sh
SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT=1 \
  sysknife --dangerously-skip-approval --json "apply pending security updates"
```

## What it lifts

The approval gate, and only that.

- The cap on `--yes` moves from MEDIUM to HIGH.
- The post-preview confirmation on a HIGH step stops asking. It still fetches and prints the preview, because that is the only record of what an unattended run was about to change. Short-circuiting the predicate instead would have skipped the preview itself.
- An explicit `--max-risk` still wins: `--dangerously-skip-approval --max-risk low` aborts on a MEDIUM step. The flag removes the ceiling the project imposes, not the one the operator asked for.
- `--dry-run` still executes nothing.

## What it does not lift

Only catalogue actions with validated parameters can run. The polkit allowlist still gates every privileged call. The run still aborts when the daemon rates a step above what the CLI approved. Role authorization is unchanged. Every step is still previewed, still gets a transaction row, and is still signed.

A flag that also switched those off would not be a setting; it would leave a language model with unmediated root and delete the reason this project exists. `docs/cli.md` says so in those words rather than implying the flag does more than it does.

## Two keys

The flag alone prints an explanation and exits 1. It also needs `SYSKNIFE_I_ACCEPT_UNATTENDED_ROOT=1`, and only that exact string: `true`, `yes`, `0` and an empty value all read as unset.

A flag left in a script and a variable left in a profile are the two ways this gets armed by accident, and requiring both means neither accident is enough on its own. There is no short form and no abbreviation.

The check runs in `dispatch` before any subcommand, so the flag on `doctor` fails just as loudly as on an intent. A flag that is sometimes silently ignored teaches people it is harmless.

## The audit trail records it

This is the part that took the design work. The mode is a client-side decision, so the daemon can only know because the client says so, and a declaration nobody records is worth nothing.

The CLI declares it on the preview request. The daemon appends `UNATTENDED_WARNING` to `preview.warnings`, which is copied into `NewTransaction.warnings`, stored as `warnings_json`, and signed as one of the fields in `ChainContent::canonical_bytes`. No new chain generation and no migration, because that column was already inside the signature.

`unattended_audit_stamp.rs` proves the property rather than asserting the string is present: it edits the marker out of the stored column and shows `verify_audit_chain` stops returning `Intact`. A test that only checked presence would pass just as happily if `warnings_json` were an unsigned column.

Two more properties pinned there:

- **The declaration grants no authority.** That is what makes it safe to accept an unauthenticated boolean from a client at all. An `Observer` claiming to be unattended still gets `authorization_failure` on `AptUpgrade`.
- **An absent field means attended.** `#[serde(default)]`, so a client that predates the field keeps working and is not mislabelled.

The CLI refuses to execute if the marker does not come back, which is how it detects a daemon too old to record the fact. The comparison is against the daemon crate's own constant, not a local copy of the sentence, and near-miss wording does not count.

## Mutation proof

Eight mutations, eight caught:

| Mutation | Caught by |
|---|---|
| the daemon never appends the stamp | 2 tests |
| the cap reverts to MEDIUM | 6 tests |
| the flag alone grants consent | 4 tests |
| any environment value satisfies the second key | 2 tests |
| the CLI stops checking the marker came back | 2 tests |
| the consent gate is unwired from `dispatch` | 4 tests |
| the banner never prints | 2 tests |
| the execute loop gates before previewing | 2 tests |

## One thing found on the way

`the_execute_loop_previews_before_it_gates` searched a window that included its own two string literals, so it had started reading itself. The production call could have been renamed away entirely and the assertion would still have found a match, in the wrong order, and reported a defect that was really a stale anchor. Renaming `preview` to `preview_declaring` is what surfaced it. The window now stops at the test module.

## Gates

`ci-local.sh` PASS. Postgres contract run separately under podman: `running 11 tests`, 11 passed. 1786 to 1819 tests, artifact and the three prose figures moved together.
