### PR TITLE
fix(release): validate missing registry version arguments

### DIFF
--- a/scripts/check_registry_versions.sh
+++ b/scripts/check_registry_versions.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="${1#v}"
+version="${1:-}"
+version="${version#v}"
 [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-    printf 'ERROR: expected a semantic version, got %q\n' "$1" >&2
+    printf 'ERROR: expected a semantic version, got %q\n' "${1:-}" >&2
     exit 2
 }
 

--- a/tests/release/release-rehearsal.test.sh
+++ b/tests/release/release-rehearsal.test.sh
@@ -4,6 +4,27 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 rehearsal="${repo_root}/scripts/release_rehearsal.sh"
 
+# Invalid registry versions must fail validation before attempting any network
+# requests, including when no positional argument was supplied.
+assert_invalid_registry_version() {
+    local output status
+    if output="$(bash "${repo_root}/scripts/check_registry_versions.sh" "$@" 2>&1)"; then
+        printf 'FAIL: registry preflight accepted an invalid version\n' >&2
+        exit 1
+    else
+        status=$?
+    fi
+    if [[ "$status" -ne 2 ]]; then
+        printf 'FAIL: registry preflight expected exit 2, got %s: %s\n' "$status" "$output" >&2
+        exit 1
+    fi
+    grep -Fq 'ERROR: expected a semantic version' <<<"$output"
+}
+
+assert_invalid_registry_version nope
+assert_invalid_registry_version
+assert_invalid_registry_version ''
+
 if [[ ! -x "$rehearsal" ]]; then
     printf 'FAIL: release rehearsal is missing or not executable: %s\n' "$rehearsal" >&2
     exit 1


### PR DESCRIPTION
## Summary
A missing version argument previously triggered Bash's unbound-variable error and exit 1. Default the argument before stripping the optional v prefix, and use a safe expansion in the diagnostic too, so missing/empty input receives the existing semantic-version error and exit 2.

## Related Issue
Closes #396.

## Validation
- [x] Tests added or updated — missing, empty, and malformed input in the existing release rehearsal test.
- [x] Security impact considered.
- [x] Trust boundary preserved.
- [ ] CI passes — awaiting upstream CI; full local CI did not pass.
- Wrote the regression first: the malformed input passed, then the no-argument case failed with expected exit 2 / actual exit 1. After the change, `bash tests/release/release-rehearsal.test.sh` passes.
- `python3 scripts/check_evidence_claims.py`, Bash syntax checks, and `git diff --check` pass.
- Ran `bash scripts/ci-local.sh --no-postgres`: 19 checks passed, eight failed. Failures: Rust/frontend dependency DNS access; existing GNU sed/grep expectations on macOS (four tests); setup test's Unix socket bind denied by sandbox. Optional lint/audit/nextest tools were absent. No Rust files changed.
- Tests ran with an isolated Bash 5.2.37 because macOS Bash 3.2 cannot run existing mapfile/associative-array scripts.

## Notes for Reviewers
Audited other top-level positional-argument handling: check_release_versions.sh, check_public_claims.sh, markdown-link-files.sh, test_baseline.sh, and check_no_secrets.sh already use default expansions. release_rehearsal.sh and ci-local.sh guard their argument loops; release_rehearsal also checks for a missing --output value.

No release, registry publication, runtime API, or schema changes. This repairs the existing invalid-input contract, so no documentation changes were needed.

AI-assisted with Codex; the diff and test results were inspected by the agent. No independent human-review claim. Two browser commits can be squashed.