### PR TITLE
fix(setup): align wizard guidance with installation outcomes

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -36,6 +36,13 @@ npx sysknife-setup --claude --no-prompts --daemon-mode=system
 actions work, and anything mutating (installing packages, restarting services)
 does not, because the sudoers grants belong to the `sysknife` system user.
 
+For system mode, follow the printed installation commands; the wizard does not
+install the system service itself. A skipped install or a host without systemd
+gets manual daemon steps instead of commands for a user unit that was never
+installed. With `--no-prompts`, supply any required API key through the
+environment (see Step 2); the wizard does not collect one interactively.
+Redirected downloads print periodic progress lines and a final byte count.
+
 ### From source
 
 **Prerequisites:** Rust stable (`rustup update stable`), **a C compiler and

--- a/packages/setup/index.js
+++ b/packages/setup/index.js
@@ -478,13 +478,8 @@ async function collectTarget(rl, lineQueue, idx) {
       ok(`Daemon socket reachable: ${socket}`);
     } else if (reachable === false) {
       warn(`Daemon socket not reachable: ${socket}`);
-      // A socket under /run/user/<uid> belongs to the user service; telling
-      // someone to `sudo systemctl start` it sends them to a unit that does
-      // not exist on their machine.
-      step(socket.includes('/run/user/')
-        ? `Start the daemon:  systemctl --user start sysknife-daemon`
-        : `Start the daemon:  sudo systemctl start sysknife-daemon`);
-      step(`       or build:   cargo run -p sysknife-daemon`);
+      // Installation has not happened yet. Defer commands until its outcome
+      // tells us which service, if any, exists.
     }
   }
 
