### PR TITLE
fix: close six findings from the post-merge review sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Check the secret scanner catches keys and ignores fixtures
         run: bash tests/release/no-secrets.test.sh
 
+      - name: Check the installer and the daemon agree on the database path
+        run: bash tests/release/database-path-agreement.test.sh
+
       - name: Check no workflow pins an end-of-life Node release
         run: bash tests/release/node-eol.test.sh
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,786 Rust tests and 72 frontend tests** form the current deterministic
+**1,787 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -817,9 +817,29 @@ pub async fn run_audit_export(args: AuditExportArgs, log: &Logger) -> Result<(),
             use sysknife_daemon::transactions::TransactionStore;
 
             let db_path = resolved_store.path();
-            if !db_path.exists() {
+            // `Path::exists()` answers false for both ENOENT and EACCES, so
+            // probing with it tells an operator the root-owned 0700 system
+            // store does not exist and suggests starting the daemon, when the
+            // daemon is running and the fix is sudo. `run_audit_verify` has
+            // carried the corrected form since #275; export was written
+            // without it.
+            if !sysknife_core::path_is_present(db_path) {
                 return Err(CliError::ConfigOrDaemon(format!(
                     "audit database not found at {}; set $SYSKNIFE_DATABASE_PATH or run the daemon first",
+                    db_path.display()
+                )));
+            }
+            if !db_path.exists() {
+                let sudo_hint =
+                    if db_path == std::path::Path::new(sysknife_core::PRODUCTION_DATABASE_PATH) {
+                        "; the system daemon's store is root-owned, so run this under sudo or \
+                     set $SYSKNIFE_DATABASE_PATH"
+                    } else {
+                        ""
+                    };
+                return Err(CliError::ConfigOrDaemon(format!(
+                    "audit database not found or not readable at {}; set $SYSKNIFE_DATABASE_PATH \
+                     or run the daemon first{sudo_hint}",
                     db_path.display()
                 )));
             }

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -239,3 +239,61 @@ fn timeout_flag_bounds_a_daemon_that_accepts_but_never_replies() {
         "--timeout 1 must give up promptly against a silent daemon, took {elapsed:?}"
     );
 }
