### PR TITLE
fix(evidence): remove unverifiable test baseline provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check public support and approval claims
         run: bash tests/release/public-claims.test.sh
 
+      - name: Check test-baseline artifact contract
+        run: bash tests/release/test-baseline-provenance.test.sh
+
       - name: Test setup package contracts
         run: npm test --prefix packages/setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,12 @@ UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh
 grep -rn 'Rust tests' README.md docs/introduction.md docs/distro-support.md
 ```
 
+`workspace-tests.json` stores the expected count for each suite and the canonical
+command that measures it. Verification re-runs the suite on the current
+checkout and requires the observed count to match. It makes no historical claim
+about a Git commit or measurement timestamp. Do not add provenance metadata by
+hand.
+
 `cargo-nextest` itself needs no system packages. If it is the missing piece,
 install it directly:
 

--- a/scripts/check_evidence_claims.py
+++ b/scripts/check_evidence_claims.py
@@ -30,6 +30,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+# The release contract tests import this module to derive CLAIM_FILES. Keep the
+# sibling baseline schema available in both direct-script and importlib modes.
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from record_test_baseline import validate_document
+
 # Files that carry public claims. Kept in step with claim_files in
 # check_public_claims.sh; a file listed there but not here is simply unchecked
 # for numbers, which is why the pristine-fixture guard in the test matters.
@@ -261,10 +269,12 @@ def _canonical_story_metadata(root: Path) -> list[tuple[str, str, str]]:
             f"could not derive story families: canonical metadata runner is "
             f"missing: {STORY_METADATA_RUNNER}"
         )
+    runner_arg = runner.relative_to(root).as_posix()
     try:
         completed = subprocess.run(
-            ["bash", str(runner), "--metadata"],
+            ["bash", runner_arg, "--metadata"],
             capture_output=True,
+            cwd=root,
             text=True,
             encoding="utf-8",
             timeout=120,
@@ -754,21 +764,30 @@ def check_validated_tiers(texts: dict[str, str], root: Path) -> list[str]:
     return problems
 
 
+def load_test_baseline(root: Path) -> dict:
+    path = root / TEST_BASELINE
+    if not path.exists():
+        raise Failure(
+            f"{TEST_BASELINE} is missing; record it with "
+            "UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh"
+        )
+    try:
+        baseline = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise Failure(f"{TEST_BASELINE} is not readable JSON: {exc}") from exc
+
+    problems = validate_document(baseline, require_all_fields=True)
+    if problems:
+        raise Failure(f"{TEST_BASELINE} is invalid: {'; '.join(problems)}")
+    return baseline
+
+
 def main() -> int:
     root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
     try:
         texts = read_claim_files(root)
 
-        baseline_path = root / TEST_BASELINE
-        if not baseline_path.exists():
-            raise Failure(
-                f"{TEST_BASELINE} is missing; record it with "
-                "UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh"
-            )
-        baseline = json.loads(baseline_path.read_text())
-        for field in ("tests", "frontend_tests"):
-            if not isinstance(baseline.get(field), int):
-                raise Failure(f"{TEST_BASELINE} has no integer '{field}' field")
+        baseline = load_test_baseline(root)
 
         problems = []
         problems += check_figure(texts, "Rust tests", baseline["tests"])

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -264,6 +264,7 @@ run_hygiene_group() {
     run_step 'hygiene: check_release_versions.sh' bash "$repo_root/scripts/check_release_versions.sh"
     run_step 'hygiene: release-version-pins.test.sh' bash "$repo_root/tests/release/release-version-pins.test.sh"
     run_step 'hygiene: public-claims.test.sh' bash "$repo_root/tests/release/public-claims.test.sh"
+    run_step 'hygiene: test-baseline-provenance.test.sh' bash "$repo_root/tests/release/test-baseline-provenance.test.sh"
     run_step 'hygiene: npm test --prefix packages/setup' npm test --prefix "$repo_root/packages/setup"
     run_step 'hygiene: registry-manifest.test.sh' bash "$repo_root/tests/release/registry-manifest.test.sh"
     run_step 'hygiene: smithery-manifest.test.sh' bash "$repo_root/tests/release/smithery-manifest.test.sh"

--- a/scripts/record_test_baseline.py
+++ b/scripts/record_test_baseline.py
@@ -1,25 +1,118 @@
 #!/usr/bin/env python3
 """Read or update one suite's count in the test-baseline evidence artifact.
 
-Split out of test_baseline.sh because the artifact has to be *merged*, not
-rewritten: the Rust and frontend counts are produced by different commands in
-different CI jobs, so whichever runs second must leave the other's measurement
-alone. Doing that in shell means hand-rolled JSON editing, which is how a
-measurement gets replaced by a guess.
+The artifact is deliberately count-only. The wrapper that calls this module
+measures the working tree, while a commit SHA would describe neither a dirty
+working tree nor a squash-merged contributor tree. The Rust and frontend counts
+are still merged one field at a time because they come from different commands
+and CI jobs.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from pathlib import Path
 
+VERSION = 2
 COMMANDS = {
     "tests": "cargo nextest run --workspace --locked",
     "frontend_tests": "vitest run (apps/sysknife-shell)",
 }
+SUITE_FIELDS = tuple(COMMANDS)
+ALLOWED_KEYS = frozenset(("commands", "version", *SUITE_FIELDS))
+LEGACY_KEYS = ALLOWED_KEYS | {"commit", "measured_at"}
+
+
+def validate_document(document: object, *, require_all_fields: bool) -> list[str]:
+    """Return schema errors for a baseline document.
+
+    A partial document is valid while the two independent recorders are being
+    run. The committed evidence artifact must contain both suite counts.
+    """
+    if not isinstance(document, dict):
+        return ["artifact root must be a JSON object"]
+
+    problems: list[str] = []
+    version = document.get("version")
+    if not isinstance(version, int) or isinstance(version, bool) or version != VERSION:
+        problems.append(f"unsupported artifact version {version!r}; expected {VERSION}")
+
+    unknown = sorted(str(key) for key in set(document) - ALLOWED_KEYS)
+    if unknown:
+        problems.append(
+            "unsupported top-level fields: "
+            + ", ".join(unknown)
+            + "; schema 2 stores counts only"
+        )
+
+    commands = document.get("commands")
+    if not isinstance(commands, dict):
+        problems.append("commands must be an object")
+    else:
+        unknown_commands = sorted(str(key) for key in set(commands) - set(COMMANDS))
+        if unknown_commands:
+            problems.append(
+                "unsupported command fields: " + ", ".join(unknown_commands)
+            )
+        for field, expected in COMMANDS.items():
+            if field not in commands:
+                if require_all_fields:
+                    problems.append(f"commands is missing '{field}'")
+            elif commands[field] != expected:
+                problems.append(f"commands['{field}'] does not match the recorder")
+
+    for field in SUITE_FIELDS:
+        if field not in document:
+            if require_all_fields:
+                problems.append(f"artifact is missing '{field}'")
+            continue
+        value = document[field]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            problems.append(f"'{field}' must be a non-negative integer")
+
+    return problems
+
+
+def _load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path} is not readable JSON: {exc}") from exc
+
+
+def load_document(path: Path, *, migrate_legacy: bool) -> dict:
+    if not path.exists():
+        return {}
+
+    document = _load_json(path)
+    if not isinstance(document, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    version = document.get("version")
+    if (
+        migrate_legacy
+        and isinstance(version, int)
+        and not isinstance(version, bool)
+        and version == 1
+    ):
+        unknown = sorted(str(key) for key in set(document) - LEGACY_KEYS)
+        if unknown:
+            raise ValueError(
+                f"{path} has unsupported legacy fields: {', '.join(unknown)}"
+            )
+        document = {
+            key: value
+            for key, value in document.items()
+            if key in ALLOWED_KEYS
+        }
+        document["version"] = VERSION
+
+    problems = validate_document(document, require_all_fields=False)
+    if problems:
+        raise ValueError(f"{path} is invalid: {'; '.join(problems)}")
+    return document
 
 
 def main() -> int:
@@ -27,7 +120,6 @@ def main() -> int:
     parser.add_argument("--artifact", required=True, type=Path)
     parser.add_argument("--field", required=True, choices=sorted(COMMANDS))
     parser.add_argument("--count", type=int)
-    parser.add_argument("--commit")
     parser.add_argument(
         "--read",
         action="store_true",
@@ -35,34 +127,38 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    doc: dict = {}
-    if args.artifact.exists():
-        doc = json.loads(args.artifact.read_text())
+    try:
+        doc = load_document(args.artifact, migrate_legacy=not args.read)
+    except (OSError, ValueError) as exc:
+        print(f"record_test_baseline: {exc}", file=sys.stderr)
+        return 1
 
     if args.read:
         value = doc.get(args.field)
-        if value is None:
+        if not isinstance(value, int) or isinstance(value, bool):
             return 1
         print(value)
         return 0
 
     if args.count is None:
         parser.error("--count is required unless --read is given")
+    if args.count < 0:
+        parser.error("--count must be non-negative")
 
-    doc["version"] = 1
+    doc["version"] = VERSION
     doc[args.field] = args.count
     doc.setdefault("commands", {})[args.field] = COMMANDS[args.field]
-    # Recorded per field: one suite's figure can be fresh while the other is
-    # stale, and a single timestamp would hide that.
-    doc.setdefault("measured_at", {})[args.field] = subprocess.run(
-        ["date", "--iso-8601=seconds"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-    doc.setdefault("commit", {})[args.field] = args.commit or "unknown"
+    problems = validate_document(doc, require_all_fields=False)
+    if problems:
+        print(
+            f"record_test_baseline: generated artifact is invalid: {'; '.join(problems)}",
+            file=sys.stderr,
+        )
+        return 1
 
-    args.artifact.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n")
+    args.artifact.write_text(
+        json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     return 0
 
 

--- a/scripts/test_baseline.sh
+++ b/scripts/test_baseline.sh
@@ -101,8 +101,7 @@ if [[ "${UPDATE_TEST_BASELINE:-0}" == "1" ]]; then
     python3 "$recorder" \
         --artifact "$artifact" \
         --field "$field" \
-        --count "$count" \
-        --commit "$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+        --count "$count"
     printf '\ntest_baseline: recorded %s %s tests in %s\n' \
         "$count" "$suite" "${artifact#"$repo_root"/}"
     exit 0

--- a/tests/evidence/README.md
+++ b/tests/evidence/README.md
@@ -57,7 +57,9 @@ Two things this cost, worth stating because both are easy to repeat:
 
 ## `workspace-tests.json`
 
-Suite sizes, one field per suite, each written by the command that measured it:
+Suite sizes, one field per suite, are the only claims in this artifact. Schema
+version 2 also records the canonical command string for each field. Readers reject
+other versions and extra top-level fields:
 
 ```sh
 UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh              # Rust workspace