@@ -509,7 +504,7 @@ async function collectTarget(rl, lineQueue, idx) {
 // Next-step hint for a single target
 // ---------------------------------------------------------------------------
 
-function targetNextStep(target) {
+function targetNextStep(target, daemonInstall) {
   const { socket, name } = target;
   const label = name ? `${name} (${socket})` : socket;
 
@@ -524,18 +519,17 @@ function targetNextStep(target) {
 
   if (socket.startsWith('vsock://')) {
     step(`Start daemon in ${label} guest:  sudo systemctl start sysknife-daemon`);
-  } else if (socket === userServiceSocket) {
-    // Default: a per-user daemon managed by a `systemctl --user` unit.
-    step('Start the daemon:  systemctl --user enable --now sysknife-daemon');
-    step('              or:  cargo run -p sysknife-daemon');
   } else if (!localSockets.has(socket)) {
     // Likely an SSH tunnel socket — remind user to open the tunnel
     step(`Open SSH tunnel for ${label}:  ssh -fN -L ${socket}:/run/sysknife/daemon.sock <user>@<host>`);
     step(`Then start the daemon in the guest:  sudo systemctl start sysknife-daemon`);
-  } else {
-    step('Start the daemon:  sudo systemctl start sysknife-daemon');
+  } else if (socket === userServiceSocket
+      && daemonInstall?.mode === 'user' && daemonInstall.daemonInstalled) {
+    step('Start the daemon:  systemctl --user enable --now sysknife-daemon');
     step('              or:  cargo run -p sysknife-daemon');
   }
+  // System, skipped and no-systemd installs supply their own manual steps in
+  // the outstanding-steps block; a socket path alone does not establish a unit.
 }
 
 // ---------------------------------------------------------------------------
@@ -623,7 +617,7 @@ async function main() {
     const existing = process.env[envVar];
     if (existing) {
       ok(`${envVar} already set in environment — will not embed in config files`);
-    } else {
+    } else if (!NO_PROMPTS) {
       console.log();
       console.log(`  ${Y}Note:${X} The key will be stored in plain text in the generated config files.`);
       console.log(`  Leave blank to set ${envVar} in your shell profile instead.`);
@@ -884,7 +878,7 @@ async function main() {
   // ── Daemon service install ────────────────────────────────────────────────
   //
   // Offer to install the systemd service now that the binary is in place.
-  // The user may skip; they can always run `systemctl --user enable sysknife-daemon` later.
+  // A skipped install leaves manual steps, not an installed service unit.
 
   const daemonBinPath = binaryPath.replace(/\/sysknife$/, '/sysknife-daemon');
   const daemonInstall = await installDaemonService({
@@ -908,7 +902,10 @@ async function main() {
       ok(`Daemon socket reachable: ${firstLocalSocket.socket}`);
     } else if (daemonSocketReachable === false) {
       warn(`Daemon socket not reachable after 6s: ${firstLocalSocket.socket}`);
-      step('Check it with:  systemctl --user status sysknife-daemon');
+      if (firstLocalSocket.socket === runtimeSocketPath()
+          && daemonInstall?.mode === 'user' && daemonInstall.daemonInstalled) {
+        step('Check it with:  systemctl --user status sysknife-daemon');
+      }
     }
   }
 
@@ -952,7 +949,7 @@ async function main() {
   }
 
   for (const t of targets) {
-    targetNextStep(t);
+    targetNextStep(t, daemonInstall);
   }
 
   console.log();

--- a/packages/setup/install-binary.js
+++ b/packages/setup/install-binary.js
@@ -227,7 +227,8 @@ function fetchBuffer(url, opts = {}) {
 
 /**
  * Perform an HTTPS GET with progress reporting.
- * Prints a CR-overwritten progress line: [ 12.3 MB / 23.5 MB ]
+ * Overwrites a progress line in a terminal; captured logs get at most one
+ * progress row per second, plus the final byte count.
  *
  * @param {string} url
  * @param {string} label  - short label shown in the progress line
@@ -255,17 +256,28 @@ function fetchWithProgress(url, label, redirectsLeft = 5) {
       const total = parseInt(res.headers['content-length'] || '0', 10);
       const chunks = [];
       let received = 0;
+      const isTTY = process.stdout.isTTY;
+      let lastProgressAt = null;
+
+      const reportProgress = () => {
+        const recMb = (received / 1_048_576).toFixed(1);
+        const totMb = total ? (total / 1_048_576).toFixed(1) : '?';
+        process.stdout.write(`${isTTY ? '\r' : ''}  ${D}↓${X}  ${label}: [ ${recMb} MB / ${totMb} MB ]${isTTY ? '' : '\n'}`);
+      };
 
       res.on('data', (chunk) => {
         chunks.push(chunk);
         received += chunk.length;
-        const recMb  = (received / 1_048_576).toFixed(1);
-        const totMb  = total ? (total / 1_048_576).toFixed(1) : '?';
-        process.stdout.write(`\r  ${D}↓${X}  ${label}: [ ${recMb} MB / ${totMb} MB ]`);
+        const now = Date.now();
+        if (isTTY || lastProgressAt === null || now - lastProgressAt >= 1000) {
+          reportProgress();
+          lastProgressAt = now;
+        }
       });
 
       res.on('end', () => {
-        process.stdout.write('\n');
+        if (isTTY) process.stdout.write('\n');
+        else reportProgress();
         resolve(Buffer.concat(chunks));
       });
 

--- a/packages/setup/tests/download-progress.test.mjs
+++ b/packages/setup/tests/download-progress.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const require = createRequire(import.meta.url);
+const installerPath = fileURLToPath(new URL('../install-binary.js', import.meta.url));
+const source = fs.readFileSync(installerPath, 'utf8');
+
+async function download({ chunks, total, isTTY = false, intervalMs = 10 }) {
+  let output = '';
+  let now = 0;
+  const response = new EventEmitter();
+  response.statusCode = 200;
+  response.headers = total === undefined ? {} : { 'content-length': String(total) };
+  const fakeHttps = {
+    get(url, options, onResponse) {
+      assert.equal(url, 'https://example.invalid/asset');
+      assert.equal(options.headers.Accept, 'application/octet-stream');
+      queueMicrotask(() => {
+        onResponse(response);
+        for (const chunk of chunks) {
+          now += intervalMs;
+          response.emit('data', chunk);
+        }
+        response.emit('end');
+      });
+      return new EventEmitter();
+    },
+  };
+
+  // Exercise the private production downloader without exporting a test-only
+  // API or contacting a server. The source is unchanged; only HTTPS, stdout
+  // and the clock are substituted in its module context.
+  const fetchWithProgress = vm.runInNewContext(`${source}\nfetchWithProgress;`, {
+    require: id => id === 'node:https' ? fakeHttps : require(id),
+    module: { exports: {} },
+    Buffer,
+    process: { stdout: { isTTY, write: text => { output += text; } } },
+    Date: class extends Date { static now() { return now; } },
+  }, { filename: installerPath });
+
+  const bytes = await fetchWithProgress('https://example.invalid/asset', 'fixture');
+  assert.deepEqual(bytes, Buffer.concat(chunks), 'progress must not change downloaded bytes');
+  return output.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+for (const knownTotal of [true, false]) {
+  test(`non-TTY progress is periodic and line-oriented with ${knownTotal ? 'known' : 'unknown'} size`, async () => {
+    const chunks = Array.from({ length: 400 }, () => Buffer.alloc(4096, 0x61));
+    const total = chunks.length * chunks[0].length;
+    const output = await download({ chunks, total: knownTotal ? total : undefined });
+    assert.doesNotMatch(output, /\r/, 'a captured log must not rely on terminal overwrites');
+    assert.ok(output.endsWith('\n'));
+    const lines = output.trimEnd().split('\n');
+    assert.ok(lines.length >= 3, 'a longer download should report progress before completion');
+    assert.ok(lines.length <= 6, `400 chunks over four seconds produced ${lines.length} lines`);
+    const totalText = knownTotal ? '1.6' : '?';
+    assert.ok(lines.every(line => line.includes(` MB / ${totalText} MB ]`)));
+    assert.ok(lines.at(-1).endsWith(`[ 1.6 MB / ${totalText} MB ]`), 'report the final byte count');
+  });
+}
+
+test('a fast non-TTY download reports its final count without one row per chunk', async () => {
+  const chunks = Array.from({ length: 400 }, () => Buffer.alloc(4096, 0x62));
+  const output = await download({ chunks, intervalMs: 0 });
+  assert.doesNotMatch(output, /\r/);
+  assert.ok(output.trimEnd().split('\n').length <= 2);
+  assert.ok(output.endsWith('[ 1.6 MB / ? MB ]\n'));
+});
+
+test('empty and single-chunk non-TTY downloads still produce a final progress row', async () => {
+  for (const chunks of [[], [Buffer.alloc(1_048_576, 0x63)]]) {
+    const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const output = await download({ chunks, total });
+    assert.doesNotMatch(output, /\r/);
+    const received = (total / 1_048_576).toFixed(1);
+    const expectedTotal = total ? received : '?';
+    assert.ok(output.endsWith(`[ ${received} MB / ${expectedTotal} MB ]\n`));
+  }
+});
+
+test('TTY progress keeps overwriting the same line and terminates it once', async () => {
+  const output = await download({
+    chunks: [Buffer.alloc(1_048_576), Buffer.alloc(1_048_576)],
+    total: 2_097_152,
+    isTTY: true,
+  });
+  assert.equal(output,
+    '\r  ↓  fixture: [ 1.0 MB / 2.0 MB ]'
+    + '\r  ↓  fixture: [ 2.0 MB / 2.0 MB ]\n');
+});

--- a/packages/setup/tests/setup-contract.test.mjs
+++ b/packages/setup/tests/setup-contract.test.mjs
@@ -17,7 +17,7 @@ function runWizard({ daemonMode = 'skip', daemonInstall, cwd: suppliedCwd, env =
   const ownsCwd = suppliedCwd === undefined;
   const entry = path.join(setupDir, 'index.js');
   const setupArgs = ['--claude', '--no-prompts', '--no-binary', `--daemon-mode=${daemonMode}`];
-  const childEnv = { ...process.env, HOME: cwd, ...env };
+  const childEnv = { ...process.env, HOME: cwd, XDG_RUNTIME_DIR: cwd, OPENAI_API_KEY: '', ...env };
   const bootstrap = [
     "if (typeof process.getuid !== 'function') process.getuid = () => 1000;",
   ];
@@ -233,3 +233,63 @@ test(
     }
   },
 );
+
+for (const mode of ['system', 'skip', 'none']) {
+  test(`next steps for ${mode} do not claim a user service was installed`, () => {
+    const manualSteps = mode === 'system'
+      ? ['sudo make install', 'sudo systemctl enable --now sysknife-daemon']
+      : ['Start manually:  /fixture/sysknife-daemon'];
+    const result = runWizard({
+      daemonMode: mode === 'none' ? 'skip' : mode,
+      daemonInstall: { mode, daemonInstalled: false, manualSteps },
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    assert.equal(result.status, 3, output);
+    assert.doesNotMatch(output, /systemctl --user (?:start|enable|status)/);
+    if (mode !== 'system') assert.doesNotMatch(output, /sudo systemctl/);
+    for (const command of manualSteps) assert.ok(output.includes(command), output);
+  });
+}
+
+test('an installed user service retains its start and status guidance', () => {
+  const result = runWizard({
+    daemonMode: 'user',
+    daemonInstall: { mode: 'user', daemonInstalled: true, manualSteps: [] },
+  });
+  const output = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, 0, output);
+  assert.match(output, /systemctl --user enable --now sysknife-daemon/);
+  assert.match(output, /systemctl --user status sysknife-daemon/);
+  assert.doesNotMatch(output, /sudo systemctl/);
+});
+
+test('unattended key setup explains the missing environment key without offering a prompt', () => {
+  const result = runWizard({
+    daemonInstall: { mode: 'skip', daemonInstalled: false, manualSteps: ['Start manually: fixture'] },
+  });
+  const output = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, 3, output);
+  assert.doesNotMatch(output, /The key will be stored in plain text|Leave blank to set/);
+  assert.match(output, /export OPENAI_API_KEY=your-key-here/);
+});
+
+test('unattended setup keeps a supplied environment key out of generated config and output', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sysknife-setup-env-key-'));
+  const fixtureKey = 'synthetic-key-for-wizard-test';
+  try {
+    const result = runWizard({
+      cwd,
+      env: { OPENAI_API_KEY: fixtureKey },
+      daemonInstall: { mode: 'skip', daemonInstalled: false, manualSteps: ['Start manually: fixture'] },
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    const config = fs.readFileSync(path.join(cwd, '.mcp.json'), 'utf8');
+    assert.equal(result.status, 3, output);
+    assert.match(output, /OPENAI_API_KEY already set in environment/);
+    assert.doesNotMatch(output, /Leave blank to set|export OPENAI_API_KEY=your-key-here/);
+    assert.ok(!output.includes(fixtureKey), output);
+    assert.ok(!config.includes(fixtureKey), config);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

The setup wizard could suggest starting or inspecting a user service after a system, skipped, or no-systemd installation. It now defers service commands until the installation result is known, keeps the existing manual steps for incomplete installations, and retains user-service guidance when that unit was installed.

Redirected downloads now print periodic newline-terminated progress and a final count; terminals retain the existing carriage-return display. `--no-prompts` omits interactive key-entry instructions while preserving the environment-key reminder and avoiding embedding supplied keys.

## Related Issue

Partially addresses #337: the invited wizard findings **1, 3 and 4**. Provider selection (finding 2) remains separate, so this PR does not close the issue.

## Validation

- [x] Tests added or updated: six real-wizard transcript cases and five offline downloader cases.
- [x] Documentation updated in `docs/quickstart.md`.
- [x] Security impact considered; installation, execution and approval behavior are unchanged.
- [x] Trust boundary preserved (daemon remains the only privileged executor).
- [x] All hosted checks completed — [Ubuntu CI](https://github.com/lacs-project/sysknife/actions/runs/34166705548) passed, including all 113 setup tests. Secret scanning and both Rust and JavaScript CodeQL passed: all three workflows and nine jobs succeeded on `9dfb171`.

Pinned upstream: `c82bb1f1bd017cca6fb40a14106710d16e32fd8f`. Local validation used Ubuntu 26.04 under WSL and Node 24.16.0:

```text
npm test --prefix packages/setup
  pristine baseline: 102 passed
  final: 113 passed, 0 failed, 0 skipped
node --test packages/setup/tests/setup-contract.test.mjs
  before production changes: 10 passed, 5 expected failures
  after: 15 passed
node --test packages/setup/tests/download-progress.test.mjs
  before production changes: 1 passed, 4 expected failures
  after: 5 passed
python3 scripts/check_evidence_claims.py
  passed in the required Bash/POSIX environment
git diff --check
  passed
```

No Rust file or published Rust test-count file changed; the documented no-Rust validation path applies. Tests use isolated configuration/socket fixtures, synthetic keys and an offline HTTPS stream. Live installation/provider behavior was not exercised.

## Notes for Reviewers

Prepared, tested, reviewed and submitted autonomously by OpenAI Codex using the configured personal account. An independent Codex agent reviewed the complete diff. No human pre-submission review was performed or is claimed.

The change corrects human-readable guidance and progress without changing arguments, exit codes, generated configuration, provider defaults or the downloader's returned bytes. Remote SSH/vsock next steps and the incomplete-setup contract from #312 are preserved.
