### PR TITLE
fix(daemon): bind a transaction to the account that created it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+### Security
+
+- **A transaction can only be approved, cancelled, inspected or executed by the
+  account that created it.**
+  `authorize_for_transaction` checked the caller's role and nothing else, so any
+  account permitted to reach the daemon socket could mint an approval receipt
+  for a transaction it had never previewed, read that preview's unredacted
+  parameters and host-state snapshot, cancel it, or execute it. `handle_execute`
+  and `handle_approval_details` had the same gap on their own paths.
+
+  `caller_principal` was already captured at preview, stored, and signed into
+  the chain. No authorization decision read it back, so the receipt proved that
+  *a* permitted account confirmed a preview, never which one, and the signed row
+  went on naming the account that previewed rather than the one that approved.
+
+  The rule is principal equality, not connection equality. `sysknife approve` is
+  deliberately a separate process from the client that previewed, and every CLI
+  call opens its own connection, so both keep working. Two cases refuse rather
+  than compare: an `Unattributed` peer, because the kernel could not name it and
+  two such callers are not known to be the same account, and a row with no
+  recorded owner.
+
+  Scope, stated plainly: `/run/sysknife` is `0750` and the socket is `0660`, so
+  only members of group `sysknife` and root could reach this at all, and the
+  role ceiling always held, so it was never a route past your own role. The
+  defect was same-role and cross-account, inside the trusted group.
+
 ## [0.11.0] — 2026-09-01
 
 The middle digit moves because of [#312](https://github.com/lacs-project/sysknife/pull/312).

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,820 Rust tests and 72 frontend tests** form the current deterministic
+**1,829 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -733,6 +733,104 @@ fn authorization_failure_message(
 /// Returns `Ok(true)` when authorized (proceed). Returns `Ok(false)` when a
 /// response has already been sent (transaction missing, load error, or denied)
 /// and the caller must return early.
+/// Whether `caller` is the account that created `transaction_id`.
+///
+/// The approval receipt is documented as proof that a human confirmed one
+/// specific preview. Checking only the caller's role made that proof
+/// unattributed: any account permitted to reach the socket could mint a
+/// receipt for a transaction it had never previewed, and the signed row would
+/// still name the account that *previewed* it, so the trail blamed the wrong
+/// person. `caller_principal` was already captured, stored and signed; nothing
+/// read it back.
+///
+/// The rule is principal equality, not connection equality. `sysknife approve`
+/// is deliberately a separate process from the client that previewed, and every
+/// CLI call opens its own connection, so requiring one connection would break
+/// the product. Requiring one account does not: both halves run as the same
+/// uid, and a vsock client previews and approves over the same channel.
+///
+/// Two cases refuse rather than compare:
+///
+/// - `Unattributed`, on either side. The kernel could not name the peer, so
+///   two such callers are not known to be the same account. Treating them as
+///   equal would put a claim in the signed record that the daemon has no
+///   evidence for, which is the thing [`CallerPrincipal::Unattributed`] exists
+///   to avoid.
+/// - A row with no stored principal. Only a chain imported from before the
+///   `caller_principal` migration can be in that state, and such a row cannot
+///   legitimately be queued for approval on a daemon running this code.
+async fn caller_owns_transaction(
+    state: &DaemonState,
+    caller: &CallerAttribution,
+    transaction_id: &str,
+) -> Ownership {
+    if matches!(
+        caller.principal(),
+        crate::auth::CallerPrincipal::Unattributed
+    ) {
+        return Ownership::CannotEstablish(
+            "this connection could not be attributed to an account, so it cannot approve, \
+             cancel, inspect or execute a transaction. The daemon reports the peer as \
+             unattributed when SO_PEERCRED fails or when the peer is not representable in \
+             this daemon's user namespace."
+                .to_string(),
+        );
+    }
+    let row = match state.audit.fetch_chain_row(transaction_id).await {
+        Ok(row) => row,
+        Err(e) => {
+            return Ownership::CannotEstablish(format!(
+                "failed to load transaction ownership: {e}"
+            ));
+        }
+    };
+    // A transaction that does not exist is not an ownership question. Saying
+    // "that belongs to someone else" about an id nobody ever created would be
+    // both wrong and a way to probe which ids exist, so this hands the case
+    // back to the caller's own missing-transaction path.
+    let Some(row) = row else {
+        return Ownership::NoSuchTransaction;
+    };
+    let Some(owner) = row.caller_principal.as_deref() else {
+        return Ownership::CannotEstablish(format!(
+            "transaction {transaction_id} records no owning account, so ownership cannot be \
+             established"
+        ));
+    };
+    if owner == caller.principal().as_signed_str() {
+        Ownership::Owned
+    } else {
+        Ownership::NotOwned
+    }
+}
+
+/// The four answers [`caller_owns_transaction`] can give.
+///
+/// An enum rather than a `Result<bool, _>` because "no such transaction" and
+/// "someone else's transaction" need different answers to the caller, and a
+/// boolean forced them together. The first version of this check reported a
+/// nonexistent id as belonging to another account, which is both untrue and a
+/// way to probe the id space.
+enum Ownership {
+    Owned,
+    NotOwned,
+    NoSuchTransaction,
+    CannotEstablish(String),
+}
+
+/// The refusal an operator sees when they act on someone else's transaction.
+///
+/// Deliberately does not name the owning account. Telling one caller which
+/// other account queued a transaction would hand out exactly the cross-account
+/// information this check exists to withhold.
+fn not_your_transaction_message(transaction_id: &str) -> String {
+    format!(
+        "transaction {transaction_id} was created by a different account. An approval receipt \
+         is proof that a specific account confirmed a specific preview, so only the account \
+         that previewed an action can approve, cancel, inspect or execute it."
+    )
+}
+
 async fn authorize_for_transaction(
     framed: &mut FramedStream<impl AsyncRead + AsyncWrite + Unpin>,
     state: &DaemonState,
@@ -744,6 +842,23 @@ async fn authorize_for_transaction(
 ) -> Result<bool, HandlerError> {
     match state.audit.get(transaction_id).await {
         Ok(Some(transaction)) => {
+            match caller_owns_transaction(state, caller, transaction_id).await {
+                Ownership::Owned | Ownership::NoSuchTransaction => {}
+                Ownership::NotOwned => {
+                    send_error(
+                        framed,
+                        request_id,
+                        "authorization_failure",
+                        not_your_transaction_message(transaction_id),
+                    )
+                    .await?;
+                    return Ok(false);
+                }
+                Ownership::CannotEstablish(message) => {
+                    send_error(framed, request_id, "authorization_failure", message).await?;
+                    return Ok(false);
+                }
+            }
             if authorize_action(&state.policy, &caller.role(), &transaction.action_name) {
                 Ok(true)
             } else {
@@ -1452,6 +1567,21 @@ async fn handle_approval_details(
     request_id: &str,
     transaction_id: &str,
 ) -> Result<(), HandlerError> {
+    match caller_owns_transaction(state, caller, transaction_id).await {
+        Ownership::Owned | Ownership::NoSuchTransaction => {}
+        Ownership::NotOwned => {
+            return send_error(
+                framed,
+                request_id,
+                "authorization_failure",
+                not_your_transaction_message(transaction_id),
+            )
+            .await;
+        }
+        Ownership::CannotEstablish(message) => {
+            return send_error(framed, request_id, "authorization_failure", message).await;
+        }
+    }
     let transaction = match state.audit.get(transaction_id).await {
         Ok(Some(transaction)) if transaction.status == JobState::Queued => transaction,
         Ok(_) => {
@@ -2367,6 +2497,25 @@ async fn handle_execute(
             return send_error(framed, request_id, "validation_failure", e.to_string()).await;
         }
     };
+
+    // Checked here as well as at approve, not instead of it. A receipt is a
+    // bearer token for one transaction, so an account that obtained one it was
+    // never issued must still be refused at the point of execution.
+    match caller_owns_transaction(state, caller, transaction_id).await {
+        Ownership::Owned | Ownership::NoSuchTransaction => {}
+        Ownership::NotOwned => {
+            return send_error(
+                framed,
+                request_id,
+                "authorization_failure",
+                not_your_transaction_message(transaction_id),
+            )
+            .await;
+        }
+        Ownership::CannotEstablish(message) => {
+            return send_error(framed, request_id, "authorization_failure", message).await;
+        }
+    }
 
     if !authorize_action(&state.policy, &caller.role(), action_name) {
         return send_error(

--- a/crates/sysknife-daemon/tests/transaction_ownership.rs
+++ b/crates/sysknife-daemon/tests/transaction_ownership.rs
@@ -1,0 +1,329 @@
+//! A transaction belongs to the account that created it.
+//!
+//! The approval receipt is documented as proof that a human confirmed one
+//! specific preview. Before this was enforced, `authorize_for_transaction`
+//! checked the caller's *role* and nothing else, so any account permitted to
+//! reach the daemon could mint a receipt for, and execute, a transaction it had
+//! never previewed. `caller_principal` was captured at preview, stored, and
+//! signed into the chain, and no authorization decision read it back.
+//!
+//! The rule enforced here is principal equality, not connection equality.
+//! `sysknife approve <id>` is deliberately a separate process from the client
+//! that previewed, and each CLI call opens its own connection, so requiring the
+//! same connection would break the product. Requiring the same account does
+//! not: every CLI flow runs both halves as the same uid, and a vsock client
+//! previews and approves over the same token-authenticated channel.
+//!
+//! `Unattributed` is the interesting case and it fails closed. It means the
+//! kernel could not name the peer, so two `Unattributed` callers are not known
+//! to be the same account. Treating them as equal would sign a claim the daemon
+//! cannot support, which `auth.rs` already argues against in as many words: a
+//! signed lie about who acted is worse than a signed admission of ignorance.
+
+use std::io;
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+use sysknife_daemon::auth::CallerAttribution;
+use sysknife_daemon::dispatcher::connection_handler_with_executor;
+use sysknife_daemon::executor::{ActionExecutor, RealActionExecutor};
+use sysknife_daemon::state::{DaemonConfig, DaemonState};
+use sysknife_daemon::state_collector::CommandRunner;
+use sysknife_daemon::transport::{framing::FramedStream, listen::ListenTarget};
+use sysknife_types::CallerRole;
+use tempfile::{tempdir, TempDir};
+use tokio::net::UnixStream;
+
+struct QuietRunner;
+
+impl CommandRunner for QuietRunner {
+    fn run(&self, program: &str, _args: &[&str]) -> Result<String, io::Error> {
+        match program {
+            "rpm-ostree" => Ok("{}".to_string()),
+            _ => Ok(String::new()),
+        }
+    }
+}
+
+/// A daemon plus a way to open connections attributed to different accounts.
+struct Daemon {
+    config: DaemonConfig,
+    _dir: TempDir,
+}
+
+impl Daemon {
+    fn start(name: &str) -> Self {
+        let dir = tempdir().unwrap();
+        let config = DaemonConfig::new(
+            ListenTarget::Unix(dir.path().join(format!("{name}.sock"))),
+            dir.path().join(format!("{name}.db")),
+        );
+        Self { config, _dir: dir }
+    }
+
+    /// One connection, attributed to `caller`. Each call is a fresh connection,
+    /// which is what the CLI does too.
+    fn connect(&self, caller: CallerAttribution) -> FramedStream<UnixStream> {
+        let state = DaemonState::open(self.config.clone()).unwrap();
+        let (client, server) = UnixStream::pair().unwrap();
+        let runner: Arc<dyn CommandRunner + Send + Sync> = Arc::new(QuietRunner);
+        let executor: Arc<dyn ActionExecutor> = Arc::new(RealActionExecutor);
+        tokio::spawn(async move {
+            connection_handler_with_executor(server, state, runner, executor, caller).await;
+        });
+        FramedStream::new(client)
+    }
+}
+
+async fn call(framed: &mut FramedStream<UnixStream>, req: Value) -> Value {
+    framed
+        .send(&serde_json::to_vec(&req).unwrap())
+        .await
+        .unwrap();
+    serde_json::from_slice(&framed.recv().await.unwrap()).unwrap()
+}
+
+async fn preview_as(d: &Daemon, caller: CallerAttribution) -> String {
+    let mut c = d.connect(caller);
+    let resp = call(
+        &mut c,
+        json!({
+            "type": "preview",
+            "request_id": "own-preview",
+            "action_name": "GetMemoryInfo",
+            "params": {},
+        }),
+    )
+    .await;
+    assert_eq!(resp["type"], "preview_response", "preview failed: {resp}");
+    resp["transaction_id"].as_str().unwrap().to_string()
+}
+
+fn uid(n: u32) -> CallerAttribution {
+    CallerAttribution::from_peer_uid(n, CallerRole::Admin)
+}
+
+// ---------------------------------------------------------------------------
+// The account that created the transaction
+// ---------------------------------------------------------------------------
+
+/// The ordinary flow. Preview and approve arrive on different connections from
+/// the same account, which is exactly what `sysknife approve` does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_same_account_on_a_new_connection_can_approve() {
+    let d = Daemon::start("own-ok");
+    let tx = preview_as(&d, uid(1000)).await;
+
+    let mut second = d.connect(uid(1000));
+    let resp = call(
+        &mut second,
+        json!({ "type": "approve", "request_id": "r", "transaction_id": tx }),
+    )
+    .await;
+    assert_eq!(
+        resp["type"], "approval_response",
+        "the creating account must still be able to approve from another connection: {resp}"
+    );
+}
+
+/// The defect this file exists for.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_different_account_cannot_approve() {
+    let d = Daemon::start("other-approve");
+    let tx = preview_as(&d, uid(1000)).await;
+
+    let mut attacker = d.connect(uid(4242));
+    let resp = call(
+        &mut attacker,
+        json!({ "type": "approve", "request_id": "r", "transaction_id": tx }),
+    )
+    .await;
+    assert_eq!(
+        resp["type"], "error_response",
+        "uid 4242 approved a transaction created by uid 1000: {resp}"
+    );
+    assert_eq!(resp["category"], "authorization_failure", "{resp}");
+}
+
+/// Cancelling someone else's queued action is a denial of service on their
+/// work, and it shares the same authorization helper.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_different_account_cannot_cancel() {
+    let d = Daemon::start("other-cancel");
+    let tx = preview_as(&d, uid(1000)).await;
+
+    let mut attacker = d.connect(uid(4242));
+    let resp = call(
+        &mut attacker,
+        json!({ "type": "cancel", "request_id": "r", "transaction_id": tx }),
+    )
+    .await;
+    assert_eq!(
+        resp["type"], "error_response",
+        "uid 4242 cancelled uid 1000's transaction: {resp}"
+    );
+}
+
+/// The preview carries unredacted parameters and a full host-state snapshot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_different_account_cannot_read_the_preview() {
+    let d = Daemon::start("other-details");
+    let tx = preview_as(&d, uid(1000)).await;
+
+    let mut attacker = d.connect(uid(4242));
+    let resp = call(
+        &mut attacker,
+        json!({ "type": "approval_details", "request_id": "r", "transaction_id": tx }),
+    )
+    .await;
+    assert_eq!(
+        resp["type"], "error_response",
+        "uid 4242 read uid 1000's preview: {resp}"
+    );
+}
+
+/// Belt and braces: even holding a valid receipt, a different account must not
+/// be able to execute. The receipt is minted here by the rightful owner, so
+/// this tests the execute path on its own rather than reusing the approve gate.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_different_account_cannot_execute_with_a_stolen_receipt() {
+    let d = Daemon::start("stolen-receipt");
+    let tx = preview_as(&d, uid(1000)).await;
+
+    let mut owner = d.connect(uid(1000));
+    let approved = call(
+        &mut owner,
+        json!({ "type": "approve", "request_id": "r", "transaction_id": tx }),
+    )
+    .await;
+    assert_eq!(approved["type"], "approval_response", "{approved}");
+    let receipt = approved["approval_receipt"].as_str().unwrap().to_string();
+
+    let mut attacker = d.connect(uid(4242));
+    let resp = call(
+        &mut attacker,
+        json!({
+            "type": "execute",
+            "request_id": "r",
+            "transaction_id": tx,
+            "action_name": "GetMemoryInfo",
+            "params": {},
+            "approval_receipt": receipt,
+        }),
+    )
+    .await;
+    assert_eq!(
+        resp["type"], "error_response",
+        "uid 4242 executed uid 1000's approved transaction with its receipt: {resp}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The two non-uid principals
+// ---------------------------------------------------------------------------
+
+/// A vsock client previews and approves over the same token-authenticated
+/// channel, so the principal matches and the flow keeps working.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_vsock_client_can_approve_its_own_transaction() {
+    let d = Daemon::start("vsock-ok");
+    let vsock = || CallerAttribution::from_vsock_token(CallerRole::Admin);
+    let tx = preview_as(&d, vsock()).await;
+
+    let mut second = d.connect(vsock());
+    let resp = call(
+        &mut second,
+        json!({ "type": "approve", "request_id": "r", "transaction_id": tx }),
+    )
+    .await;
+    assert_eq!(
+        resp["type"], "approval_response",
+        "the vsock channel must still be able to approve its own work: {resp}"
+    );
+}
+
+/// A uid peer must not be able to approve a vsock transaction, or the token
+/// channel becomes a way to launder work onto a local account.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_uid_peer_cannot_approve_a_vsock_transaction() {
+    let d = Daemon::start("vsock-cross");
+    let tx = preview_as(&d, CallerAttribution::from_vsock_token(CallerRole::Admin)).await;
+
+    let mut local = d.connect(uid(1000));
+    let resp = call(
+        &mut local,
+        json!({ "type": "approve", "request_id": "r", "transaction_id": tx }),
+    )
+    .await;
+    assert_eq!(resp["type"], "error_response", "{resp}");
+}
+
+/// `Unattributed` fails closed, including against itself.
+///
+/// The daemon could not name either peer, so it cannot say they are the same
+/// account. Letting the comparison succeed would put a claim in the signed
+/// record that the daemon has no evidence for.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_unattributed_caller_cannot_approve_even_its_own_transaction() {
+    let d = Daemon::start("unattributed");
+    let anon = CallerAttribution::unattributed;
+    let tx = preview_as(&d, anon()).await;
+
+    let mut second = d.connect(anon());
+    let resp = call(
+        &mut second,
+        json!({ "type": "approve", "request_id": "r", "transaction_id": tx }),
+    )
+    .await;
+    assert_eq!(
+        resp["type"], "error_response",
+        "an unnameable peer must not mint an attributed approval receipt: {resp}"
+    );
+    let msg = resp["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("could not") || msg.contains("attribut"),
+        "the refusal must say why, so an operator can fix the deployment: {resp}"
+    );
+}
+
+/// A row that records no owning account fails closed.
+///
+/// Only a chain imported from before the `caller_principal` migration can be
+/// in that state, and such a row cannot legitimately be queued on a daemon
+/// running this code. The guard exists anyway, because the alternative to
+/// refusing is treating "we do not know who owns this" as "you own this".
+///
+/// Reached by nulling the column directly, since the daemon's own API cannot
+/// produce the state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_row_with_no_recorded_owner_is_refused() {
+    let d = Daemon::start("no-owner");
+    let tx = preview_as(&d, uid(1000)).await;
+
+    let conn = rusqlite::Connection::open(&d.config.database_path).expect("open the store");
+    let changed = conn
+        .execute(
+            "UPDATE transactions SET caller_principal = NULL WHERE transaction_id = ?1",
+            rusqlite::params![tx],
+        )
+        .expect("null the owner column");
+    assert_eq!(changed, 1, "the mutation must actually apply");
+    drop(conn);
+
+    let mut owner = d.connect(uid(1000));
+    let resp = call(
+        &mut owner,
+        json!({ "type": "approve", "request_id": "r", "transaction_id": tx }),
+    )
+    .await;
+    assert_eq!(
+        resp["type"], "error_response",
+        "a row with no recorded owner must not be approvable, even by the account that \
+         actually created it: {resp}"
+    );
+    let msg = resp["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("no owning account"),
+        "the refusal must name the reason: {resp}"
+    );
+}

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,820 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,829 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,820 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,829 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "47d15196da46da394bf07bcf23d2ae53773186f2"
+    "tests": "b9f20620a2f08f7a8889a42251b4c073ea7b2d6a"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-09-01T16:07:03-06:00"
+    "tests": "2026-09-01T17:23:17-06:00"
   },
-  "tests": 1820,
+  "tests": 1829,
   "version": 1
 }


### PR DESCRIPTION
Closes the finding in GHSA-84hj-8hp3-r43c.

## What was wrong

`authorize_for_transaction` checked the caller's **role** and nothing else. Any account permitted to reach the daemon socket could mint an approval receipt for a transaction it had never previewed, read that preview's unredacted parameters and host-state snapshot, cancel it, or execute it. `handle_execute` and `handle_approval_details` had the same gap on their own paths.

`caller_principal` was already captured at preview, stored, and signed into the chain. Nothing read it back. So the receipt proved that *a* permitted account confirmed a preview, never which one, and the signed row went on naming the account that previewed rather than the one that approved. That is the enforcement half of #249, which reports the forensic half.

Reproduced before the fix, two connections at different uids:

```
A (uid 1000) queued transaction 435bae57-…
B (uid 4242) approve -> "approval_response"
B execute -> "job_started"
```

## Scope, stated plainly

Not a route past your own role, and not reachable by every local user. `/run/sysknife` is `0750 sysknife:sysknife` and the socket is `0660`, so only group members and root could reach it, and `authorize_action` always bounded the caller to their own tier. The defect was same-role and cross-account, inside the trusted group.

## The rule

Principal equality, not connection equality.

`sysknife approve <id>` is deliberately a separate process from the client that previewed, and every CLI call opens its own connection, so requiring one connection would break the product. Requiring one account does not: both halves run as the same uid, and a vsock client previews and approves over the same token-authenticated channel. Both of those are pinned by passing tests.

Two cases refuse rather than compare:

- **`Unattributed`.** The kernel could not name the peer, so two such callers are not known to be the same account. Treating them as equal would put a claim in the signed record the daemon has no evidence for, which is the thing that variant exists to avoid. This is a behaviour change for a deployment whose peers are not representable, and the refusal says so and names why.
- **A row with no recorded owner.** Only an imported pre-migration chain can produce it. Reached in the test by nulling the column directly, since the daemon's own API cannot.

Checked at execute as well as at approve, not instead of it. A receipt is a bearer token for one transaction, so an account holding one it was never issued must still be refused at the point of use.

## A flaw my own first version had

The check answered with a `bool`, which forced "no such transaction" and "someone else's transaction" into the same answer. It reported a nonexistent id as belonging to another account: untrue, and a way to probe which ids exist. `execute_without_prior_preview_returns_stale_approval`, an existing test, caught it. The four-state `Ownership` enum is what replaced the bool, and the missing-transaction case now falls through to the handler's own stale path.

## Mutation proof

| Mutation | Result |
|---|---|
| ownership always answers Owned | 10 failing |
| `Unattributed` treated as equal to itself | 2 failing |
| `NotOwned` falls through at approve | 6 failing |
| a row with no owner is treated as owned | 1 failing |

Nine tests, covering the two legitimate flows as well as the six refusals, so the fix cannot pass by refusing everything.

1820 to 1829 tests. `ci-local.sh` PASS.