@@ -67,6 +69,11 @@ UPDATE_TEST_BASELINE=1 scripts/test_baseline.sh --frontend   # vitest
 Without `UPDATE_TEST_BASELINE` those commands *verify* instead, and they are what
 CI runs in place of the bare test commands — so a suite that grows without the
 baseline moving fails in the job that knows the real number.
+
+`workspace-tests.json` stores the expected count for each suite and the canonical
+command that measures it. Verification re-runs the suite on the current
+checkout and requires the observed count to match. It makes no historical claim
+about a Git commit or measurement timestamp.
 
 ## `story-runs/*.json`
 

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -3,15 +3,7 @@
     "frontend_tests": "vitest run (apps/sysknife-shell)",
     "tests": "cargo nextest run --workspace --locked"
   },
-  "commit": {
-    "frontend_tests": "656b399035ee5fc81bd949e871daee65b4a1f3c4",
-    "tests": "5bef5e6c48f73d23d10404b72901be9a920bc46f"
-  },
   "frontend_tests": 72,
-  "measured_at": {
-    "frontend_tests": "2026-08-05T09:23:15-06:00",
-    "tests": "2026-09-07T14:24:31-06:00"
-  },
   "tests": 1845,
-  "version": 1
+  "version": 2
 }

--- a/tests/release/test-baseline-provenance.test.sh
+++ b/tests/release/test-baseline-provenance.test.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+recorder="$repo_root/scripts/record_test_baseline.py"
+checker="$repo_root/scripts/check_evidence_claims.py"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+rust_count="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['tests'])" \
+    "$repo_root/tests/evidence/workspace-tests.json")"
+frontend_count="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['frontend_tests'])" \
+    "$repo_root/tests/evidence/workspace-tests.json")"
+
+record() {
+    python3 "$recorder" \
+        --artifact "$1" \
+        --field "$2" \
+        --count "$3"
+}
+
+# The pristine artifact must still pass the full evidence checker; its live suite
+# gates remain independent from this schema contract.
+python3 "$checker" "$repo_root" >/dev/null
+
+artifact="$fixture/workspace-tests.json"
+record "$artifact" tests "$rust_count"
+record "$artifact" frontend_tests "$frontend_count"
+
+python3 - "$artifact" "$recorder" "$checker" <<'PY'
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+
+artifact_path, recorder_path, checker_path = sys.argv[1:]
+document = json.loads(open(artifact_path, encoding="utf-8").read())
+expected_keys = {"commands", "frontend_tests", "tests", "version"}
+if set(document) != expected_keys:
+    raise SystemExit(
+        f"generated artifact has {sorted(document)}, expected {sorted(expected_keys)}"
+    )
+if document["version"] != 2:
+    raise SystemExit(f"generated artifact has schema version {document['version']}, expected 2")
+
+spec = importlib.util.spec_from_file_location("record_test_baseline", recorder_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+if not hasattr(module, "validate_document"):
+    raise SystemExit("record_test_baseline.py must expose the schema validator")
+
+problems = module.validate_document(document, require_all_fields=True)
+if problems:
+    raise SystemExit("generated artifact was rejected: " + "; ".join(problems))
+if document["commands"] != module.COMMANDS:
+    raise SystemExit(
+        f"generated artifact commands {document['commands']!r} do not match "
+        f"the canonical commands {module.COMMANDS!r}"
+    )
+
+for field in ("tests", "frontend_tests"):
+    command_edit = dict(document)
+    command_edit["commands"] = dict(document["commands"])
+    command_edit["commands"][field] += " --altered"
+    problems = module.validate_document(command_edit, require_all_fields=True)
+    if not problems or not any(f"commands['{field}']" in problem for problem in problems):
+        raise SystemExit(f"altered {field} command was not rejected")
+
+# A count-only artifact remains valid if its expected number changes. The live
+# runner gate, not this schema check, decides whether that number is true.
+count_edit = dict(document)
+count_edit["tests"] += 1
+if module.validate_document(count_edit, require_all_fields=True):
+    raise SystemExit("schema validation must not reject a count solely because it changed")
+
+# Old-looking metadata is the false provenance this issue is about. It must not
+# survive as an authoritative-looking extension to the count-only contract.
+metadata_edit = dict(document)
+metadata_edit["commit"] = {"tests": "a" * 40}
+metadata_edit["measured_at"] = {"tests": "2026-09-07T00:00:00Z"}
+problems = module.validate_document(metadata_edit, require_all_fields=True)
+if not problems or not any("unsupported top-level fields" in problem for problem in problems):
+    raise SystemExit("hand-edited provenance metadata was not rejected")
+
+checker_spec = importlib.util.spec_from_file_location("check_evidence_claims", checker_path)
+checker_module = importlib.util.module_from_spec(checker_spec)
+checker_spec.loader.exec_module(checker_module)
+checker_root = Path(artifact_path).parent / "checker-root"
+checker_artifact = checker_root / "tests" / "evidence" / "workspace-tests.json"
+checker_artifact.parent.mkdir(parents=True)
+shutil.copyfile(artifact_path, checker_artifact)
+checker_module.load_test_baseline(checker_root)
+checker_artifact.write_text(json.dumps(metadata_edit), encoding="utf-8")
+try:
+    checker_module.load_test_baseline(checker_root)
+except checker_module.Failure:
+    pass
+else:
+    raise SystemExit("evidence checker accepted hand-edited provenance metadata")
+
+for label, version in (("legacy", 1), ("future", 3)):
+    version_edit = dict(document)
+    version_edit["version"] = version
+    problems = module.validate_document(version_edit, require_all_fields=True)
+    if not problems or not any("version" in problem for problem in problems):
+        raise SystemExit(f"{label} schema version was not rejected")
+
+malformed = dict(document)
+malformed["tests"] = True
+problems = module.validate_document(malformed, require_all_fields=True)
+if not problems or not any("tests" in problem for problem in problems):
+    raise SystemExit("boolean test count was not rejected")
+PY
+
+# Exercise the actual wrapper's count gate with isolated runners. This keeps the
+# live-suite proof intact without requiring the Rust or Node toolchains here.
+fake_bin="$fixture/fake-bin"
+sandbox="$fixture/baseline-root"
+mkdir -p "$fake_bin" "$sandbox/scripts" "$sandbox/tests/evidence" \
+    "$sandbox/apps/sysknife-shell/node_modules/.bin"
+cp "$repo_root/scripts/test_baseline.sh" "$sandbox/scripts/test_baseline.sh"
+cp "$recorder" "$sandbox/scripts/record_test_baseline.py"
+cp "$repo_root/tests/evidence/workspace-tests.json" \
+    "$sandbox/tests/evidence/workspace-tests.json"
+python3 - "$fake_bin/cargo" "$fake_bin/vitest" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+cargo_path, vitest_path = map(Path, sys.argv[1:])
+cargo_path.write_text(
+    r'''#!/usr/bin/env bash
+printf 'Starting %s tests across 1 binaries\n' "${FAKE_RUST_COUNT:-0}"
+exit "${FAKE_RUST_STATUS:-0}"
+''',
+    encoding="utf-8",
+)
+vitest_path.write_text(
+    r'''#!/usr/bin/env bash
+printf 'Tests  %s passed (%s)\n' "${FAKE_FRONTEND_COUNT:-0}" "${FAKE_FRONTEND_COUNT:-0}"
+exit "${FAKE_FRONTEND_STATUS:-0}"
+''',
+    encoding="utf-8",
+)
+for path in (cargo_path, vitest_path):
+    os.chmod(path, 0o755)
+PY
+cp "$fake_bin/vitest" "$sandbox/apps/sysknife-shell/node_modules/.bin/vitest"
+
+run_baseline() {
+    PATH="$fake_bin:$PATH" bash "$sandbox/scripts/test_baseline.sh" "$@"
+}
+
+FAKE_RUST_COUNT="$rust_count" run_baseline >/dev/null
+if frontend_mismatch_output="$(FAKE_FRONTEND_COUNT=$((frontend_count + 1)) \
+    run_baseline --frontend 2>&1)"; then
+    printf 'FAIL: frontend count mismatch was accepted\n' >&2
+    exit 1
+fi
+if [[ "$frontend_mismatch_output" != *"baseline says $frontend_count"* ]]; then
+    printf 'FAIL: frontend mismatch diagnostic was incomplete\n%s\n' \
+        "$frontend_mismatch_output" >&2
+    exit 1
+fi
+before_failed_frontend="$fixture/baseline-before-failed-frontend.json"
+cp "$sandbox/tests/evidence/workspace-tests.json" "$before_failed_frontend"
+if FAKE_FRONTEND_COUNT="$frontend_count" FAKE_FRONTEND_STATUS=7 \
+    run_baseline --frontend >/dev/null 2>&1; then
+    printf 'FAIL: failed frontend suite was accepted\n' >&2
+    exit 1
+fi
+cmp "$before_failed_frontend" "$sandbox/tests/evidence/workspace-tests.json"
+
+FAKE_FRONTEND_COUNT="$frontend_count" run_baseline --frontend >/dev/null
+
+if mismatch_output="$(FAKE_RUST_COUNT=$((rust_count + 1)) run_baseline 2>&1)"; then
+    printf 'FAIL: Rust count mismatch was accepted\n' >&2
+    exit 1
+fi
+if [[ "$mismatch_output" != *"baseline says $rust_count"* ]]; then
+    printf 'FAIL: Rust mismatch diagnostic was incomplete\n%s\n' "$mismatch_output" >&2
+    exit 1
+fi
+
+before_failed_run="$fixture/baseline-before-failed-run.json"
+cp "$sandbox/tests/evidence/workspace-tests.json" "$before_failed_run"
+if FAKE_RUST_COUNT="$rust_count" FAKE_RUST_STATUS=7 run_baseline >/dev/null 2>&1; then
+    printf 'FAIL: failed Rust suite was accepted\n' >&2
+    exit 1
+fi
+cmp "$before_failed_run" "$sandbox/tests/evidence/workspace-tests.json"
+
+legacy_read="$fixture/legacy-read.json"
+python3 - "$sandbox/tests/evidence/workspace-tests.json" "$legacy_read" <<'PY'
+import json
+import sys
+
+document = json.loads(open(sys.argv[1], encoding="utf-8").read())
+document["version"] = 1
+document["commit"] = {"tests": "c" * 40}
+document["measured_at"] = {"tests": "2026-09-07T00:00:00Z"}
+open(sys.argv[2], "w", encoding="utf-8").write(json.dumps(document))
+PY
+legacy_read_before="$fixture/legacy-read-before.json"
+cp "$legacy_read" "$legacy_read_before"
+if python3 "$recorder" --artifact "$legacy_read" --field tests --read >/dev/null 2>&1; then
+    printf 'FAIL: --read accepted a legacy provenance artifact\n' >&2
+    exit 1
+fi
+cmp "$legacy_read_before" "$legacy_read"
+
+UPDATE_TEST_BASELINE=1 FAKE_RUST_COUNT=$((rust_count + 1)) run_baseline >/dev/null
+python3 - "$sandbox/tests/evidence/workspace-tests.json" "$frontend_count" "$rust_count" <<'PY'
+import json
+import sys
+
+document = json.loads(open(sys.argv[1], encoding="utf-8").read())
+if document["tests"] != int(sys.argv[3]) + 1:
+    raise SystemExit("wrapper did not record the selected Rust count")
+if document["frontend_tests"] != int(sys.argv[2]):
+    raise SystemExit("Rust wrapper update changed the frontend count")
+PY
+
+FAKE_FRONTEND_COUNT="$frontend_count" run_baseline --frontend >/dev/null
+UPDATE_TEST_BASELINE=1 FAKE_FRONTEND_COUNT=$((frontend_count + 1)) \
+    run_baseline --frontend >/dev/null
+python3 - "$sandbox/tests/evidence/workspace-tests.json" "$frontend_count" "$rust_count" <<'PY'
+import json
+import sys
+
+document = json.loads(open(sys.argv[1], encoding="utf-8").read())
+if document["frontend_tests"] != int(sys.argv[2]) + 1:
+    raise SystemExit("wrapper did not record the selected frontend count")
+if document["tests"] != int(sys.argv[3]) + 1:
+    raise SystemExit("frontend wrapper update changed the Rust count")
+if "commit" in document or "measured_at" in document:
+    raise SystemExit("wrapper reintroduced removed provenance metadata")
+PY
+
+# Updating one suite must preserve the other suite's independently measured
+# count, without adding metadata for either one.
+record "$artifact" tests "$((rust_count + 1))"
+python3 - "$artifact" "$frontend_count" "$rust_count" <<'PY'
+import json
+import sys
+
+document = json.loads(open(sys.argv[1], encoding="utf-8").read())
+if document["tests"] != int(sys.argv[3]) + 1:
+    raise SystemExit("Rust update did not land")
+if document["frontend_tests"] != int(sys.argv[2]):
+    raise SystemExit("Rust update rewrote the frontend count")
+if "commit" in document or "measured_at" in document:
+    raise SystemExit("Rust update reintroduced removed provenance metadata")
+PY
+
+record "$artifact" frontend_tests "$((frontend_count + 1))"
+python3 - "$artifact" "$frontend_count" "$rust_count" <<'PY'
+import json
+import sys
+
+document = json.loads(open(sys.argv[1], encoding="utf-8").read())
+if document["frontend_tests"] != int(sys.argv[2]) + 1:
+    raise SystemExit("frontend update did not land")
+if document["tests"] != int(sys.argv[3]) + 1:
+    raise SystemExit("frontend update rewrote the Rust count")
+if "commit" in document or "measured_at" in document:
+    raise SystemExit("frontend update reintroduced removed provenance metadata")
+PY
+
+# A v1 artifact already exists in released main. A real refresh migrates its
+# useful counts and drops the fields whose meaning cannot be defended.
+legacy_artifact="$fixture/legacy.json"
+python3 - "$artifact" "$legacy_artifact" <<'PY'
+import json
+import sys
+
+document = json.loads(open(sys.argv[1], encoding="utf-8").read())
+document["version"] = 1
+document["commit"] = {"tests": "b" * 40}
+document["measured_at"] = {"tests": "2026-09-07T00:00:00Z"}
+open(sys.argv[2], "w", encoding="utf-8").write(json.dumps(document))
+PY
+record "$legacy_artifact" tests "$rust_count"
+python3 - "$legacy_artifact" "$rust_count" "$((frontend_count + 1))" <<'PY'
+import json
+import sys
+
+document = json.loads(open(sys.argv[1], encoding="utf-8").read())
+if document["version"] != 2 or document["tests"] != int(sys.argv[2]):
+    raise SystemExit("legacy artifact was not migrated to schema 2")
+if document["frontend_tests"] != int(sys.argv[3]):
+    raise SystemExit("legacy migration changed the other suite count")
+if "commit" in document or "measured_at" in document:
+    raise SystemExit("legacy provenance metadata survived migration")
+PY
+
+# A dirty working tree is represented by the measured count only. The recorder
+# must not turn HEAD into provenance for an uncommitted measurement.
+dirty_repo="$fixture/dirty-repo"
+mkdir -p "$dirty_repo"
+git -C "$dirty_repo" init -q
+git -C "$dirty_repo" config user.name baseline-test
+git -C "$dirty_repo" config user.email baseline-test@example.invalid
+printf 'one test\n' > "$dirty_repo/suite.txt"
+git -C "$dirty_repo" add suite.txt
+git -C "$dirty_repo" -c user.name=baseline-test -c user.email=baseline-test@example.invalid \
+    commit -qm baseline
+printf 'second test\n' >> "$dirty_repo/suite.txt"
+if git -C "$dirty_repo" diff --quiet; then
+    printf 'FAIL: dirty-worktree fixture did not become dirty\n' >&2
+    exit 1
+fi
+dirty_artifact="$dirty_repo/workspace-tests.json"
+record "$dirty_artifact" tests 2
+python3 - "$dirty_artifact" <<'PY'
+import json
+import sys
+
+document = json.loads(open(sys.argv[1], encoding="utf-8").read())
+if document["tests"] != 2:
+    raise SystemExit("dirty-worktree measurement was not recorded")
+if "commit" in document or "measured_at" in document:
+    raise SystemExit("dirty-worktree measurement acquired false HEAD provenance")
+PY
+
+# A squash-equivalent tree is valid even though the contributor commit is not an
+# ancestor of the squash commit. The count-only contract has no ancestry rule to
+# reject it.
+squash_repo="$fixture/squash-repo"
+mkdir -p "$squash_repo"
+git -C "$squash_repo" init -q
+git -C "$squash_repo" config user.name baseline-test
+git -C "$squash_repo" config user.email baseline-test@example.invalid
+printf 'base\n' > "$squash_repo/suite.txt"
+git -C "$squash_repo" add suite.txt
+git -C "$squash_repo" -c user.name=baseline-test -c user.email=baseline-test@example.invalid \
+    commit -qm base
+git -C "$squash_repo" branch -M main
+git -C "$squash_repo" branch contributor
+git -C "$squash_repo" switch -q contributor
+printf 'base\nnew test\n' > "$squash_repo/suite.txt"
+git -C "$squash_repo" add suite.txt
+git -C "$squash_repo" -c user.name=baseline-test -c user.email=baseline-test@example.invalid \
+    commit -qm contributor
+contributor_commit="$(git -C "$squash_repo" rev-parse HEAD)"
+git -C "$squash_repo" switch -q main
+git -C "$squash_repo" switch -q -c squash
+printf 'base\nnew test\n' > "$squash_repo/suite.txt"
+git -C "$squash_repo" add suite.txt
+git -C "$squash_repo" -c user.name=baseline-test -c user.email=baseline-test@example.invalid \
+    commit -qm squash
+squash_commit="$(git -C "$squash_repo" rev-parse HEAD)"
+if git -C "$squash_repo" merge-base --is-ancestor "$contributor_commit" "$squash_commit"; then
+    printf 'FAIL: squash fixture unexpectedly preserved contributor ancestry\n' >&2
+    exit 1
+fi
+squash_a="$fixture/squash-a.json"
+squash_b="$fixture/squash-b.json"
+(cd "$squash_repo" && record "$squash_a" tests 2)
+(cd "$squash_repo" && git switch -q contributor && record "$squash_b" tests 2)
+cmp "$squash_a" "$squash_b"
+
+printf 'Test-baseline provenance contract passed.\n'


### PR DESCRIPTION
## Summary

- replace `workspace-tests.json`'s unverifiable commit/timestamp provenance with a strict count-only schema
- validate the canonical command associated with each suite
- keep Rust and frontend baselines independently refreshable
- add a focused contract test covering schema mutations, legacy migration, dirty worktrees, and squash-merge-safe behavior
- wire the new contract into local and GitHub CI hygiene gates

Closes #278.

## Why

`workspace-tests.json` recorded a test count beside a Git commit and measurement timestamp, but nothing proved that those fields identified the tree that was actually measured.

That breaks in two normal cases:

- `test_baseline.sh` measures the working tree, so an uncommitted test can change the observed count while `git rev-parse HEAD` still names the old tree;
- SysKnife squash-merges PRs, so a contributor commit that legitimately produced a baseline can disappear from `main` even when the squash commit carries the same change.

A Git ancestry check would therefore create false confidence rather than trustworthy provenance.

Schema v2 makes the contract narrower and verifiable:

> `workspace-tests.json` stores the expected count for each suite and the canonical command that measures it. Verification re-runs the suite on the current checkout and requires the observed count to match. It makes no historical claim about a Git commit or measurement timestamp.

The existing Rust and frontend CI jobs remain the authority for whether the stored count is true.

## Schema

The committed artifact now contains only:

```json
{
  "commands": {
    "frontend_tests": "vitest run (apps/sysknife-shell)",
    "tests": "cargo nextest run --workspace --locked"
  },
  "frontend_tests": 72,
  "tests": 1845,
  "version": 2
}
```

Readers reject:

* schema versions other than 2
* malformed or negative counts
* altered canonical commands
* extra fields such as `commit` or `measured_at`

Explicit recording can migrate a legacy v1 artifact to v2 while preserving the untouched suite's independent count. Read-only verification does not rewrite legacy artifacts.

## Regression coverage

`tests/release/test-baseline-provenance.test.sh` covers:

* valid generated v2 artifacts
* Rust and frontend count mismatch handling
* failed suites leaving the artifact untouched
* altered canonical Rust/frontend commands
* hand-added `commit` / `measured_at`
* unsupported schema versions
* per-suite preservation
* v1 → v2 migration
* dirty-working-tree measurement
* squash-equivalent Git histories

The squash fixture deliberately proves the contributor commit is not an ancestor of the squash commit; the count-only contract remains valid because it has no Git-history dependency.

## Related cleanup

`check_evidence_claims.py` invokes the canonical story metadata runner using a repository-relative POSIX path with `cwd` set to the repository root. This preserves #386's `run-stories.sh --metadata` behavior while avoiding host-path translation issues when Bash is used from Windows.

## Validation

Passed:

* `bash tests/release/test-baseline-provenance.test.sh`
* `bash tests/release/public-claims.test.sh`
* `bash tests/e2e/story-metadata.test.sh`
* `bash tests/e2e/story-runner-verdicts.test.sh`
* `python3 scripts/check_evidence_claims.py .`
* `python3 -m py_compile scripts/record_test_baseline.py`
* `bash -n scripts/test_baseline.sh`
* ShellCheck on touched shell files
* `git diff --check`

Story metadata remains:

```text
133 total
79 ubuntu
54 atomic
```

Local full Rust remeasurement is unavailable because the local Rust toolchain is 1.88.0 while current dependencies require 1.94.0. Local frontend remeasurement is unavailable because Vitest is not installed. The baseline was therefore not estimated or regenerated; the upstream 1845 Rust / 72 frontend values were preserved.
