### PR TITLE
chore(release): 0.13.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "homepage": "https://lacs-project.github.io/sysknife/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-09-03
+
+The middle digit moves because of [#360](https://github.com/lacs-project/sysknife/pull/360).
+`query_action` used to run `AptUpdate`, and now refuses it. That call succeeded
+before, so a client scripting it against the raw IPC socket will see an
+`authorization_failure` where it previously got a result.
+
+Take the upgrade anyway. `AptUpdate` runs `sudo apt-get update`, writes the root
+apt index and takes the dpkg lock, and it reached the executor through
+`query_action` with no preview, no approval receipt, no transaction row and no
+exclusion gate. `RiskLevel::Low` was never a claim that an action is read-only;
+it decides how much authorization the caller needs. Every installed copy before
+this release will run that mutation for any client that can reach the socket.
+
+Nine changes. Two of them, #348 and #360, are the same boundary approached from
+opposite sides: one exposes read-only actions as direct MCP tools, the other
+makes sure the classification that decides "read-only" is enforced by the daemon
+rather than trusted from the surface. Both came from the same outside
+contributor within two days.
+
 ### Added
 
 - **MCP clients can query live system state without an LLM planning round trip.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,12 +15,12 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.12.0" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.12.0" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.12.0" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.13.0" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.13.0" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.13.0" }
 chrono = "0.4"
 libc = "0.2"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.12.0" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.13.0" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -40,11 +40,11 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.12.0", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.13.0", features = ["test-support"] }
 # and `AttributionCensus::from_counts_for_tests`, so the verify renderers can be
 # tested without building signed chain rows. Dev-only: production builds of this
 # bin do not compile dev-dependencies, so the constructor stays unreachable there.
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.12.0", features = ["test-support"] }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.13.0", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "react": "^19.2.8",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.12.0" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.12.0" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.13.0" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.13.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.12.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.12.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.13.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.13.0" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.12.0"
+version = "0.13.0"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.12.0" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.13.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,8 +17,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 test-support = []
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.12.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.12.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.13.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.13.0" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -61,7 +61,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.12.0" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.13.0" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.12.0" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.13.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Cuts 0.13.0. Nine changes since v0.12.0, five of them from four outside contributors.

## Why the middle digit

#360 makes `query_action` refuse `AptUpdate`. That call succeeded before, so a client scripting the raw IPC socket gets `authorization_failure` where it previously got a result. `docs/release.md` counts a behaviour change a caller relied on as a break in the `0.y` series, same rule that gave v0.12.0.

## Why take it anyway

`AptUpdate` runs `sudo apt-get update`, writes the root apt index and takes the dpkg lock. It reached the executor through `query_action` with **no preview, no approval receipt, no transaction row and no exclusion gate**. `RiskLevel::Low` was never a claim that an action is read-only; it decides how much authorization the caller needs.

Every installed copy before this release runs that mutation for any client that can reach the socket. `/run/sysknife` is `0750` and the socket `0660`, so the reachable set is members of group `sysknife` and root, which bounds it without making it fine.

## What is in it

| PR | |
|---|---|
| #348 | read-only actions as direct MCP tools, drift-tested (@QinXi-ai) |
| #360 | `query_action` gates Low-risk mutations (@QinXi-ai) |
| #340 | `audit verify` exit-code precedence (@k4its1t) |
| #359 | pins that precedence against reversion (@k4its1t) |
| #351 | karg charset comment corrected (@Georgefifth) |
| #349 | five hygiene guards print their diagnostic (@iamjaeholee) |
| #353 | dev-stories default selection covered (@bferanmi806-sketch) |
| #354, #358, #361 | contributor setup steps, changelog, LF line endings |

#348 and #360 are the same boundary from opposite sides: one exposes read-only actions as direct tools, the other makes the daemon enforce the classification rather than trust the surface.

## Verification at `release/0.13.0`

```
scripts/check_release_versions.sh v0.13.0    15 internal dependency pins checked
scripts/check_registry_versions.sh v0.13.0   all 7 packages available
tests/release/public-claims.test.sh          passed
tests/release/registry-manifest.test.sh      sysknife-cli@0.13.0, marker rendered
scripts/release_rehearsal.sh --check         preflight passed on x86_64
pre-commit hook                              fmt, clippy --all-targets, doc, test baseline
```

Twenty-nine version sites, fifteen internal pins, six JSON manifests.
