### PR TITLE
fix(e2e): check story tag vocabulary per word, not per whole string

### DIFF
--- a/tests/e2e/run-stories.sh
+++ b/tests/e2e/run-stories.sh
@@ -155,6 +155,15 @@ declare -A STORY_FAMILY
 ALL_STORY_IDS=()
 UBUNTU_STORY_IDS=()
 
+# Closed per-word tag vocabulary (#390). An unrecognised word exits like an
+# unparseable header, naming the file: a typo in one header must not silently
+# move a story between families and change every derived count. The inventory
+# this was settled against is every distinct tag word in tests/e2e/stories.
+STORY_TAG_VOCAB=(
+    ubuntu destructive medium-risk high-risk read-only low-risk
+    rejection compound "hard compound"
+)
+
 for _story_file in "$STORY_DIR"/story-*.sh; do
     [ -f "$_story_file" ] || continue
     _header="$(sed -n '2p' "$_story_file")"
@@ -177,25 +186,38 @@ for _story_file in "$STORY_DIR"/story-*.sh; do
     # SYSKNIFE_ALLOW_DESTRUCTIVE=1). An empty tag string — a header with no
     # parenthesized field, which many atomic stories carry — is valid atomic.
     #
-    # The strings below are historical labels, not a redesigned schema, and
-    # they are not one semantic dimension: `ubuntu` is family metadata,
+    # The vocabulary is per comma-separated word, not per whole string: a new
+    # story tagged `(ubuntu, destructive)` is a combination that does not
+    # exist in the tree today and is perfectly meaningful, and a whole-string
+    # whitelist would fail it in CI until somebody edited a `case` arm (#390).
+    # The words are historical labels, not a redesigned schema, and they are
+    # not one semantic dimension: `ubuntu` is family metadata,
     # `read-only` / `medium-risk` / `high-risk` follow the execution/risk
     # convention from #219, atomic `destructive` names the host-changing gated
     # subset (not ActionSpec `high-risk`), `rejection` marks a negative
     # planner-behavior test, and `compound` / `hard compound` are scenario
