### PR TITLE
fix(daemon): declare CHAIN_ROW_COLUMNS once, in store.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ milestone.
 | **Every Ubuntu LTS validated** — 22.04, 24.04 and 26.04 all at 79/79, each with a replay twin that reproduces it | ✅ |
 | Telegram approval interface | 📋 roadmap |
 
-**1,852 Rust tests and 72 frontend tests** form the current deterministic
+**1,853 Rust tests and 72 frontend tests** form the current deterministic
 release baseline.
 
 ## Configure your LLM

--- a/crates/sysknife-daemon/src/store.rs
+++ b/crates/sysknife-daemon/src/store.rs
@@ -49,6 +49,28 @@ use crate::transactions::{
 
 pub mod postgres;
 
+/// Column list every `ChainRow` read shares, on both backends. The SQLite
+/// path (`transactions.rs`) maps rows positionally and the Postgres path
+/// (`store/postgres.rs`) maps them by name, but both SELECT this exact list
+/// in this exact order, so the list, the column count, and the mapper order
+/// are one invariant.
+///
+/// This used to be declared twice — once per backend — kept in sync only by
+/// a "Mirrors" doc comment. Adding the caller-identity columns updated the
+/// mapper and one of the two queries, and the miss showed up only as a
+/// runtime "no column found for name: chain_version" from the live-Postgres
+/// test — the unit tests, which never touch this SQL, stayed green. One
+/// declaration means that class of drift is a compile-time impossibility
+/// rather than a live-database surprise (#397).
+///
+/// Parameter placeholders stay per-backend on purpose: SQLite binds `?1`,
+/// Postgres binds `$1`. Only the column list is shared.
+pub(crate) const CHAIN_ROW_COLUMNS: &str =
+    "seq, key_id, transaction_id, request_id, request_hash, \
+     action_name, risk_level, summary, approval_id, warnings_json, \
+     created_at, prev_chain_hash, chain_hash, chain_version, caller_role, event_tip, \
+     caller_principal";
+
 /// Async, polymorphic interface to the audit log. Implemented by
 /// [`SqliteStore`] (rusqlite, blocking under the hood) and
 /// [`postgres::PostgresStore`] (sqlx, native async).
@@ -415,6 +437,47 @@ mod tests {
     fn sqlite_store(path: std::path::PathBuf) -> SqliteStore {
         let key = Arc::new(AuditKey::from_bytes(vec![0x42; 32]));
         SqliteStore::new(crate::transactions::TransactionStore::open_with_key(path, key).unwrap())
+    }
+
+    /// `CHAIN_ROW_COLUMNS` is now declared once (store.rs), so there is no
+    /// second copy left to compare — the drift test that justified the hoist
+    /// ran green first, was mutated red on purpose (see #397's PR), and is
+    /// replaced by this pin. The invariant that matters is the one the
+    /// positional mapper (`chain_row_from_sqlite`) and the by-name mapper
+    /// (`row_to_chain_row`) both depend on: 17 columns, in this exact order.
+    /// Adding a column to the chain means updating this list deliberately,
+    /// together with both mappers.
+    #[test]
+    fn chain_row_columns_pinned() {
+        let columns: Vec<&str> = crate::store::CHAIN_ROW_COLUMNS
+            .split(',')
+            .map(str::trim)
+            .collect();
+        assert_eq!(
+            columns,
+            [
+                "seq",
+                "key_id",
+                "transaction_id",
+                "request_id",
+                "request_hash",
+                "action_name",
+                "risk_level",
+                "summary",
+                "approval_id",
+                "warnings_json",
+                "created_at",
+                "prev_chain_hash",
+                "chain_hash",
+                "chain_version",
+                "caller_role",
+                "event_tip",
+                "caller_principal",
+            ],
+            "CHAIN_ROW_COLUMNS changed — both ChainRow mappers read these \
+             columns in this order, so update them in the same change"
+        );
+        assert_eq!(columns.len(), 17, "column count drifted from 17");
     }
 
     fn new_tx(request_id: &str) -> NewTransaction {

--- a/crates/sysknife-daemon/src/store/postgres.rs
+++ b/crates/sysknife-daemon/src/store/postgres.rs
@@ -48,17 +48,15 @@ use crate::transactions::{
 
 const MIGRATION_LOCK_ID: i64 = 0x5359_534b_4e49_4645;
 
-/// Column list every `ChainRow` read shares, kept next to `row_to_chain_row`.
+/// Column list every `ChainRow` read shares, declared once in `store.rs`
+/// (#397) and kept next to `row_to_chain_row` here by import.
 ///
 /// The two read paths each spelled the list out. Adding the caller-identity
 /// columns updated the mapper and one of the two queries, and the miss showed
 /// up only as a runtime "no column found for name: chain_version" from the
 /// live-Postgres test — the unit tests, which never touch this SQL, stayed
-/// green. Mirrors `CHAIN_ROW_COLUMNS` in `transactions.rs`.
-const CHAIN_ROW_COLUMNS: &str = "seq, key_id, transaction_id, request_id, request_hash, \
-     action_name, risk_level, summary, approval_id, warnings_json, \
-     created_at, prev_chain_hash, chain_hash, chain_version, caller_role, event_tip, \
-     caller_principal";
+/// green. That history now lives on the single declaration.
+use crate::store::CHAIN_ROW_COLUMNS;
 
 struct Migration {
     version: i64,

--- a/crates/sysknife-daemon/src/transactions.rs
+++ b/crates/sysknife-daemon/src/transactions.rs
@@ -204,16 +204,10 @@ const SQLITE_MIGRATIONS: &[SqliteMigration] = &[
     },
 ];
 
-/// Column list for every `ChainRow` read, kept next to the mapper below.
-///
-/// The two read paths (`fetch_chain_rows`, `fetch_chain_row`) used to repeat
-/// both the SELECT and a positional `row.get(n)` block. Adding a column meant
-/// editing four places in step, and a mismatch between the two would surface
-/// as a verification failure rather than a compile error.
-const CHAIN_ROW_COLUMNS: &str = "seq, key_id, transaction_id, request_id, request_hash, \
-     action_name, risk_level, summary, approval_id, warnings_json, \
-     created_at, prev_chain_hash, chain_hash, chain_version, caller_role, event_tip, \
-     caller_principal";
+/// Column list for every `ChainRow` read, shared with the Postgres backend
+/// and declared once in `store.rs` (#397) — the mapper below reads columns
+/// positionally in exactly that order.
+use crate::store::CHAIN_ROW_COLUMNS;
 
 fn chain_row_from_sqlite(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChainRow> {
     Ok(ChainRow {

--- a/docs/distro-support.md
+++ b/docs/distro-support.md
@@ -91,7 +91,7 @@ family and the atomic story family are implemented and covered by the workspace
 suite. What is missing is a way to put the helpers somewhere the daemon's own
 grants already point.
 
-The deterministic workspace baseline is 1,852 Rust tests plus 72 frontend
+The deterministic workspace baseline is 1,853 Rust tests plus 72 frontend
 tests. Those tests verify action construction, policy, approval, storage, and
 UI behavior, but they do not replace a real distribution VM run.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -141,7 +141,7 @@ flow.
 
 ## Status
 
-190 typed actions · 1,852 Rust tests + 72 frontend tests · MIT
+190 typed actions · 1,853 Rust tests + 72 frontend tests · MIT
 
 SysKnife is the reference implementation of the
 [LACS specification](https://github.com/lacs-project/specification) — a

--- a/tests/evidence/workspace-tests.json
+++ b/tests/evidence/workspace-tests.json
@@ -4,6 +4,6 @@
     "tests": "cargo nextest run --workspace --locked"
   },
   "frontend_tests": 72,
-  "tests": 1852,
+  "tests": 1853,
   "version": 2
 }


### PR DESCRIPTION
## Problem

`CHAIN_ROW_COLUMNS` — the 17-column SELECT list every `ChainRow` read shares — was declared twice: once in `transactions.rs` (SQLite) and once in `store/postgres.rs`, kept in sync only by a "Mirrors" doc comment. The Postgres copy's own comment records the last drift: adding the caller-identity columns updated the mapper and one of the two queries, and the miss surfaced only as a runtime `no column found for name: chain_version` from the live-Postgres test while unit tests stayed green. A contributor adding a column still has to remember the second file, and only a running Postgres catches the miss (#397).

## Solution

- Hoist one `pub(crate) const CHAIN_ROW_COLUMNS` into `store.rs`, the shared parent of both backends; the drift history paragraph moves with it.
- Both modules import it; all four SELECT sites are unchanged (placeholders stay per-backend — SQLite `?1`, Postgres `$1` — only the column list is shared). The second declaration is deleted.

Tests, per the issue's sequence:

1. Before the hoist, added `chain_row_columns_agree_across_backends` asserting the two copies are equal, and ran it green.
2. Mutated it red on purpose — changed `caller_principal` to `caller_principaI` in the Postgres copy:

```
assertion `left == right` failed: CHAIN_ROW_COLUMNS drifted between transactions.rs (SQLite) and store/postgres.rs — the positional mappers read columns in this order, so a mismatch breaks one backend's chain reads at runtime
  left:  "…, event_tip, caller_principal"
  right: "…, event_tip, caller_principaI"
    FAIL sysknife-daemon store::tests::chain_row_columns_agree_across_backends
```

3. After the hoist there is no second copy to compare, so replaced it with `chain_row_columns_pinned`: asserts the exact 17-column list and count, which is the invariant both mappers (positional SQLite, by-name Postgres) actually depend on.

## Result

`cargo nextest run -p sysknife-daemon`: 1081 passed, 5 skipped. `cargo fmt --check` and `cargo clippy --all-targets` clean. No Postgres needed — this removes the check the live-Postgres job was uniquely positioned to catch.

Closes #397
