### PR TITLE
fix(audit): include anchor in verification verdict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,11 @@ jobs:
       - name: Run live Postgres migration and store contract
         run: cargo test -p sysknife-daemon --test postgres_store --locked -- --include-ignored
 
+      - name: Run live CLI anchor exit-code contract
+        run: >-
+          cargo test -p sysknife-cli --test cli_smoke --locked
+          audit_verify_exits_with_code_1_when_anchor_is_truncated -- --ignored --exact
+
   security-audit:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4847,6 +4847,8 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "sqlx-core",
+ "sqlx-postgres",
  "strip-ansi-escapes",
  "sysknife-brain",
  "sysknife-core",

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,831 Rust tests and 72 frontend tests** form the current deterministic
+**1,833 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,829 Rust tests and 72 frontend tests** form the current deterministic
+**1,831 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -49,3 +49,8 @@ assert_cmd = "2"
 predicates = "3"
 tempfile = "3"
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "net", "io-util"] }
+sqlx-core = { version = "0.9", default-features = false, features = [
+    "_rt-tokio",
+    "_tls-rustls-ring-webpki",
+] }
+sqlx-postgres = { version = "0.9", default-features = false }

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -1015,14 +1015,7 @@ pub async fn run_audit_verify(args: AuditVerifyArgs, log: &Logger) -> Result<(),
     // this command used to report `audit_anchor: {configured: true}` without
     // ever reading the anchor — implying a check it did not perform.
     let anchor = verify_configured_anchor(&lacs_config, &db_path, &verifier).await;
