### PR TITLE
release: 0.14.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Linux sysadmin co-pilot as an MCP server: plain-language requests become typed, risk-classified actions that a privileged daemon runs only after out-of-band terminal approval, with an Ed25519-signed audit chain and automatic rollback.",
   "repository": "https://github.com/lacs-project/sysknife",
   "homepage": "https://lacs-project.github.io/sysknife/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Releases before `0.2.5` predate the public launch; their notes live in the
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-09-07
+
+The middle digit moves because an exit code changed. `sysknife audit checkpoint`
+with no database configured returned 2 and now returns 4, and an exit code is
+the contract a wrapper script reads. Nothing was removed and no signature
+changed; under the rule in [docs/release.md](docs/release.md#version-numbering)
+that is still a compatibility break, the same way v0.9.0 was when
+`sysknife-setup` began refusing a malformed `.mcp.json` it used to overwrite.
+
+Two of these are security fixes in the daemon's authorization path. A cancelled
+transaction could keep a live approval receipt, and a peer the kernel could not
+pin was still credited with the supplementary groups of whatever process held
+that PID by the time `/proc` was read.
+
 ### Changed
 
 - **A CLI timeout no longer reports that an action ran, and a missing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-brain"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-cli"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-core"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-daemon-test"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "serde_json",
  "sysknife-daemon",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-proto"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-shell"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "sysknife-types"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "prost",
  "serde",

--- a/apps/sysknife-cli/Cargo.toml
+++ b/apps/sysknife-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-cli"
-version = "0.13.1"
+version = "0.14.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,12 +15,12 @@ name = "sysknife"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.13.1" }
-sysknife-core = { path = "../../crates/sysknife-core", version = "0.13.1" }
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.13.1" }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.14.0" }
+sysknife-core = { path = "../../crates/sysknife-core", version = "0.14.0" }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.14.0" }
 chrono = "0.4"
 libc = "0.2"
-sysknife-types = { path = "../../crates/sysknife-types", version = "0.13.1" }
+sysknife-types = { path = "../../crates/sysknife-types", version = "0.14.0" }
 
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
@@ -40,11 +40,11 @@ tokio-vsock = "0.7.2"
 
 [dev-dependencies]
 # `test-support` unlocks `Plan::assume_authorized` for tests only.
-sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.13.1", features = ["test-support"] }
+sysknife-brain = { path = "../../crates/sysknife-brain", version = "0.14.0", features = ["test-support"] }
 # and `AttributionCensus::from_counts_for_tests`, so the verify renderers can be
 # tested without building signed chain rows. Dev-only: production builds of this
 # bin do not compile dev-dependencies, so the constructor stays unreachable there.
-sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.13.1", features = ["test-support"] }
+sysknife-daemon = { path = "../../crates/sysknife-daemon", version = "0.14.0", features = ["test-support"] }
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"

