### PR TITLE
fix(ci): derive markdown link coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Check the audit export states its confidentiality class
         run: bash tests/release/audit-export-confidentiality.test.sh
 
+      - name: Check markdown link file discovery
+        run: bash tests/release/markdown-link-files.test.sh
+
       - name: Check provider parity across E2E entry points
         run: bash tests/e2e/provider-parity.test.sh
 
@@ -134,20 +137,15 @@ jobs:
             docs/developer-guide.md \
             docs/adr/*.md
 
-      - name: Check markdown links
+      - name: Check internal markdown links
         run: |
-          for file in \
-            README.md \
-            CONTRIBUTING.md \
-            SECURITY.md \
-            CODE_OF_CONDUCT.md \
-            ROADMAP.md \
-            docs/architecture.md \
-            docs/developer-guide.md \
-            docs/adr/0001-system-boundaries.md \
-            docs/adr/0002-brain-provider-layer.md \
-            docs/adr/0003-ipc-wire-protocol.md
-          do
+          while IFS= read -r -d '' file; do
+            markdown-link-check --config .markdown-link-check-internal.json "$file"
+          done < <(scripts/markdown-link-files.sh)
+
+      - name: Check external markdown links
+        run: |
+          while IFS= read -r -d '' file; do
             # Retry on transient network failure. `retryOn429` in the config only
             # covers rate limiting, and the failures actually seen here were
             # Status 0 — a connection/DNS blip on the runner against hosts that
@@ -168,7 +166,7 @@ jobs:
               echo "link check for $file failed (attempt $attempt/3); retrying in 10s"
               sleep 10
             done
-          done
+          done < <(scripts/markdown-link-files.sh --external)
 
       - name: Lint GitHub issue templates
         run: yamllint .github/ISSUE_TEMPLATE/*.yml .github/workflows/*.yml

--- a/.markdown-link-check-internal.json
+++ b/.markdown-link-check-internal.json
@@ -1,0 +1,11 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https?://"
+    },
+    {
+      "pattern": "\\.html(?:[#?].*)?$"
+    }
+  ],
+  "_comment": "The repository-wide pass checks source-relative links without making network requests. Relative .html links target mdBook output and are checked after the book is built, not against the Markdown source tree. The bounded external pass uses .markdown-link-check.json."
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,13 @@ purpose: this file is screened by `scripts/check_evidence_claims.py`, and an
 illustrative figure reads as a published claim. That screen caught this very
 paragraph.)
 
+**Markdown links are discovered from the tracked tree.** Both local and remote
+CI call `scripts/markdown-link-files.sh`: every tracked Markdown file gets the
+deterministic source-relative check, while external URLs stay bounded to
+`scripts/markdown-link-external-files.txt`. Add a documented entry to
+`scripts/markdown-link-exclusions.txt` only when a source file must be skipped;
+the discovery test rejects exclusions that no longer name a tracked file.
+
 **A change that touches no Rust skips the Rust gate.** The workspace suite exists
 to stop a Rust regression reaching `main`, and a diff with no `.rs` file in it
 cannot cause one:

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -236,21 +236,12 @@ hygiene_markdownlint() (
 
 hygiene_markdown_link_check() (
     cd "$repo_root" || exit 1
-    files=(
-        README.md
-        CONTRIBUTING.md
-        SECURITY.md
-        CODE_OF_CONDUCT.md
-        ROADMAP.md
-        docs/architecture.md
-        docs/developer-guide.md
-        docs/adr/0001-system-boundaries.md
-        docs/adr/0002-brain-provider-layer.md
-        docs/adr/0003-ipc-wire-protocol.md
-    )
-    for f in "${files[@]}"; do
+    while IFS= read -r -d '' f; do
+        markdown-link-check --config .markdown-link-check-internal.json "$f" || exit 1
+    done < <(scripts/markdown-link-files.sh)
+    while IFS= read -r -d '' f; do
         markdown-link-check --config .markdown-link-check.json "$f" || exit 1
-    done
+    done < <(scripts/markdown-link-files.sh --external)
 )
 
 hygiene_yamllint() (
@@ -289,6 +280,7 @@ run_hygiene_group() {
     run_step 'hygiene: install-paths.test.sh' bash "$repo_root/tests/release/install-paths.test.sh"
     run_step 'hygiene: postgres-contract-guard.test.sh' bash "$repo_root/tests/release/postgres-contract-guard.test.sh"
     run_step 'hygiene: audit-export-confidentiality.test.sh' bash "$repo_root/tests/release/audit-export-confidentiality.test.sh"
+    run_step 'hygiene: markdown-link-files.test.sh' bash "$repo_root/tests/release/markdown-link-files.test.sh"
 
     if have markdownlint-cli2; then
         run_step 'hygiene: markdownlint-cli2' hygiene_markdownlint

--- a/scripts/markdown-link-exclusions.txt
+++ b/scripts/markdown-link-exclusions.txt
@@ -1,0 +1,3 @@
+# Every tracked Markdown file is checked by default. Add an entry only when the
+# file must be skipped, with a comment explaining why. The listing script fails
+# if an exclusion stops naming a tracked Markdown file.

--- a/scripts/markdown-link-external-files.txt
+++ b/scripts/markdown-link-external-files.txt
@@ -1,0 +1,13 @@
+# External URLs remain checked in the documents covered before issue #372.
+# Keeping this bounded avoids multiplying network requests and CI flakiness as
+# the derived internal-link set grows.
+README.md
+CONTRIBUTING.md
+SECURITY.md
+CODE_OF_CONDUCT.md
+ROADMAP.md
+docs/architecture.md
+docs/developer-guide.md
+docs/adr/0001-system-boundaries.md
+docs/adr/0002-brain-provider-layer.md
+docs/adr/0003-ipc-wire-protocol.md

--- a/scripts/markdown-link-files.sh
+++ b/scripts/markdown-link-files.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exclusions_file="$repo_root/scripts/markdown-link-exclusions.txt"
+external_files="$repo_root/scripts/markdown-link-external-files.txt"
+
+if [[ "${1:-}" == "--external" ]]; then
+    while IFS= read -r path || [[ -n "$path" ]]; do
+        [[ -z "$path" || "$path" == \#* ]] && continue
+        if ! git -C "$repo_root" ls-files --error-unmatch -- "$path" >/dev/null 2>&1 \
+            || [[ "$path" != *.md ]]; then
+            printf 'markdown-link-files: external-check path is not a tracked Markdown file: %s\n' \
+                "$path" >&2
+            exit 1
+        fi
+        printf '%s\0' "$path"
+    done < "$external_files"
+    exit 0
+fi
+
+if [[ $# -ne 0 ]]; then
+    printf 'usage: %s [--external]\n' "${0##*/}" >&2
+    exit 2
+fi
+
+exclusions=()
+while IFS= read -r path || [[ -n "$path" ]]; do
+    [[ -z "$path" || "$path" == \#* ]] && continue
+    if ! git -C "$repo_root" ls-files --error-unmatch -- "$path" >/dev/null 2>&1 \
+        || [[ "$path" != *.md ]]; then
+        printf 'markdown-link-files: excluded path is not a tracked Markdown file: %s\n' \
+            "$path" >&2
+        exit 1
+    fi
+    exclusions+=("$path")
+done < "$exclusions_file"
+
+while IFS= read -r -d '' path; do
+    skip=false
+    for excluded in "${exclusions[@]}"; do
+        if [[ "$path" == "$excluded" ]]; then
+            skip=true
+            break
+        fi
+    done
+    [[ "$skip" == true ]] || printf '%s\0' "$path"
+done < <(git -C "$repo_root" ls-files -z -- '*.md')

--- a/tests/release/markdown-link-files.test.sh
+++ b/tests/release/markdown-link-files.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/scripts" "$fixture/docs"
+cp "$repo_root/scripts/markdown-link-files.sh" "$fixture/scripts/"
+cat > "$fixture/scripts/markdown-link-exclusions.txt" <<'EOF'
+# One deliberately excluded fixture document.
+docs/skipped.md
+EOF
+cat > "$fixture/scripts/markdown-link-external-files.txt" <<'EOF'
+README.md
+EOF
+touch "$fixture/README.md" "$fixture/docs/guide.md" "$fixture/docs/skipped.md"
+
+git -C "$fixture" init -q
+git -C "$fixture" add README.md docs scripts/markdown-link-exclusions.txt \
+    scripts/markdown-link-external-files.txt
+
+files=()
+while IFS= read -r -d '' file; do
+    files+=("$file")
+done < <("$fixture/scripts/markdown-link-files.sh")
+expected=(README.md docs/guide.md)
+[[ "${files[*]}" == "${expected[*]}" ]] || {
+    printf 'markdown-link-files: expected <%s>, got <%s>\n' \
+        "${expected[*]}" "${files[*]}" >&2
+    exit 1
+}
+
+external_files=()
+while IFS= read -r -d '' file; do
+    external_files+=("$file")
+done < <("$fixture/scripts/markdown-link-files.sh" --external)
+[[ "${external_files[*]}" == 'README.md' ]] || {
+    printf 'markdown-link-files: expected external set <README.md>, got <%s>\n' \
+        "${external_files[*]}" >&2
+    exit 1
+}
+
+printf 'docs/missing.md\n' > "$fixture/scripts/markdown-link-external-files.txt"
+if output="$("$fixture/scripts/markdown-link-files.sh" --external 2>&1)"; then
+    printf 'markdown-link-files: stale external-check path unexpectedly passed\n' >&2
+    exit 1
+fi
+grep -Fq 'external-check path is not a tracked Markdown file: docs/missing.md' \
+    <<< "$output" || {
+    printf 'markdown-link-files: stale external-check error omitted its path: %s\n' \
+        "$output" >&2
+    exit 1
+}
+
+printf 'docs/missing.md\n' >> "$fixture/scripts/markdown-link-exclusions.txt"
+if output="$("$fixture/scripts/markdown-link-files.sh" 2>&1)"; then
+    printf 'markdown-link-files: stale exclusion unexpectedly passed\n' >&2
+    exit 1
+fi
+grep -Fq 'excluded path is not a tracked Markdown file: docs/missing.md' <<< "$output" || {
+    printf 'markdown-link-files: stale exclusion error omitted its path: %s\n' "$output" >&2
+    exit 1
+}
+
+printf 'markdown-link-files: derived files and exclusions validated.\n'


### PR DESCRIPTION
## Summary

- derive the internal link-check set from every tracked Markdown file
- keep external URL checks bounded to the ten existing documents
- reject stale exclusions and external-check entries with a regression test
- use the same discovery script in GitHub Actions and `ci-local.sh`

## Related Issue

Closes #372

## Validation

- [x] `bash tests/release/markdown-link-files.test.sh`
- [x] complete internal scan: 54 files
- [x] complete external scan: 10 files
- [x] ShellCheck, markdownlint-cli2, yamllint, evidence claims, and `git diff --check`
- [x] Documentation updated
- [x] Security impact considered; no trust-boundary behavior changed

## Notes for Reviewers

`npm test --prefix packages/setup` passes 101/102 locally. The Unix-socket reachability test fails identically on an untouched `origin/main` worktree on macOS.

Implementation and validation were performed with Codex.
