### PR TITLE
test(audit): pin CLI exit-code precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,833 Rust tests and 72 frontend tests** form the current deterministic
+**1,834 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -1015,11 +1015,7 @@ pub async fn run_audit_verify(args: AuditVerifyArgs, log: &Logger) -> Result<(),
     // this command used to report `audit_anchor: {configured: true}` without
     // ever reading the anchor — implying a check it did not perform.
     let anchor = verify_configured_anchor(&lacs_config, &db_path, &verifier).await;
-    let anchor_exit = anchor
-        .as_ref()
-        .map(sysknife_daemon::audit_chain::checkpoint_outcome_to_exit_code)
-        .unwrap_or(0);
-    let exit_code = outcome.exit_code().max(anchor_exit);
+    let exit_code = combined_verification_exit_code(&outcome, anchor.as_ref());
     emit_verification(&args, log, &outcome, &label_for_diag, anchor.as_ref());
     if exit_code == 0 {
         Ok(())

--- a/apps/sysknife-cli/src/runner.rs
+++ b/apps/sysknife-cli/src/runner.rs
@@ -1015,7 +1015,11 @@ pub async fn run_audit_verify(args: AuditVerifyArgs, log: &Logger) -> Result<(),
     // this command used to report `audit_anchor: {configured: true}` without
     // ever reading the anchor — implying a check it did not perform.
     let anchor = verify_configured_anchor(&lacs_config, &db_path, &verifier).await;
-    let exit_code = combined_verification_exit_code(&outcome, anchor.as_ref());
+    let anchor_exit = anchor
+        .as_ref()
+        .map(sysknife_daemon::audit_chain::checkpoint_outcome_to_exit_code)
+        .unwrap_or(0);
+    let exit_code = outcome.exit_code().max(anchor_exit);
     emit_verification(&args, log, &outcome, &label_for_diag, anchor.as_ref());
     if exit_code == 0 {
         Ok(())

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -130,6 +130,45 @@ fn audit_verify_exits_with_code_2_when_the_key_file_is_missing() {
         .code(2);
 }
 
+#[test]
+fn audit_verify_exit_code_prefers_broken_chain_to_inconclusive_anchor() {
+    let dir = tempfile::tempdir().expect("create CLI fixture directory");
+    let db_path = dir.path().join("daemon.sqlite");
+    let key = AuditKey::load_or_generate(&dir.path().join("audit-key"))
+        .expect("generate audit key");
+    let store = TransactionStore::open_with_key(&db_path, Arc::new(key.clone()))
+        .expect("create audit store");
+    store
+        .record(NewTransaction {
+            request_id: "broken-chain-exit-code".to_string(),
+            request_hash: "broken-chain-exit-code-hash".to_string(),
+            action_name: "UpdateSystem".to_string(),
+            risk_level: RiskLevel::High,
+            summary: "Upgrade the system".to_string(),
+            warnings: vec![],
+            caller_role: CallerRole::Dev,
+            caller_principal: CallerPrincipal::Uid(1000),
+        })
+        .expect("record audit row");
+    drop(store);
+
+    let wrong_key_path = dir.path().join("wrong-audit-key");
+    let wrong_key = AuditKey::load_or_generate(&wrong_key_path).expect("generate mismatched key");
+    assert_ne!(key.verifying_key_hex(), wrong_key.verifying_key_hex());
+
+    cli()
+        .env("SYSKNIFE_DATABASE_PATH", &db_path)
+        .env("SYSKNIFE_CHECKPOINT_DB", "not-a-postgres-url")
+        .env("HOME", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .args(["audit", "verify", "--pubkey"])
+        .arg(dir.path().join("wrong-audit-key.pub"))
+        .assert()
+        // The wrong public key makes the local chain Broken (1), while the
+        // unusable configured anchor is CannotVerify (2). A break must win.
+        .code(1);
+}
+
 #[tokio::test]
 #[ignore = "live Postgres; set SYSKNIFE_TEST_POSTGRES_URL and run with --ignored"]
 async fn audit_verify_exits_with_code_1_when_anchor_is_truncated() {

--- a/apps/sysknife-cli/tests/cli_smoke.rs
+++ b/apps/sysknife-cli/tests/cli_smoke.rs
@@ -134,8 +134,8 @@ fn audit_verify_exits_with_code_2_when_the_key_file_is_missing() {
 fn audit_verify_exit_code_prefers_broken_chain_to_inconclusive_anchor() {
     let dir = tempfile::tempdir().expect("create CLI fixture directory");
     let db_path = dir.path().join("daemon.sqlite");
-    let key = AuditKey::load_or_generate(&dir.path().join("audit-key"))
-        .expect("generate audit key");
+    let key =
+        AuditKey::load_or_generate(&dir.path().join("audit-key")).expect("generate audit key");
     let store = TransactionStore::open_with_key(&db_path, Arc::new(key.clone()))
         .expect("create audit store");
     store

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -82,7 +82,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,833 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,834 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,833 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,834 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -5,13 +5,13 @@
   },
   "commit": {
     "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "5776193d286368ceb36f03afad181c49742f36d9"
+    "tests": "a0354104c73b78f08706195c0a0f080a009a1457"
   },
   "frontend_tests": 72,
   "measured_at": {
     "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-09-02T14:32:46+00:00"
+    "tests": "2026-09-03T14:57:03+00:00"
   },
-  "tests": 1833,
+  "tests": 1834,
   "version": 1
 }


### PR DESCRIPTION
Closes #357

## Summary

- drive the real `sysknife audit verify` binary with a local chain that is `Broken` under a mismatched public key
- configure an unusable checkpoint anchor so the anchor result is `CannotVerify`
- assert that the process exits `1`, pinning the precedence at the `run_audit_verify` call site
- record the CI-measured workspace baseline at 1,834 Rust tests

## Mutation proof

Temporarily restored the old `outcome.exit_code().max(anchor_exit)` implementation in commit `865d752`.

The new test failed exactly as required in [the mutation CI run](https://github.com/lacs-project/sysknife/actions/runs/33769949261/job/100697320969): expected exit code `1`, actual exit code `2`. Its captured output simultaneously reported `BROKEN` for the local chain and `ANCHOR NOT CHECKED` for the unusable checkpoint URL. Commit `4595173` reverted the mutation; there is no production-code diff in the final PR.

## Validation

Final Linux CI at `5c3f164`:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`
- `cargo doc --no-deps --workspace --locked` with warnings denied
- `scripts/test_baseline.sh`: 1,834/1,834 passed, 6 skipped
- live Postgres migration/store contract and CLI anchor contract
- docs and public-evidence checks
- frontend type check/tests and production dependency audit
- security audit, dependency review, TruffleHog, and E2E scripts lint

Local checks: `git diff --check`, JSON parse, and `python3 scripts/check_evidence_claims.py`. The full Rust validation used GitHub's Linux CI because this Mac does not have a Rust toolchain installed.

## Scope

Test and required evidence updates only. No production-code, dependency, or workflow changes in the final diff.

## AI assistance

Codex assisted with repository inspection, test implementation, and CI monitoring. I reviewed the complete diff and the reported validation evidence.