-    let anchor_exit = anchor
-        .as_ref()
-        .map(sysknife_daemon::audit_chain::checkpoint_outcome_to_exit_code)
-        .unwrap_or(0);
-
-    // Worst verdict wins: a chain that verifies against itself but not against
-    // its anchor has been tampered with, whatever the local check said.
-    let exit_code = outcome.exit_code().max(anchor_exit);
+    let exit_code = combined_verification_exit_code(&outcome, anchor.as_ref());
     emit_verification(&args, log, &outcome, &label_for_diag, anchor.as_ref());
     if exit_code == 0 {
         Ok(())
@@ -1484,7 +1477,7 @@ fn emit_verification(
 
     if args.json {
         let payload = json!({
-            "status": status_word(verification.exit_code()),
+            "status": status_word(combined_verification_exit_code(verification, anchor)),
             "backend": backend_label,
             "chain": outcome_json(&verification.chain),
             "approval_events": outcome_json(&verification.events),
@@ -1602,6 +1595,29 @@ fn emit_verification(
                  were deleted from the end of the chain"
             ));
         }
+    }
+}
+
+/// Combine the local audit checks with the external anchor using the same
+/// precedence as [`AuditVerification::exit_code`]. A detected break is stronger
+/// evidence than a different check being inconclusive, so exit code `1` must
+/// outrank `2` rather than relying on numeric ordering.
+fn combined_verification_exit_code(
+    verification: &AuditVerification,
+    anchor: Option<&CheckpointOutcome>,
+) -> i32 {
+    let codes = [
+        verification.exit_code(),
+        anchor
+            .map(sysknife_daemon::audit_chain::checkpoint_outcome_to_exit_code)
+            .unwrap_or(0),
+    ];
+    if codes.contains(&1) {
+        1
+    } else if codes.contains(&2) {
+        2
+    } else {
+        0
     }
 }
 
@@ -2210,6 +2226,15 @@ mod tests {
         attribution: Option<sysknife_daemon::audit_chain::AttributionCensus>,
         json: bool,
     ) -> String {
+        rendered_with_anchor(chain, attribution, json, None)
+    }
+
+    fn rendered_with_anchor(
+        chain: sysknife_daemon::audit_chain::VerifyOutcome,
+        attribution: Option<sysknife_daemon::audit_chain::AttributionCensus>,
+        json: bool,
+        anchor: Option<&CheckpointOutcome>,
+    ) -> String {
         use sysknife_daemon::audit_chain::{BindingOutcome, VerifyOutcome};
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("verify.log");
@@ -2227,7 +2252,7 @@ mod tests {
             &log,
             &verification,
             "/tmp/test.db",
-            None,
+            anchor,
         );
         std::fs::read_to_string(&path).expect("logger wrote the rendered output")
     }
@@ -2868,6 +2893,54 @@ mod tests {
         };
         assert_eq!(anchor_json(&empty)["status"], "cannot_verify");
         assert_eq!(checkpoint_outcome_to_exit_code(&empty), 2);
+    }
+
+    #[test]
+    fn a_detected_break_outranks_an_inconclusive_anchor_in_the_cli_exit_code() {
+        use sysknife_daemon::audit_chain::{BindingOutcome, VerifyOutcome};
+
+        let verification = AuditVerification {
+            chain: VerifyOutcome::Broken {
+                rows_checked: 3,
+                first_broken_seq: 4,
+                first_broken_transaction_id: "tx-4".to_string(),
+                expected: "expected".to_string(),
+                actual: "actual".to_string(),
+            },
+            events: VerifyOutcome::Intact { rows_checked: 4 },
+            binding: BindingOutcome::Consistent {
+                bindings_checked: 4,
+            },
+            attribution: None,
+        };
+        let anchor = CheckpointOutcome::CannotVerify {
+            reason: "checkpoint database unavailable".to_string(),
+        };
+
+        assert_eq!(
+            combined_verification_exit_code(&verification, Some(&anchor)),
+            1
+        );
+    }
+
+    #[test]
+    fn json_status_includes_a_truncated_anchor_verdict() {
+        use sysknife_daemon::audit_chain::VerifyOutcome;
+
+        let anchor = CheckpointOutcome::Truncated {
+            checkpoint_seq: 42,
+            current_max_seq: 17,
+        };
+        let text = rendered_with_anchor(
+            VerifyOutcome::Intact { rows_checked: 17 },
+            None,
+            true,
+            Some(&anchor),
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(&text).expect("--json must emit one JSON document");
+
+        assert_eq!(parsed["status"], "broken");
     }
 
     // -----------------------------------------------------------------------

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -174,8 +174,8 @@ async fn audit_verify_exits_with_code_1_when_anchor_is_truncated() {
 
     let dir = tempfile::tempdir().expect("create CLI fixture directory");
     let db_path = dir.path().join("daemon.sqlite");
-    let key = AuditKey::load_or_generate(&resolve_audit_key_path(&db_path))
-        .expect("generate audit key");
+    let key =
+        AuditKey::load_or_generate(&resolve_audit_key_path(&db_path)).expect("generate audit key");
     let store = TransactionStore::open_with_key(&db_path, Arc::new(key.clone()))
         .expect("create audit store");
     store
@@ -195,13 +195,9 @@ async fn audit_verify_exits_with_code_1_when_anchor_is_truncated() {
     let sink = PostgresCheckpointSink::connect(&scoped_url)
         .await
         .expect("connect checkpoint sink");
-    sink.append(&key.sign_checkpoint(
-        2,
-        "anchored-tip-beyond-local-chain",
-        "2026-09-02T12:00:00Z",
-    ))
-    .await
-    .expect("store checkpoint beyond the local tip");
+    sink.append(&key.sign_checkpoint(2, "anchored-tip-beyond-local-chain", "2026-09-02T12:00:00Z"))
+        .await
+        .expect("store checkpoint beyond the local tip");
     drop(sink);
 
     let output = cli()

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -205,7 +205,7 @@ async fn audit_verify_exits_with_code_1_when_anchor_is_truncated() {
         .env("SYSKNIFE_CHECKPOINT_DB", &scoped_url)
         .env("HOME", dir.path())
         .env("XDG_CONFIG_HOME", dir.path())
-        .args(["audit", "verify"])
+        .args(["audit", "verify", "--json"])
         .output()
         .expect("run audit verify");
 
@@ -222,6 +222,14 @@ async fn audit_verify_exits_with_code_1_when_anchor_is_truncated() {
         "stdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+    let doc: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("--json emits one document");
+    assert_eq!(
+        doc["status"],
+        "broken",
+        "the --json verdict must reflect the anchor: {}",
+        String::from_utf8_lossy(&output.stdout)
     );
 }
 

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -130,6 +130,105 @@ fn audit_verify_exits_with_code_2_when_the_key_file_is_missing() {
         .code(2);
 }
 
+#[tokio::test]
+#[ignore = "live Postgres; set SYSKNIFE_TEST_POSTGRES_URL and run with --ignored"]
+async fn audit_verify_exits_with_code_1_when_anchor_is_truncated() {
+    use sqlx_postgres::{PgConnectOptions, PgPoolOptions};
+    use std::str::FromStr;
+    use sysknife_daemon::audit_chain::resolve_audit_key_path;
+    use sysknife_daemon::checkpoint_sink::{CheckpointSink, PostgresCheckpointSink};
+
+    let required = std::env::var_os("SYSKNIFE_REQUIRE_POSTGRES").is_some();
+    let url = std::env::var("SYSKNIFE_TEST_POSTGRES_URL")
+        .ok()
+        .filter(|url| !url.is_empty());
+    let Some(url) = url else {
+        assert!(
+            !required,
+            "SYSKNIFE_REQUIRE_POSTGRES is set but SYSKNIFE_TEST_POSTGRES_URL is unset"
+        );
+        return;
+    };
+    assert!(
+        url.contains("sysknife_test"),
+        "refusing destructive integration test against a non-test database"
+    );
+
+    const SCHEMA: &str = "cli_smoke_anchor_exit";
+    let admin = PgPoolOptions::new()
+        .max_connections(1)
+        .connect_with(PgConnectOptions::from_str(&url).expect("valid test URL"))
+        .await
+        .expect("connect for schema setup");
+    for statement in [
+        format!("DROP SCHEMA IF EXISTS {SCHEMA} CASCADE"),
+        format!("CREATE SCHEMA {SCHEMA}"),
+    ] {
+        sqlx_core::query::query(sqlx_core::sql_str::AssertSqlSafe(statement))
+            .execute(&admin)
+            .await
+            .expect("prepare isolated schema");
+    }
+    let separator = if url.contains('?') { '&' } else { '?' };
+    let scoped_url = format!("{url}{separator}options=-csearch_path%3D{SCHEMA}");
+
+    let dir = tempfile::tempdir().expect("create CLI fixture directory");
+    let db_path = dir.path().join("daemon.sqlite");
+    let key = AuditKey::load_or_generate(&resolve_audit_key_path(&db_path))
+        .expect("generate audit key");
+    let store = TransactionStore::open_with_key(&db_path, Arc::new(key.clone()))
+        .expect("create audit store");
+    store
+        .record(NewTransaction {
+            request_id: "anchor-exit-code".to_string(),
+            request_hash: "anchor-exit-code-hash".to_string(),
+            action_name: "UpdateSystem".to_string(),
+            risk_level: RiskLevel::High,
+            summary: "Upgrade the system".to_string(),
+            warnings: vec![],
+            caller_role: CallerRole::Dev,
+            caller_principal: CallerPrincipal::Uid(1000),
+        })
+        .expect("record intact local chain");
+    drop(store);
+
+    let sink = PostgresCheckpointSink::connect(&scoped_url)
+        .await
+        .expect("connect checkpoint sink");
+    sink.append(&key.sign_checkpoint(
+        2,
+        "anchored-tip-beyond-local-chain",
+        "2026-09-02T12:00:00Z",
+    ))
+    .await
+    .expect("store checkpoint beyond the local tip");
+    drop(sink);
+
+    let output = cli()
+        .env("SYSKNIFE_DATABASE_PATH", &db_path)
+        .env("SYSKNIFE_CHECKPOINT_DB", &scoped_url)
+        .env("HOME", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .args(["audit", "verify"])
+        .output()
+        .expect("run audit verify");
+
+    sqlx_core::query::query(sqlx_core::sql_str::AssertSqlSafe(format!(
+        "DROP SCHEMA {SCHEMA} CASCADE"
+    )))
+    .execute(&admin)
+    .await
+    .expect("drop isolated schema");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn audit_export_emits_the_stored_rows_as_parseable_json() {
     let dir = tempfile::tempdir().unwrap();

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,831 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,833 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,829 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,831 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,831 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,833 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,829 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,831 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "cf81ecc4581f8d25333db25f7f23f1ee1285799b"
+    "tests": "5776193d286368ceb36f03afad181c49742f36d9"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-09-02T06:10:39+02:00"
+    "tests": "2026-09-02T14:32:46+00:00"
   },
-  "tests": 1831,
+  "tests": 1833,
   "version": 1
 }

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "b9f20620a2f08f7a8889a42251b4c073ea7b2d6a"
+    "tests": "07179ab3c3c152c8f720535d4b6f071621dbd1a1"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-09-01T17:23:17-06:00"
+    "tests": "2026-09-02T04:23:10+00:00"
   },
-  "tests": 1829,
+  "tests": 1831,
   "version": 1
 }


### PR DESCRIPTION
## Summary

- combine the local audit checks and configured anchor with the documented tamper-over-inconclusive precedence
- derive the JSON headline status from that same combined verdict
- run the real CLI binary with `--json` against an intact SQLite chain and a higher signed checkpoint in an isolated live-Postgres schema, asserting process exit code 1 and JSON status `broken`
- run that regression in the existing Postgres contract job and retain the measured 1,833-test Linux baseline

Closes #221

## Validation

GitHub Actions on final commit `22dfe55`:

- Rust format, Clippy, rustdoc, and workspace suite: 1,833/1,833 passed, 6 skipped
- live Postgres contract: `audit_verify_exits_with_code_1_when_anchor_is_truncated` passed with the exit-code and JSON assertions
- docs and hygiene, scripts lint, frontend, dependency review, security audit, secret scan, and CodeQL

The baseline records the Linux run at commit `5776193d286368ceb36f03afad181c49742f36d9`, rather than inferring a count from the macOS-visible suite. `python3 scripts/check_evidence_claims.py .` passed in CI, and `git diff --check` passes locally.

AI assistance was used to inspect the issue and review, implement the focused change, run validation, and prepare this PR. I reviewed the diff and test results.
