### PR TITLE
fix(evidence): make story metadata single-source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,8 +166,10 @@ git diff --name-only upstream/main... | grep '\.rs$'   # empty means the gate do
 For such a diff the gate is the Node suite for the package you touched,
 `scripts/check_evidence_claims.py`, and CI on Ubuntu. Run the claim screen even
 for a JavaScript change: `packages/setup/index.js` is in `CLAIM_FILES`, and the
-screen is pure Python with no subprocess calls, so it runs anywhere Python does.
-Say which of the three you ran.
+screen remains the claim-screen entry point. Story-family derivation delegates to
+`tests/e2e/run-stories.sh --metadata`, so story-related claim checks require
+Bash and the repository's normal POSIX-style environment. Say which of the
+three you ran.
 
 **Which release your change lands in.** While SysKnife is in the `0.y` series, a
 change that breaks a consumer moves the middle digit and everything else moves the

--- a/scripts/check_evidence_claims.py
+++ b/scripts/check_evidence_claims.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -236,42 +237,111 @@ def check_story_claims(texts: dict[str, str], runs: list[dict]) -> list[str]:
     return problems
 
 
-STORY_HEADER = re.compile(r"^#\s*Story\s+\d+\s*(?:\(([^)]*)\))?\s*:")
+# The Story-header grammar has exactly one implementation:
+# `tests/e2e/run-stories.sh`, surfaced as `run-stories.sh --metadata`
+# (tab-separated `id`, `family`, `title` rows). This checker must not parse
+# story files itself — a second parser is a second answer, and the two have
+# already disagreed about which line the header lives on and what an
+# unparseable header means. Family counts are derived by running the runner
+# and counting column 2.
+STORY_METADATA_RUNNER = "tests/e2e/run-stories.sh"
+STORY_FAMILIES = ("ubuntu", "atomic")
+
+
+def _canonical_story_metadata(root: Path) -> list[tuple[str, str, str]]:
+    """Load `(id, family, title)` rows from the canonical story parser.
+
+    Every failure here raises `Failure` naming the cause: a broken or missing
+    parser must never read as "zero stories", which would let the guards that
+    consume these counts pass vacuously over an empty set.
+    """
+    runner = root / STORY_METADATA_RUNNER
+    if not runner.is_file():
+        raise Failure(
+            f"could not derive story families: canonical metadata runner is "
+            f"missing: {STORY_METADATA_RUNNER}"
+        )
+    try:
+        completed = subprocess.run(
+            ["bash", str(runner), "--metadata"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=120,
+        )
+    except (OSError, UnicodeDecodeError) as exc:
+        raise Failure(
+            f"could not derive story families: could not run "
+            f"{STORY_METADATA_RUNNER} --metadata: {exc}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise Failure(
+            f"could not derive story families: {STORY_METADATA_RUNNER} "
+            f"--metadata timed out: {exc}"
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip().splitlines()
+        detail = "; ".join(line for line in detail if line.strip())
+        raise Failure(
+            f"could not derive story families: {STORY_METADATA_RUNNER} "
+            f"--metadata exited {completed.returncode}"
+            + (f": {detail}" if detail else "")
+        )
+    rows: list[tuple[str, str, str]] = []
+    for lineno, line in enumerate(completed.stdout.splitlines(), 1):
+        fields = line.split("\t")
+        if len(fields) != 3:
+            raise Failure(
+                f"could not derive story families: malformed metadata row "
+                f"{lineno} from {STORY_METADATA_RUNNER} --metadata: {line!r}"
+            )
+        story_id, family, title = fields
+        if not story_id.isdigit():
+            raise Failure(
+                f"could not derive story families: malformed story id in "
+                f"metadata row {lineno}: {line!r}"
+            )
+        if family not in STORY_FAMILIES:
+            raise Failure(
+                f"could not derive story families: unknown family "
+                f"{family!r} in metadata row {lineno}: {line!r}"
+            )
+        if not title.strip():
+            raise Failure(
+                f"could not derive story families: empty title in metadata "
+                f"row {lineno}: {line!r}"
+            )
+        rows.append((story_id, family, title))
+    if not rows:
+        raise Failure(
+            f"could not derive story families: {STORY_METADATA_RUNNER} "
+            f"--metadata returned no stories while {STORY_DIR}/ holds story "
+            f"files; refusing to treat the suite as empty"
+        )
+    return rows
 
 
 def story_family_sizes(root: Path) -> dict[str, int]:
-    """Return story-family sizes using the harness's header classification.
+    """Return story-family sizes counted from the canonical story metadata.
 
-    A story whose header tags name `ubuntu` is in the ubuntu family; everything
-    else is atomic. This is the same rule as `tests/e2e/run-stories.sh`, rather
-    than a second classification maintained by the claims checker.
+    Runs `tests/e2e/run-stories.sh --metadata` and counts column 2, rather
+    than reimplementing the header grammar. A story whose tags name `ubuntu`
+    is in the ubuntu family; everything else is atomic — that classification
+    lives in the runner, not here.
     """
     directory = root / STORY_DIR
     if not directory.is_dir():
         return {}
-    families: dict[str, int] = {"ubuntu": 0, "atomic": 0}
-    paths = sorted(directory.glob("story-*.sh"))
-    if not paths:
+    if not sorted(directory.glob("story-*.sh")):
         return {}
-    for path in paths:
-        # The header lives on line 2, exactly where `tests/e2e/run-stories.sh`
-        # reads it (`sed -n '2p'`). Scanning a wider window would accept a
-        # header the harness itself rejects, letting this checker derive a
-        # different family table from the runner it is supposed to agree with.
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        match = STORY_HEADER.match(lines[1]) if len(lines) > 1 else None
-        if not match:
-            raise Failure(
-                f"could not derive a family from {STORY_DIR}/{path.name}; "
-                "expected the '# Story N (...): title' header on line 2"
-            )
-        tags = match.group(1) or ""
-        families["ubuntu" if "ubuntu" in tags else "atomic"] += 1
+    families: dict[str, int] = {"ubuntu": 0, "atomic": 0}
+    for _, family, _ in _canonical_story_metadata(root):
+        families[family] += 1
     return families
 
 
 def story_set_sizes(root: Path) -> set[int]:
-    """Legitimate story-suite sizes, derived from the story files themselves."""
+    """Legitimate story-suite sizes, derived from the canonical story metadata."""
     families = story_family_sizes(root)
     if not families:
         return set()

--- a/tests/e2e/run-stories.sh
+++ b/tests/e2e/run-stories.sh
@@ -170,6 +170,32 @@ for _story_file in "$STORY_DIR"/story-*.sh; do
         printf 'ERROR: unparseable story header in %s: %s\n' "$_story_file" "$_header" >&2
         exit 1
     fi
+    # The tag vocabulary is closed: anything not listed here fails the run.
+    # Only the substring `ubuntu` ever decided the family, so a typo like
+    # `ubunut` silently moved a story from the ubuntu family (run by the
+    # documented suite) into the atomic family (run by default with
+    # SYSKNIFE_ALLOW_DESTRUCTIVE=1). An empty tag string — a header with no
+    # parenthesized field, which many atomic stories carry — is valid atomic.
+    #
+    # The strings below are historical labels, not a redesigned schema, and
+    # they are not one semantic dimension: `ubuntu` is family metadata,
+    # `read-only` / `medium-risk` / `high-risk` follow the execution/risk
+    # convention from #219, atomic `destructive` names the host-changing gated
+    # subset (not ActionSpec `high-risk`), `rejection` marks a negative
+    # planner-behavior test, and `compound` / `hard compound` are scenario
+    # labels. `ubuntu, low-risk` stays as legacy vocabulary: story 55 asserts
+    # risk `low` for AptUpdate, which mutates host state, so it is not a
+    # spelling of `ubuntu, read-only` and must not be normalized into one.
+    case "$_tags" in
+        ""|"destructive"|"read-only"|"hard compound"|\
+        "ubuntu, low-risk"|"ubuntu, read-only"|"ubuntu, medium-risk"|\
+        "ubuntu, high-risk"|"ubuntu, rejection"|"ubuntu, compound") ;;
+        *)
+            printf 'ERROR: unrecognized story tags in %s: %s\n' \
+                "$_story_file" "$_tags" >&2
+            exit 1
+            ;;
+    esac
     STORY_NAMES[$_id]="$_title"
     if [[ "$_tags" == *ubuntu* ]]; then
         STORY_FAMILY[$_id]="ubuntu"

--- a/tests/e2e/story-metadata.test.sh
+++ b/tests/e2e/story-metadata.test.sh
@@ -94,7 +94,8 @@ fi
 # instead, a story could drop out of the suite without a word — which is the
 # failure mode the old hand-maintained table had.
 mutant="$(mktemp -d)"
-trap 'rm -rf "$mutant"' EXIT
+fakeroot="$(mktemp -d)"
+trap 'rm -rf "$mutant" "$fakeroot"' EXIT
 cp "$runner" "$mutant/run-stories.sh"
 cp -r "$story_dir" "$mutant/stories"
 printf '#!/usr/bin/env bash\n# this header says nothing about a story\nexit 0\n' \
@@ -108,6 +109,157 @@ rm -f "$mutant/stories/story-9999.sh"
 if ! bash "$mutant/run-stories.sh" --metadata >/dev/null 2>&1; then
     report "the unmutated copy also fails — the mutation result is meaningless"
 fi
+
+# #252: an unrecognised tag must fail, not silently reclassify. A typo like
+# `ubunut` used to move an ubuntu story into the atomic family with no word
+# from either parser, shifting the family counts the evidence guard derives.
+cp "$story_dir/story-63.sh" "$mutant/stories/story-9999.sh"
+sed -i '2s/.*/# Story 9999 (ubunut, read-only): Typo family/' \
+    "$mutant/stories/story-9999.sh"
+if ! grep -Fq '# Story 9999 (ubunut, read-only)' \
+    "$mutant/stories/story-9999.sh"; then
+    report "unknown-tag mutation did not apply — the assertion below is vacuous"
+fi
+if bash "$mutant/run-stories.sh" --metadata >/dev/null 2>&1; then
+    report "an unrecognised story tag did not fail the derivation"
+fi
+tag_diag="$(bash "$mutant/run-stories.sh" --metadata 2>&1 || true)"
+case "$tag_diag" in
+    *story-9999.sh*ubunut*) ;;
+    *) report "unknown-tag failure did not name the file/tag: $tag_diag" ;;
+esac
+
+# ...and the pristine copy must still pass, or the mutation above proved nothing.
+rm -f "$mutant/stories/story-9999.sh"
+if ! bash "$mutant/run-stories.sh" --metadata >/dev/null 2>&1; then
+    report "the unmutated copy also fails — the unknown-tag result is meaningless"
+fi
+
+# #252: the grammar says the Story header lives on line 2. A valid header
+# shifted to line 3 must fail rather than derive a row from the wrong line.
+cp "$story_dir/story-63.sh" "$mutant/stories/story-9999.sh"
+sed -i '2s/.*/# Story 9999 (ubuntu, read-only): Shifted header/' \
+    "$mutant/stories/story-9999.sh"
+sed -i '1i # fixture: this line pushes the header to line 3' \
+    "$mutant/stories/story-9999.sh"
+if sed -n '2p' "$mutant/stories/story-9999.sh" | grep -q '^# Story'; then
+    report "line-3 mutation did not move the header off line 2"
+fi
+if bash "$mutant/run-stories.sh" --metadata >/dev/null 2>&1; then
+    report "a story header moved off line 2 did not fail the derivation"
+fi
+
+# ...and the pristine copy must still pass, or the mutation above proved nothing.
+rm -f "$mutant/stories/story-9999.sh"
+if ! bash "$mutant/run-stories.sh" --metadata >/dev/null 2>&1; then
+    report "the unmutated copy also fails — the line-3 result is meaningless"
+fi
+
+# #252: the Python evidence checker derives families by delegating to this same
+# runner, so every rejection above must surface through that path too — with the
+# canonical parser's own diagnostic, not a second Python grammar. The fake root
+# mirrors the layout story_family_sizes() expects (tests/e2e/run-stories.sh).
+mkdir -p "$fakeroot/tests/e2e/stories"
+cp "$runner" "$fakeroot/tests/e2e/run-stories.sh"
+cp "$story_dir"/story-*.sh "$fakeroot/tests/e2e/stories/"
+python_consumer() {
+    python3 - "$fakeroot" "$repo_root/scripts/check_evidence_claims.py" <<'PYEOF'
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("checker", sys.argv[2])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+try:
+    sizes = mod.story_family_sizes(Path(sys.argv[1]))
+except mod.Failure as exc:
+    print(f"FAILURE: {exc}")
+    raise SystemExit(10)
+print(f"OK: ubuntu={sizes['ubuntu']} atomic={sizes['atomic']}")
+PYEOF
+}
+
+# Pristine tree: the consumer must agree with the runner, derived not retyped.
+consumer_ok="$(python_consumer 2>&1)" || {
+    report "the Python consumer rejected the pristine tree: $consumer_ok"
+    consumer_ok=""
+}
+if [ -n "${consumer_ok:-}" ]; then
+    case "$consumer_ok" in
+        *"OK: ubuntu=$ubuntu_count atomic=$atomic_count"*) ;;
+        *) report "consumer disagrees with the runner: $consumer_ok" ;;
+    esac
+fi
+
+# Unknown tag through the delegation path: Python must reject it because the
+# one parser rejected it, naming the file and the bad tag.
+cp "$story_dir/story-63.sh" "$fakeroot/tests/e2e/stories/story-9999.sh"
+sed -i '2s/.*/# Story 9999 (ubunut, read-only): Typo family/' \
+    "$fakeroot/tests/e2e/stories/story-9999.sh"
+if consumer_out="$(python_consumer 2>&1)"; then
+    report "the Python consumer accepted an unrecognised story tag"
+    consumer_out=""
+fi
+if [ -n "${consumer_out:-}" ]; then
+    case "$consumer_out" in
+        *story-9999.sh*ubunut*) ;;
+        *) report "consumer unknown-tag failure did not name the file/tag: $consumer_out" ;;
+    esac
+fi
+rm -f "$fakeroot/tests/e2e/stories/story-9999.sh"
+
+# Header on line 3 through the delegation path.
+cp "$story_dir/story-63.sh" "$fakeroot/tests/e2e/stories/story-9999.sh"
+sed -i '2s/.*/# Story 9999 (ubuntu, read-only): Shifted header/' \
+    "$fakeroot/tests/e2e/stories/story-9999.sh"
+sed -i '1i # fixture: this line pushes the header to line 3' \
+    "$fakeroot/tests/e2e/stories/story-9999.sh"
+if consumer_out="$(python_consumer 2>&1)"; then
+    report "the Python consumer accepted a header moved off line 2"
+    consumer_out=""
+fi
+if [ -n "${consumer_out:-}" ]; then
+    case "$consumer_out" in
+        *story-9999.sh*) ;;
+        *) report "consumer line-3 failure did not name the file: $consumer_out" ;;
+    esac
+fi
+rm -f "$fakeroot/tests/e2e/stories/story-9999.sh"
+consumer_ok="$(python_consumer 2>&1)" || {
+    report "the restored fixture is rejected — the mutation results are meaningless"
+}
+
+# Delegation negative controls: the consumer must fail loudly when the
+# canonical surface itself is unusable, never read it as "zero stories". The
+# repo has had guards go green over an empty set; an empty family table here
+# would let every bare-count claim pass vacuously.
+assert_consumer_fails() {
+    local label="$1"
+    local output
+    if output="$(python_consumer 2>&1)"; then
+        report "the Python consumer went green over $label: $output"
+    elif [ -z "$output" ]; then
+        report "the Python consumer failed silently over $label"
+    fi
+}
+mv "$fakeroot/tests/e2e/run-stories.sh" "$fakeroot/tests/e2e/run-stories.held"
+assert_consumer_fails "a missing canonical runner"
+mv "$fakeroot/tests/e2e/run-stories.held" "$fakeroot/tests/e2e/run-stories.sh"
+printf '#!/usr/bin/env bash\nexit 3\n' > "$fakeroot/tests/e2e/run-stories.sh"
+assert_consumer_fails "a canonical runner that exits non-zero"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$fakeroot/tests/e2e/run-stories.sh"
+assert_consumer_fails "empty metadata over a non-empty story tree"
+printf '#!/usr/bin/env bash\nprintf "this is not a metadata row\\n"\n' \
+    > "$fakeroot/tests/e2e/run-stories.sh"
+assert_consumer_fails "a malformed metadata row"
+printf '#!/usr/bin/env bash\nprintf "9999\\tmint\\tTypo family\\n"\n' \
+    > "$fakeroot/tests/e2e/run-stories.sh"
+assert_consumer_fails "an unknown family value"
+cp "$runner" "$fakeroot/tests/e2e/run-stories.sh"
+consumer_ok="$(python_consumer 2>&1)" || {
+    report "the restored canonical runner is rejected — the control results are meaningless"
+}
 
 if [ "$failures" -ne 0 ]; then
     printf '\n%d story-metadata failure(s).\n' "$failures" >&2

--- a/tests/release/public-claims.test.sh
+++ b/tests/release/public-claims.test.sh
@@ -61,8 +61,14 @@ done
 # suite and family sizes counted from these headers, so without them a legitimate
 # figure (the 54-story atomic family, which no recorded run covers) reads as
 # fabricated and the pristine fixture fails.
+#
+# The canonical parser travels with them. The checker derives families by
+# running tests/e2e/run-stories.sh --metadata out of the tree under check, not
+# by parsing headers itself, so the fixture carries that runner too — without
+# it the derivation fails closed and the pristine check below fails.
 mkdir -p "$fixture/tests/e2e/stories"
 cp "$repo_root"/tests/e2e/stories/story-*.sh "$fixture/tests/e2e/stories/"
+cp "$repo_root/tests/e2e/run-stories.sh" "$fixture/tests/e2e/run-stories.sh"
 
 # Guard against re-introducing the vacuous-fixture bug: the pristine copy must
 # PASS, proving rejections below come from the mutation, not a missing input.
@@ -475,9 +481,10 @@ if ! "$checker" "$fixture" >/dev/null 2>&1; then
     exit 1
 fi
 
-# The harness parses the story header from line 2, so the checker must too. A
-# header shifted off line 2 is rejected by the runner; the evidence derivation
-# has to fail loudly rather than silently derive a different family table.
+# The harness parses the story header from line 2, and the checker delegates to
+# the harness rather than parsing headers itself. A header shifted off line 2
+# is rejected by the runner; the evidence derivation has to fail loudly through
+# that same path rather than silently derive a different family table.
 read -r moved_story < <(
     python3 - "$fixture/tests/e2e/stories" <<'PY'
 import sys
@@ -505,7 +512,7 @@ if sed -n '2p' "$fixture/tests/e2e/stories/$moved_story" | grep -q '^# Story'; t
 fi
 assert_rejected_with_diagnostic \
     'story header moved from the production line-2 location' \
-    'could not derive a family' "$moved_story"
+    'could not derive story families' "$moved_story"
 cp "$repo_root"/tests/e2e/stories/story-*.sh "$fixture/tests/e2e/stories/"
 if ! "$checker" "$fixture" >/dev/null 2>&1; then
     printf 'FAIL: restored header fixture rejected — mutation result is meaningless\n' >&2


### PR DESCRIPTION
## Summary

- derive story family metadata from `run-stories.sh --metadata` instead of maintaining a second Story-header parser in Python
- close the canonical story-tag vocabulary so unknown spellings fail instead of silently changing families
- make the Python evidence consumer fail closed on runner errors and unusable metadata
- add mutation coverage for unknown tags, misplaced headers, and broken metadata derivation

Closes #252.

## Why

After #370, the Bash and Python Story-header parsers agreed on reading line 2 and on rejecting malformed headers, but they were still two independent implementations of the same grammar.

Both also classified families from the substring `ubuntu`.

That left this failure mode:

```text
ubuntu -> ubunut
```

A syntactically valid typo could silently move a story from the Ubuntu family into the atomic family, changing the derived suite sizes used by the evidence claim guard.

The Python side now consumes the metadata emitted by the runner instead of parsing Story headers itself.

The path is:

```text
story files
    -> run-stories.sh --metadata
    -> canonical (id, family, title) rows
    -> check_evidence_claims.py
```

There is no Story-header regex left in `check_evidence_claims.py`.

## Tag vocabulary

I kept the current vocabulary closed rather than redesigning the header schema in this PR.

In particular, I did **not** normalize `ubuntu, low-risk` to `ubuntu, read-only`.

I audited all 14 `ubuntu, low-risk` stories. Thirteen are read-only query scenarios, but story 55 asserts `AptUpdate` at low risk. `AptUpdate` changes the host's package metadata, so low-risk and read-only are not equivalent concepts in the current suite.

`ubuntu, low-risk` therefore remains accepted legacy metadata.

Atomic `destructive` is also preserved as-is; it describes the gated host-changing story subset rather than being an alias for ActionSpec high risk.

## Fail-closed behavior

The Python consumer now rejects:

* a missing metadata runner
* a non-zero runner exit
* empty metadata from a non-empty story tree
* malformed TSV rows
* non-numeric story IDs
* unknown family values
* empty titles

A broken metadata source cannot silently become an empty family set and pass a claim check.

## Mutation proof

Using `story-63.sh`:

### Unknown tag

Changed:

```text
ubuntu, read-only
```

to:

```text
ubunut, read-only
```

The canonical runner failed:

```text
ERROR: unrecognized story tags in .../story-63.sh: ubunut, read-only
```

The Python evidence guard also failed through the canonical metadata path:

```text
could not derive story families: ... --metadata exited 1:
ERROR: unrecognized story tags in .../story-63.sh: ubunut, read-only
```

After reverting the mutation, metadata returned all 133 rows and the evidence guard passed.

### Header moved to line 3

Moving the Story header from line 2 to line 3 made `run-stories.sh --metadata` fail with an unparseable-header diagnostic naming `story-63.sh`.

The Python evidence guard propagated the same canonical-parser failure.

Reverting restored both consumers to green.

## Validation

Passed:

```text
bash tests/e2e/story-metadata.test.sh
  Story metadata derived cleanly: 133 stories (79 ubuntu, 54 atomic).

python3 scripts/check_evidence_claims.py .
  Published figures match the evidence artifacts.

bash tests/release/public-claims.test.sh
  Public claims contract passed.

bash tests/e2e/story-runner-verdicts.test.sh
  contract passed across all three production runners.
```

Also passed:

```text
bash -n tests/e2e/run-stories.sh
bash -n tests/e2e/story-metadata.test.sh
bash -n tests/release/public-claims.test.sh
python3 -m py_compile scripts/check_evidence_claims.py
git diff --check
```

`scripts/ci-local.sh` was attempted but stopped at its tool preflight because this environment does not have `cargo` or `node` installed:

```text
ci-local: FATAL missing required tool(s): cargo node
```

No Rust files are changed. I have not substituted an estimated workspace result for the gate that could not run.

## Result

The current tree remains:

```text
79 ubuntu
54 atomic
133 total
```

A misspelled Ubuntu family tag can no longer silently alter that partition.
