### PR TITLE
docs(contributing): document test-baseline fallback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,16 +115,31 @@ UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh
 grep -rn 'Rust tests' README.md docs/introduction.md docs/distro-support.md
 ```
 
+`cargo-nextest` itself needs no system packages. If it is the missing piece,
+install it directly:
+
+```sh
+cargo install cargo-nextest --locked
+```
+
+The GUI workspace members still need the platform libraries named in CI. If
+you cannot install those, do not estimate a count or edit the evidence metadata
+by hand. Leave `tests/evidence/workspace-tests.json` and the three prose files
+untouched. In the PR body, name the command you could not run and the missing
+tool or system library that blocked it. A maintainer will run the full suite and
+regenerate all four files before merge. This is the supported fallback; an
+honest missing measurement is better than metadata that describes a run which
+never happened.
+
 CI gates both halves, so bumping the artifact alone turns `docs-and-hygiene` red
 after `rust` goes green.
 
 **Do not chase the figure.** It moved fifteen times in the twenty days to
 2026-08-24, so on any PR that waits a day or two the number you recorded stops
 being the answer, and that is not your problem to solve. Record it once, say in
-the PR how many tests you added, and if it has expired by the time the PR is
-ready the maintainer regenerates it at merge. Whoever merges is what moves the
-figure, so whoever merges carries it. If `rust` is red only on the baseline, the
-PR is not blocked on you.
+the PR how many tests you added, and let the maintainer refresh it after later
+merges. Whoever merges is what moves the figure, so whoever merges carries it.
+If `rust` is red only on the baseline, the PR is not blocked on you.
 
 `scripts/test_baseline.sh` names both numbers when they disagree, in the form
 `rust suite has <measured> tests, baseline says <recorded>`, so a red run tells


### PR DESCRIPTION
## Summary

- document the supported fallback for contributors who cannot build the full workspace: leave the evidence artifact and all three published prose counts untouched, and state the blocked command plus missing dependency in the PR
- make the maintainer-owned pre-merge regeneration step explicit so contributors do not guess a count or manufacture `commit` / `measured_at` provenance
- document that `cargo-nextest` itself can be installed with `cargo install cargo-nextest --locked`, independently of the GUI system libraries

I chose the smaller solution explicitly allowed by #344. The full two-workflow design needs a credential that can write to the contributor's fork: GitHub documents that the built-in `GITHUB_TOKEN` can only access the workflow repository, so `maintainer_can_modify` alone does not let an upstream Actions token write across repositories. This repository has no declared GitHub App or PAT for that role, and adding an undeclared long-lived credential would not be a complete or safer fix.

GitHub reference: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#authenticating-to-the-api-in-a-github-actions-workflow

Closes #344

## Validation

- [x] `npx --offline --yes --package=markdownlint-cli2@0.23.2 -- markdownlint-cli2 CONTRIBUTING.md`
- [x] `python3 scripts/check_evidence_claims.py`
- [x] `bash scripts/check_no_secrets.sh CONTRIBUTING.md`
- [x] `git diff --check`
- [x] Documentation updated
- [x] Security impact considered; no writable workflow or credential added
- [ ] `tests/release/public-claims.test.sh` — macOS system Bash 3 lacks the script's required `mapfile`; the underlying evidence-claim checker passed and Ubuntu CI is authoritative

## Notes for Reviewers

This is a documentation-only fallback, not partial automation. It deliberately adds no workflow, helper, token, dependency, or generated evidence change.

AI assistance was used to inspect the issue and repository conventions, draft the documentation, and run the listed checks. I reviewed the final one-file diff and all claims above.
