### PR TITLE
fix(ci): fail closed when staged secret enumeration fails

### DIFF
--- a/scripts/check_no_secrets.sh
+++ b/scripts/check_no_secrets.sh
@@ -75,11 +75,21 @@ scan_text() {
 status=0
 if [ "${1:-}" = "--staged" ]; then
     # The staged content itself, not the working tree: those differ, and it is
-    # the staged bytes that become the commit.
-    while IFS= read -r path; do
+    # the staged bytes that become the commit. Capture the producer status
+    # explicitly: strict mode cannot see failures inside process substitution.
+    staged_list=""
+    if ! staged_list="$(git diff --cached --name-only --diff-filter=ACMR)"; then
+        echo "Refusing to commit: git could not enumerate staged files." >&2
+        exit 1
+    fi
+    staged_paths=()
+    if [ -n "$staged_list" ]; then
+        mapfile -t staged_paths <<< "$staged_list"
+    fi
+    for path in "${staged_paths[@]}"; do
         [ -n "$path" ] || continue
         git show ":$path" 2>/dev/null | scan_text "staged $path" || status=1
-    done < <(git diff --cached --name-only --diff-filter=ACMR)
+    done
 else
     for path in "$@"; do
         [ -f "$path" ] || continue

--- a/scripts/check_no_secrets.sh
+++ b/scripts/check_no_secrets.sh
@@ -88,7 +88,12 @@ if [ "${1:-}" = "--staged" ]; then
     fi
     for path in "${staged_paths[@]}"; do
         [ -n "$path" ] || continue
-        git show ":$path" 2>/dev/null | scan_text "staged $path" || status=1
+        staged_content=""
+        if ! staged_content="$(git show ":$path" 2>/dev/null)"; then
+            printf 'Refusing to commit: git could not read staged bytes for %s.\n' "$path" >&2
+            exit 1
+        fi
+        printf '%s' "$staged_content" | scan_text "staged $path" || status=1
     done
 else
     for path in "$@"; do

--- a/tests/release/no-secrets.test.sh
+++ b/tests/release/no-secrets.test.sh
@@ -154,6 +154,21 @@ else
     echo "FAIL: --staged rejected an honest empty staged set"
     fail=1
 fi
+
+# --- 6. A staged blob read failure must not masquerade as a finding ----------
+fake_oid='1111111111111111111111111111111111111111'
+git -C "$staged_repo" update-index --add --cacheinfo 100644,$fake_oid,unreadable.txt
+if unreadable_output="$(cd "$staged_repo" && "$CHECK" --staged 2>&1)"; then
+    echo "FAIL: --staged passed when git could not read staged bytes"
+    fail=1
+elif ! grep -Fq 'could not read staged bytes for unreadable.txt' <<< "$unreadable_output"; then
+    echo "FAIL: --staged did not distinguish an unreadable staged blob"
+    fail=1
+elif grep -Fq 'staged content contains' <<< "$unreadable_output"; then
+    echo "FAIL: unreadable staged bytes were reported as a credential finding"
+    fail=1
+fi
+git -C "$staged_repo" update-index --force-remove unreadable.txt
 if [ "$fail" != 0 ]; then exit 1; fi
 echo "ok: catches real-shaped credentials, ignores this repo's fixtures"
 echo "ok: the whole tracked tree scans clean, and findings never echo the secret"

--- a/tests/release/no-secrets.test.sh
+++ b/tests/release/no-secrets.test.sh
@@ -112,6 +112,48 @@ if ! grep -qF "$leak" <<< "$out"; then
 fi
 CHECK="$real_check"
 
+# --- 5. The pre-commit --staged path must fail closed -----------------------
+staged_repo="$tmp/staged-repo"
+mkdir -p "$staged_repo"
+git -C "$staged_repo" init -q
+git -C "$staged_repo" config user.name 'SysKnife test'
+git -C "$staged_repo" config user.email 'sysknife-test@example.invalid'
+printf 'clean\n' > "$staged_repo/README.md"
+git -C "$staged_repo" add README.md
+git -C "$staged_repo" commit -qm 'fixture baseline'
+
+printf 'k = "%s"\n' "$leak" > "$staged_repo/leak.txt"
+git -C "$staged_repo" add leak.txt
+if staged_output="$(cd "$staged_repo" && "$CHECK" --staged 2>&1)"; then
+    echo "FAIL: --staged accepted content that the explicit-file path rejects"
+    fail=1
+elif ! grep -Fq 'Refusing to commit' <<< "$staged_output"; then
+    echo "FAIL: --staged did not report the staged finding"
+    fail=1
+fi
+
+cp "$staged_repo/.git/index" "$staged_repo/index.good"
+printf 'DIRT' > "$staged_repo/.git/index"
+if git_error_output="$(cd "$staged_repo" && "$CHECK" --staged 2>&1)"; then
+    echo "FAIL: --staged passed when git could not enumerate the index"
+    fail=1
+elif ! grep -Fq 'could not enumerate staged files' <<< "$git_error_output"; then
+    echo "FAIL: --staged did not explain that staged-file enumeration failed"
+    fail=1
+fi
+mv "$staged_repo/index.good" "$staged_repo/.git/index"
+
+git -C "$staged_repo" reset -q HEAD -- leak.txt
+rm -f "$staged_repo/leak.txt"
+if empty_output="$(cd "$staged_repo" && "$CHECK" --staged 2>&1)"; then
+    if [ -n "$empty_output" ]; then
+        echo "FAIL: --staged printed output for an honest empty staged set"
+        fail=1
+    fi
+else
+    echo "FAIL: --staged rejected an honest empty staged set"
+    fail=1
+fi
 if [ "$fail" != 0 ]; then exit 1; fi
 echo "ok: catches real-shaped credentials, ignores this repo's fixtures"
 echo "ok: the whole tracked tree scans clean, and findings never echo the secret"


### PR DESCRIPTION
## Summary
- capture the staged file list before scanning and fail closed when `git diff --cached` cannot enumerate it
- keep an honest empty staged set quiet and allowed
- add regression coverage for the real `--staged` pre-commit path
- distinguish a staged-blob read failure from an actual credential finding in a separate commit

## Validation
- reproduced the issue on current `main`: `git diff --cached` exited 128 while the scanner exited 0
- after the fix, the same case exits 1 with `git could not enumerate staged files`
- staged synthetic finding: PASS
- broken-index enumeration failure: PASS
- honest empty staging: PASS
- unreadable staged blob message: PASS
- `bash -n scripts/check_no_secrets.sh tests/release/no-secrets.test.sh`
- `git diff --check`

Closes #406