### PR TITLE
chore(release): 0.13.1

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "homepage": "https://lacs-project.github.io/sysknife/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+## [0.13.1] — 2026-09-05
+
+The last digit moves. No shipped code changed: `crates/**`, `apps/*/src/**` and
+`packaging/**` are byte-identical to 0.13.0, so an installed copy behaves exactly
+as it did. What changed is what CI will let into the tree from here on.
+
+### Fixed
+
+- **Story-coverage figures are derived from the tree instead of maintained by
+  hand** ([#370](https://github.com/lacs-project/sysknife/pull/370), closes
+  [#229](https://github.com/lacs-project/sysknife/issues/229)). `CONTRIBUTING.md`
+  said "Every Debian-only action now has one" four lines below a row saying five
+  of them still have none, and `docs/introduction.md` carried the same false
+  sentence. Nothing derived either claim, so they drifted for a day in August,
+  somebody fixed them by hand, and the next story landing would have broken them
+  again. The claim screen now recomputes the uncovered All / Fedora / Ubuntu
+  counts from `docs/action-reference.md` and `tests/e2e/stories`, and the atomic
+  and Ubuntu family sizes from the story headers, using the same line-2 rule
+  `tests/e2e/run-stories.sh` reads so the checker and the harness cannot disagree
+  about how big a family is. Both directions of the Debian-only prose are
+  screened in every claim file: a stated gap must equal the derived count, and a
+  universal "every ... has a story" is accepted only when that count is zero, so
+  two contradictory sentences can never pass together. Family-labelled counts are
+  checked against the family they name, so swapping the labels no longer passes
+  on the strength of both numbers being legitimate sizes somewhere.
+
+  The guard fails loudly rather than inspecting nothing: a story header off line
+  2, a mangled catalogue table, an empty story directory and a story set with no
+  quoted identifiers each stop the screen with a message naming the file.
+
 ## [0.13.0] — 2026-09-03
 
 The middle digit moves because of [#360](https://github.com/lacs-project/sysknife/pull/360).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "serde",
  "tempfile",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "prost",
  "prost-build",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,12 +15,12 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.13.0" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.13.0" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.13.0" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.13.1" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.13.1" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.13.1" }
 chrono = "0.4"
 libc = "0.2"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.13.0" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.13.1" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -40,11 +40,11 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.13.0", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.13.1", features = ["test-support"] }
 # and `AttributionCensus::from_counts_for_tests`, so the verify renderers can be
 # tested without building signed chain rows. Dev-only: production builds of this
 # bin do not compile dev-dependencies, so the constructor stays unreachable there.
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.13.0", features = ["test-support"] }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.13.1", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "react": "^19.2.8",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.13.0" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.13.0" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.13.1" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.13.1" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.13.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.13.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.13.1" }
+sysknife-types = { path = "../sysknife-types", version = "0.13.1" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.13.0"
+version = "0.13.1"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.13.0" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.13.1" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,8 +17,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 test-support = []
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.13.0" }
-sysknife-types = { path = "../sysknife-types", version = "0.13.0" }
+sysknife-core = { path = "../sysknife-core", version = "0.13.1" }
+sysknife-types = { path = "../sysknife-types", version = "0.13.1" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -61,7 +61,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.13.0" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.13.1" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.13.0" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.13.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The last digit moves. No shipped code changed: `crates/**`, `apps/*/src/**` and `packaging/**` are byte-identical to 0.13.0, so an installed copy behaves exactly as it did. What changed is what CI will let into the tree from here on.

Three commits since v0.13.0, all of them guards.

- **#365** stopped four hygiene checks exiting 1 with no output when their grep found nothing, so a failing gate says which file and which value.
- **#366** documented the test-baseline fallback, which is the step contributors were most often missing.
- **#370** derived the story-coverage figures from the tree. `CONTRIBUTING.md` said "Every Debian-only action now has one" four lines below a row saying five of them still have none, and `docs/introduction.md` carried the same false sentence. Both are now recomputed from `docs/action-reference.md` and `tests/e2e/stories` on every run, using the same line-2 header rule `run-stories.sh` reads, so the checker and the harness cannot disagree about how big a family is.

Twenty-nine version sites, fifteen internal dependency pins and six JSON manifests.

## Gates run locally

```
$ bash scripts/check_release_versions.sh v0.13.1
All release versions match 0.13.1 (15 internal dependency pins checked).
$ bash scripts/check_registry_versions.sh v0.13.1
Registry preflight: sysknife-types  0.13.1 available   (and brain, daemon, cli)
$ cargo nextest run --workspace
Summary [13.335s] 1837 tests run: 1837 passed, 6 skipped
```

`registry-manifest`, `smithery-manifest`, `codex-plugin-manifest` and `release-rehearsal` all pass, and `tests/evidence/workspace-tests.json` still reads 1837.

## Checklist

- [x] The change is described in `CHANGELOG.md` under a released heading
- [x] Every version site agrees with the tag
- [x] The workspace suite passes and the evidence artifact matches
- [x] No production code changed, so the digit is the last one
