### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "homepage": "https://lacs-project.github.io/sysknife/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-09-03
+
+The middle digit moves because of [#334](https://github.com/lacs-project/sysknife/pull/334).
+The daemon now binds a transaction to the account that created it, and refuses
+two calls that used to succeed: one account acting on another account's
+transaction, and an `Unattributed` peer acting on its own. No signature changed,
+and [docs/release.md](docs/release.md#version-numbering) counts a behaviour
+change a caller relied on as a break, with v0.9.0 as the precedent.
+
+If you run `sysknife approve` in a terminal after an MCP preview, nothing
+changes. The daemon compares accounts rather than connections, and both halves
+of that flow run as your uid.
+
+Three changes, two of them from outside contributors. The authorization fix is
+the reason to upgrade.
+
 ### Fixed
 
 - **A story suite that proved nothing no longer reports success.** All three
@@ -29,6 +45,21 @@ Releases before `0.2.5` predate the public launch; their notes live in the
   gates, so a reverted fix turns the suite red. Story 28 also left the
   no-argument default sets, which selected a Fedora-only story on every Ubuntu
   host. ([#247](https://github.com/lacs-project/sysknife/issues/247))
+
+- **A manually created socket directory now gets the mode the package
+  declares.** `bind_unix_listener` creates a missing parent for the socket path,
+  and it created it with whatever the process umask gave, so a daemon started by
+  hand could sit behind a directory more permissive than the `0750` that
+  `packaging/sysknife-tmpfiles.conf` sets under systemd. It now sets `0750` on a
+  directory it created, and leaves an existing one alone: an operator who put
+  the socket in their own `0700` directory keeps that mode rather than having it
+  widened. `tests/e2e/ubuntu-provision.sh` derives the expected runtime and
+  state directory modes from the tmpfiles config and asserts the live modes on
+  `/run/sysknife` and `/var/lib/sysknife` immediately after systemd starts the
+  daemon, which is the only point where the mode a running daemon has is a
+  different question from the mode a file declares.
+  ([#269](https://github.com/lacs-project/sysknife/issues/269), thanks to
+  [@ITSMERNB](https://github.com/ITSMERNB))
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4898,7 +4898,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4907,7 +4907,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4916,7 +4916,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,12 +15,12 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.11.0" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.11.0" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.11.0" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.12.0" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.12.0" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.12.0" }
 chrono = "0.4"
 libc = "0.2"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.11.0" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.12.0" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -40,11 +40,11 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.11.0", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.12.0", features = ["test-support"] }
 # and `AttributionCensus::from_counts_for_tests`, so the verify renderers can be
 # tested without building signed chain rows. Dev-only: production builds of this
 # bin do not compile dev-dependencies, so the constructor stays unreachable there.
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.11.0", features = ["test-support"] }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.12.0", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "react": "^19.2.8",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.11.0" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.11.0" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.12.0" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.12.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.11.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.11.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.12.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.12.0" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.11.0"
+version = "0.12.0"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.11.0" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.12.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,8 +17,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 test-support = []
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.11.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.11.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.12.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.12.0" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -61,7 +61,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.11.0" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.12.0" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.11.0" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.12.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Cuts 0.12.0. Three changes since v0.11.0, two of them from outside contributors.

## Why the middle digit

#334 binds a transaction to the account that created it. Two calls that used to
succeed now fail:

| Caller | Before | After |
|---|---|---|
| Same uid, second connection (`sysknife approve` after an MCP preview) | works | works |
| vsock token, own transaction | works | works |
| A different uid approving, cancelling, inspecting or executing someone else's transaction | worked | refused |
| `Unattributed` acting on its own transaction | worked | refused |

No signature changed and nothing `pub` moved. `docs/release.md` counts a
behaviour change a caller relied on as a break in the `0.y` series, with v0.9.0
as the precedent, so the middle digit moves rather than the last one.

The fourth row is the narrow one: `unattributed()` hardcodes `Observer`, so
those callers only ever reached read-only actions, and they arise when
`SO_PEERCRED` fails or the peer is not representable. An operator on a socket
where the kernel cannot name the peer will now see refusals where a preview and
approve used to work. The release notes say so.

## What is in it

- **#334** authorization fix, above.
- **#328** `bind_unix_listener` sets `0750` on a socket parent it creates, and
  leaves an existing operator-owned directory alone. Thanks to @ITSMERNB.
- **#341** all three story runners fail a run that proved nothing. Thanks to
  @bferanmi806-sketch.

`#328` had no CHANGELOG entry, so this PR writes one.

## Verification

Run on this exact tree at `5ab607b`:

```
scripts/check_release_versions.sh v0.12.0   15 internal dependency pins checked
scripts/check_repo_completeness.sh          pass
tests/release/public-claims.test.sh         figures match the evidence artifacts
tests/release/registry-manifest.test.sh     cargo sysknife-cli@0.12.0, marker rendered
tests/release/codex-plugin-manifest.test.sh pass
tests/release/smithery-manifest.test.sh     pass
scripts/release_rehearsal.sh --check        preflight passed for v0.12.0 on x86_64
cargo fmt --all --check                     clean
cargo clippy --all-targets --locked         exit 0
cargo nextest run --workspace --locked      1831 passed, 0 failed, 5 skipped
scripts/ci-local.sh --fast                  PASS, 72 frontend tests at baseline
```

Sixteen version sites, fifteen internal dependency pins, six JSON manifests. No
test count moved, so `tests/evidence/workspace-tests.json` and the `1,831 Rust
tests` literals in `README.md`, `docs/introduction.md` and
`docs/distro-support.md` are unchanged and still agree with the run.

Tag `v0.12.0` goes on `main` after this merges.
