### PR TITLE
test: fail when sudo action filter selects nothing

### DIFF
--- a/crates/sysknife-daemon/tests/sudoers_grants_match_argv.rs
+++ b/crates/sysknife-daemon/tests/sudoers_grants_match_argv.rs
@@ -97,6 +97,7 @@ fn every_sudo_action_is_authorised_by_a_packaged_grant() {
     );
 
     let mut unauthorised = Vec::new();
+    let mut checked = 0;
     for (_section, specs) in catalogue() {
         for spec in specs {
             let ActionMechanism::Command { program, args } = &spec.mechanism else {
@@ -105,12 +106,17 @@ fn every_sudo_action_is_authorised_by_a_packaged_grant() {
             if *program != "sudo" {
                 continue;
             }
+            checked += 1;
             if !grants.iter().any(|g| grant_allows(g, args)) {
                 unauthorised.push(format!("{}: sudo {}", spec.action_name, args.join(" ")));
             }
         }
     }
 
+    assert!(
+        checked > 50,
+        "only {checked} sudo action specs were checked; the mechanism or program filter must have changed and this guard is no longer looking at anything"
+    );
     assert!(
         unauthorised.is_empty(),
         "these actions invoke sudo with an argv no rule in packaging/sysknife-sudoers \


### PR DESCRIPTION
## Summary
- count sudo action specs that survive both catalogue filters
- fail if the guard is no longer looking at a meaningful set of actions
- keep the threshold as a floor so adding new sudo actions does not create churn

## Validation
- `sudo` -> `sudoz` mutation: targeted nextest run started 2 tests and failed with `only 0 sudo action specs were checked`
- restored filter: targeted nextest run started 2 tests and passed 2/2
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #408