### PR TITLE
fix(e2e): reject incomplete story runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Check story metadata is derived from the story files
         run: bash tests/e2e/story-metadata.test.sh
 
+      - name: Check story runners reject unproven results
+        run: bash tests/e2e/story-runner-verdicts.test.sh
+
       - name: Check Ubuntu VM bootstrap contract
         run: bash tests/e2e/ubuntu-vm-bootstrap.test.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+### Fixed
+
+- **A story suite that proved nothing no longer reports success.** All three
+  runners (`run-stories.sh`, `exec/run-exec-stories.sh`, `dev-stories.sh`)
+  decided their exit status from `fail_count` alone, so a run where every story
+  was skipped or rate-limited printed `0/N passed, 0 failed` and exited 0.
+  `run-stories.sh` also rewrote a failing story's verdict to `RATELIMIT`, moving
+  it out of the only counter that could fail the run. A pass is now a positive
+  `PASS` marker rather than an inferred exit status, and skipped, rate-limited
+  and zero-pass runs all fail. `scripts/check_evidence_claims.py` refuses an
+  artifact carrying a non-zero `skipped` or `rate_limited` as evidence for a
+  published pass rate or a Validated tier.
+  `tests/e2e/story-runner-verdicts.test.sh` pins the contract by executing
+  staged copies of the three production runners and mutating their real exit
+  gates, so a reverted fix turns the suite red. Story 28 also left the
+  no-argument default sets, which selected a Fedora-only story on every Ubuntu
+  host. ([#247](https://github.com/lacs-project/sysknife/issues/247))
+
 ### Security
 
 - **A transaction can only be approved, cancelled, inspected or executed by the

--- a/scripts/check_evidence_claims.py
+++ b/scripts/check_evidence_claims.py
@@ -178,6 +178,19 @@ def load_story_runs(root: Path) -> list[dict]:
     return runs
 
 
+def story_run_has_no_unproven_results(run: dict) -> bool:
+    """Only a run with explicit zero skipped and rate-limited stories can prove claims."""
+    totals = run.get("totals")
+    if not isinstance(totals, dict):
+        return False
+    return all(
+        isinstance(totals.get(field), int)
+        and not isinstance(totals.get(field), bool)
+        and totals[field] == 0
+        for field in ("skipped", "rate_limited")
+    )
+
+
 def check_story_claims(texts: dict[str, str], runs: list[dict]) -> list[str]:
     problems = []
     pattern = re.compile(r"([0-9]+)\s*/\s*([0-9]+)\s+stories")
@@ -193,6 +206,7 @@ def check_story_claims(texts: dict[str, str], runs: list[dict]) -> list[str]:
                 if run.get("story_set") in FULL_STORY_SETS
                 and run.get("totals", {}).get("passed") == passed
                 and run.get("totals", {}).get("total") == total
+                and story_run_has_no_unproven_results(run)
                 # A replay that missed, or served nothing, proves nothing — the
                 # harness says so and fails the run. Such an artifact used to be
                 # written anyway, with a healthy-looking pass rate.
@@ -355,9 +369,12 @@ def replay_verified_releases(root: Path) -> set[str]:
         if not release:
             continue
         if path.name.endswith(".replay.json"):
-            if str(run.get("cassette_audit", {}).get("verdict", "")) == "ok":
+            if (
+                str(run.get("cassette_audit", {}).get("verdict", "")) == "ok"
+                and story_run_has_no_unproven_results(run)
+            ):
                 replays.add(release)
-        else:
+        elif story_run_has_no_unproven_results(run):
             records[release] = path
     return set(records) & replays
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -283,6 +283,7 @@ run_hygiene_group() {
     run_step 'hygiene: provider-parity.test.sh' bash "$repo_root/tests/e2e/provider-parity.test.sh"
     run_step 'hygiene: vm-env-secrets.test.sh' bash "$repo_root/tests/e2e/vm-env-secrets.test.sh"
     run_step 'hygiene: story-metadata.test.sh' bash "$repo_root/tests/e2e/story-metadata.test.sh"
+    run_step 'hygiene: story-runner-verdicts.test.sh' bash "$repo_root/tests/e2e/story-runner-verdicts.test.sh"
     run_step 'hygiene: vm-sync-parity.test.sh' bash "$repo_root/tests/e2e/vm-sync-parity.test.sh"
     run_step 'hygiene: docs-share-cards.test.sh' bash "$repo_root/tests/release/docs-share-cards.test.sh"
     run_step 'hygiene: install-paths.test.sh' bash "$repo_root/tests/release/install-paths.test.sh"

--- a/tests/e2e/dev-stories.sh
+++ b/tests/e2e/dev-stories.sh
@@ -218,7 +218,7 @@ if [[ $# -gt 0 ]]; then
 elif [[ "$ALLOW_DESTRUCTIVE" == "1" ]]; then
     STORIES=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54)
 else
-    STORIES=(1 2 3 4 5 6 7 11 12 13 14 15 16 17 21 22 25 26 28 29 32 38 41 46 47 48 49)
+    STORIES=(1 2 3 4 5 6 7 11 12 13 14 15 16 17 21 22 25 26 29 32 38 41 46 47 48 49)
 fi
 
 # ---------------------------------------------------------------------------
@@ -345,7 +345,7 @@ echo ""
 if (( fail_count > 0 || skip_count > 0 || pass_count == 0 )); then
     echo "NOTE: On a non-Fedora-Atomic host, stories 8 and 10 are expected to fail"
     echo "because query_packages and query_authorized_keys call rpm-ostree and SSH"
-    echo "tools that are absent. Stories 1-7, 11-17, and 21-22, 25-26, 28-29 should"
+    echo "tools that are absent. Stories 1-7, 11-17, and 21-22, 25-26, 29 should"
     echo "always pass on any Linux host (plan-structure checks only, no execution)."
     echo "Run on a provisioned Silverblue VM for full coverage."
     echo ""

--- a/tests/e2e/dev-stories.sh
+++ b/tests/e2e/dev-stories.sh
@@ -259,9 +259,13 @@ run_story() {
             RESULTS[$n]="SKIP"
             MESSAGES[$n]="${last_line#SKIP}"
             echo "SKIP"
-        else
+        elif [[ "$last_line" == PASS* ]]; then
             RESULTS[$n]="PASS"
             echo "PASS (${elapsed}s)"
+        else
+            RESULTS[$n]="FAIL"
+            MESSAGES[$n]="exited 0 without a PASS marker"
+            echo "FAIL (${elapsed}s)"
         fi
     else
         RESULTS[$n]="FAIL"
@@ -338,7 +342,7 @@ echo "Summary: $pass_count/$total passed, $fail_count failed, $skip_count skippe
 echo "Logs:    $LOG_DIR/"
 echo ""
 
-if (( fail_count > 0 )); then
+if (( fail_count > 0 || skip_count > 0 || pass_count == 0 )); then
     echo "NOTE: On a non-Fedora-Atomic host, stories 8 and 10 are expected to fail"
     echo "because query_packages and query_authorized_keys call rpm-ostree and SSH"
     echo "tools that are absent. Stories 1-7, 11-17, and 21-22, 25-26, 28-29 should"

--- a/tests/e2e/exec/run-exec-stories.sh
+++ b/tests/e2e/exec/run-exec-stories.sh
@@ -156,12 +156,19 @@ run_exec() {
       MESSAGES[$n]="${last_line#SKIP}"
       DURATIONS[$n]="0.0"
       echo "SKIP"
-    else
+    elif [[ "$last_line" == PASS* ]]; then
       RESULTS[$n]="PASS"
       local end_time
       end_time=$(date +%s.%N)
       DURATIONS[$n]=$(echo "$end_time - $start_time" | bc 2>/dev/null || echo "?")
       echo "PASS (${DURATIONS[$n]}s)"
+    else
+      RESULTS[$n]="FAIL"
+      MESSAGES[$n]="exited 0 without a PASS marker"
+      local end_time
+      end_time=$(date +%s.%N)
+      DURATIONS[$n]=$(echo "$end_time - $start_time" | bc 2>/dev/null || echo "?")
+      echo "FAIL (${DURATIONS[$n]}s)"
     fi
   else
     local exit_code=$?
@@ -238,7 +245,7 @@ echo "Summary: $pass_count/$total passed, $fail_count failed, $skip_count skippe
 echo "Logs:    $LOG_DIR/"
 echo ""
 
-if [[ $fail_count -gt 0 ]]; then
+if [[ $fail_count -gt 0 || $skip_count -gt 0 || $pass_count -eq 0 ]]; then
   exit 1
 fi
 exit 0

--- a/tests/e2e/run-stories.sh
+++ b/tests/e2e/run-stories.sh
@@ -226,7 +226,7 @@ else
   # This subset is curated, not derivable: it is the atomic-family stories that
   # need no live rpm-ostree host, which no header tag records.
   STORIES=(1 2 3 4 5 6 7 11 12 13 14 15 16 17 \
-           21 22 25 26 28 29 32 38 41 46 47 48 49)
+           21 22 25 26 29 32 38 41 46 47 48 49)
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/run-stories.sh
+++ b/tests/e2e/run-stories.sh
@@ -311,12 +311,19 @@ run_story() {
       MESSAGES[$n]="${last_line#SKIP}"
       DURATIONS[$n]="0.0"
       echo "SKIP"
-    else
+    elif [[ "$last_line" == PASS* ]]; then
       RESULTS[$n]="PASS"
       local end_time
       end_time=$(date +%s.%N)
       DURATIONS[$n]=$(echo "$end_time - $start_time" | bc 2>/dev/null || echo "?")
       echo "PASS (${DURATIONS[$n]}s)"
+    else
+      RESULTS[$n]="FAIL"
+      MESSAGES[$n]="exited 0 without a PASS marker"
+      local end_time
+      end_time=$(date +%s.%N)
+      DURATIONS[$n]=$(echo "$end_time - $start_time" | bc 2>/dev/null || echo "?")
+      echo "FAIL (${DURATIONS[$n]}s)"
     fi
   else
     local exit_code=$?
@@ -587,7 +594,8 @@ elif [[ -n "$STORY_SET" ]]; then
   echo ""
 fi
 
-if [[ $fail_count -gt 0 || $cassette_failed -gt 0 ]]; then
+if [[ $fail_count -gt 0 || $skip_count -gt 0 || $ratelimit_count -gt 0 ||
+  $pass_count -eq 0 || $cassette_failed -gt 0 ]]; then
   exit 1
 fi
 exit 0

--- a/tests/e2e/story-runner-verdicts.test.sh
+++ b/tests/e2e/story-runner-verdicts.test.sh
@@ -155,6 +155,20 @@ else
     run_case 'mutated run-stories accepts SKIP' 0 "$run_mutant" 1 2
 fi
 
+# Exercise the production runner's no-argument default selection without
+# restating its curated list. Derive one passing fixture per checked-in story,
+# then make the Fedora-only story fail the aggregate contract if selected.
+for story_file in "$repo_root"/tests/e2e/stories/story-*.sh; do
+    story_name="${story_file##*/}"
+    story_id="${story_name#story-}"
+    story_id="${story_id%.sh}"
+    write_story "$run_root/stories" story- "$story_id" pass
+done
+write_story "$run_root/stories" story- 28 skip
+
+run_case 'run-stories default set accepts portable stories' 0 "$run_runner"
+assert_output_not_contains 'run-stories default set omits Fedora-only story 28' 'Story 28'
+
 # The exec runner has the same result contract but its own production loop.
 exec_root="$fixture/exec"
 mkdir -p "$exec_root"

--- a/tests/e2e/story-runner-verdicts.test.sh
+++ b/tests/e2e/story-runner-verdicts.test.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Verify the result contract by executing staged copies of the production
+# runners. Only their VM/build prerequisites and story scripts are replaced;
+# classification, summaries, and exit decisions are the real runner paths.
+#
+# Host-side only: no VM, daemon, LLM, or network.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+fake_bin="$fixture/bin"
+mkdir -p "$fake_bin"
+
+write_fake_command() {
+    local name="$1"
+    if [[ "$name" == "timeout" ]]; then
+        printf '%s\n' '#!/usr/bin/env bash' 'shift' 'exec "$@"' >"$fake_bin/$name"
+    else
+        printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$fake_bin/$name"
+    fi
+    chmod +x "$fake_bin/$name"
+}
+
+for command in cargo jq sysknife systemctl timeout; do
+    write_fake_command "$command"
+done
+
+write_story() {
+    local directory="$1" prefix="$2" story_id="$3" outcome="$4"
+    local path="$directory/${prefix}${story_id}.sh"
+
+    case "$outcome" in
+        pass)
+            printf '%s\n' '#!/usr/bin/env bash' "# Story $story_id: fixture" \
+                'echo "PASS: fixture story"' >"$path"
+            ;;
+        skip)
+            printf '%s\n' '#!/usr/bin/env bash' "# Story $story_id: fixture" \
+                'echo "SKIP: fixture story"' >"$path"
+            ;;
+        rate)
+            printf '%s\n' '#!/usr/bin/env bash' "# Story $story_id: fixture" \
+                'echo "rate limit exceeded"' 'exit 1' >"$path"
+            ;;
+        silent)
+            printf '%s\n' '#!/usr/bin/env bash' "# Story $story_id: fixture" \
+                'exit 0' >"$path"
+            ;;
+        *)
+            printf 'unknown fixture outcome: %s\n' "$outcome" >&2
+            exit 1
+            ;;
+    esac
+    chmod +x "$path"
+}
+
+CASE_OUTPUT=""
+CASE_STATUS=0
+run_case() {
+    local label="$1" expected_status="$2" runner="$3"
+    shift 3
+
+    if CASE_OUTPUT="$(
+        PATH="$fake_bin:$PATH" \
+        SYSKNIFE_LLM_MODEL=fixture \
+        SYSKNIFE_LLM_PROVIDER=ollama \
+        SYSKNIFE_STORY_DELAY=0 \
+        SYSKNIFE_STORY_DELAY_SECS=0 \
+        SYSKNIFE_STORY_TIMEOUT=30 \
+            bash "$runner" "$@" 2>&1
+    )"; then
+        CASE_STATUS=0
+    else
+        CASE_STATUS=$?
+    fi
+
+    if [[ "$CASE_STATUS" -ne "$expected_status" ]]; then
+        printf 'FAIL: %s (expected exit %s, got %s)\n' \
+            "$label" "$expected_status" "$CASE_STATUS" >&2
+        printf '%s\n' "$CASE_OUTPUT" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+assert_output_contains() {
+    local label="$1" needle="$2"
+    if ! grep -Fq -- "$needle" <<<"$CASE_OUTPUT"; then
+        printf 'FAIL: %s (output did not contain %s)\n' "$label" "$needle" >&2
+        printf '%s\n' "$CASE_OUTPUT" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+assert_output_not_contains() {
+    local label="$1" needle="$2"
+    if grep -Fq -- "$needle" <<<"$CASE_OUTPUT"; then
+        printf 'FAIL: %s (output contained %s)\n' "$label" "$needle" >&2
+        printf '%s\n' "$CASE_OUTPUT" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+failures=0
+
+# run-stories.sh has the rate-limit diagnostic in addition to SKIP. Replace only
+# the fixed host paths needed to run its real story loop without root.
+run_root="$fixture/run-stories"
+mkdir -p "$run_root/stories"
+run_runner="$run_root/run-stories.sh"
+cp "$repo_root/tests/e2e/run-stories.sh" "$run_runner"
+sed -i 's/\r$//' "$run_runner"
+ready_marker="$run_root/ready"
+touch "$ready_marker"
+sed -i "s|/var/lib/sysknife-e2e/ready|$ready_marker|g" "$run_runner"
+sed -i "s|/tmp/sysknife-story-|$fixture/sysknife-story-|g" "$run_runner"
+write_story "$run_root/stories" story- 1 pass
+write_story "$run_root/stories" story- 2 skip
+write_story "$run_root/stories" story- 3 rate
+write_story "$run_root/stories" story- 4 silent
+
+run_case 'run-stories rejects SKIP' 1 "$run_runner" 1 2
+assert_output_contains 'run-stories reports SKIP' 'SKIP'
+run_case 'run-stories rejects RATELIMIT' 1 "$run_runner" 1 3
+assert_output_contains 'run-stories keeps RATELIMIT diagnostic' 'RATELIMIT'
+assert_output_not_contains 'run-stories does not relabel RATELIMIT as FAIL' 'FAIL'
+run_case 'run-stories rejects an unmarked zero exit' 1 "$run_runner" 4
+assert_output_contains 'run-stories explains an unmarked zero exit' \
+    'exited 0 without a PASS marker'
+run_case 'run-stories accepts an explicit PASS' 0 "$run_runner" 1
+
+# Mutation check: removing the aggregate guard from a staged production copy
+# must make the SKIP fixture green. This proves the assertions above are
+# sensitive to the production decision, not merely to a parallel expectation.
+run_mutant="$run_root/run-stories-no-unproven-gate.sh"
+cp "$run_runner" "$run_mutant"
+python3 - "$run_mutant" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+old = """if [[ $fail_count -gt 0 || $skip_count -gt 0 || $ratelimit_count -gt 0 ||
+  $pass_count -eq 0 || $cassette_failed -gt 0 ]]; then"""
+new = """if [[ $fail_count -gt 0 || $cassette_failed -gt 0 ]]; then"""
+if text.count(old) != 1:
+    raise SystemExit("story-runner gate mutation did not find one production guard")
+path.write_text(text.replace(old, new))
+PY
+if ! grep -Fq -- 'if [[ $fail_count -gt 0 || $cassette_failed -gt 0 ]]; then' "$run_mutant"; then
+    printf 'FAIL: story-runner gate mutation did not apply\n' >&2
+    failures=$((failures + 1))
+else
+    run_case 'mutated run-stories accepts SKIP' 0 "$run_mutant" 1 2
+fi
+
+# The exec runner has the same result contract but its own production loop.
+exec_root="$fixture/exec"
+mkdir -p "$exec_root"
+exec_runner="$exec_root/run-exec-stories.sh"
+cp "$repo_root/tests/e2e/exec/run-exec-stories.sh" "$exec_runner"
+sed -i 's/\r$//' "$exec_runner"
+exec_ready="$exec_root/ready"
+touch "$exec_ready"
+sed -i "s|/var/lib/sysknife-e2e/ready|$exec_ready|g" "$exec_runner"
+write_story "$exec_root" exec- 1 pass
+write_story "$exec_root" exec- 2 skip
+write_story "$exec_root" exec- 3 silent
+
+run_case 'run-exec-stories rejects SKIP' 1 "$exec_runner" 1 2
+run_case 'run-exec-stories rejects an unmarked zero exit' 1 "$exec_runner" 3
+run_case 'run-exec-stories accepts an explicit PASS' 0 "$exec_runner" 1
+
+# dev-stories.sh builds and starts a daemon before entering its production story
+# loop. A fake successful build plus a pre-existing staged socket avoids both
+# external operations while leaving the verdict path untouched.
+dev_root="$fixture/dev"
+dev_e2e="$dev_root/tests/e2e"
+mkdir -p "$dev_e2e/stories"
+dev_runner="$dev_e2e/dev-stories.sh"
+cp "$repo_root/tests/e2e/dev-stories.sh" "$dev_runner"
+sed -i 's/\r$//' "$dev_runner"
+dev_socket="$dev_root/daemon.sock"
+touch "$dev_socket"
+sed -i "s|SOCKET_PATH=\"/tmp/sysknife-daemon.sock\"|SOCKET_PATH=\"$dev_socket\"|" \
+    "$dev_runner"
+write_story "$dev_e2e/stories" story- 1 pass
+write_story "$dev_e2e/stories" story- 2 skip
+write_story "$dev_e2e/stories" story- 3 silent
+
+run_case 'dev-stories rejects SKIP' 1 "$dev_runner" 1 2
+run_case 'dev-stories rejects an unmarked zero exit' 1 "$dev_runner" 3
+run_case 'dev-stories accepts an explicit PASS' 0 "$dev_runner" 1
+
+if [[ "$failures" -ne 0 ]]; then
+    printf '\n%d story-runner verdict failure(s).\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'Story-runner verdict contract passed across all three production runners.\n'

--- a/tests/release/public-claims.test.sh
+++ b/tests/release/public-claims.test.sh
@@ -139,6 +139,43 @@ if ! "$checker" "$fixture" >/dev/null 2>&1; then
     exit 1
 fi
 
+# A pass rate backed by a run that skipped stories is not a validated story
+# claim. Mutate the writer-produced artifact so this exercises the same schema
+# the production recorder emits rather than a hand-written JSON shape.
+python3 - "$fixture/tests/evidence/story-runs/fixture-run.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+run = json.loads(open(path).read())
+run["totals"]["skipped"] = 1
+open(path, "w").write(json.dumps(run, indent=2, sort_keys=True) + "\n")
+PY
+grep -q '"skipped": 1' "$fixture/tests/evidence/story-runs/fixture-run.json" || {
+    printf 'FAIL: skipped-story mutation did not apply\n' >&2
+    exit 1
+}
+assert_rejected 'story pass rate backed by skipped stories'
+write_fixture_run ubuntu 50 47 ok
+
+# Rate-limited stories are a separate diagnostic, but they are just as unable
+# to support a published pass rate as skipped stories.
+python3 - "$fixture/tests/evidence/story-runs/fixture-run.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+run = json.loads(open(path).read())
+run["totals"]["rate_limited"] = 1
+open(path, "w").write(json.dumps(run, indent=2, sort_keys=True) + "\n")
+PY
+grep -q '"rate_limited": 1' "$fixture/tests/evidence/story-runs/fixture-run.json" || {
+    printf 'FAIL: rate-limited-story mutation did not apply\n' >&2
+    exit 1
+}
+assert_rejected 'story pass rate backed by rate-limited stories'
+write_fixture_run ubuntu 50 47 ok
+
 # Backed by a run, but attributed to a model that did not produce it.
 sed -i 's|47/50 stories on a live VM.|47/50 stories on a live VM with gpt-4.1.|' "$fixture/README.md"
 grep -q 'gpt-4.1' "$fixture/README.md" || {
@@ -266,5 +303,42 @@ grep -q '"verdict": "failed"' "$fixture"/tests/evidence/story-runs/ubuntu-22.04-
 }
 assert_rejected 'a release tiered Validated on a replay whose cassette audit failed'
 cp "$repo_root"/tests/evidence/story-runs/*.json "$fixture/tests/evidence/story-runs/"
+
+# A record with skipped stories cannot earn a Validated tier, even if its replay
+# twin is otherwise healthy.
+python3 - "$fixture/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+run = json.loads(open(path).read())
+run["totals"]["skipped"] = 1
+open(path, "w").write(json.dumps(run, indent=2, sort_keys=True) + "\n")
+PY
+grep -q '"skipped": 1' "$fixture/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json" || {
+    printf 'FAIL: skipped-record tier mutation did not apply\n' >&2
+    exit 1
+}
+assert_rejected 'Validated tier backed by a record with skipped stories'
+cp "$repo_root/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json" \
+    "$fixture/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.json"
+
+# Keep the diagnostic separate in the artifact contract too: a replay with a
+# rate-limited story cannot validate a release.
+python3 - "$fixture/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+run = json.loads(open(path).read())
+run["totals"]["rate_limited"] = 1
+open(path, "w").write(json.dumps(run, indent=2, sort_keys=True) + "\n")
+PY
+grep -q '"rate_limited": 1' \
+    "$fixture/tests/evidence/story-runs/ubuntu-22.04-gpt-oss-120b.replay.json" || {
+    printf 'FAIL: rate-limited-replay tier mutation did not apply\n' >&2
+    exit 1
+}
+assert_rejected 'Validated tier backed by a replay with rate-limited stories'
 
 printf 'Public claims contract passed.\n'


### PR DESCRIPTION
## Summary

- Fixed the false-green story verdict contract across `run-stories.sh`, `exec/run-exec-stories.sh`, and `dev-stories.sh`.
- A suite now fails when any story is `SKIP`, `RATELIMIT`, or exits 0 without an explicit `PASS` marker. `RATELIMIT` remains a distinct diagnostic.
- The evidence guard now rejects story claims and Validated record/replay pairs whose artifacts report skipped or rate-limited stories.
- Added a host-side mutation regression test that executes staged copies of all three production runners, mutates the aggregate gate, and exercises the writer-produced evidence path.
- Wired the regression test into GitHub CI and `scripts/ci-local.sh`.

## Verification

- Passed: `bash tests/e2e/story-runner-verdicts.test.sh`.
- Passed: `bash tests/release/public-claims.test.sh`.
- Passed: evidence checker, Python compilation, Bash syntax, `cargo fmt --all --check`, ShellCheck 0.11.0 on touched shell files, yamllint on the changed workflow, and `git diff --check`.
- Linux non-GUI nextest: 1,815 passed, 1 failed, 5 skipped. `action_reference_doc_is_current` is a pre-existing failure reproduced on clean `main`.
- Full GUI workspace tests could not run in WSL because GTK/GLib system packages are unavailable.

Closes #247