+
+/// `audit export` must give the same diagnosis as `audit verify` when the store
+/// exists but cannot be read.
+///
+/// `Path::exists()` answers false for both ENOENT and EACCES, so probing with
+/// it told an operator the root-owned 0700 system store did not exist and to
+/// start the daemon, while the daemon was running and the fix was sudo. Export
+/// was written without the `path_is_present` call that verify has carried since
+/// #275.
+///
+/// Skipped as root, which stats straight through mode 000; the assertion on the
+/// captured precondition is what turns that into a skip rather than a false
+/// pass.
+#[test]
+#[cfg(unix)]
+fn audit_export_distinguishes_unreadable_from_absent() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store_dir = dir.path().join("state");
+    std::fs::create_dir_all(&store_dir).unwrap();
+    let db = store_dir.join("daemon.sqlite");
+    std::fs::write(&db, b"not really a database").unwrap();
+    std::fs::set_permissions(&store_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    // Capture the probe on this side of the restore. A test that chmods back
+    // first and then probes reads the restored state and proves nothing.
+    let unreadable = std::fs::metadata(&db).is_err();
+
+    let assertion = if unreadable {
+        Some(
+            cli()
+                .env("SYSKNIFE_DATABASE_PATH", &db)
+                .env("SYSKNIFE_SOCKET", fake_socket(&dir))
+                .args(["audit", "export"])
+                .assert()
+                .failure(),
+        )
+    } else {
+        None
+    };
+
+    std::fs::set_permissions(&store_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    match assertion {
+        Some(a) => {
+            a.stderr(
+                predicate::str::contains("not readable")
+                    .or(predicate::str::contains("Permission denied")),
+            );
+        }
+        None => {
+            // Running as root, so mode 000 is not a barrier and there is
+            // nothing to assert. Say so rather than passing quietly.
+            eprintln!("skipped: this user stats through mode 000 (probably root)");
+        }
+    }
+}

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,786 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,787 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,786 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,787 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -276,6 +276,7 @@ run_hygiene_group() {
     run_step 'hygiene: registry-manifest.test.sh' bash "$repo_root/tests/release/registry-manifest.test.sh"
     run_step 'hygiene: smithery-manifest.test.sh' bash "$repo_root/tests/release/smithery-manifest.test.sh"
     run_step 'hygiene: release-rehearsal.test.sh' bash "$repo_root/tests/release/release-rehearsal.test.sh"
+    run_step 'hygiene: database-path-agreement.test.sh' bash "$repo_root/tests/release/database-path-agreement.test.sh"
     run_step 'hygiene: node-eol.test.sh' bash "$repo_root/tests/release/node-eol.test.sh"
     run_step 'hygiene: systemd-directory-modes.test.sh' bash "$repo_root/tests/release/systemd-directory-modes.test.sh"
     run_step 'hygiene: ubuntu-vm-bootstrap.test.sh' bash "$repo_root/tests/e2e/ubuntu-vm-bootstrap.test.sh"

--- a/tests/e2e/atomic-vm.sh
+++ b/tests/e2e/atomic-vm.sh
@@ -128,8 +128,12 @@ write_guest_env_file() {
         fi
     done
 
+    # `rm -f` first, because `cat >` truncates and reuses an existing inode:
+    # umask governs the mode only when the redirection creates the file. A
+    # leftover from a killed run, or a symlink planted at that path, would
+    # otherwise receive the secrets at whatever mode it already had.
     printf '%s\n' "${assignments[@]}" \
-        | cmd_ssh "sudo sh -c 'umask 077 && cat > ${GUEST_ENV_FILE}'"
+        | cmd_ssh "sudo sh -c 'rm -f ${GUEST_ENV_FILE} && umask 077 && cat > ${GUEST_ENV_FILE}'"
 }
 
 require_tools() {

--- a/tests/e2e/exec/run-exec-stories.sh
+++ b/tests/e2e/exec/run-exec-stories.sh
@@ -111,6 +111,7 @@ EXEC_NAMES[8]="SetHostname cycle — change and restore (destructive)"
 EXEC_NAMES[9]="SetTimezone cycle — Chicago then restore UTC (destructive)"
 EXEC_NAMES[10]="Group membership cycle — audio add then remove (destructive)"
 EXEC_NAMES[11]="ConfigureFirewall cycle — ftp add then remove (destructive)"
+EXEC_NAMES[12]="UfwAllow + UfwDeny cycle — port 8080 open then blocked (destructive)"
 
 declare -A RESULTS
 declare -A DURATIONS
@@ -119,7 +120,7 @@ declare -A MESSAGES
 if [[ $# -gt 0 ]]; then
   STORIES=("$@")
 elif [[ "$ALLOW_DESTRUCTIVE" == "1" ]]; then
-  STORIES=(1 2 3 4 5 6 7 8 9 10 11)
+  STORIES=(1 2 3 4 5 6 7 8 9 10 11 12)
 else
   # Safe (non-destructive, Low risk) stories only.
   STORIES=(1 2 3 6)

--- a/tests/e2e/ubuntu-vm.sh
+++ b/tests/e2e/ubuntu-vm.sh
@@ -118,8 +118,12 @@ write_guest_env_file() {
         fi
     done
 
+    # `rm -f` first, because `cat >` truncates and reuses an existing inode:
+    # umask governs the mode only when the redirection creates the file. A
+    # leftover from a killed run, or a symlink planted at that path, would
+    # otherwise receive the secrets at whatever mode it already had.
     printf '%s\n' "${assignments[@]}" \
-        | cmd_ssh "sudo sh -c 'umask 077 && cat > ${GUEST_ENV_FILE}'"
+        | cmd_ssh "sudo sh -c 'rm -f ${GUEST_ENV_FILE} && umask 077 && cat > ${GUEST_ENV_FILE}'"
 }
 
 require_tools() {

--- a/tests/e2e/vm-env-secrets.test.sh
+++ b/tests/e2e/vm-env-secrets.test.sh
@@ -29,18 +29,45 @@ for rel in "${harnesses[@]}"; do
 
     [ "$(grep -c '^[[:space:]]*write_guest_env_file \\' "$harness")" -eq 2 ] \
         || report "$rel must stage environment for both provision and run"
-    grep -Fq "| cmd_ssh \"sudo sh -c 'umask 077 && cat > \${GUEST_ENV_FILE}'\"" "$harness" \
-        || report "$rel does not transfer the environment over SSH stdin"
+    grep -Fq "| cmd_ssh \"sudo sh -c 'rm -f \${GUEST_ENV_FILE} && umask 077 && cat > \${GUEST_ENV_FILE}'\"" "$harness" \
+        || report "$rel does not transfer the environment over SSH stdin into a fresh 0600 file"
     [ "$(grep -c 'rm -f \${GUEST_ENV_FILE}.*exec bash tests/e2e/' "$harness")" -eq 2 ] \
         || report "$rel must remove the guest environment before both scripts execute"
 
-    if grep -Eq '[a-z_]+_env\+="? \$var=|sudo\$\{[a-z_]+_env\}' "$harness"; then
-        report "$rel still interpolates forwarded variables into an argv command"
+    # The regression to catch is a secret value reaching argv, not one
+    # particular way of spelling it. The previous form matched the old
+    # accumulator by name (`prov_env`, `sudo_env`), so reintroducing the same
+    # bug under any other variable name passed silently.
+    #
+    # Structural instead: no line that invokes cmd_ssh may interpolate a
+    # shell variable straight after `sudo`, which is the shape that puts a
+    # value on the guest command line. The stdin transfer and the `sudo bash
+    # -c` consumer both name a literal command after sudo, so neither matches.
+    if grep -nE 'cmd_ssh[^#]*sudo *[$"]?\$\{?[A-Za-z_]' "$harness" \
+        | grep -vE 'sudo (sh|bash) -c' >/dev/null; then
+        report "$rel interpolates a variable into an argv command after sudo"
     fi
 
+    # And the specific values must never appear on a cmd_ssh line at all.
     for key in "${keys[@]}"; do
-        grep -Fq "$key" "$harness" \
-            || report "$rel does not forward $key"
+        if grep -n 'cmd_ssh' "$harness" | grep -Fq "$key"; then
+            report "$rel names $key on a cmd_ssh line, which puts it in argv"
+        fi
+    done
+
+    # Anchored to the call sites. `grep -Fq "$key" "$harness"` asked only
+    # whether the name appears anywhere, so a key deleted from cmd_run and
+    # left in a comment still passed. Extract the arguments of each
+    # write_guest_env_file call and require the key in the run one.
+    run_block="$(awk '/^cmd_run\(\)/,/^}/' "$harness")"
+    prov_block="$(awk '/^cmd_provision\(\)/,/^}/' "$harness")"
+    if [ -z "$run_block" ] || [ -z "$prov_block" ]; then
+        report "$rel: could not read cmd_run/cmd_provision; the extraction is broken"
+        continue
+    fi
+    for key in "${keys[@]}"; do
+        printf '%s' "$run_block" | grep -Fq "$key" \
+            || report "$rel does not forward $key from cmd_run"
     done
 done
 

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "2b9a55dfcd88aba0d3fa02f1c75f974605e78010"
+    "tests": "55475ffa3cecb8689e5aaab240e80ef2edf83afc"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-09-01T14:19:49-06:00"
+    "tests": "2026-09-01T15:53:27-06:00"
   },
-  "tests": 1786,
+  "tests": 1787,
   "version": 1
 }

--- a/tests/release/node-eol.test.sh
+++ b/tests/release/node-eol.test.sh
@@ -70,6 +70,19 @@ while IFS= read -r hit; do
     fi
 done < <(grep -rn '^[[:space:]]*node-version:' "$workflows" || true)
 
+# The extraction above recognises the block-style `node-version:` key only.
+# Two other spellings pin a Node major without matching it, and neither would
+# trip the "found no pin" fallback while other files still carry real pins:
+# `node-version-file:` (reads a possibly stale .nvmrc) and a flow-style inline
+# mapping. Neither is used here today. Refuse them rather than let a future
+# workflow pin an end-of-life release through a form this test cannot read.
+while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    file="${hit%%:*}"
+    rest="${hit#*:}"
+    report "$(basename "$file"):${rest%%:*} pins Node through a form this check cannot read; use a literal \`node-version:\` line"
+done < <(grep -rnE '^[[:space:]]*node-version-file:|\{[^}]*node-version[[:space:]]*:' "$workflows" || true)
+
 if [ "$pins" -eq 0 ]; then
     printf 'no node-version pin found under .github/workflows; the extraction is broken, not the workflows\n' >&2
     exit 1


### PR DESCRIPTION
Six findings from a review sweep over everything merged since v0.10.0, split into four functional groups. Each was verified against the file at HEAD before anything was touched, and each fix is mutation-proved.

## audit export gave the wrong diagnosis on an unreadable store

`run_audit_export` probed with `Path::exists()`, which answers false for both ENOENT and EACCES. A non-root operator running against the root-owned 0700 system store was told the database does not exist and to start the daemon, while the daemon was running and the fix was `sudo`.

`run_audit_verify` has carried the corrected `path_is_present` form since #275, with the reasoning in a comment three lines above. Export was written without it. Same code, same file, one function apart.

`audit_export_distinguishes_unreadable_from_absent` pins it, captures the probe on the unreadable side of the restore rather than after it, and skips loudly when the user stats through mode 000.

## The guest env file could be written into an existing inode

`cat > "$GUEST_ENV_FILE"` truncates and reuses whatever is already at the path. `umask 077` governs the mode only when the redirection creates the file, so a leftover from a killed run, or a symlink planted in `/run`, would have received every provider key at whatever mode it already had. `rm -f` first.

Not exploitable on today's guests, where the e2e user already has passwordless sudo. The code should still not depend on that.

## The argv anti-regression check matched a variable name

```
grep -Eq '[a-z_]+_env\+="? \$var=|sudo\$\{[a-z_]+_env\}'
```

Tied to `prov_env` and `sudo_env`, the names the pre-#316 code happened to use. Reintroducing the identical bug under any other name passed silently. Replaced with a structural check: no `cmd_ssh` line may interpolate a variable straight after `sudo`, and no key name may appear on a `cmd_ssh` line at all.

The mutation that proves it is the original vulnerability rebuilt under the name `leak_str`. The old check said nothing; the new one names the file and the shape.

## The per-key check was not anchored to a call site

`grep -Fq "$key" "$harness"` asked whether the name appears anywhere in 700 lines. A key deleted from `cmd_run` and left in a comment still passed, and so did a key present in `cmd_provision` alone. It now reads the `cmd_run` body and fails if the extraction comes back empty.

## exec-12.sh ran only if you named it

`STORIES=(1 … 11)` and `EXEC_NAMES` both stopped at 11 while a twelfth story sat on disk. The UfwAllow/UfwDeny execution proof, the Ubuntu counterpart to exec-11, never ran by default, and the runner reported 11/11 passed.

## database-path-agreement.test.sh was wired into no gate

Zero references in `ci.yml`, `e2e.yml`, `release.yml` or `ci-local.sh`, and it never had any. It guards the installer and the daemon resolving different SQLite paths, which splits the audit chain. Now in `docs-and-hygiene` and `ci-local.sh`.

Nothing requires that every `tests/release/*.test.sh` be invoked somewhere, so this omission was itself unguarded. Filing that separately.

## Also

`node-eol.test.sh` reads block-style `node-version:` only. `node-version-file:` pointing at a stale `.nvmrc`, or a flow-style inline mapping, would pin a retired release without tripping it, and the "found no pin" fallback would not fire because other files still carry real pins. Both forms are now refused outright.

## Mutation proof

| Mutation | Result |
|---|---|
| the pre-#316 argv leak, rebuilt under a different variable name | `interpolates a variable into an argv command after sudo` |
| a key dropped from `cmd_run` only | `does not forward GROQ_API_KEY from cmd_run` |
| `rm -f` removed before the write | `does not transfer the environment over SSH stdin into a fresh 0600 file` |
| the `cmd_run` extraction broken | `could not read cmd_run/cmd_provision; the extraction is broken` |
| a workflow switched to `node-version-file:` | `pins Node through a form this check cannot read` |
| `path_is_present` reverted to `exists()` in export | the new EACCES test fails |

Six for six.

## Not in this PR

#247, the exit code that reports success for a fully throttled or skipped suite, is confirmed live and duplicated in `run-exec-stories.sh` and `dev-stories.sh`. It is offered to a contributor, so it stays theirs.
