### PR TITLE
fix(tests): mask empty grep results to show error messages

### DIFF
--- a/tests/release/audit-export-confidentiality.test.sh
+++ b/tests/release/audit-export-confidentiality.test.sh
@@ -29,8 +29,8 @@ failures=0
 report() { printf 'FAIL  %s\n' "$1" >&2; failures=$((failures + 1)); }
 
 # The code fact. An empty line number is a failure, not a pass over nothing.
-hash_line="$(grep -n 'let request_hash = compute_request_hash(' "$dispatcher" | head -1 | cut -d: -f1)"
-redact_line="$(grep -n 'let redacted_params = redact_params(' "$dispatcher" | head -1 | cut -d: -f1)"
+hash_line="$(grep -n 'let request_hash = compute_request_hash(' "$dispatcher" | head -1 | cut -d: -f1 || true)"
+redact_line="$(grep -n 'let redacted_params = redact_params(' "$dispatcher" | head -1 | cut -d: -f1 || true)"
 
 if [ -z "$hash_line" ] || [ -z "$redact_line" ]; then
     printf 'FAIL: cannot locate compute_request_hash / redact_params in %s\n' "$dispatcher" >&2

--- a/tests/release/database-path-agreement.test.sh
+++ b/tests/release/database-path-agreement.test.sh
@@ -41,7 +41,7 @@ js_path="$(HOME=/home/testuser node -e "
 
 # The daemon's answer, read out of the source rather than executed, so this stays
 # a fast host-side check that needs no build.
-rs_suffix="$(grep -oE '"\.local/state/sysknife/daemon\.sqlite"|"\.local/share/sysknife/daemon\.sqlite"' "$core_rs" | head -1 | tr -d '"')"
+rs_suffix="$(grep -oE '"\.local/state/sysknife/daemon\.sqlite"|"\.local/share/sysknife/daemon\.sqlite"' "$core_rs" | head -1 | tr -d '"' || true)"
 if [ -z "$rs_suffix" ]; then
     printf 'FAIL: could not find the fallback database path in %s.\n' "$core_rs" >&2
     printf '      default_database_path() changed shape; update this guard rather than deleting it.\n' >&2

--- a/tests/release/postgres-contract-guard.test.sh
+++ b/tests/release/postgres-contract-guard.test.sh
@@ -46,7 +46,7 @@ done
 # Fail-closed env var, taken from the store test the job runs.
 # sort -u consumes every grep hit so a later head cannot SIGPIPE the pipeline
 # under `set -o pipefail`.
-require_token="$(grep -o 'SYSKNIFE_REQUIRE_POSTGRES' "$store" | sort -u)"
+require_token="$(grep -o 'SYSKNIFE_REQUIRE_POSTGRES' "$store" | sort -u || true)"
 if [ -z "$require_token" ]; then
     printf 'FAIL: %s no longer names SYSKNIFE_REQUIRE_POSTGRES; the job token cannot be derived\n' \
         "$store" >&2

--- a/tests/release/public-claims.test.sh
+++ b/tests/release/public-claims.test.sh
@@ -206,7 +206,7 @@ assert_rejected 'a claim file missing from the checked surface'
 mv "$fixture/ROADMAP.held" "$fixture/ROADMAP.md"
 
 # The action count is derived from the catalogue source, so a retyped one fails.
-actions="$(grep -oE '[0-9]+ typed actions' "$fixture/docs/introduction.md" | head -1 | grep -oE '^[0-9]+')"
+actions="$(grep -oE '[0-9]+ typed actions' "$fixture/docs/introduction.md" | head -1 | grep -oE '^[0-9]+' || true)"
 if [[ -z "$actions" ]]; then
     printf 'FAIL: could not find the typed-action count in the fixture\n' >&2
     exit 1

--- a/tests/release/smithery-manifest.test.sh
+++ b/tests/release/smithery-manifest.test.sh
@@ -45,7 +45,7 @@ if grep -qE '^[[:space:]]*runtime:' "$manifest"; then
     fail 'smithery.yaml declares a runtime; hosted runtimes need Streamable HTTP and a daemonless container cannot serve SysKnife'
 fi
 
-start_type="$(grep -A2 '^startCommand:' "$manifest" | grep -oP '^\s*type:\s*"?\K[a-z]+' | head -1)"
+start_type="$(grep -A2 '^startCommand:' "$manifest" | grep -oP '^\s*type:\s*"?\K[a-z]+' | head -1 || true)"
 [[ "$start_type" == "stdio" ]] \
     || fail "startCommand.type is '${start_type:-<missing>}', expected stdio"
 
@@ -56,7 +56,7 @@ grep -q 'commandFunction:' "$manifest" \
 grep -q "command: *'sysknife'" "$manifest" \
     || fail "commandFunction does not spawn the 'sysknife' binary"
 
-subcommand="$(grep -oP "args: *\[ *'\K[a-z-]+" "$manifest" | head -1)"
+subcommand="$(grep -oP "args: *\[ *'\K[a-z-]+" "$manifest" | head -1 || true)"
 [[ -n "$subcommand" ]] || fail 'commandFunction passes no subcommand'
 
 # Cross-check against the CLI itself: #[command(name = "mcp-server")] is the


### PR DESCRIPTION
## Summary

Added `|| true` to the six places mentioned in the issue. Now empty grep results don't kill the script, and the error messages show up correctly.

 I intentionally broke the code in all 5 files one by one and ran them. I checked with my own eyes that the `FAIL:` messages are printed successfully.

## Related Issue

Closes #347

## Validation

- [x] Tests added or updated
- [ ] Documentation updated if behavior changed
- [ ] Security impact considered
- [ ] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes

## Notes for Reviewers

Call out any tradeoffs, migrations, or follow-up work.
