### PR TITLE
fix(repo): enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Keep tracked text byte-stable across Linux, Windows, and WSL checkouts.
+* text=auto eol=lf
+
+# Shell entry points must keep an LF shebang even on Windows.
+*.sh text eol=lf
+.githooks/* text eol=lf
+
+# Binary assets must never be line-ending normalized.
+*.gif -text
+*.ico -text
+*.png -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check no workflow pins an end-of-life Node release
         run: bash tests/release/node-eol.test.sh
 
+      - name: Check tracked files use portable line endings
+        run: bash tests/release/tracked-eol.test.sh
+
       - name: Check systemd directory modes match tmpfiles
         run: bash tests/release/systemd-directory-modes.test.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,24 @@ A one-line comment prevents it. If an issue already carries `claimed` and the
 thread has been quiet for a week, say you are taking it over rather than opening
 a competing PR.
 
+**Windows and WSL line endings.** This repository pins tracked text to LF via
+`.gitattributes`. On Windows or WSL, configure this checkout with:
+
+```sh
+git config core.autocrlf false
+```
+
+If an existing checkout already has CRLF line endings, first make sure the
+working tree is clean, then renormalise it:
+
+```sh
+git config core.autocrlf false
+git rm --cached -r . && git reset --hard
+```
+
+`git reset --hard` discards local changes, so do not run the recovery sequence
+with work you have not committed or stashed.
+
 ### 2. Branch, code, test
 
 ```sh

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -271,6 +271,7 @@ run_hygiene_group() {
     run_step 'hygiene: release-rehearsal.test.sh' bash "$repo_root/tests/release/release-rehearsal.test.sh"
     run_step 'hygiene: database-path-agreement.test.sh' bash "$repo_root/tests/release/database-path-agreement.test.sh"
     run_step 'hygiene: node-eol.test.sh' bash "$repo_root/tests/release/node-eol.test.sh"
+    run_step 'hygiene: tracked-eol.test.sh' bash "$repo_root/tests/release/tracked-eol.test.sh"
     run_step 'hygiene: systemd-directory-modes.test.sh' bash "$repo_root/tests/release/systemd-directory-modes.test.sh"
     run_step 'hygiene: ubuntu-vm-bootstrap.test.sh' bash "$repo_root/tests/e2e/ubuntu-vm-bootstrap.test.sh"
     run_step 'hygiene: provider-parity.test.sh' bash "$repo_root/tests/e2e/provider-parity.test.sh"

--- a/tests/release/tracked-eol.test.sh
+++ b/tests/release/tracked-eol.test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Keep tracked text normalized in the Git index.
+#
+# A Windows or WSL checkout can otherwise follow contributor-specific line-ending
+# settings. Without a repository policy, CRLF can enter the index. Some SysKnife
+# tests compare generated documents byte-for-byte, so that corruption looks like
+# an unrelated content failure.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+if ! eol="$(git ls-files --eol)"; then
+    echo "FAIL: could not inspect tracked file line endings" >&2
+    exit 1
+fi
+
+bad="$(printf '%s\n' "$eol" | grep -E '^i/(crlf|mixed)[[:space:]]' || true)"
+if [ -n "$bad" ]; then
+    echo "FAIL: tracked files contain CRLF or mixed line endings in the Git index:" >&2
+    printf '%s\n' "$bad" >&2
+    exit 1
+fi
+
+echo "ok: tracked Git index contains no CRLF or mixed line endings"


### PR DESCRIPTION
## Summary
- add repository-level LF policy for tracked text while excluding the existing PNG/ICO/GIF binary assets
- keep shell scripts and extensionless Git hooks explicitly on LF so their shebangs stay executable
- add a release guard that fails if any tracked index entry is CRLF or mixed, and run it in CI and `ci-local`
- document the Windows/WSL checkout and renormalisation steps

## Proof first
Before adding `.gitattributes`, I committed a CRLF fixture on a local scratch branch. `git ls-files --eol` reported:

```text
i/crlf  w/crlf  attr/    tests/evidence/crlf-guard-proof.txt
```

and `tests/release/tracked-eol.test.sh` failed with exit 1 and named that file. The scratch branch was then deleted.

With the new attributes present, staging a CRLF working-tree fixture produced `i/lf w/crlf attr/text=auto eol=lf`, proving the repository policy normalises the index rather than only making the guard green.

I also compared raw working-tree hashes for the tracked PNG, GIF and ICO samples against their index OIDs; all three stayed byte-identical under the binary exclusions.

## Validation
- `bash tests/release/tracked-eol.test.sh`
- `bash -n tests/release/tracked-eol.test.sh scripts/ci-local.sh`
- `bash scripts/check_repo_completeness.sh`
- `bash tests/release/markdown-link-files.test.sh`
- `git diff upstream/main...HEAD --check`

`npm test --prefix packages/setup` is not green on native Windows: 111 pass, 14 fail, 1 skip. The failures are existing POSIX assumptions around Unix modes, `process.getuid`, `/run` paths and executable discovery; this PR does not touch `packages/setup`. Linux CI is the authoritative run for those tests.

Closes #342