-    # labels. `ubuntu, low-risk` stays as legacy vocabulary: story 55 asserts
-    # risk `low` for AptUpdate, which mutates host state, so it is not a
-    # spelling of `ubuntu, read-only` and must not be normalized into one.
-    case "$_tags" in
-        ""|"destructive"|"read-only"|"hard compound"|\
-        "ubuntu, low-risk"|"ubuntu, read-only"|"ubuntu, medium-risk"|\
-        "ubuntu, high-risk"|"ubuntu, rejection"|"ubuntu, compound") ;;
-        *)
-            printf 'ERROR: unrecognized story tags in %s: %s\n' \
-                "$_story_file" "$_tags" >&2
-            exit 1
-            ;;
-    esac
+    # labels. `low-risk` stays distinct from `read-only` as legacy vocabulary:
+    # story 55 asserts risk `low` for AptUpdate, which mutates host state, so
+    # it is not a spelling of `read-only` and must not be normalized into one.
+    if [[ -n "$_tags" ]]; then
+        IFS=',' read -r -a _tag_parts <<< "$_tags"
+        for _tag in "${_tag_parts[@]}"; do
+            _tag="${_tag#"${_tag%%[![:space:]]*}"}"
+            _tag="${_tag%"${_tag##*[![:space:]]}"}"
+            _tag_known=false
+            for _vocab in "${STORY_TAG_VOCAB[@]}"; do
+                if [[ "$_tag" == "$_vocab" ]]; then
+                    _tag_known=true
+                    break
+                fi
+            done
+            if [[ "$_tag_known" != true ]]; then
+                printf 'ERROR: %s: unrecognised story tag %q (vocabulary: %s)\n' \
+                    "$_story_file" "$_tag" "${STORY_TAG_VOCAB[*]}" >&2
+                exit 1
+            fi
+        done
+    fi
     STORY_NAMES[$_id]="$_title"
     if [[ "$_tags" == *ubuntu* ]]; then
         STORY_FAMILY[$_id]="ubuntu"

--- a/tests/e2e/story-metadata.test.sh
+++ b/tests/e2e/story-metadata.test.sh
@@ -135,6 +135,24 @@ if ! bash "$mutant/run-stories.sh" --metadata >/dev/null 2>&1; then
     report "the unmutated copy also fails — the unknown-tag result is meaningless"
 fi
 
+# #390: the vocabulary is per-word, so a combination of known words that does
+# not exist in the tree today — `(ubuntu, destructive)` is exactly that — is
+# perfectly meaningful and must be derived, not rejected. A whole-string
+# whitelist fails CI on it until somebody edits a `case` arm, which is the
+# brittleness in the direction this repository grows that #390 names.
+cp "$story_dir/story-63.sh" "$mutant/stories/story-9999.sh"
+sed -i '2s/.*/# Story 9999 (ubuntu, destructive): New combination/' \
+    "$mutant/stories/story-9999.sh"
+if ! bash "$mutant/run-stories.sh" --metadata >/dev/null 2>&1; then
+    report "a valid new tag combination was rejected by the vocabulary"
+fi
+combo_family="$(bash "$mutant/run-stories.sh" --metadata 2>/dev/null \
+    | awk -F'\t' '$1 == "9999" { print $2 }')"
+if [ "$combo_family" != ubuntu ]; then
+    report "story 9999 (ubuntu, destructive) derived family '$combo_family', expected ubuntu"
+fi
+rm -f "$mutant/stories/story-9999.sh"
+
 # #252: the grammar says the Story header lives on line 2. A valid header
 # shifted to line 3 must fail rather than derive a row from the wrong line.
 cp "$story_dir/story-63.sh" "$mutant/stories/story-9999.sh"


### PR DESCRIPTION
Follow-up to vladimirrott's review here: rebased onto `main` (post-#386), keeping only what the merged PR does not already cover — the per-word vocabulary and the both-consumers mutation cases. Now against #390, which is the tag-vocabulary half re-opened and assigned.

## What changed vs. what landed in #386

`#386` checks the whole tag string against ten exact combinations. This replaces the `case` block with a nine-word `STORY_TAG_VOCAB`, checked per comma-separated word (trimmed). Both catch `ubunut` and a misspelled risk word — equivalent on the #252 bug. They differ afterwards: a new story tagged `(ubuntu, destructive)` is a combination that does not exist in the tree today and is perfectly meaningful; under the whole-string whitelist it fails CI until somebody edits a `case` arm, under this it just works.

## Dropped (already covered by #386)

- The `STORY_HEADER` regex removal in `check_evidence_claims.py` — `story_family_sizes()` on `main` already delegates to `run-stories.sh --metadata`.
- The runner copy in the `public-claims` fixture — already on `main`.
- The single-consumer unknown-tag and line-3 mutations — already in `story-metadata.test.sh` on `main`.

## Kept / added

- `STORY_TAG_VOCAB` per-word check replacing the `case` block. The diagnostic names the file first, then the word (`ERROR: <file>: unrecognised story tag <word> (vocabulary: …)`), matching the file-before-detail order the existing `*story-9999.sh*ubunut*` assertions expect.
- The both-consumers mutation block: unknown tag word and header shifted to line 3 must be rejected by the runner **and** by `check_evidence_claims.py` through the delegation path, each naming the file — testing the delegation rather than one side of it.
- New case for #390 itself: an `(ubuntu, destructive)` mutant must be **derived** (family `ubuntu`), not rejected — pinning the per-word behaviour the whole-string whitelist breaks.

## Vocabulary note

`low-risk` and `read-only` both stay, distinct — per the review and #386's own comment: story 55 asserts risk `low` for `AptUpdate`, which writes the package index, so folding `low-risk` into `read-only` would misname it.

## Verified

- `tests/e2e/story-metadata.test.sh` — 133 stories (79 ubuntu, 54 atomic), including the new combination case
- `python3 scripts/check_evidence_claims.py .`
- `tests/release/public-claims.test.sh`, `tests/e2e/story-runner-verdicts.test.sh`, `tests/e2e/provider-parity.test.sh`
- shellcheck `--severity=warning` (same as CI) clean on both touched scripts

Closes #390.