--- a/apps/sysknife-shell/package-lock.json
+++ b/apps/sysknife-shell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysknife-shell",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysknife-shell",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "dependencies": {
         "@tauri-apps/api": "^2.4.1",
         "react": "^19.2.8",

--- a/apps/sysknife-shell/package.json
+++ b/apps/sysknife-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sysknife-shell",
   "private": true,
-  "version": "0.13.1",
+  "version": "0.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/sysknife-shell/src-tauri/Cargo.toml
+++ b/apps/sysknife-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-shell"
-version = "0.13.1"
+version = "0.14.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ default = ["demo"]
 demo = []
 
 [dependencies]
-sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.13.1" }
-sysknife-core = { path = "../../../crates/sysknife-core", version = "0.13.1" }
+sysknife-brain = { path = "../../../crates/sysknife-brain", version = "0.14.0" }
+sysknife-core = { path = "../../../crates/sysknife-core", version = "0.14.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { version = "2.5.6" }

--- a/apps/sysknife-shell/src-tauri/tauri.conf.json
+++ b/apps/sysknife-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.lacsfoundation.LacsShell",
   "productName": "SysKnife Shell",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/crates/sysknife-brain/Cargo.toml
+++ b/crates/sysknife-brain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-brain"
-version = "0.13.1"
+version = "0.14.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,8 +18,8 @@ test-support = []
 [dependencies]
 async-trait = { workspace = true }
 futures = "0.3"
-sysknife-core = { path = "../sysknife-core", version = "0.13.1" }
-sysknife-types = { path = "../sysknife-types", version = "0.13.1" }
+sysknife-core = { path = "../sysknife-core", version = "0.14.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.14.0" }
 async-openai = { version = "0.41", features = ["chat-completion"] }
 # rig-core 0.40 renamed its lib crate `rig` -> `rig_core`; alias it back to `rig`
 # so existing `use rig::...` paths keep working.

--- a/crates/sysknife-core/Cargo.toml
+++ b/crates/sysknife-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-core"
-version = "0.13.1"
+version = "0.14.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/sysknife-daemon-test/Cargo.toml
+++ b/crates/sysknife-daemon-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon-test"
-version = "0.13.1"
+version = "0.14.0"
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -13,6 +13,6 @@ name = "sysknife-daemon-test"
 path = "src/main.rs"
 
 [dependencies]
-sysknife-daemon = { path = "../sysknife-daemon", version = "0.13.1" }
+sysknife-daemon = { path = "../sysknife-daemon", version = "0.14.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sysknife-daemon/Cargo.toml
+++ b/crates/sysknife-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-daemon"
-version = "0.13.1"
+version = "0.14.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,8 +17,8 @@ categories = ["command-line-utilities", "os::linux-apis"]
 test-support = []
 
 [dependencies]
-sysknife-core = { path = "../sysknife-core", version = "0.13.1" }
-sysknife-types = { path = "../sysknife-types", version = "0.13.1" }
+sysknife-core = { path = "../sysknife-core", version = "0.14.0" }
+sysknife-types = { path = "../sysknife-types", version = "0.14.0" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -61,7 +61,7 @@ sqlx-postgres = { version = "0.9", default-features = false, features = [
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-sysknife-brain = { path = "../sysknife-brain", version = "0.13.1" }
+sysknife-brain = { path = "../sysknife-brain", version = "0.14.0" }
 # `test-util` provides the paused test clock, so deadline tests assert on the
 # timer firing instead of sleeping for the real duration.
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/sysknife-proto/Cargo.toml
+++ b/crates/sysknife-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-proto"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 build = "build.rs"
 license.workspace = true

--- a/crates/sysknife-types/Cargo.toml
+++ b/crates/sysknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysknife-types"
-version = "0.13.1"
+version = "0.14.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +10,7 @@ keywords = ["llm", "ai-agent", "linux", "actions", "types"]
 categories = ["command-line-utilities", "os::linux-apis"]
 
 [dependencies]
-sysknife-proto = { path = "../sysknife-proto", version = "0.13.1" }
+sysknife-proto = { path = "../sysknife-proto", version = "0.14.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysknife-setup",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Zero-friction setup for SysKnife MCP server \u2014 Claude Code, Cursor, and Codex CLI",
   "author": "Vladimir Rotariu",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.lacs-project/sysknife",
   "title": "SysKnife",
   "description": "Administers Linux via typed, approval-gated actions with an Ed25519-signed audit trail.",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "websiteUrl": "https://lacs-project.github.io/sysknife/",
   "repository": {
     "url": "https://github.com/lacs-project/sysknife",
@@ -23,7 +23,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "sysknife-cli",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump and CHANGELOG for 0.14.0.

## Why the middle digit

`sysknife audit checkpoint` with no database configured returned exit 2 and now returns exit 4 (#381). `docs/cli.md` calls the exit codes the contract a wrapper script reads, and `docs/release.md#version-numbering` is explicit that behaviour counts and not only signatures:

> v0.9.0 also made `sysknife-setup` refuse a malformed `.mcp.json` that earlier versions overwrote, so a run that used to succeed now exits 1. No signature changed and it is still a compatibility break.

So this is 0.14.0 rather than 0.13.2, and it would have been even without the API change queued in #384.

## What is in it

Two fixes in the daemon's authorization path:

- a cancelled transaction could keep a live approval receipt, so `claim_approved_for_execution` could still consume it (#380, closes #251)
- a peer the kernel could not pin was still credited with the supplementary groups of whatever process held that PID by the time `/proc` was read (#382, closes #250)

Plus the CLI exit-code contract (#381), the release-pin check that was filtering out the one broken pin it existed to catch (#378), single-source story metadata (#386), derived markdown link coverage (#376), and a dead daemon lock arm (#375).

## The lockfile

`Cargo.lock` was regenerated by `cargo`, not edited. `phf`, `phf_codegen`, `phf_generator`, `phf_macros` and `phf_shared` are also pinned at 0.13.1, so substituting the string across the lockfile would have moved five unrelated crates to a version that does not exist. Only the 8 workspace crates moved; `phf` is untouched.

## Verification

```
test_baseline: 1845 rust tests, matching the recorded baseline
Public claims contract passed
release-version-pins: missing inline versions fail explicitly
All release versions match 0.14.0 (15 internal dependency pins checked)
Registry preflight: sysknife-types/brain/daemon/cli  0.14.0 available
```