### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "homepage": "https://lacs-project.github.io/sysknife/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-09-01
+
+The middle digit moves because of [#312](https://github.com/lacs-project/sysknife/pull/312).
+`npx sysknife-setup --claude --no-prompts --daemon-mode=system`, the automation
+one-liner in `docs/quickstart.md`, now exits 3 where it exited 0. No signature
+changed, and a run that used to succeed now reports failure, which
+[docs/release.md](docs/release.md#version-numbering) already counts as a break.
+System mode is a two-phase install by design, so the honest exit code is
+non-zero.
+
+Sixteen changes, four of them from three outside contributors and seven from
+Dependabot. Two closed cases where a secret was readable by anyone on the host,
+and one added a way to run without a human that records the fact in the signed
+chain rather than hiding it.
+
+
 ### Added
 
 - **`sysknife --dangerously-skip-approval` runs with no human in the loop.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4898,7 +4898,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4907,7 +4907,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4916,7 +4916,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,12 +15,12 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.10.0" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.10.0" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.10.0" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.11.0" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.11.0" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.11.0" }
 chrono = "0.4"
 libc = "0.2"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.10.0" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.11.0" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -40,11 +40,11 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.10.0", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.11.0", features = ["test-support"] }
 # and `AttributionCensus::from_counts_for_tests`, so the verify renderers can be
 # tested without building signed chain rows. Dev-only: production builds of this
 # bin do not compile dev-dependencies, so the constructor stays unreachable there.
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.10.0", features = ["test-support"] }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.11.0", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "react": "^19.2.8",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.10.0" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.10.0" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.11.0" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.11.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.10.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.10.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.11.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.11.0" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.10.0"
+version = "0.11.0"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.10.0" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.11.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,8 +17,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 test-support = []
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.10.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.10.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.11.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.11.0" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -61,7 +61,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.10.0" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.11.0" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.10.0" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.11.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why the middle digit

[#312](https://github.com/lacs-project/sysknife/pull/312). `npx sysknife-setup --claude --no-prompts --daemon-mode=system` is the automation one-liner in `docs/quickstart.md`, and it now exits 3 where it exited 0. No signature changed. A run that used to succeed now reports failure, and `docs/release.md` already counts that as a break, with v0.9.0 as the precedent: the wizard started refusing a malformed `.mcp.json` it used to overwrite, and that moved the middle digit too.

System mode is a two-phase install by design, so a non-zero exit is the honest answer. Anyone scripting that line under `set -e` will see it stop, which is the point of the issue it closes.

Nothing else in this batch breaks. `ApprovalPolicy::new` gained a parameter but `sysknife-cli` publishes no library. `rmcp` 2 to 3 is a binary's dependency. The preview request gained an optional field, and both directions of that skew are covered by tests.

## What ships

Sixteen changes, four from three outside contributors and seven from Dependabot.

**Two secrets stopped being readable by anyone on the host.** #316 moved every provider API key out of the VM harnesses' process arguments, proved by argv canaries rather than by reading. #326 moved CI off Node 20, which reached end-of-life on 2026-04-30, and pinned three lint tools that were being installed unpinned in a job holding the workflow token.

**A way to run with no human, that says so in the chain.** #329 adds `--dangerously-skip-approval`. It lifts the approval gate and nothing else, needs a second key in the environment, and the daemon writes the fact into the transaction's `warnings_json`, which is inside the row's Ed25519 signature. Scrubbing it makes `audit verify` report that row `Broken`.

**The audit chain became exportable.** #318, contributed by @danial-razi, writes the signed rows as JSON with the linkage and signature bytes, and states in `docs/cli.md` that an export inherits the confidentiality of the database it came from.

**Three gates stopped reporting verdicts they had not earned.** #313 and #317 on the Postgres contract, and #330 on six review findings including a guard that matched a variable by name and so could not see the same bug renamed.

## Verification

- `cargo nextest run --workspace --locked`: 1820 passed, 5 skipped.
- `scripts/check_release_versions.sh v0.11.0`: fifteen version sites, fifteen internal pins, five JSON manifests.
- `scripts/release_rehearsal.sh --check`: preflight passed for v0.11.0 on x86_64.
- `scripts/ci-local.sh`: PASS.
- Postgres contract under podman: `running 11 tests`, 11 passed.

Merging this does not publish anything. The signed tag does.
