### PR TITLE
docs(packaging): stop claiming the karg charset matches validated_safe_arg

### DIFF
--- a/packaging/sysknife-grub-kargs-edit
+++ b/packaging/sysknife-grub-kargs-edit
@@ -40,9 +40,14 @@ GRUB_DEFAULT = "/etc/default/grub"
 GRUB_BACKUP = "/etc/default/grub.sysknife.bak"
 
 # Defense-in-depth: each karg token is validated independently.
-# Matches the same allowlist as validated_safe_arg in validate.rs:
-#   ASCII alphanumeric, '.', '_', ':', '/', '+', '@', '=', '-'
-# No leading dash (kernel args may contain '=' but cannot start with '-').
+# Deliberately wider than validated_safe_arg in validate.rs: kernel
+# arguments take the key=value form (module.sig_enforce=1), so '=' must be
+# accepted here, while validated_safe_arg rejects it. '=' stays out of that
+# validator because a comma or an '=' there would let a caller inject extra
+# tokens into the comma-separated list this helper receives — see the
+# charset-check comment at the GrubSetKargs branch in executor.rs. The
+# daemon screens every token before invoking the helper, and the denylist
+# below enforces the boot-security policy independently of it.
 KARG_PATTERN = re.compile(r"^[A-Za-z0-9_.+@:/=-]+$")
 
 # Defense-in-depth denylist — mirrors validated_safe_kernel_arg in executor.rs.


### PR DESCRIPTION
## Summary

The comment above `KARG_PATTERN` in `packaging/sysknife-grub-kargs-edit:43` claims the pattern "matches the same allowlist as `validated_safe_arg` in validate.rs" and lists `=` as part of that allowlist. Neither half is true: `validated_safe_arg` allows `.` `_` `:` `/` `+` `@` `-` and rejects `=`, and `executor.rs` documents that the rejection is deliberate — a comma or an `=` in a caller-supplied arg would inject extra tokens into the helper's comma-separated list. The helper, by contrast, must accept `=` because kernel arguments take the key=value form (`module.sig_enforce=1`), and the helper is directly sudo-invocable.

The fix is comment-only: state what the pattern is for and why it deliberately differs from `validated_safe_arg`, instead of claiming a parity that would be wrong to restore. No code changes; `KARG_PATTERN` itself is unchanged.

Per #339, the line 48 denylist comment is left alone.

## Related Issue

Closes #339

## Validation

- [x] Tests added or updated — no test change needed: comment-only fix; the existing `tests/release/grub-kargs-edit.test.sh` suite still passes locally (all 6 ok markers)
- [x] Documentation updated if behavior changed — behavior unchanged
- [x] Security impact considered — none: no validation logic touched
- [x] Trust boundary preserved (daemon remains the only privileged executor)
- [x] CI passes — pending; ran the release test and `python3 -m py_compile` locally

## Notes for Reviewers

Every factual claim in the new comment was checked against the current tree (`validated_safe_arg` at `crates/sysknife-daemon/src/actions/validate.rs`, the charset-check comment at the `GrubSetKargs` branch in `crates/sysknife-daemon/src/executor.rs`).
