### PR TITLE
fix(daemon): gate mutating query actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ### Fixed
 
+- **`query_action` can no longer bypass approval for Low-risk mutations.**
+  The daemon now rejects `AptUpdate` on the raw approval-free query path using
+  the same explicit Observer-mutating classification as the generated MCP
+  router. Direct socket clients must use preview, approval receipts and execute,
+  so the root apt index cannot be changed without an audit-backed approval or
+  concurrently with an action holding the dpkg exclusion gate.
+  ([#226](https://github.com/lacs-project/sysknife/issues/226))
+
 - **`sysknife audit verify` no longer lets an inconclusive anchor hide a broken
   chain.** The command combined the local audit result with the configured
   external anchor using `.max()` on their exit codes. Exit 1 means a break was

--- a/apps/sysknife-cli/src/mcp_server.rs
+++ b/apps/sysknife-cli/src/mcp_server.rs
@@ -63,6 +63,7 @@ use sysknife_brain::planning_tools::propose_plan::KNOWN_ACTIONS;
 use sysknife_brain::state_client::StateClient as _;
 use sysknife_core::action_family::{DEBIAN_ONLY_ACTIONS, FEDORA_ONLY_ACTIONS};
 use sysknife_core::distro::DistroId;
+use sysknife_daemon::actions::OBSERVER_MUTATING_ACTIONS;
 
 use crate::client::{DaemonClient, DescribeInfo};
 use crate::error::CliError;
@@ -475,9 +476,6 @@ const MCP_READ_ONLY_ACTIONS: &[&str] = &[
     // Dispatcher-internal, with no ActionSpec of its own.
     "ListJobHistory",
 ];
-
-/// Low-risk actions that still mutate the host and therefore remain plan-only.
-const OBSERVER_MUTATING_ACTIONS: &[&str] = &["AptUpdate"];
 
 impl SysknifeMcpServer {
     fn new() -> Self {

--- a/crates/sysknife-daemon/src/actions/mod.rs
+++ b/crates/sysknife-daemon/src/actions/mod.rs
@@ -42,6 +42,14 @@ pub mod ufw;
 pub mod users;
 pub(crate) mod validate;
 
+/// Observer-callable actions that still mutate the host and therefore require
+/// the preview/approve/execute interlock.
+///
+/// This is shared by every approval-free surface. Keeping the exception beside
+/// the action catalogue prevents the CLI's generated MCP router and the
+/// daemon's `query_action` endpoint from making independent safety decisions.
+pub const OBSERVER_MUTATING_ACTIONS: &[&str] = &["AptUpdate"];
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ActionMechanism {
     Command {

--- a/crates/sysknife-daemon/src/dispatcher.rs
+++ b/crates/sysknife-daemon/src/dispatcher.rs
@@ -1833,6 +1833,25 @@ async fn handle_query_action(
         .await;
     }
 
+    // Risk answers how much authorization an action needs; it does not prove
+    // that an action is read-only. `AptUpdate`, for example, is Low/Observer but
+    // runs `sudo apt-get update`, writes the root apt index and takes the dpkg
+    // lock. The shared catalogue exception keeps this raw IPC path aligned with
+    // the generated MCP surface instead of letting direct clients bypass the
+    // preview, receipt and exclusion gates.
+    if crate::actions::OBSERVER_MUTATING_ACTIONS.contains(&action_name) {
+        return send_error(
+            framed,
+            request_id,
+            "authorization_failure",
+            format!(
+                "{action_name} mutates the host and is not available through query_action; \
+                 use preview+execute instead"
+            ),
+        )
+        .await;
+    }
+
     // Same fence preview and execute apply. Without it a Fedora-only read-only
     // action reached the executor on a Debian host and failed as "rpm-ostree:
     // No such file or directory" — an execution error where the other paths

--- a/crates/sysknife-daemon/tests/coverage_gaps.rs
+++ b/crates/sysknife-daemon/tests/coverage_gaps.rs
@@ -267,26 +267,36 @@ async fn list_job_history_rejects_non_integer_since_hours() {
 }
 
 // ---------------------------------------------------------------------------
-// query_action blocks non-Observer actions
+// query_action blocks every action that requires approval
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn query_action_rejects_non_observer_action() {
-    // UpdateSystem requires Admin role — query_action only allows Observer-level.
-    // Even an Admin caller should be blocked from using query_action for this.
+async fn query_action_rejects_actions_that_require_approval() {
+    // An action can require approval either because its risk tier is above Low,
+    // or because it mutates the host despite being Low/Observer-callable. Even
+    // an Admin caller must not bypass preview + approval through query_action.
     let dir = tempdir().unwrap();
-    let state = test_state(&dir);
+    let mut state = test_state(&dir);
+    state.host_distro = Some(sysknife_core::distro::DistroId::Ubuntu {
+        major: 24,
+        minor: 4,
+    });
     let mut framed = spawn_handler_with_role(state, CallerRole::Admin).await;
-    let resp = query_action(&mut framed, "UpdateSystem", json!({}), "non-observer-req").await;
 
-    assert_eq!(
-        resp["type"], "error_response",
-        "expected error_response for non-observer action, got: {resp}"
-    );
-    assert_eq!(
-        resp["category"], "authorization_failure",
-        "non-observer action must return authorization_failure, got: {resp}"
-    );
+    for (action_name, request_id) in [
+        ("UpdateSystem", "non-observer-req"),
+        ("AptUpdate", "observer-mutation-req"),
+    ] {
+        let resp = query_action(&mut framed, action_name, json!({}), request_id).await;
+        assert_eq!(
+            resp["type"], "error_response",
+            "expected error_response for approval-gated {action_name}, got: {resp}"
+        );
+        assert_eq!(
+            resp["category"], "authorization_failure",
+            "approval-gated {action_name} must return authorization_failure, got: {resp}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -132,14 +132,16 @@ Every explicitly classified read-only catalogue action is exposed as
 
 Tool arguments are the action parameters described in each tool's generated
 description. Calls go through the daemon's `query_action` path, which preserves
-the Observer-role and distro fences. The tool annotations declare the routes
-read-only and non-destructive.
+the Observer-role and distro fences and independently rejects every action in
+the shared Observer-mutating classification. The tool annotations declare the
+routes read-only and non-destructive.
 
 The allowlist is deliberately not equivalent to `RiskLevel::Low`. `AptUpdate`
 runs `sudo apt-get update`; it is Low/Observer-callable but mutating, so it is
-never registered as a direct tool. A drift test compares the explicit read-only
-and mutating classifications with the live catalogue, forcing every future
-Observer action to be reviewed before the surface can change.
+never registered as a direct tool and the daemon refuses raw `query_action`
+requests for it. A drift test compares the explicit read-only and mutating
+classifications with the live catalogue, forcing every future Observer action
+to be reviewed before the surface can change.
 
 ---
 


### PR DESCRIPTION
## Summary

- move the explicit `OBSERVER_MUTATING_ACTIONS` classification next to the daemon action catalogue so every approval-free surface shares it
- reject Low/Observer actions that mutate the host at the raw `query_action` IPC boundary, before platform validation, spec construction, or execution
- extend the existing approval-gate IPC regression to cover both a conventional higher-risk action and `AptUpdate`
- document the daemon-side enforcement and changelog the fix

## Security boundary

`RiskLevel::Low` determines the baseline caller role; it does not prove an action is read-only. `AptUpdate` runs `sudo apt-get update`, writes the root apt index, and takes the dpkg lock. A direct socket client could previously invoke it through `query_action` without preview, an approval receipt, a transaction row, or the exclusion gate.

The daemon now fails closed with `authorization_failure` using the same explicit classification that already prevents the CLI from advertising `AptUpdate` as a direct MCP tool. Ordinary read-only queries and operator risk raises keep their existing behavior.

## Verification

PASS locally on Windows:

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `python -X utf8 scripts/check_evidence_claims.py`
- `git diff --check`

NOT TESTED locally:

- Rust execution tests and full workspace CI. The Windows build stops in the unchanged Linux-only `vsock` dependency because Unix/VSOCK APIs are unavailable. The targeted regression is included for the repository's Linux CI.

Closes #226.
